### PR TITLE
Declare some avifSampleTable * pointers as const

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -217,11 +217,11 @@ static void avifSampleTableDestroy(avifSampleTable * sampleTable)
     avifFree(sampleTable);
 }
 
-static uint32_t avifSampleTableGetImageDelta(avifSampleTable * sampleTable, int imageIndex)
+static uint32_t avifSampleTableGetImageDelta(const avifSampleTable * sampleTable, int imageIndex)
 {
     int maxSampleIndex = 0;
     for (uint32_t i = 0; i < sampleTable->timeToSamples.count; ++i) {
-        avifSampleTableTimeToSample * timeToSample = &sampleTable->timeToSamples.timeToSample[i];
+        const avifSampleTableTimeToSample * timeToSample = &sampleTable->timeToSamples.timeToSample[i];
         maxSampleIndex += timeToSample->sampleCount;
         if ((imageIndex < maxSampleIndex) || (i == (sampleTable->timeToSamples.count - 1))) {
             return timeToSample->sampleDelta;
@@ -232,7 +232,7 @@ static uint32_t avifSampleTableGetImageDelta(avifSampleTable * sampleTable, int 
     return 1;
 }
 
-static avifBool avifSampleTableHasFormat(avifSampleTable * sampleTable, const char * format)
+static avifBool avifSampleTableHasFormat(const avifSampleTable * sampleTable, const char * format)
 {
     for (uint32_t i = 0; i < sampleTable->sampleDescriptions.count; ++i) {
         if (!memcmp(sampleTable->sampleDescriptions.description[i].format, format, 4)) {
@@ -242,7 +242,7 @@ static avifBool avifSampleTableHasFormat(avifSampleTable * sampleTable, const ch
     return AVIF_FALSE;
 }
 
-static uint32_t avifCodecConfigurationBoxGetDepth(avifCodecConfigurationBox * av1C)
+static uint32_t avifCodecConfigurationBoxGetDepth(const avifCodecConfigurationBox * av1C)
 {
     if (av1C->twelveBit) {
         return 12;
@@ -252,10 +252,10 @@ static uint32_t avifCodecConfigurationBoxGetDepth(avifCodecConfigurationBox * av
     return 8;
 }
 
-static uint32_t avifSampleTableGetDepth(avifSampleTable * sampleTable)
+static uint32_t avifSampleTableGetDepth(const avifSampleTable * sampleTable)
 {
     for (uint32_t i = 0; i < sampleTable->sampleDescriptions.count; ++i) {
-        avifSampleDescription * description = &sampleTable->sampleDescriptions.description[i];
+        const avifSampleDescription * description = &sampleTable->sampleDescriptions.description[i];
         if (!memcmp(description->format, "av01", 4) && description->av1CPresent) {
             return avifCodecConfigurationBoxGetDepth(&description->av1C);
         }
@@ -379,7 +379,7 @@ typedef struct avifDecoderData
     avifImageGrid colorGrid;
     avifImageGrid alphaGrid;
     avifDecoderSource source;
-    avifSampleTable * sourceSampleTable; // NULL unless (source == AVIF_DECODER_SOURCE_TRACKS), owned by an avifTrack
+    const avifSampleTable * sourceSampleTable; // NULL unless (source == AVIF_DECODER_SOURCE_TRACKS), owned by an avifTrack
     uint32_t primaryItemID;
     uint32_t metaBoxID; // Ever-incrementing ID for tracking which 'meta' box contains an idat, and which idat an iloc might refer to
 } avifDecoderData;


### PR DESCRIPTION
This makes it easier to analyze the side effects of the code.