### PR TITLE
Fix potential buffer overflow in avifCodecVersions

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -482,25 +482,25 @@ void avifCodecVersions(char outBuffer[256])
     size_t len;
     for (int i = 0; i < availableCodecsCount; ++i) {
         if (i > 0) {
-            len = (maxChars < 2) ? maxChars : 2;
+            len = AVIF_MIN(maxChars, 2);
             memcpy(dest, ", ", len);
             dest += len;
             maxChars -= len;
         }
 
         len = strlen(availableCodecs[i].name);
-        len = (maxChars < len) ? maxChars : len;
+        len = AVIF_MIN(maxChars, len);
         memcpy(dest, availableCodecs[i].name, len);
         dest += len;
         maxChars -= len;
 
-        len = (maxChars < 1) ? maxChars : 1;
+        len = AVIF_MIN(maxChars, 1);
         memcpy(dest, ":", len);
         dest += len;
         maxChars -= len;
 
         len = strlen(availableCodecs[i].version());
-        len = (maxChars < len) ? maxChars : len;
+        len = AVIF_MIN(maxChars, len);
         memcpy(dest, availableCodecs[i].version(), len);
         dest += len;
         maxChars -= len;

--- a/src/avif.c
+++ b/src/avif.c
@@ -477,14 +477,33 @@ avifCodec * avifCodecCreate(avifCodecChoice choice, uint32_t requiredFlags)
 
 void avifCodecVersions(char outBuffer[256])
 {
-    const size_t maxChars = 255;
-    outBuffer[0] = 0;
+    char * dest = outBuffer;
+    size_t maxChars = 255;
+    size_t len;
     for (int i = 0; i < availableCodecsCount; ++i) {
         if (i > 0) {
-            strncat(outBuffer, ", ", maxChars);
+            len = (maxChars < 2) ? maxChars : 2;
+            memcpy(dest, ", ", len);
+            dest += len;
+            maxChars -= len;
         }
-        strncat(outBuffer, availableCodecs[i].name, maxChars);
-        strncat(outBuffer, ":", maxChars);
-        strncat(outBuffer, availableCodecs[i].version(), maxChars);
+
+        len = strlen(availableCodecs[i].name);
+        len = (maxChars < len) ? maxChars : len;
+        memcpy(dest, availableCodecs[i].name, len);
+        dest += len;
+        maxChars -= len;
+
+        len = (maxChars < 1) ? maxChars : 1;
+        memcpy(dest, ":", len);
+        dest += len;
+        maxChars -= len;
+
+        len = strlen(availableCodecs[i].version());
+        len = (maxChars < len) ? maxChars : len;
+        memcpy(dest, availableCodecs[i].version(), len);
+        dest += len;
+        maxChars -= len;
     }
+    dest[0] = '\0';
 }


### PR DESCRIPTION
This is not the most elegant fix. Note that it does not bother to break
out of the for loop early if we reach the end of outBuffer, because that
is an unlikely event.

Fix issue https://github.com/AOMediaCodec/libavif/issues/129.