### PR TITLE
Ext: Update to dav1d 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Removed ICC inspection code regarding chroma-derived mtxCoeffs; this was overdesigned. Now just honor the assoc. colorPrimaries enum
   * Reworked all examples in the README to reflect the new state of things, and clean out some cruft
 * Update libaom.cmd to point at the v2.0.0 tag
-* Update dav1d.cmd to point at the 0.7.0 tag
+* Update dav1d.cmd to point at the 0.7.1 tag
 * Re-enable cpu-used=7+ in codec_aom when libaom major version > 1
 
 ## [0.7.3] - 2020-05-04

--- a/ext/dav1d.cmd
+++ b/ext/dav1d.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2017 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b 0.7.0 --depth 1 https://code.videolan.org/videolan/dav1d.git
+git clone -b 0.7.1 --depth 1 https://code.videolan.org/videolan/dav1d.git
 
 cd dav1d
 mkdir build


### PR DESCRIPTION
Updates the default dav1d version to [0.7.1](https://code.videolan.org/videolan/dav1d/-/tags/0.7.1).