### PR TITLE
Check out Abseil release tag 20200225.2

### DIFF
--- a/ext/libgav1.cmd
+++ b/ext/libgav1.cmd
@@ -12,7 +12,7 @@ git clone --single-branch https://chromium.googlesource.com/codecs/libgav1
 
 cd libgav1
 git checkout 45a1d76
-git clone https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
+git clone -b 20200225.2 --depth 1 https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
 mkdir build
 cd build
 


### PR DESCRIPTION
Abseil has release tags: https://github.com/abseil/abseil-cpp/releases.
The latest release is 20200225.2 (Abseil LTS branch, Feb 2020, Patch 2).