### PR TITLE
Misc cleanup for avifenc and avifdec

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -23,12 +23,12 @@
 
 static void syntax(void)
 {
-    printf("Syntax: avifdec [options] input.avif output.[jpg|png|y4m]\n");
+    printf("Syntax: avifdec [options] input.avif output.[jpg|jpeg|png|y4m]\n");
     printf("Options:\n");
     printf("    -h,--help         : Show syntax help\n");
     printf("    -c,--codec C      : AV1 codec to use (choose from versions list below)\n");
     printf("    -d,--depth D      : Output depth [8,16]. (PNG only; For y4m, depth is retained, and JPEG is always 8bpc)\n");
-    printf("    -q,--quality Q    : Output quality [1-100]. (JPEG only, default: %d)\n", DEFAULT_JPEG_QUALITY);
+    printf("    -q,--quality Q    : Output quality [0-100]. (JPEG only, default: %d)\n", DEFAULT_JPEG_QUALITY);
     printf("\n");
     avifPrintVersions();
 }
@@ -76,8 +76,8 @@ int main(int argc, char * argv[])
         } else if (!strcmp(arg, "-q") || !strcmp(arg, "--quality")) {
             NEXTARG();
             jpegQuality = atoi(arg);
-            if (jpegQuality < 1) {
-                jpegQuality = 1;
+            if (jpegQuality < 0) {
+                jpegQuality = 0;
             } else if (jpegQuality > 100) {
                 jpegQuality = 100;
             }
@@ -143,9 +143,8 @@ int main(int argc, char * argv[])
         const char * fileExt = strrchr(outputFilename, '.');
         if (!fileExt) {
             fprintf(stderr, "Cannot determine output file extension: %s\n", outputFilename);
-            return 1;
-        }
-        if (!strcmp(fileExt, ".y4m")) {
+            returnCode = 1;
+        } else if (!strcmp(fileExt, ".y4m")) {
             if (!y4mWrite(avif, outputFilename)) {
                 returnCode = 1;
             }
@@ -157,6 +156,9 @@ int main(int argc, char * argv[])
             if (!avifPNGWrite(avif, outputFilename, requestedDepth)) {
                 returnCode = 1;
             }
+        } else {
+            fprintf(stderr, "Unrecognized file extension: %s\n", fileExt + 1);
+            returnCode = 1;
         }
     } else {
         printf("ERROR: Failed to decode image: %s\n", avifResultToString(decodeResult));

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -21,7 +21,7 @@
 
 static void syntax(void)
 {
-    printf("Syntax: avifenc [options] input.[jpg|png|y4m] output.avif\n");
+    printf("Syntax: avifenc [options] input.[jpg|jpeg|png|y4m] output.avif\n");
     printf("Options:\n");
     printf("    -h,--help                         : Show syntax help\n");
     printf("    -j,--jobs J                       : Number of jobs (worker threads, default: 1)\n");
@@ -31,7 +31,7 @@ static void syntax(void)
     printf("                                        P = enum avifNclxColourPrimaries\n");
     printf("                                        T = enum avifNclxTransferCharacteristics\n");
     printf("                                        M = enum avifNclxMatrixCoefficients\n");
-    printf("    -r,--range RANGE                  : YUV range [limited, full]. (JPEG/PNG only; For y4m, range is retained)\n");
+    printf("    -r,--range RANGE                  : YUV range [limited or l, full or f]. (JPEG/PNG only, default: full; For y4m, range is retained)\n");
     printf("    --min Q                           : Set min quantizer for color (%d-%d, where %d is lossless)\n",
            AVIF_QUANTIZER_BEST_QUALITY,
            AVIF_QUANTIZER_WORST_QUALITY,
@@ -337,7 +337,8 @@ int main(int argc, char * argv[])
     const char * fileExt = strrchr(inputFilename, '.');
     if (!fileExt) {
         fprintf(stderr, "Cannot determine input file extension: %s\n", inputFilename);
-        return 1;
+        returnCode = 1;
+        goto cleanup;
     }
     if (!strcmp(fileExt, ".y4m")) {
         if (requestedRangeSet) {
@@ -364,7 +365,8 @@ int main(int argc, char * argv[])
         }
     } else {
         fprintf(stderr, "Unrecognized file extension: %s\n", fileExt + 1);
-        return 1;
+        returnCode = 1;
+        goto cleanup;
     }
     printf("Successfully loaded: %s\n", inputFilename);
 


### PR DESCRIPTION
1. avifenc and avifdec: Document .jpeg as a recognized file extension.

2. avifdec: Output quality range is 0-100, not 1-100. Note: libjpeg
internally still converts 0 to 1 to avoid division by zero. See
jpeg_set_quality and jpeg_quality_scaling in jcparam.c.

3. avifenc and avifdec: Continue to clean up resources after an error
with file extension, rather than exit immediately.

4. avifdec: Fail with exit status 1 on unrecognized file extension.
(avifenc already does this.)

5. avifenc: Have the syntax help message show "l" and "f" as supported
abbreviations of "limited" and "full" and the default range is full.