### PR TITLE
Ext: Update libaom to 2.0.0 release branch

### DIFF
--- a/ext/aom.cmd
+++ b/ext/aom.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2017 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b v1.0.0-errata1-avif --depth 1 https://aomedia.googlesource.com/aom
+git clone -b applejack --depth 1 https://aomedia.googlesource.com/aom
 
 cd aom
 mkdir build.libavif


### PR DESCRIPTION
I would suggest merging this now so we can start testing the libaom 2.0.0 library, and then updating back to -b v2.0.0 when v2.0.0 is tagged.