### PR TITLE
AppVeyor: Deploy to GitHub on tag

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,3 +48,11 @@ artifacts:
   name: Static Lib and Includes
 - path: 'build\*.exe'
   name: Basic apps
+
+deploy:
+ - provider: GitHub
+   auth_token:
+     secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+   prerelease: true
+   on:
+     appveyor_repo_tag: true


### PR DESCRIPTION
With this PR AppVeyor publishes build artifacts to GitHub when a tag is made, creating a release page [like this](https://github.com/EwoutH/libavif/releases/tag/0.6.0-test2).

To enable uploading to GitHub Releases, you need update this patch with your personal authentication token. You can generate one on https://github.com/settings/tokens/new (select `public_repo` as scope), and then encrypt it with https://ci.appveyor.com/tools/encrypt. Replace the current token on line 55 (after `secure:`) in the `appveyor.yml` file.