### PR TITLE
Fix GCC -Wclobber warnings with setjmp

### DIFF
--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -12,11 +12,6 @@
 
 #include "iccjpeg.h"
 
-// This warning triggers false postives way too often in here.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wclobbered"
-#endif
-
 struct my_error_mgr
 {
     struct jpeg_error_mgr pub;
@@ -32,7 +27,6 @@ static void my_error_exit(j_common_ptr cinfo)
 
 avifBool avifJPEGRead(avifImage * avif, const char * inputFilename, avifPixelFormat requestedFormat, int requestedDepth)
 {
-    avifBool ret = AVIF_FALSE;
     FILE * f = NULL;
     uint8_t * iccData = NULL;
 
@@ -47,6 +41,7 @@ avifBool avifJPEGRead(avifImage * avif, const char * inputFilename, avifPixelFor
         return AVIF_FALSE;
     }
 
+    avifBool ret = AVIF_FALSE;
     jpeg_create_decompress(&cinfo);
 
     f = fopen(inputFilename, "rb");


### PR DESCRIPTION
DO NOT MERGE: For demonstration only

Two techniques are used:

1. avifjpeg.c: Move the declaration of the variable that GCC warns about
after the setjmp() call. This technique works in this case, but may not
work elsewhere.

2. avifpng.c: Move the variables that GCC warns about to a struct.
Apparently GCC puts struct variables on the stack rather than in
registers. Variables in registers may be clobbered. By putting the
variables on the stack, we avoid the -Wclobber warnings.

With gcc version 9.2.1, this is all I need to fix. Joe, since you added
'volatile' to a few other variables, I suspect the -Wclobber warnings
depend on gcc versions and optimizations enabled. Please try these two
techniques (especially the second one) and write your own patch. Also, I
think the dummy struct 'x' should have a comment to explain it is
intended to prevent the variables from being allocated to registers and
getting clobbered.