### PR TITLE
Declare data param of avifRWStreamWrite as void *

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -213,7 +213,7 @@ size_t avifRWStreamOffset(avifRWStream * stream);
 void avifRWStreamSetOffset(avifRWStream * stream, size_t offset);
 
 void avifRWStreamFinishWrite(avifRWStream * stream);
-void avifRWStreamWrite(avifRWStream * stream, const uint8_t * data, size_t size);
+void avifRWStreamWrite(avifRWStream * stream, const void * data, size_t size);
 void avifRWStreamWriteChars(avifRWStream * stream, const char * chars, size_t size);
 avifBoxMarker avifRWStreamWriteBox(avifRWStream * stream, const char * type, size_t contentSize);
 avifBoxMarker avifRWStreamWriteFullBox(avifRWStream * stream, const char * type, size_t contentSize, int version, uint32_t flags);

--- a/src/stream.c
+++ b/src/stream.c
@@ -239,7 +239,7 @@ void avifRWStreamFinishWrite(avifRWStream * stream)
     }
 }
 
-void avifRWStreamWrite(avifRWStream * stream, const uint8_t * data, size_t size)
+void avifRWStreamWrite(avifRWStream * stream, const void * data, size_t size)
 {
     if (!size) {
         return;
@@ -252,7 +252,7 @@ void avifRWStreamWrite(avifRWStream * stream, const uint8_t * data, size_t size)
 
 void avifRWStreamWriteChars(avifRWStream * stream, const char * chars, size_t size)
 {
-    avifRWStreamWrite(stream, (const uint8_t *)chars, size);
+    avifRWStreamWrite(stream, chars, size);
 }
 
 avifBoxMarker avifRWStreamWriteFullBox(avifRWStream * stream, const char * type, size_t contentSize, int version, uint32_t flags)

--- a/src/write.c
+++ b/src/write.c
@@ -736,7 +736,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
         avifRWStreamWriteU16(&s, 0x0100);                       // template int(16) volume = 0x0100; // typically, full volume
         avifRWStreamWriteU16(&s, 0);                            // const bit(16) reserved = 0;
         avifRWStreamWriteZeros(&s, 8);                          // const unsigned int(32)[2] reserved = 0;
-        avifRWStreamWrite(&s, (const uint8_t *)unityMatrix, sizeof(unityMatrix));
+        avifRWStreamWrite(&s, unityMatrix, sizeof(unityMatrix));
         avifRWStreamWriteZeros(&s, 24);                       // bit(32)[6] pre_defined = 0;
         avifRWStreamWriteU32(&s, encoder->data->items.count); // unsigned int(32) next_track_ID;
         avifRWStreamFinishBox(&s, mvhd);
@@ -771,7 +771,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             avifRWStreamWriteU16(&s, 0);                      // template int(16) alternate_group = 0;
             avifRWStreamWriteU16(&s, 0);                      // template int(16) volume = {if track_is_audio 0x0100 else 0};
             avifRWStreamWriteU16(&s, 0);                      // const unsigned int(16) reserved = 0;
-            avifRWStreamWrite(&s, (const uint8_t *)unityMatrix, sizeof(unityMatrix)); // template int(32)[9] matrix= // { 0x00010000,0,0,0,0x00010000,0,0,0,0x40000000 };
+            avifRWStreamWrite(&s, unityMatrix, sizeof(unityMatrix)); // template int(32)[9] matrix= // { 0x00010000,0,0,0,0x00010000,0,0,0,0x40000000 };
             avifRWStreamWriteU32(&s, imageMetadata->width << 16);  // unsigned int(32) width;
             avifRWStreamWriteU32(&s, imageMetadata->height << 16); // unsigned int(32) height;
             avifRWStreamFinishBox(&s, tkhd);


### PR DESCRIPTION
Declare the 'data' parameter of avifRWStreamWrite() as const void *.
This avoids the need to cast that argument to const uint8_t * at some
call sites.