### PR TITLE
Call dav1d_data_unref in dav1dCodecDestroyInternal

### DIFF
--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -28,6 +28,9 @@ struct avifCodecInternal
 
 static void dav1dCodecDestroyInternal(avifCodec * codec)
 {
+    if (codec->internal->dav1dData.sz) {
+        dav1d_data_unref(&codec->internal->dav1dData);
+    }
     if (codec->internal->hasPicture) {
         dav1d_picture_unref(&codec->internal->dav1dPicture);
     }
@@ -41,8 +44,6 @@ static void dav1dCodecDestroyInternal(avifCodec * codec)
 static avifBool dav1dFeedData(avifCodec * codec)
 {
     if (!codec->internal->dav1dData.sz) {
-        dav1d_data_unref(&codec->internal->dav1dData);
-
         if (codec->internal->inputSampleIndex < codec->decodeInput->samples.count) {
             avifSample * sample = &codec->decodeInput->samples.sample[codec->internal->inputSampleIndex];
             ++codec->internal->inputSampleIndex;


### PR DESCRIPTION
Call dav1d_data_unref(&codec->internal->dav1dData) in
dav1dCodecDestroyInternal(). This frees codec->internal->dav1dData after
a dav1d_send_data() failure.

Remove the dav1d_data_unref() call in dav1dFeedData(). It is a no-op.
If codec->internal->dav1dData.sz is 0, we don't need to free
codec->internal->dav1dData.