### PR TITLE
Fix regression preventing avifenc from working

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -499,7 +499,7 @@ int main(int argc, char * argv[])
     avifInputFile * firstFile = avifInputGetNextFile(&input);
     uint32_t sourceDepth = 0;
     avifAppFileFormat inputFormat = avifInputReadImage(&input, image, &sourceDepth);
-    if (avifInputReadImage(&input, image, &sourceDepth) == AVIF_APP_FILE_FORMAT_UNKNOWN) {
+    if (inputFormat == AVIF_APP_FILE_FORMAT_UNKNOWN) {
         fprintf(stderr, "Cannot determine input file format: %s\n", firstFile->filename);
         returnCode = 1;
         goto cleanup;


### PR DESCRIPTION
Since 436ab195de82b705cf0064591bd5c9593d33d415, `avifenc` would try to read its input file twice, in two consecutive calls to `avifInputReadImage()`, the latter would fail.

A test run during CI would catch this kind of issue.