### PR TITLE
Fix compilation on Windows with mingw-w64: %z is unknown, use %I instead

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -57,7 +57,7 @@ static int info(const char * inputFilename)
     avifRWData raw = AVIF_DATA_EMPTY;
     avifRWDataRealloc(&raw, inputFileSize);
     if (fread(raw.data, 1, inputFileSize, inputFile) != inputFileSize) {
-        fprintf(stderr, "Failed to read " FMT_ZU " bytes: %s\n", inputFileSize, inputFilename);
+        fprintf(stderr, "Failed to read " AVIF_FMT_ZU " bytes: %s\n", inputFileSize, inputFilename);
         fclose(inputFile);
         avifRWDataFree(&raw);
         return 1;
@@ -218,7 +218,7 @@ int main(int argc, char * argv[])
     avifRWData raw = AVIF_DATA_EMPTY;
     avifRWDataRealloc(&raw, inputFileSize);
     if (fread(raw.data, 1, inputFileSize, inputFile) != inputFileSize) {
-        fprintf(stderr, "Failed to read " FMT_ZU " bytes: %s\n", inputFileSize, inputFilename);
+        fprintf(stderr, "Failed to read " AVIF_FMT_ZU " bytes: %s\n", inputFileSize, inputFilename);
         fclose(inputFile);
         avifRWDataFree(&raw);
         return 1;

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -57,7 +57,7 @@ static int info(const char * inputFilename)
     avifRWData raw = AVIF_DATA_EMPTY;
     avifRWDataRealloc(&raw, inputFileSize);
     if (fread(raw.data, 1, inputFileSize, inputFile) != inputFileSize) {
-        fprintf(stderr, "Failed to read %zu bytes: %s\n", inputFileSize, inputFilename);
+        fprintf(stderr, "Failed to read " FMT_ZU " bytes: %s\n", inputFileSize, inputFilename);
         fclose(inputFile);
         avifRWDataFree(&raw);
         return 1;
@@ -218,7 +218,7 @@ int main(int argc, char * argv[])
     avifRWData raw = AVIF_DATA_EMPTY;
     avifRWDataRealloc(&raw, inputFileSize);
     if (fread(raw.data, 1, inputFileSize, inputFile) != inputFileSize) {
-        fprintf(stderr, "Failed to read %zu bytes: %s\n", inputFileSize, inputFilename);
+        fprintf(stderr, "Failed to read " FMT_ZU " bytes: %s\n", inputFileSize, inputFilename);
         fclose(inputFile);
         avifRWDataFree(&raw);
         return 1;

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -760,15 +760,15 @@ int main(int argc, char * argv[])
     }
 
     printf("Encoded successfully.\n");
-    printf(" * Color AV1 total size: " FMT_ZU " bytes\n", encoder->ioStats.colorOBUSize);
-    printf(" * Alpha AV1 total size: " FMT_ZU " bytes\n", encoder->ioStats.alphaOBUSize);
+    printf(" * Color AV1 total size: " AVIF_FMT_ZU " bytes\n", encoder->ioStats.colorOBUSize);
+    printf(" * Alpha AV1 total size: " AVIF_FMT_ZU " bytes\n", encoder->ioStats.alphaOBUSize);
     FILE * f = fopen(outputFilename, "wb");
     if (!f) {
         fprintf(stderr, "ERROR: Failed to open file for write: %s\n", outputFilename);
         goto cleanup;
     }
     if (fwrite(raw.data, 1, raw.size, f) != raw.size) {
-        fprintf(stderr, "Failed to write " FMT_ZU " bytes: %s\n", raw.size, outputFilename);
+        fprintf(stderr, "Failed to write " AVIF_FMT_ZU " bytes: %s\n", raw.size, outputFilename);
         returnCode = 1;
     } else {
         printf("Wrote AVIF: %s\n", outputFilename);

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -760,15 +760,15 @@ int main(int argc, char * argv[])
     }
 
     printf("Encoded successfully.\n");
-    printf(" * Color AV1 total size: %zu bytes\n", encoder->ioStats.colorOBUSize);
-    printf(" * Alpha AV1 total size: %zu bytes\n", encoder->ioStats.alphaOBUSize);
+    printf(" * Color AV1 total size: " FMT_ZU " bytes\n", encoder->ioStats.colorOBUSize);
+    printf(" * Alpha AV1 total size: " FMT_ZU " bytes\n", encoder->ioStats.alphaOBUSize);
     FILE * f = fopen(outputFilename, "wb");
     if (!f) {
         fprintf(stderr, "ERROR: Failed to open file for write: %s\n", outputFilename);
         goto cleanup;
     }
     if (fwrite(raw.data, 1, raw.size, f) != raw.size) {
-        fprintf(stderr, "Failed to write %zu bytes: %s\n", raw.size, outputFilename);
+        fprintf(stderr, "Failed to write " FMT_ZU " bytes: %s\n", raw.size, outputFilename);
         returnCode = 1;
     } else {
         printf("Wrote AVIF: %s\n", outputFilename);

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -19,9 +19,9 @@ void avifImageDump(avifImage * avif)
     printf(" * Transfer Char. : %d\n", avif->transferCharacteristics);
     printf(" * Matrix Coeffs. : %d\n", avif->matrixCoefficients);
 
-    printf(" * ICC Profile    : %s (" FMT_ZU " bytes)\n", (avif->icc.size > 0) ? "Present" : "Absent", avif->icc.size);
-    printf(" * XMP Metadata   : %s (" FMT_ZU " bytes)\n", (avif->xmp.size > 0) ? "Present" : "Absent", avif->xmp.size);
-    printf(" * EXIF Metadata  : %s (" FMT_ZU " bytes)\n", (avif->exif.size > 0) ? "Present" : "Absent", avif->exif.size);
+    printf(" * ICC Profile    : %s (" AVIF_FMT_ZU " bytes)\n", (avif->icc.size > 0) ? "Present" : "Absent", avif->icc.size);
+    printf(" * XMP Metadata   : %s (" AVIF_FMT_ZU " bytes)\n", (avif->xmp.size > 0) ? "Present" : "Absent", avif->xmp.size);
+    printf(" * EXIF Metadata  : %s (" AVIF_FMT_ZU " bytes)\n", (avif->exif.size > 0) ? "Present" : "Absent", avif->exif.size);
 
     if (avif->transformFlags == AVIF_TRANSFORM_NONE) {
         printf(" * Transformations: None\n");

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -19,9 +19,9 @@ void avifImageDump(avifImage * avif)
     printf(" * Transfer Char. : %d\n", avif->transferCharacteristics);
     printf(" * Matrix Coeffs. : %d\n", avif->matrixCoefficients);
 
-    printf(" * ICC Profile    : %s (%zu bytes)\n", (avif->icc.size > 0) ? "Present" : "Absent", avif->icc.size);
-    printf(" * XMP Metadata   : %s (%zu bytes)\n", (avif->xmp.size > 0) ? "Present" : "Absent", avif->xmp.size);
-    printf(" * EXIF Metadata  : %s (%zu bytes)\n", (avif->exif.size > 0) ? "Present" : "Absent", avif->exif.size);
+    printf(" * ICC Profile    : %s (" FMT_ZU " bytes)\n", (avif->icc.size > 0) ? "Present" : "Absent", avif->icc.size);
+    printf(" * XMP Metadata   : %s (" FMT_ZU " bytes)\n", (avif->xmp.size > 0) ? "Present" : "Absent", avif->xmp.size);
+    printf(" * EXIF Metadata  : %s (" FMT_ZU " bytes)\n", (avif->exif.size > 0) ? "Present" : "Absent", avif->exif.size);
 
     if (avif->transformFlags == AVIF_TRANSFORM_NONE) {
         printf(" * Transformations: None\n");

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -6,6 +6,11 @@
 
 #include "avif/avif.h"
 
+/*
+ * With Visual Studio before 2013 and mingw-w64 before 2020 the 29th april,
+ * (and __USE_MINGW_ANSI_STDIO not set to 1), %z precision specifier is not
+ * supported. Hence %I must be used. %I is on the other hand always supported.
+ */
 #ifdef _WIN32
 # define AVIF_FMT_ZU "%Iu"
 #else

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -6,6 +6,12 @@
 
 #include "avif/avif.h"
 
+#ifdef _WIN32
+# define FMT_ZU "%Iu"
+#else
+# define FMT_ZU "%zu"
+#endif
+
 void avifImageDump(avifImage * avif);
 void avifPrintVersions(void);
 

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -7,9 +7,9 @@
 #include "avif/avif.h"
 
 #ifdef _WIN32
-# define FMT_ZU "%Iu"
+# define AVIF_FMT_ZU "%Iu"
 #else
-# define FMT_ZU "%zu"
+# define AVIF_FMT_ZU "%zu"
 #endif
 
 void avifImageDump(avifImage * avif);


### PR DESCRIPTION
on Windows, mingw-w64 is using msvcrt.dll, which does not implement %z as printf format.  On this platform, %I should be used instead. When compiling with recent Visual Studio, both %I and %z are supported.