### PR TITLE
decoder->image can't be NULL after decoder has run

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -544,7 +544,7 @@ typedef struct avifDecoder
     // Set this via avifDecoderSetSource().
     avifDecoderSource requestedSource;
 
-    // The current decoded image, owned by the decoder. Can be NULL if the decoder hasn't run or has run
+    // The current decoded image, owned by the decoder. Is invalid if the decoder hasn't run or has run
     // out of images. The YUV and A contents of this image are likely owned by the decoder, so be
     // sure to copy any data inside of this image before advancing to the next image or reusing the
     // decoder. It is legal to call avifImageYUVToRGB() on this in between calls to avifDecoderNextImage(),

--- a/src/read.c
+++ b/src/read.c
@@ -2362,9 +2362,6 @@ avifResult avifDecoderRead(avifDecoder * decoder, avifImage * image, avifROData 
     if (result != AVIF_RESULT_OK) {
         return result;
     }
-    if (!decoder->image) {
-        return AVIF_RESULT_NO_IMAGES_REMAINING;
-    }
     avifImageCopy(image, decoder->image);
     return AVIF_RESULT_OK;
 }


### PR DESCRIPTION
decoder->image is set to NULL only in avifDecoderCleanup(), which is
only called in avifDecoderDestroy() and at the beginning of
avifDecoderParse(). Therefore, after decoder->image is allocated in
avifDecoderParse(), decoder->image cannot be NULL.

In avif.h, instead of saying when decoder->image "can be NULL", say when
decoder->image "is invalid".