### PR TITLE
avifImageIdentity8ToRGB8ColorFullRange needs 4:4:4

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -960,7 +960,8 @@ avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
         // unless the YUV data isn't subsampled or they explicitly requested AVIF_CHROMA_UPSAMPLING_NEAREST.
 
         if (state.mode == AVIF_REFORMAT_MODE_IDENTITY) {
-            if ((image->depth == 8) && (rgb->depth == 8) && hasColor && (image->yuvRange == AVIF_RANGE_FULL)) {
+            if ((image->depth == 8) && (rgb->depth == 8) && (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) &&
+                (image->yuvRange == AVIF_RANGE_FULL)) {
                 return avifImageIdentity8ToRGB8ColorFullRange(image, rgb, &state);
             }
 


### PR DESCRIPTION
Check if image->yuvFormat is AVIF_PIXEL_FORMAT_YUV444 before calling
avifImageIdentity8ToRGB8ColorFullRange() because
avifImageIdentity8ToRGB8ColorFullRange() assumes the YUV 4:4:4 format.

Note that the AV1 spec, Section 6.4.2 (Color config semantics), page 119
actually has this requirement:

    If matrix_coefficients is equal to MC_IDENTITY, it is a requirement
    of bitstream conformance that subsampling_x is equal to 0 and
    subsampling_y is equal to 0.

But not all AV1 decoders enforce this requirement. For example, dav1d
does not. So libavif needs to validate its assumptions when converting
YUV to RGB with the identity matrix.

Note: I wrote a merge request for dav1d to enforce this requirement of
bitstream conformance, but I am not sure if it will be accepted:
https://code.videolan.org/videolan/dav1d/-/merge_requests/1063