### PR TITLE
Remove an unnecessary null check for colorOBUItem

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2098,7 +2098,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             }
         }
 
-        if ((data->colorGrid.rows > 0) && (data->colorGrid.columns > 0) && colorOBUItem) {
+        if ((data->colorGrid.rows > 0) && (data->colorGrid.columns > 0)) {
             if (!avifDecoderDataGenerateImageGridTiles(data, &data->colorGrid, colorOBUItem, AVIF_FALSE)) {
                 return AVIF_RESULT_INVALID_IMAGE_GRID;
             }


### PR DESCRIPTION
The following check ensures colorOBUItem is not null:

2033         if (!colorOBUItem) {
2034             return AVIF_RESULT_NO_AV1_ITEMS_FOUND;
2035         }

After this check, colorOBUItem is dereferenced without further checking
in multiple places.