### PR TITLE
Remove a null check for codec->internal->image.

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -101,10 +101,6 @@ static avifBool aomCodecGetNextImage(avifCodec * codec, avifImage * image)
         }
     }
 
-    if (!codec->internal->image) {
-        return AVIF_FALSE;
-    }
-
     avifBool isColor = !codec->decodeInput->alpha;
     if (isColor) {
         // Color (YUV) planes - set image to correct size / format, fill color


### PR DESCRIPTION
Remove the null check after the following if-else statement in
aomCodecGetNextImage():

    if (nextFrame) {
        codec->internal->image = nextFrame;
    } else {
        if (codec->decodeInput->alpha && codec->internal->image) {
            // Special case: reuse last alpha frame
        } else {
            return AVIF_FALSE;
        }
    }

If we fall through from the if-else statement, codec->internal->image
must be non-null, so the null check is always false.