### PR TITLE
Fix coding style nits.

### DIFF
--- a/examples/avif_example1.c
+++ b/examples/avif_example1.c
@@ -56,7 +56,7 @@ int main(int argc, char * argv[])
 
     if (res != AVIF_RESULT_OK) {
         exitStatus = 1;
-        goto encode_failed;
+        goto encodeCleanup;
     }
 
     // Decode it
@@ -67,11 +67,11 @@ int main(int argc, char * argv[])
 
     if (decodeResult != AVIF_RESULT_OK) {
         exitStatus = 1;
-        goto decode_failed;
+        goto decodeCleanup;
     }
     if (avifImageYUVToRGB(decoded) != AVIF_RESULT_OK) {
         exitStatus = 1;
-        goto decode_failed;
+        goto decodeCleanup;
     }
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
@@ -86,11 +86,11 @@ int main(int argc, char * argv[])
         }
     }
 
-decode_failed:
+decodeCleanup:
     avifImageDestroy(decoded);
     avifRWDataFree(&raw);
 
-encode_failed:
+encodeCleanup:
     avifImageDestroy(image);
 #else  /* if 1 */
 

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -49,8 +49,8 @@ static avifBool gav1CodecGetNextImage(avifCodec * codec, avifImage * image)
         // Feed another sample
         avifSample * sample = &codec->decodeInput->samples.sample[codec->internal->inputSampleIndex];
         ++codec->internal->inputSampleIndex;
-        if (Libgav1DecoderEnqueueFrame(codec->internal->gav1Decoder, sample->data.data, sample->data.size, /*user_private_data=*/0) !=
-            kLibgav1StatusOk) {
+        if (Libgav1DecoderEnqueueFrame(codec->internal->gav1Decoder, sample->data.data, sample->data.size,
+                                       /*user_private_data=*/0) != kLibgav1StatusOk) {
             return AVIF_FALSE;
         }
         // Each Libgav1DecoderDequeueFrame() call invalidates the output frame

--- a/tests/aviftest.c
+++ b/tests/aviftest.c
@@ -254,7 +254,7 @@ static int runTests(const char * dataDir, const char * testFilter)
     return (failedCount == 0) ? 0 : 1;
 }
 
-static void showSyntaxHelp(void)
+static void syntax(void)
 {
     fprintf(stderr,
             "Syntax: aviftest [options] dataDir [testFilter]\n"
@@ -284,7 +284,7 @@ int main(int argc, char * argv[])
             testFilter = arg;
         } else {
             fprintf(stderr, "Too many positional arguments: %s\n", arg);
-            showSyntaxHelp();
+            syntax();
             return 1;
         }
     }
@@ -292,7 +292,7 @@ int main(int argc, char * argv[])
     // Verify all required args were set
     if (dataDir == NULL) {
         fprintf(stderr, "dataDir is required, bailing out.\n");
-        showSyntaxHelp();
+        syntax();
         return 1;
     }
 


### PR DESCRIPTION
Use xxxCleanup instead of xxx_failed as goto labels to match the names
of other goto labelsi ("cleanup" and "writeCleanup") in the source tree.

Wrap a long line at 130 columns.