### PR TITLE
Update to libgav1 revision 45a1d76.

### DIFF
--- a/ext/libgav1.cmd
+++ b/ext/libgav1.cmd
@@ -11,7 +11,7 @@
 git clone https://chromium.googlesource.com/codecs/libgav1
 
 cd libgav1
-git checkout 1fccd75
+git checkout 45a1d76
 git clone https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
 mkdir build
 cd build

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -44,8 +44,11 @@ static avifBool gav1CodecGetNextImage(avifCodec * codec, avifImage * image)
         // Feed another sample
         avifSample * sample = &codec->decodeInput->samples.sample[codec->internal->inputSampleIndex];
         ++codec->internal->inputSampleIndex;
-        if (Libgav1DecoderEnqueueFrame(codec->internal->gav1Decoder, sample->data.data, sample->data.size,
-                                       /*user_private_data=*/0) != kLibgav1StatusOk) {
+        if (Libgav1DecoderEnqueueFrame(codec->internal->gav1Decoder,
+                                       sample->data.data,
+                                       sample->data.size,
+                                       /*user_private_data=*/0,
+                                       /*buffer_private_data=*/NULL) != kLibgav1StatusOk) {
             return AVIF_FALSE;
         }
         // Each Libgav1DecoderDequeueFrame() call invalidates the output frame


### PR DESCRIPTION
This revision has a fix for the declarations of C functions that take no
parameters:
https://chromium-review.googlesource.com/c/codecs/libgav1/+/2101175

The Libgav1DecoderEnqueueFrame() function gets a new
"buffer_private_data" parameter. Pass NULL as that argument.