### PR TITLE
Add the disableGridImages setting to avifDecoder

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -579,6 +579,9 @@ typedef struct avifDecoder
     // avifDecoderNextImage() or avifDecoderNthImage(), as decoder->image->alphaPlane won't exist yet.
     avifBool alphaPresent;
 
+    // Set this to true to disable support of grid images. If a grid image is encountered, AVIF_RESULT_BMFF_PARSE_FAILED will be returned.
+    avifBool disableGridImages;
+
     // stats from the most recent read, possibly 0s if reading an image sequence
     avifIOStats ioStats;
 

--- a/src/read.c
+++ b/src/read.c
@@ -2188,6 +2188,9 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             }
 
             if (isGrid) {
+                if (decoder->disableGridImages) {
+                    return AVIF_RESULT_BMFF_PARSE_FAILED;
+                }
                 const uint8_t * itemPtr = avifDecoderDataCalcItemPtr(data, item);
                 if (itemPtr == NULL) {
                     return AVIF_RESULT_BMFF_PARSE_FAILED;
@@ -2232,6 +2235,9 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             const avifProperty * auxCProp = avifPropertyArrayFind(&item->properties, "auxC");
             if (auxCProp && isAlphaURN(auxCProp->u.auxC.auxType) && (item->auxForID == colorOBUItem->id)) {
                 if (isGrid) {
+                    if (decoder->disableGridImages) {
+                        return AVIF_RESULT_BMFF_PARSE_FAILED;
+                    }
                     const uint8_t * itemPtr = avifDecoderDataCalcItemPtr(data, item);
                     if (itemPtr == NULL) {
                         return AVIF_RESULT_BMFF_PARSE_FAILED;


### PR DESCRIPTION
This is an interim solution while we review and polish the grid image
code in src/read.c.