### PR TITLE
Use alphaRowBytes to calculate alpha plane size.

### DIFF
--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -247,7 +247,7 @@ avifBool y4mRead(avifImage * avif, const char * inputFilename)
     planeBytes[1] = avif->yuvRowBytes[1] * (avif->height >> info.chromaShiftY);
     planeBytes[2] = avif->yuvRowBytes[2] * (avif->height >> info.chromaShiftY);
     if (hasAlpha) {
-        planeBytes[3] = avif->yuvRowBytes[0] * avif->height;
+        planeBytes[3] = avif->alphaRowBytes * avif->height;
     } else {
         planeBytes[3] = 0;
     }


### PR DESCRIPTION
In y4mRead(), use avif->alphaRowBytes, not avif->yuvRowBytes[0], to
calculate the alpha plane size.