### PR TITLE
Ext: update to rav1e 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Reworked all examples in the README to reflect the new state of things, and clean out some cruft
 * Switch libaom.cmd to point at v2.0.0-rc1
 * Re-enable cpu-used=7+ in codec_aom when libaom major version > 1
+* Update default rav1e version to v0.4.0
 
 ## [0.7.3] - 2020-05-04
 ### Added

--- a/ext/rav1e.cmd
+++ b/ext/rav1e.cmd
@@ -11,7 +11,7 @@
 : # Also, the error that "The target windows-msvc is not supported yet" can safely be ignored provided that rav1e/target/release
 : # contains rav1e.h and rav1e.lib.
 
-git clone -b v0.3.1 --depth 1 https://github.com/xiph/rav1e.git
+git clone -b v0.4.0 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
 cargo install cbindgen


### PR DESCRIPTION
Updates rav1e.cmd to use rav1e v0.4.0, which includes monochrome support.