### PR TITLE
Removed unused field in codec_aom

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -35,7 +35,6 @@ struct avifCodecInternal
     uint32_t inputSampleIndex;
     aom_image_t * image;
 
-    avifRWData encodedOBU;
     avifCodecConfigurationBox config;
 };
 
@@ -44,7 +43,6 @@ static void aomCodecDestroyInternal(avifCodec * codec)
     if (codec->internal->decoderInitialized) {
         aom_codec_destroy(&codec->internal->decoder);
     }
-    avifRWDataFree(&codec->internal->encodedOBU);
     avifFree(codec->internal);
 }
 


### PR DESCRIPTION
The field `encodedOBU` is not used anywhere (these two occurrences are the only ones I find with grep).