### PR TITLE
Contrib: Update Travis, AppVeyor and Docker to Nasm 2.15.02

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - python3-pip
 
 before_script:
-  - curl -L https://github.com/netwide-assembler/nasm/archive/nasm-2.15.02.tar.gz | tar xvz
+  - curl -L -O https://github.com/netwide-assembler/nasm/archive/nasm-2.15.02.tar.gz | tar xvz
   - cd nasm-2.15.02
   - ./configure && make -j2 && sudo make install
   - nasm --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ addons:
       - python3-pip
 
 before_script:
-  - curl -L -O https://github.com/netwide-assembler/nasm/archive/nasm-2.15.02.tar.gz | tar xvz
-  - cd nasm-2.15.02
+  - curl -L https://github.com/netwide-assembler/nasm/archive/nasm-2.15.02.tar.gz | tar xvz
+  - cd nasm-nasm-2.15.02
   - ./configure && make -j2 && sudo make install
   - nasm --version
   - pip3 --disable-pip-version-check install setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ addons:
       - python3-pip
 
 before_script:
-  - curl -L https://download.videolan.org/contrib/nasm/nasm-2.14.tar.gz | tar xvz
-  - cd nasm-2.14
+  - curl -L https://github.com/netwide-assembler/nasm/archive/nasm-2.15.02.tar.gz | tar xvz
+  - cd nasm-2.15.02
   - ./configure && make -j2 && sudo make install
   - nasm --version
   - pip3 --disable-pip-version-check install setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 before_script:
   - curl -L https://github.com/netwide-assembler/nasm/archive/nasm-2.15.02.tar.gz | tar xvz
   - cd nasm-nasm-2.15.02
-  - ./configure && make -j2 && sudo make install
+  - ./autogen.sh && ./configure && make -j2 && sudo make install
   - nasm --version
   - pip3 --disable-pip-version-check install setuptools
   - pip3 --disable-pip-version-check install meson

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
  - git submodule update --init --recursive
  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
  # Install Nasm
- - appveyor DownloadFile "https://github.com/joedrago/nasm_mirror/raw/master/nasm-2.14.02-win64.zip" -FileName "nasm.zip"
+ - appveyor DownloadFile "https://www.nasm.us/pub/nasm/releasebuilds/2.15.02/win64/nasm-2.15.02-win64.zip" -FileName "nasm.zip"
  - 7z x "nasm.zip" > nul
  - move nasm-* NASM
  - set PATH=%PATH%;%CD%\NASM;

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -27,8 +27,8 @@ cargo install cargo-c
 
 # NASM
 cd
-curl -L https://download.videolan.org/contrib/nasm/nasm-2.14.tar.gz | tar xvz
-cd nasm-2.14
+curl -L https://github.com/netwide-assembler/nasm/archive/nasm-2.15.02.tar.gz | tar xvz
+cd nasm-2.15.02
 ./configure --prefix=/usr && make -j2 && make install
 nasm --version
 


### PR DESCRIPTION
Will probably fail due to an upstream bug in dav1d. It's fixed on their master branch but just missed the 0.7.1 tag.