### PR TITLE
Unbreak -DAVIF_BUILD_APPS=ON with Clang

### DIFF
--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -94,11 +94,11 @@ static avifBool getHeaderString(uint8_t * p, uint8_t * end, char * out, size_t m
 }
 
 #define ADVANCE(BYTES)    \
-    {                     \
+    do {                  \
         p += BYTES;       \
         if (p >= end)     \
             goto cleanup; \
-    }
+    } while(0)
 
 avifBool y4mRead(avifImage * avif, const char * inputFilename)
 {


### PR DESCRIPTION
Triggered by `-Weverything`. See [error log](https://github.com/AOMediaCodec/libavif/files/4082247/libavif-0.5.3.log).