### PR TITLE
Check a subtraction's result is in range of size_t

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -3,6 +3,7 @@
 
 #include "avif/internal.h"
 
+#include <stdint.h>
 #include <string.h>
 
 // ---------------------------------------------------------------------------
@@ -159,7 +160,11 @@ avifBool avifROStreamReadBoxHeader(avifROStream * stream, avifBoxHeader * header
         CHECK(avifROStreamSkip(stream, 16));
     }
 
-    header->size = (size_t)(size - (stream->offset - startOffset));
+    size_t bytesRead = stream->offset - startOffset;
+    if (size < bytesRead || size - bytesRead > SIZE_MAX) {
+        return AVIF_FALSE;
+    }
+    header->size = (size_t)(size - bytesRead);
 
     // Make the assumption here that this box's contents must fit in the remaining portion of the parent stream
     if (header->size > avifROStreamRemainingBytes(stream)) {


### PR DESCRIPTION
In avifROStreamReadBoxHeader(), make sure that the result of
size - (stream->offset - startOffset) is within the range of size_t,
i.e., nonnegative and less than or equal to SIZE_MAX. Note that the
result of stream->offset - startOffset is positive.