### PR TITLE
Ext: Update to dav1d 0.6.0 and rav1e v0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,20 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: '3.8'
+    - name: Install nasm
+      env:
+        LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
+        NASM_VERSION: 2.14.02-1
+        NASM_SHA256: >-
+          5225d0654783134ae616f56ce8649e4df09cba191d612a0300cfd0494bb5a3ef
+      run: |
+        curl -O "$LINK/nasm_${NASM_VERSION}_amd64.deb"
+        echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" | sha256sum --check
+        sudo dpkg -i "nasm_${NASM_VERSION}_amd64.deb"
     - name: Install dependencies
       run: |
         DEBIAN_FRONTEND=noninteractive sudo apt-get update
-        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ninja-build nasm gcc-8 g++-8
+        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ninja-build gcc-8 g++-8
         pip install --upgrade pip
         pip install setuptools
         pip install meson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `avifImageYUVToInterleaved*()` functions for converting directly into a pre-existing buffer, skipping temp rgbPlanes creation
+- Update default dav1d version to 0.6.0
+- Update default rav1e version to v0.3.1
 
 ## [0.5.7] - 2020-03-03
 ### Added

--- a/ext/dav1d.cmd
+++ b/ext/dav1d.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2017 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b 0.5.2 --depth 1 https://code.videolan.org/videolan/dav1d.git
+git clone -b 0.6.0 --depth 1 https://code.videolan.org/videolan/dav1d.git
 
 cd dav1d
 mkdir build

--- a/ext/rav1e.cmd
+++ b/ext/rav1e.cmd
@@ -11,7 +11,7 @@
 : # Also, the error that "The target windows-msvc is not supported yet" can safely be ignored provided that rav1e/target/release
 : # contains rav1e.h and rav1e.lib.
 
-git clone -b v0.3.0 --depth 1 https://github.com/xiph/rav1e.git
+git clone -b v0.3.1 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
 cargo install cbindgen


### PR DESCRIPTION
Updates the default dav1d version from 0.5.2 to 0.6.0 and the default rav1e version from 0.3.0 to 0.3.1. Both have been tested extensively on their own CI systems.