### PR TITLE
ext: Clone shallow, single and stable branch in aom.cmd, dav1d.cmd and rav1e.cmd

### DIFF
--- a/ext/aom.cmd
+++ b/ext/aom.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2017 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -n --shallow-since=2019-12-01 --single-branch https://aomedia.googlesource.com/aom && cd aom && git checkout aadb0b4b23b0aaa031c8aca15c9f86a42010acf6 && cd ..
+git clone -b libaom-v0.9.0 --depth 1 https://aomedia.googlesource.com/aom
 
 cd aom
 mkdir build.libavif

--- a/ext/aom.cmd
+++ b/ext/aom.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2017 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -n https://aomedia.googlesource.com/aom && cd aom && git checkout 60d06c8721605ecd40c3b21bdd3685115b82ebf2 && cd ..
+git clone -n --shallow-since=2019-12-01 --single-branch https://aomedia.googlesource.com/aom && cd aom && git checkout aadb0b4b23b0aaa031c8aca15c9f86a42010acf6 && cd ..
 
 cd aom
 mkdir build.libavif

--- a/ext/aom.cmd
+++ b/ext/aom.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2017 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b libaom-v0.9.0 --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v1.0.0-errata1-avif --depth 1 https://aomedia.googlesource.com/aom
 
 cd aom
 mkdir build.libavif

--- a/ext/dav1d.cmd
+++ b/ext/dav1d.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2017 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -n -b 0.5.2 --depth 1 https://code.videolan.org/videolan/dav1d.git
+git clone -b 0.5.2 --depth 1 https://code.videolan.org/videolan/dav1d.git
 
 cd dav1d
 mkdir build

--- a/ext/dav1d.cmd
+++ b/ext/dav1d.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2017 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -n https://code.videolan.org/videolan/dav1d.git && cd dav1d && git checkout 0.5.1 && cd ..
+git clone -n -b 0.5.2 --depth 1 https://code.videolan.org/videolan/dav1d.git
 
 cd dav1d
 mkdir build

--- a/ext/rav1e.cmd
+++ b/ext/rav1e.cmd
@@ -11,7 +11,7 @@
 : # Also, the error that "The target windows-msvc is not supported yet" can safely be ignored provided that rav1e/target/release
 : # contains rav1e.h and rav1e.lib.
 
-git clone -n -b p20191201 --depth 1 https://github.com/xiph/rav1e.git
+git clone -b p20191201 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
 cargo install cbindgen

--- a/ext/rav1e.cmd
+++ b/ext/rav1e.cmd
@@ -11,7 +11,7 @@
 : # Also, the error that "The target windows-msvc is not supported yet" can safely be ignored provided that rav1e/target/release
 : # contains rav1e.h and rav1e.lib.
 
-git clone -n https://github.com/xiph/rav1e.git && cd rav1e && git checkout 97538d104f3548fc55ec594579eed24ab7bb6abd && cd ..
+git clone -n -b p20191201 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
 cargo install cbindgen


### PR DESCRIPTION
Speedup `aom.cmd`, `dav1d.cmd` and `rav1e.cmd` in `/ext` massively by online cloning a single and shallow branch. dav1d and rav1e use the latest tagged (pre-)release, aom the latest build from master.

In Travis, the builds are approximately a minute faster.