### PR TITLE
cmake: fix typos in pkg-config file

### DIFF
--- a/libavif.pc.cmake
+++ b/libavif.pc.cmake
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_FULL_PREFIX@
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}/bin
 libdir=${prefix}/lib
 includedir=${prefix}/include
@@ -7,4 +7,4 @@ Name: @PROJECT_NAME@
 Description: Library for encoding and decoding .avif files
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lavif
-Cflags: -I{includedir}
+Cflags: -I${includedir}


### PR DESCRIPTION
Found on FreeBSD:
```
$ pkg info -l libavif
libavif-0.5.7:
[...]
        /usr/local/include/avif/avif.h
        /usr/local/lib/libavif.so
        /usr/local/lib/libavif.so.0
        /usr/local/lib/libavif.so.1.0.0
        /usr/local/libdata/pkgconfig/libavif.pc
[...]
```
Current output:
```
$ pkg-config libavif --cflags --libs
-I\{includedir\} -L/lib -lavif
```
After the fix:
```
$ pkg-config libavif --cflags --libs
-I/usr/local/include -L/usr/local/lib -lavif
```
