### PR TITLE
Support copying monochrome YUV image.

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -149,7 +149,7 @@ void avifImageCopy(avifImage * dstImage, avifImage * srcImage)
         }
     }
 
-    if (srcImage->yuvPlanes[AVIF_CHAN_Y] && srcImage->yuvPlanes[AVIF_CHAN_U] && srcImage->yuvPlanes[AVIF_CHAN_V]) {
+    if (srcImage->yuvPlanes[AVIF_CHAN_Y]) {
         avifImageAllocatePlanes(dstImage, AVIF_PLANES_YUV);
 
         avifPixelFormatInfo formatInfo;
@@ -166,8 +166,10 @@ void avifImageCopy(avifImage * dstImage, avifImage * srcImage)
                 planeHeight = uvHeight;
             }
 
-            if (!srcImage->yuvRowBytes[aomPlaneIndex]) {
-                // plane is absent, move on
+            if (!srcImage->yuvRowBytes[aomPlaneIndex] || !srcImage->yuvPlanes[aomPlaneIndex]) {
+                // plane is absent, free dstPlane and move on
+                avifFree(dstImage->yuvPlanes[aomPlaneIndex]);
+                dstImage->yuvRowBytes[aomPlaneIndex] = 0;
                 continue;
             }
 


### PR DESCRIPTION
Hi! I' m working at Link-U, a company that publishes digital comics for smart phones.

When monochrome images are decoded by dav1d, U and V planes will be NULL.

However, `avifImageCopy` assumes that all Y, U and V planes are filled with non-NULL values if and only if the image has YUV planes:

https://github.com/AOMediaCodec/libavif/blob/c541cf98613bf3fd6dc3966483579796276d8360/src/avif.c#L152-L154

Thus, when `avifDecoderRead` reads a monochrome image (that has only Y plane), the last call of `avifImageCopy` does not copy at all, and all planes in the returned copied image will be NULL.

https://github.com/AOMediaCodec/libavif/blob/c541cf98613bf3fd6dc3966483579796276d8360/src/read.c#L1924-L1939

In this patch, just check Y plane to determine an image has YUV planes, and free U, V planes if they are unused.

Please take a look.

## P.S.

I also have an idea adding `AVIF_PLANES_Y` enum to `avifPlanesFlags`, to tell `avifImageAllocatePlanes` to allocate just only Y plane. How about this idea?
