### PR TITLE
cmake: Don't use the project version as library version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       - cd ..
       - mkdir build
       - cd build
-      - cmake -DCMAKE_BUILD_TYPE=Debug -DAVIF_BUILD_STATIC=1 -DAVIF_CODEC_AOM=1 -DAVIF_LOCAL_AOM=1 -DAVIF_CODEC_DAV1D=1 -DAVIF_LOCAL_DAV1D=1 ..
+      - cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON ..
     script:
       - make
 
@@ -50,7 +50,7 @@ matrix:
       - cd ..
       - mkdir build
       - cd build
-      - cmake -DCMAKE_BUILD_TYPE=Release -DAVIF_BUILD_STATIC=1 -DAVIF_CODEC_AOM=1 -DAVIF_LOCAL_AOM=1 -DAVIF_CODEC_DAV1D=1 -DAVIF_LOCAL_DAV1D=1 ..
+      - cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON ..
     script:
       - make
 
@@ -75,7 +75,7 @@ matrix:
       - cd ..
       - mkdir build
       - cd build
-      - cmake -DCMAKE_BUILD_TYPE=Debug -DAVIF_BUILD_STATIC=1 -DAVIF_CODEC_AOM=1 -DAVIF_LOCAL_AOM=1 -DAVIF_CODEC_DAV1D=1 -DAVIF_LOCAL_DAV1D=1 ..
+      - cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON ..
     script:
       - make
 
@@ -100,6 +100,6 @@ matrix:
       - cd ..
       - mkdir build
       - cd build
-      - cmake -DCMAKE_BUILD_TYPE=Release -DAVIF_BUILD_STATIC=1 -DAVIF_CODEC_AOM=1 -DAVIF_LOCAL_AOM=1 -DAVIF_CODEC_DAV1D=1 -DAVIF_LOCAL_DAV1D=1 ..
+      - cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON ..
     script:
       - make

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Define version and SO-version for shared library
+- Use -DBUILD_SHARED_LIBS=OFF for building a static lib
 
 ## [0.4.8] - 2019-11-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Pass through PROJECT_VERSION to shared library's SOVERSION in CMake
+- Define version and SO-version for shared library
 
 ## [0.4.8] - 2019-11-19
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU")
   add_definitions(-std=c99) # Enforce C99 for gcc
 endif()
 
-option(AVIF_BUILD_STATIC "Build static avif library" OFF)
+option(BUILD_SHARED_LIBS "Build shared avif library" ON)
 
 option(AVIF_CODEC_AOM "Use the AOM codec for encoding (and decoding if no other decoder is present)" OFF)
 option(AVIF_CODEC_DAV1D "Use the dav1d codec for decoding (overrides AOM decoding if also enabled)" OFF)
@@ -226,15 +226,11 @@ if(NOT AVIF_CODEC_AOM AND NOT AVIF_CODEC_DAV1D)
     message(FATAL_ERROR "libavif: No decoding library is enabled, bailing out.")
 endif()
 
-if(AVIF_BUILD_STATIC)
-    add_library(avif STATIC ${AVIF_SRCS})
-else()
-    add_library(avif SHARED ${AVIF_SRCS})
-    set_target_properties(avif
-                          PROPERTIES
+add_library(avif ${AVIF_SRCS})
+set_target_properties(avif
+                      PROPERTIES
                           VERSION ${LIBRARY_VERSION}
                           SOVERSION ${LIBRARY_SOVERSION})
-endif()
 target_link_libraries(avif
                       PRIVATE ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
 target_include_directories(avif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,16 @@
 cmake_minimum_required(VERSION 3.5)
 project(libavif LANGUAGES C VERSION 0.4.8)
 
+# SOVERSION scheme: CURRENT.AGE.REVISION
+#   If there was an incompatible interface change:
+#     Increment CURRENT. Set AGE and REVISION to 0
+#   If there was a compatible interface change:
+#     Increment AGE. Set REVISION to 0
+#   If the source code was changed, but there were no interface changes:
+#     Increment REVISION.
+set(LIBRARY_VERSION "0.1.0")
+set(LIBRARY_SOVERSION "0")
+
 if(CMAKE_C_COMPILER_ID MATCHES "GNU")
   add_definitions(-std=c99) # Enforce C99 for gcc
 endif()
@@ -220,7 +230,10 @@ if(AVIF_BUILD_STATIC)
     add_library(avif STATIC ${AVIF_SRCS})
 else()
     add_library(avif SHARED ${AVIF_SRCS})
-    set_target_properties(avif PROPERTIES SOVERSION ${PROJECT_VERSION})
+    set_target_properties(avif
+                          PROPERTIES
+                          VERSION ${LIBRARY_VERSION}
+                          SOVERSION ${LIBRARY_SOVERSION})
 endif()
 target_link_libraries(avif
                       PRIVATE ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})


### PR DESCRIPTION
You should never use the project version as the SO version. This will sooner or later lead to trouble :-)