### PR TITLE
rawdata: Fix a segfault freeing invalid data

### DIFF
--- a/src/rawdata.c
+++ b/src/rawdata.c
@@ -26,7 +26,7 @@ void avifRWDataSet(avifRWData * raw, const uint8_t * data, size_t len)
         avifRWDataRealloc(raw, len);
         memcpy(raw->data, data, len);
     } else {
-        avifFree(raw);
+        avifFree(raw->data);
     }
 }
 


### PR DESCRIPTION
I discovered a segfault in avifdec when the image doesn't contain XMP data.

```
(gdb) bt
#0  0x00007ffff7e615ce in free () from /lib64/libc.so.6
#1  0x00007ffff7dcfe98 in avifImageCopy (dstImage=dstImage@entry=0x555555559490, srcImage=0x555555559ef0) at /usr/src/debug/libavif-0.5.1-1.1.x86_64/src/avif.c:141
#2  0x00007ffff7dd0111 in avifDecoderRead (input=<optimized out>, image=0x555555559490, decoder=0x555555559550) at /usr/src/debug/libavif-0.5.1-1.1.x86_64/src/read.c:1937
#3  avifDecoderRead (decoder=0x555555559550, image=0x555555559490, input=<optimized out>) at /usr/src/debug/libavif-0.5.1-1.1.x86_64/src/read.c:1924
#4  0x00005555555552f4 in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/libavif-0.5.1-1.1.x86_64/apps/avifdec.c:85
```