### PR TITLE
Minor edit of ext/aom.cmd.

### DIFF
--- a/ext/aom.cmd
+++ b/ext/aom.cmd
@@ -1,4 +1,4 @@
-: # If you want libavif to build libaom for you, you must clone the aom repo in this directory first, then enable CMake's AVIF_CODEC_AOM and AVIF_LOCAL_AOM options.
+: # If you want to use a local build of libaom, you must clone the aom repo in this directory first, then enable CMake's AVIF_CODEC_AOM and AVIF_LOCAL_AOM options.
 : # The git SHA below is known to work, and will occasionally be updated. Feel free to use a more recent commit.
 
 : # The odd choice of comment style in this file is to try to share this script between *nix and win32.


### PR DESCRIPTION
If CMake's AVIF_CODEC_AOM and AVIF_LOCAL_AOM options are both ON,
libavif does not build libaom. Therefore the first sentence in aom.cmd:

    If you want libavif to build libaom for you, ...

is not accurate. Change it to:

    If you want to use a local build of libaom, ...

which is the form used in the other <codec>.cmd files.