### PR TITLE
Miscellaneous cleanup related to UV width, height.

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -155,7 +155,7 @@ void avifImageCopy(avifImage * dstImage, avifImage * srcImage)
 
         avifPixelFormatInfo formatInfo;
         avifGetPixelFormatInfo(srcImage->yuvFormat, &formatInfo);
-        int uvHeight = dstImage->height >> formatInfo.chromaShiftY;
+        int uvHeight = (dstImage->height + formatInfo.chromaShiftY) >> formatInfo.chromaShiftY;
         for (int yuvPlane = 0; yuvPlane < 3; ++yuvPlane) {
             int aomPlaneIndex = yuvPlane;
             int planeHeight = dstImage->height;
@@ -261,14 +261,8 @@ void avifImageAllocatePlanes(avifImage * image, uint32_t planes)
         avifPixelFormatInfo info;
         avifGetPixelFormatInfo(image->yuvFormat, &info);
 
-        int shiftedW = image->width;
-        if (info.chromaShiftX) {
-            shiftedW = (image->width + 1) >> info.chromaShiftX;
-        }
-        int shiftedH = image->height;
-        if (info.chromaShiftY) {
-            shiftedH = (image->height + 1) >> info.chromaShiftY;
-        }
+        int shiftedW = (image->width + info.chromaShiftX) >> info.chromaShiftX;
+        int shiftedH = (image->height + info.chromaShiftY) >> info.chromaShiftY;
 
         int uvRowBytes = channelSize * shiftedW;
         int uvSize = uvRowBytes * shiftedH;

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -134,10 +134,7 @@ static avifBool rav1eCodecEncodeImage(avifCodec * codec, avifImage * image, avif
     if (alpha) {
         rav1e_frame_fill_plane(rav1eFrame, 0, image->alphaPlane, image->alphaRowBytes * image->height, image->alphaRowBytes, byteWidth);
     } else {
-        uint32_t uvHeight = image->height >> yShift;
-        if (uvHeight < 1) {
-            uvHeight = 1;
-        }
+        uint32_t uvHeight = (image->height + yShift) >> yShift;
         rav1e_frame_fill_plane(rav1eFrame, 0, image->yuvPlanes[0], image->yuvRowBytes[0] * image->height, image->yuvRowBytes[0], byteWidth);
         rav1e_frame_fill_plane(rav1eFrame, 1, image->yuvPlanes[1], image->yuvRowBytes[1] * uvHeight, image->yuvRowBytes[1], byteWidth);
         rav1e_frame_fill_plane(rav1eFrame, 2, image->yuvPlanes[2], image->yuvRowBytes[2] * uvHeight, image->yuvRowBytes[2], byteWidth);


### PR DESCRIPTION
Clean up the calculations of UV width and height. If the chroma shift is
1, we need to add 1 to width or height before right shifting by 1. This
can be written in a branch-free form.

Also clean up some code in src/codec_aom.c:
1. The type of the 'flags' parameter of aom_codec_enc_init() is
aom_codec_flags_t.
2. The memset() calls in a for loop can be merged because the row
strides are contiguous.