### PR TITLE
AppVeyor: Skip when changes only affect non-essential code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,11 @@
 image: Visual Studio 2019
 configuration: Release
-#branches:
-#  only:
-#  - master
+skip_commits:
+  files:
+    - '.github/*'
+    - '.travis.yml'
+    - '.gitignore'
+    - '*.md'
 
 install:
  - git submodule update --init --recursive


### PR DESCRIPTION
Prevents AppVeyor from running when changes to Travis CI, GitHub Actions or documentation are made