### PR TITLE
Add support for XRGB formats in RGB->YUV helpers

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -399,6 +399,8 @@ typedef struct avifRGBImage
     avifRGBFormat format;                  // all channels are always full range
     avifChromaUpsampling chromaUpsampling; // How to upsample non-4:4:4 UV (ignored for 444) when converting to RGB.
                                            // Unused when converting to YUV. avifRGBImageSetDefaults() prefers quality over speed.
+    avifBool ignoreAlpha;                  // Used for XRGB formats, treats formats containing alpha (such as ARGB) as if they were
+                                           // RGB, treating the alpha bits as if they were all 1.
 
     uint8_t * pixels;
     uint32_t rowBytes;

--- a/src/avif.c
+++ b/src/avif.c
@@ -353,6 +353,7 @@ void avifRGBImageSetDefaults(avifRGBImage * rgb, const avifImage * image)
     rgb->depth = image->depth;
     rgb->format = AVIF_RGB_FORMAT_RGBA;
     rgb->chromaUpsampling = AVIF_CHROMA_UPSAMPLING_BILINEAR;
+    rgb->ignoreAlpha = AVIF_FALSE;
     rgb->pixels = NULL;
     rgb->rowBytes = 0;
 }

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -134,7 +134,7 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
     }
 
     avifImageAllocatePlanes(image, AVIF_PLANES_YUV);
-    if (avifRGBFormatHasAlpha(rgb->format)) {
+    if (avifRGBFormatHasAlpha(rgb->format) && !rgb->ignoreAlpha) {
         avifImageAllocatePlanes(image, AVIF_PLANES_A);
     }
 
@@ -297,7 +297,7 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
         params.dstOffsetBytes = 0;
         params.dstPixelBytes = state.yuvChannelBytes;
 
-        if (avifRGBFormatHasAlpha(rgb->format)) {
+        if (avifRGBFormatHasAlpha(rgb->format) && !rgb->ignoreAlpha) {
             params.srcDepth = rgb->depth;
             params.srcRange = AVIF_RANGE_FULL;
             params.srcPlane = rgb->pixels;
@@ -925,7 +925,7 @@ avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
         return AVIF_RESULT_REFORMAT_FAILED;
     }
 
-    if (avifRGBFormatHasAlpha(rgb->format)) {
+    if (avifRGBFormatHasAlpha(rgb->format) && !rgb->ignoreAlpha) {
         avifAlphaParams params;
 
         params.width = rgb->width;


### PR DESCRIPTION
These are similar to the ARGB formats, except the bits where there would
otherwise be the alpha channel are unused.

These formats are quite common, especially in real-time image generation
where proper alignment is more important than memory usage.