### PR TITLE
use right-most and bottom-most UV pixels in images with odd-dimensions

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -190,8 +190,8 @@ static avifResult avifImageYUVToRGB16Color(avifImage * image, avifReformatState 
     const float kr = state->kr;
     const float kg = state->kg;
     const float kb = state->kb;
-    const uint32_t maxUVI = (image->width > 1) ? (image->width >> state->formatInfo.chromaShiftX) - 1 : 0;
-    const uint32_t maxUVJ = (image->height > 1) ? (image->height >> state->formatInfo.chromaShiftY) - 1 : 0;
+    const uint32_t maxUVI = (image->width > 1) ? ((image->width+state->formatInfo.chromaShiftX) >> state->formatInfo.chromaShiftX) - 1 : 0;
+    const uint32_t maxUVJ = (image->height > 1) ? ((image->height+state->formatInfo.chromaShiftY) >> state->formatInfo.chromaShiftY) - 1 : 0;
 
     float maxChannel = (float)((1 << image->depth) - 1);
     uint8_t ** rgbPlanes = image->rgbPlanes;
@@ -288,8 +288,8 @@ static avifResult avifImageYUVToRGB8Color(avifImage * image, avifReformatState *
     const float kr = state->kr;
     const float kg = state->kg;
     const float kb = state->kb;
-    const uint32_t maxUVI = (image->width > 1) ? (image->width >> state->formatInfo.chromaShiftX) - 1 : 0;
-    const uint32_t maxUVJ = (image->height > 1) ? (image->height >> state->formatInfo.chromaShiftY) - 1 : 0;
+    const uint32_t maxUVI = (image->width > 1) ? ((image->width+state->formatInfo.chromaShiftX) >> state->formatInfo.chromaShiftX) - 1 : 0;
+    const uint32_t maxUVJ = (image->height > 1) ? ((image->height+state->formatInfo.chromaShiftY) >> state->formatInfo.chromaShiftY) - 1 : 0;
 
     float maxChannel = (float)((1 << image->depth) - 1);
     uint8_t ** rgbPlanes = image->rgbPlanes;

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -190,8 +190,8 @@ static avifResult avifImageYUVToRGB16Color(avifImage * image, avifReformatState 
     const float kr = state->kr;
     const float kg = state->kg;
     const float kb = state->kb;
-    const uint32_t maxUVI = (image->width > 1) ? ((image->width+state->formatInfo.chromaShiftX) >> state->formatInfo.chromaShiftX) - 1 : 0;
-    const uint32_t maxUVJ = (image->height > 1) ? ((image->height+state->formatInfo.chromaShiftY) >> state->formatInfo.chromaShiftY) - 1 : 0;
+    const uint32_t maxUVI = ((image->width + state->formatInfo.chromaShiftX) >> state->formatInfo.chromaShiftX) - 1;
+    const uint32_t maxUVJ = ((image->height + state->formatInfo.chromaShiftY) >> state->formatInfo.chromaShiftY) - 1;
 
     float maxChannel = (float)((1 << image->depth) - 1);
     uint8_t ** rgbPlanes = image->rgbPlanes;
@@ -288,8 +288,8 @@ static avifResult avifImageYUVToRGB8Color(avifImage * image, avifReformatState *
     const float kr = state->kr;
     const float kg = state->kg;
     const float kb = state->kb;
-    const uint32_t maxUVI = (image->width > 1) ? ((image->width+state->formatInfo.chromaShiftX) >> state->formatInfo.chromaShiftX) - 1 : 0;
-    const uint32_t maxUVJ = (image->height > 1) ? ((image->height+state->formatInfo.chromaShiftY) >> state->formatInfo.chromaShiftY) - 1 : 0;
+    const uint32_t maxUVI = ((image->width + state->formatInfo.chromaShiftX) >> state->formatInfo.chromaShiftX) - 1;
+    const uint32_t maxUVJ = ((image->height + state->formatInfo.chromaShiftY) >> state->formatInfo.chromaShiftY) - 1;
 
     float maxChannel = (float)((1 << image->depth) - 1);
     uint8_t ** rgbPlanes = image->rgbPlanes;


### PR DESCRIPTION
Hi!

According to [av1-spec](https://aomediacodec.github.io/av1-spec/av1-spec.pdf), sizes of UV image shall be `ceil(width / (subX<<1))` or `ceil(height/(subY << 1))`, not `floor(width/(subX<<1))` or `floor(height/(subY<<1))`.

For example:

> 7.18.2. Intermediate output preparation process
> The array OutU is (w + subX) >> subX samples across by (h + subY) >> subY samples ...

I also read [libaom](https://aomedia.googlesource.com/aom/+/refs/tags/v1.0.0-errata1-avif/aom/src/aom_image.c#277) and it also allocates images with those size.

```c
int aom_img_plane_width(const aom_image_t *img, int plane) {
  if (plane > 0 && img->x_chroma_shift > 0)
    return (img->d_w + 1) >> img->x_chroma_shift;
  else
    return img->d_w;
}
int aom_img_plane_height(const aom_image_t *img, int plane) {
  if (plane > 0 && img->y_chroma_shift > 0)
    return (img->d_h + 1) >> img->y_chroma_shift;
  else
    return img->d_h;
}
```

Please take a look!

(It looks `avifImageRGBToYUV` also ignores right-most or bottom-most UV pixels, so I will send additional pull request after discussing about this issue.)
