### PR TITLE
Ext: Only clone single branch of libgav1

### DIFF
--- a/ext/libgav1.cmd
+++ b/ext/libgav1.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2017 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone https://chromium.googlesource.com/codecs/libgav1
+git clone --single-branch https://chromium.googlesource.com/codecs/libgav1
 
 cd libgav1
 git checkout 45a1d76


### PR DESCRIPTION
Speeds up the build process and lowers memory requirements while compiling a little.