### PR TITLE
Add an AArch64 run in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ matrix:
   - name: "GCC Release"
     compiler: gcc
     config: Release
+  - name: "AArch64 GCC Release"
+    arch: arm64
+    compiler: gcc
+    config: Release
   - name: "Clang Debug"
     compiler: clang
     config: Debug


### PR DESCRIPTION
Travis now has ARMv8 builders, so make use of them to discover any regression on AArch64.