### PR TITLE
Unbreak build on Unix systems without /usr/lib/libdl.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ if(AVIF_CODEC_RAV1E)
     if(WIN32)
         set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ws2_32.lib userenv.lib)
     elseif(UNIX AND NOT APPLE)
-        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} dl) # for backtrace
+        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${CMAKE_DL_LIBS}) # for backtrace
     endif()
 endif()
 


### PR DESCRIPTION
NetBSD and OpenBSD cannot use `-ldl` while [DragonFly](https://github.com/DragonFlyBSD/DragonFlyBSD/commit/2f60b541a1a5) and [FreeBSD](https://github.com/freebsd/freebsd/commit/84be924362c6) don't need it.