### PR TITLE
Remove duplicate declarations of avifAlloc,avifFre

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -64,12 +64,6 @@ AVIF_ARRAY_DECLARE(avifRWDataArray, avifRWData, raw);
 void avifImageCopyDecoderAlpha(avifImage * image);
 
 // ---------------------------------------------------------------------------
-// Memory management
-
-void * avifAlloc(size_t size);
-void avifFree(void * p);
-
-// ---------------------------------------------------------------------------
 // avifCodecDecodeInput
 
 typedef struct avifSample


### PR DESCRIPTION
Remove duplicate declarations of avifAlloc() and avifFree() in
include/avif/internal.h. include/avif/internal.h includes "avif/avif.h",
which declares these two functions.