### PR TITLE
nclx: change uint16_t casts to enum type casts

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -139,9 +139,9 @@ static avifBool aomCodecGetNextImage(avifCodec * codec, avifImage * image)
         if (image->profileFormat == AVIF_PROFILE_FORMAT_NONE) {
             // If the AVIF container doesn't provide a color profile, allow the AV1 OBU to provide one as a fallback
             avifNclxColorProfile nclx;
-            nclx.colourPrimaries = (uint16_t)codec->internal->image->cp;
-            nclx.transferCharacteristics = (uint16_t)codec->internal->image->tc;
-            nclx.matrixCoefficients = (uint16_t)codec->internal->image->mc;
+            nclx.colourPrimaries = (avifNclxColourPrimaries)codec->internal->image->cp;
+            nclx.transferCharacteristics = (avifNclxTransferCharacteristics)codec->internal->image->tc;
+            nclx.matrixCoefficients = (avifNclxMatrixCoefficients)codec->internal->image->mc;
             nclx.range = image->yuvRange;
             avifImageSetProfileNCLX(image, &nclx);
         }
@@ -367,9 +367,9 @@ static avifBool aomCodecEncodeImage(avifCodec * codec, avifImage * image, avifEn
         }
 
         if (image->profileFormat == AVIF_PROFILE_FORMAT_NCLX) {
-            aomImage->cp = image->nclx.colourPrimaries;
-            aomImage->tc = image->nclx.transferCharacteristics;
-            aomImage->mc = image->nclx.matrixCoefficients;
+            aomImage->cp = (aom_color_primaries_t)image->nclx.colourPrimaries;
+            aomImage->tc = (aom_transfer_characteristics_t)image->nclx.transferCharacteristics;
+            aomImage->mc = (aom_matrix_coefficients_t)image->nclx.matrixCoefficients;
             aom_codec_control(&aomEncoder, AV1E_SET_COLOR_PRIMARIES, aomImage->cp);
             aom_codec_control(&aomEncoder, AV1E_SET_TRANSFER_CHARACTERISTICS, aomImage->tc);
             aom_codec_control(&aomEncoder, AV1E_SET_MATRIX_COEFFICIENTS, aomImage->mc);

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -147,9 +147,9 @@ static avifBool dav1dCodecGetNextImage(avifCodec * codec, avifImage * image)
         if (image->profileFormat == AVIF_PROFILE_FORMAT_NONE) {
             // If the AVIF container doesn't provide a color profile, allow the AV1 OBU to provide one as a fallback
             avifNclxColorProfile nclx;
-            nclx.colourPrimaries = (uint16_t)dav1dImage->seq_hdr->pri;
-            nclx.transferCharacteristics = (uint16_t)dav1dImage->seq_hdr->trc;
-            nclx.matrixCoefficients = (uint16_t)dav1dImage->seq_hdr->mtrx;
+            nclx.colourPrimaries = (avifNclxColourPrimaries)dav1dImage->seq_hdr->pri;
+            nclx.transferCharacteristics = (avifNclxTransferCharacteristics)dav1dImage->seq_hdr->trc;
+            nclx.matrixCoefficients = (avifNclxMatrixCoefficients)dav1dImage->seq_hdr->mtrx;
             nclx.range = image->yuvRange;
             avifImageSetProfileNCLX(image, &nclx);
         }

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -109,9 +109,9 @@ static avifBool gav1CodecGetNextImage(avifCodec * codec, avifImage * image)
         if (image->profileFormat == AVIF_PROFILE_FORMAT_NONE) {
             // If the AVIF container doesn't provide a color profile, allow the AV1 OBU to provide one as a fallback
             avifNclxColorProfile nclx;
-            nclx.colourPrimaries = (uint16_t)gav1Image->color_primary;
-            nclx.transferCharacteristics = (uint16_t)gav1Image->transfer_characteristics;
-            nclx.matrixCoefficients = (uint16_t)gav1Image->matrix_coefficients;
+            nclx.colourPrimaries = (avifNclxColourPrimaries)gav1Image->color_primary;
+            nclx.transferCharacteristics = (avifNclxTransferCharacteristics)gav1Image->transfer_characteristics;
+            nclx.matrixCoefficients = (avifNclxMatrixCoefficients)gav1Image->matrix_coefficients;
             nclx.range = image->yuvRange;
             avifImageSetProfileNCLX(image, &nclx);
         }


### PR DESCRIPTION
The first three members of struct avifNclxColorProfile were of the
uint16_t type before. In v0.7.0 they were changed to enum types. So
change the uint16_t casts for those struct members to enum type casts.

Note: v0.7.0 added -Wno-conversion to CMakeLists.txt, so we can also
just delete the uint16_t casts for those struct members.