### PR TITLE
Set dav1dSettings.frame_size_limit to avoid OOM.

### DIFF
--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -201,5 +201,7 @@ avifCodec * avifCodecCreateDav1d(void)
     codec->internal = (struct avifCodecInternal *)avifAlloc(sizeof(struct avifCodecInternal));
     memset(codec->internal, 0, sizeof(struct avifCodecInternal));
     dav1d_default_settings(&codec->internal->dav1dSettings);
+    // Set a maximum frame size limit to avoid OOM'ing fuzzers.
+    codec->internal->dav1dSettings.frame_size_limit = 16384 * 16384;
     return codec;
 }


### PR DESCRIPTION
Set dav1dSettings.frame_size_limit to avoid the out-of-memory errors in
avif_decode_fuzzer, which is run with the -rss_limit_mb=2560
command-line option.

BUG=oss-fuzz:20645