### PR TITLE
Remove checks for the "av01" brand

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1872,25 +1872,11 @@ static avifBool avifParse(avifDecoderData * data, const uint8_t * raw, size_t ra
 
 static avifBool avifFileTypeIsCompatible(avifFileType * ftyp)
 {
-    avifBool avifCompatible = (memcmp(ftyp->majorBrand, "avif", 4) == 0);
-    if (!avifCompatible) {
-        avifCompatible = (memcmp(ftyp->majorBrand, "avis", 4) == 0);
-    }
-    if (!avifCompatible) {
-        avifCompatible = (memcmp(ftyp->majorBrand, "av01", 4) == 0);
-    }
+    avifBool avifCompatible = (memcmp(ftyp->majorBrand, "avif", 4) == 0 || memcmp(ftyp->majorBrand, "avis", 4) == 0);
     if (!avifCompatible) {
         for (int compatibleBrandIndex = 0; compatibleBrandIndex < ftyp->compatibleBrandsCount; ++compatibleBrandIndex) {
             uint8_t * compatibleBrand = &ftyp->compatibleBrands[4 * compatibleBrandIndex];
-            if (!memcmp(compatibleBrand, "avif", 4)) {
-                avifCompatible = AVIF_TRUE;
-                break;
-            }
-            if (!memcmp(compatibleBrand, "avis", 4)) {
-                avifCompatible = AVIF_TRUE;
-                break;
-            }
-            if (!memcmp(compatibleBrand, "av01", 4)) {
+            if (!memcmp(compatibleBrand, "avif", 4) || !memcmp(compatibleBrand, "avis", 4)) {
                 avifCompatible = AVIF_TRUE;
                 break;
             }


### PR DESCRIPTION
https://aomediacodec.github.io/av1-isobmff/ says a file conformant to
that spec shall have the 'av01' brand among the compatible brands array
of the FileTypeBox. The 'av01' brand (as opposed to the 'av01' image
item type) is not mentioned in the AVIF spec.

Therefore, 'av01' may be present in the compatible brands array of an
AVIF file, but it should not be the major brand of an AVIF file. In
addition, the presence of 'av01' in the compatible brands array does not
imply the file is AVIF.

Also use the || operator to connect the checks for the "avif" and "avis"
brands.