### PR TITLE
Clarify "the image" in comment.

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -157,7 +157,7 @@ static avifBool aomCodecGetNextImage(avifCodec * codec, avifImage * image)
         avifPixelFormatInfo formatInfo;
         avifGetPixelFormatInfo(yuvFormat, &formatInfo);
 
-        // Steal the pointers from the image directly
+        // Steal the pointers from the decoder's image directly
         avifImageFreePlanes(image, AVIF_PLANES_YUV);
         for (int yuvPlane = 0; yuvPlane < 3; ++yuvPlane) {
             int aomPlaneIndex = yuvPlane;

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -121,7 +121,7 @@ static avifBool gav1CodecGetNextImage(avifCodec * codec, avifImage * image)
         avifPixelFormatInfo formatInfo;
         avifGetPixelFormatInfo(yuvFormat, &formatInfo);
 
-        // Steal the pointers from the image directly
+        // Steal the pointers from the decoder's image directly
         avifImageFreePlanes(image, AVIF_PLANES_YUV);
         for (int yuvPlane = 0; yuvPlane < 3; ++yuvPlane) {
             image->yuvPlanes[yuvPlane] = gav1Image->plane[yuvPlane];


### PR DESCRIPTION
The code in question has two image variables: 'image' and
codec->internal->image (or gav1Image). So it is not clear which image
variable "the image" refers to. I believe it refers to
codec->internal->image (or gav1Image). So change "the image" to "the
decoder's image". This also matches the subsequent code that sets
image->decoderOwnsYUVPlanes to AVIF_TRUE.