### PR TITLE
Abort the process in case of memory allocation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update libaom.cmd to point at the v2.0.0 tag
 * Update dav1d.cmd to point at the 0.7.1 tag
 * Re-enable cpu-used=7+ in codec_aom when libaom major version > 1
+* Memory allocation failures now cause libavif to abort the process (rather than undefined behavior)
 
 ## [0.7.3] - 2020-05-04
 ### Added

--- a/src/mem.c
+++ b/src/mem.c
@@ -7,7 +7,11 @@
 
 void * avifAlloc(size_t size)
 {
-    return malloc(size);
+    void* out = malloc(size);
+    if (out == NULL) {
+        abort();
+    }
+    return out;
 }
 
 void avifFree(void * p)


### PR DESCRIPTION
We currently do not check the results of our memory allocations, and simply dereference the result without any checks. This leads to undefined behavior whenever `malloc` returns null.

With this change, we replace this undefined behavior by deterministically aborting the process.

Fixes #103