### PR TITLE
Cast 'char' argument of tolower to unsigned char

### DIFF
--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -80,7 +80,7 @@ avifAppFileFormat avifGuessFileFormat(const char * filename)
     }
 
     for (size_t i = 0; i < fileExtLen; ++i) {
-        lowercaseExt[i] = (char)tolower(fileExt[i]);
+        lowercaseExt[i] = (char)tolower((unsigned char)fileExt[i]);
     }
     lowercaseExt[fileExtLen] = 0;
 


### PR DESCRIPTION
The tolower() function takes an input parameter of type 'int'. If the
input parameter is not representable as unsigned char and does not equal
EOF, the behavior is undefined.

If the plain 'char' type is signed and a 'char' variable holds a
non-ASCII character, it will be converted to a negative 'int' value by
integer promotion. Therefore we need to cast the 'char' variable to
'unsigned char' before passing it to tolower() or any other function in
<ctype.h>.

This issue is described in
https://en.cppreference.com/w/cpp/string/byte/tolower. I have run into
this kind of bug more than once before.