### PR TITLE
Declare some stream functions to take const param

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -185,11 +185,11 @@ typedef struct avifROStream
 
 const uint8_t * avifROStreamCurrent(avifROStream * stream);
 void avifROStreamStart(avifROStream * stream, avifROData * raw);
-size_t avifROStreamOffset(avifROStream * stream);
+size_t avifROStreamOffset(const avifROStream * stream);
 void avifROStreamSetOffset(avifROStream * stream, size_t offset);
 
-avifBool avifROStreamHasBytesLeft(avifROStream * stream, size_t byteCount);
-size_t avifROStreamRemainingBytes(avifROStream * stream);
+avifBool avifROStreamHasBytesLeft(const avifROStream * stream, size_t byteCount);
+size_t avifROStreamRemainingBytes(const avifROStream * stream);
 avifBool avifROStreamSkip(avifROStream * stream, size_t byteCount);
 avifBool avifROStreamRead(avifROStream * stream, uint8_t * data, size_t size);
 avifBool avifROStreamReadU16(avifROStream * stream, uint16_t * v);
@@ -209,7 +209,7 @@ typedef struct avifRWStream
 
 uint8_t * avifRWStreamCurrent(avifRWStream * stream);
 void avifRWStreamStart(avifRWStream * stream, avifRWData * raw);
-size_t avifRWStreamOffset(avifRWStream * stream);
+size_t avifRWStreamOffset(const avifRWStream * stream);
 void avifRWStreamSetOffset(avifRWStream * stream, size_t offset);
 
 void avifRWStreamFinishWrite(avifRWStream * stream);

--- a/src/stream.c
+++ b/src/stream.c
@@ -20,17 +20,17 @@ void avifROStreamStart(avifROStream * stream, avifROData * raw)
     stream->offset = 0;
 }
 
-avifBool avifROStreamHasBytesLeft(avifROStream * stream, size_t byteCount)
+avifBool avifROStreamHasBytesLeft(const avifROStream * stream, size_t byteCount)
 {
     return (stream->offset + byteCount) <= stream->raw->size;
 }
 
-size_t avifROStreamRemainingBytes(avifROStream * stream)
+size_t avifROStreamRemainingBytes(const avifROStream * stream)
 {
     return stream->raw->size - stream->offset;
 }
 
-size_t avifROStreamOffset(avifROStream * stream)
+size_t avifROStreamOffset(const avifROStream * stream)
 {
     return stream->offset;
 }
@@ -215,7 +215,7 @@ void avifRWStreamStart(avifRWStream * stream, avifRWData * raw)
     stream->offset = 0;
 }
 
-size_t avifRWStreamOffset(avifRWStream * stream)
+size_t avifRWStreamOffset(const avifRWStream * stream)
 {
     return stream->offset;
 }

--- a/src/write.c
+++ b/src/write.c
@@ -155,7 +155,7 @@ static void avifEncoderDataDestroy(avifEncoderData * data)
     avifFree(data);
 }
 
-static void avifEncoderItemAddMdatFixup(avifEncoderItem * item, avifRWStream * s)
+static void avifEncoderItemAddMdatFixup(avifEncoderItem * item, const avifRWStream * s)
 {
     avifOffsetFixup * fixup = (avifOffsetFixup *)avifArrayPushPtr(&item->mdatFixups);
     fixup->offset = avifRWStreamOffset(s);


### PR DESCRIPTION
Declare some stream functions to take a const stream pointer parameter.
This helps code analysis.