### PR TITLE
Fixed memory leak in dav1d codec

### DIFF
--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -25,6 +25,9 @@ struct avifCodecInternal
 
 static void dav1dCodecDestroyInternal(avifCodec * codec)
 {
+    if (codec->internal->hasPicture) {
+      dav1d_picture_unref(&codec->internal->dav1dPicture);
+    }
     if (codec->internal->dav1dContext) {
         dav1d_close(&codec->internal->dav1dContext);
     }


### PR DESCRIPTION
There was a leak in the dav1d codec: the last frame allocate by `dav1dCodecGetNextImage` never git freed. In this commit I am adding the missing cleanup in `dav1dCodecDestroyInternal`.