### PR TITLE
Handle monochrome images correctly.

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -265,8 +265,8 @@ static avifResult avifImageYUVToRGB16Mono(avifImage * image, avifReformatState *
 
             // Convert unorm to float
             const float Y = (float)unormY / maxChannel;
-            const float Cb = -0.5f;
-            const float Cr = -0.5f;
+            const float Cb = 0.0f;
+            const float Cr = 0.0f;
 
             float R = Y + (2 * (1 - kr)) * Cr;
             float B = Y + (2 * (1 - kb)) * Cb;
@@ -363,8 +363,8 @@ static avifResult avifImageYUVToRGB8Mono(avifImage * image, avifReformatState * 
 
             // Convert unorm to float
             const float Y = (float)unormY / maxChannel;
-            const float Cb = -0.5f;
-            const float Cr = -0.5f;
+            const float Cb = 0.0f;
+            const float Cr = 0.0f;
 
             float R = Y + (2 * (1 - kr)) * Cr;
             float B = Y + (2 * (1 - kb)) * Cb;
@@ -383,7 +383,7 @@ static avifResult avifImageYUVToRGB8Mono(avifImage * image, avifReformatState * 
 
 avifResult avifImageYUVToRGB(avifImage * image)
 {
-    if (!image->yuvPlanes[AVIF_CHAN_Y] || !image->yuvPlanes[AVIF_CHAN_U] || !image->yuvPlanes[AVIF_CHAN_V]) {
+    if (!image->yuvPlanes[AVIF_CHAN_Y]) {
         return AVIF_RESULT_REFORMAT_FAILED;
     }
 


### PR DESCRIPTION
I found that `avifImageYUVToRGB` will always returns `AVIF_RESULT_REFORMAT_FAILED` for monochrome images.

And also, `avifImageYUVToRGB8Mono` and `avifImageYUVToRGB16Mono` will returns green images, because they convert monochrome images with `Cr=Cb=-0.5`, which means green.
 
Please take a look!