### PR TITLE
Miscellaneous header file cleanup.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,7 +337,7 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
     endif()
 endif()
 if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL)
-    install(FILES include/avif/avif.h include/avif/internal.h
+    install(FILES include/avif/avif.h
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/avif"
     )
 endif()

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -1,7 +1,12 @@
 // Copyright 2019 Joe Drago. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
+#ifndef LIBAVIF_APPS_SHARED_AVIFUTIL_H
+#define LIBAVIF_APPS_SHARED_AVIFUTIL_H
+
 #include "avif/avif.h"
 
 void avifImageDump(avifImage * avif);
 void avifPrintVersions(void);
+
+#endif // ifndef LIBAVIF_APPS_SHARED_AVIFUTIL_H

--- a/apps/shared/y4m.h
+++ b/apps/shared/y4m.h
@@ -1,7 +1,12 @@
 // Copyright 2019 Joe Drago. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
+#ifndef LIBAVIF_APPS_SHARED_Y4M_H
+#define LIBAVIF_APPS_SHARED_Y4M_H
+
 #include "avif/avif.h"
 
 avifBool y4mRead(avifImage * avif, const char * inputFilename);
 avifBool y4mWrite(avifImage * avif, const char * outputFilename);
+
+#endif // ifndef LIBAVIF_APPS_SHARED_Y4M_H


### PR DESCRIPTION
1. Add #ifndef header guard to apps/shared/avifutil.h and
apps/shared/y4m.h.

2. Do not install the internal header file include/avif/internal.h.
It is only used by src/*.c. (It would be good to move it to the src/
directory.)