### PR TITLE
Minor cleanup of avifEncoderWrite().

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -116,10 +116,15 @@ avifResult avifEncoderWrite(avifEncoder * encoder, avifImage * image, avifRWData
     avifRWStreamStart(&s, output);
 
     // -----------------------------------------------------------------------
-    // Reformat pixels, if need be
+    // Validate image
 
-    if (!image->width || !image->height || (image->yuvFormat == AVIF_PIXEL_FORMAT_NONE) || !image->yuvPlanes[AVIF_CHAN_Y]) {
+    if (!image->width || !image->height || !image->yuvPlanes[AVIF_CHAN_Y]) {
         result = AVIF_RESULT_NO_CONTENT;
+        goto writeCleanup;
+    }
+
+    if (image->yuvFormat == AVIF_PIXEL_FORMAT_NONE) {
+        result = AVIF_RESULT_NO_YUV_FORMAT_SELECTED;
         goto writeCleanup;
     }
 


### PR DESCRIPTION
1. Delete the comnent "Reformat pixels, if need be" because the
RGB-to-YUV conversion code is gone. Replace it with the comment
"Validate image".

2. Return AVIF_RESULT_NO_YUV_FORMAT_SELECTED if image->yuvFormat is
AVIF_PIXEL_FORMAT_NONE. This is the error code returned by the original
code (before v0.6.0).