### PR TITLE
Add AVIF_FMT_ZU to fix compiling with non-standard/old compilers

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -57,7 +57,7 @@ static int info(const char * inputFilename)
     avifRWData raw = AVIF_DATA_EMPTY;
     avifRWDataRealloc(&raw, inputFileSize);
     if (fread(raw.data, 1, inputFileSize, inputFile) != inputFileSize) {
-        fprintf(stderr, "Failed to read %zu bytes: %s\n", inputFileSize, inputFilename);
+        fprintf(stderr, "Failed to read " AVIF_FMT_ZU " bytes: %s\n", inputFileSize, inputFilename);
         fclose(inputFile);
         avifRWDataFree(&raw);
         return 1;
@@ -218,7 +218,7 @@ int main(int argc, char * argv[])
     avifRWData raw = AVIF_DATA_EMPTY;
     avifRWDataRealloc(&raw, inputFileSize);
     if (fread(raw.data, 1, inputFileSize, inputFile) != inputFileSize) {
-        fprintf(stderr, "Failed to read %zu bytes: %s\n", inputFileSize, inputFilename);
+        fprintf(stderr, "Failed to read " AVIF_FMT_ZU " bytes: %s\n", inputFileSize, inputFilename);
         fclose(inputFile);
         avifRWDataFree(&raw);
         return 1;

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -760,15 +760,15 @@ int main(int argc, char * argv[])
     }
 
     printf("Encoded successfully.\n");
-    printf(" * Color AV1 total size: %zu bytes\n", encoder->ioStats.colorOBUSize);
-    printf(" * Alpha AV1 total size: %zu bytes\n", encoder->ioStats.alphaOBUSize);
+    printf(" * Color AV1 total size: " AVIF_FMT_ZU " bytes\n", encoder->ioStats.colorOBUSize);
+    printf(" * Alpha AV1 total size: " AVIF_FMT_ZU " bytes\n", encoder->ioStats.alphaOBUSize);
     FILE * f = fopen(outputFilename, "wb");
     if (!f) {
         fprintf(stderr, "ERROR: Failed to open file for write: %s\n", outputFilename);
         goto cleanup;
     }
     if (fwrite(raw.data, 1, raw.size, f) != raw.size) {
-        fprintf(stderr, "Failed to write %zu bytes: %s\n", raw.size, outputFilename);
+        fprintf(stderr, "Failed to write " AVIF_FMT_ZU " bytes: %s\n", raw.size, outputFilename);
         returnCode = 1;
     } else {
         printf("Wrote AVIF: %s\n", outputFilename);

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -19,9 +19,9 @@ void avifImageDump(avifImage * avif)
     printf(" * Transfer Char. : %d\n", avif->transferCharacteristics);
     printf(" * Matrix Coeffs. : %d\n", avif->matrixCoefficients);
 
-    printf(" * ICC Profile    : %s (%zu bytes)\n", (avif->icc.size > 0) ? "Present" : "Absent", avif->icc.size);
-    printf(" * XMP Metadata   : %s (%zu bytes)\n", (avif->xmp.size > 0) ? "Present" : "Absent", avif->xmp.size);
-    printf(" * EXIF Metadata  : %s (%zu bytes)\n", (avif->exif.size > 0) ? "Present" : "Absent", avif->exif.size);
+    printf(" * ICC Profile    : %s (" AVIF_FMT_ZU " bytes)\n", (avif->icc.size > 0) ? "Present" : "Absent", avif->icc.size);
+    printf(" * XMP Metadata   : %s (" AVIF_FMT_ZU " bytes)\n", (avif->xmp.size > 0) ? "Present" : "Absent", avif->xmp.size);
+    printf(" * EXIF Metadata  : %s (" AVIF_FMT_ZU " bytes)\n", (avif->exif.size > 0) ? "Present" : "Absent", avif->exif.size);
 
     if (avif->transformFlags == AVIF_TRANSFORM_NONE) {
         printf(" * Transformations: None\n");

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -6,6 +6,11 @@
 
 #include "avif/avif.h"
 
+/*
+ * With Visual Studio before 2013 and mingw-w64 before 2020 the 29th april,
+ * (and __USE_MINGW_ANSI_STDIO not set to 1), %z precision specifier is not
+ * supported. Hence %I must be used. %I is on the other hand always supported.
+ */
 #ifdef _WIN32
 # define AVIF_FMT_ZU "%Iu"
 #else

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -11,7 +11,7 @@
  * (and __USE_MINGW_ANSI_STDIO not set to 1), %z precision specifier is not
  * supported. Hence %I must be used. %I is on the other hand always supported.
  */
-#ifdef _WIN32
+#if (defined(_MSVC) && _MSVC < 1800) || (defined(__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO == 0)
 # define AVIF_FMT_ZU "%Iu"
 #else
 # define AVIF_FMT_ZU "%zu"

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -6,6 +6,12 @@
 
 #include "avif/avif.h"
 
+#ifdef _WIN32
+# define AVIF_FMT_ZU "%Iu"
+#else
+# define AVIF_FMT_ZU "%zu"
+#endif
+
 void avifImageDump(avifImage * avif);
 void avifPrintVersions(void);
 

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -7,9 +7,12 @@
 #include "avif/avif.h"
 
 /*
- * With Visual Studio before 2013 and mingw-w64 before 2020 the 29th april,
- * (and __USE_MINGW_ANSI_STDIO not set to 1), %z precision specifier is not
- * supported. Hence %I must be used. %I is on the other hand always supported.
+ * The %z format specifier is not available with Visual Studios before 2013 and
+ * mingw-w64 toolchains with `__USE_MINGW_ANSI_STDIO` not set to 1.
+ * Hence the %I format specifier must be used instead to print out `size_t`.
+ * Newer Visual Studios and mingw-w64 toolchains built with the commit
+ * mentioned with c99 set as the standard supports the %z specifier properly.
+ * Related mingw-w64 commit: bfd33f6c0ec5e652cc9911857dd1492ece8d8383
  */
 #if (defined(_MSVC) && _MSVC < 1800) || (defined(__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO == 0)
 # define AVIF_FMT_ZU "%Iu"


### PR DESCRIPTION
Succeding #239, this pr is focused on fixing compilation issues with non-c99 conforming compilers such as those older than Visual Studio 2013 and mingw-w64 toolchains with `__USE_MINGW_ANSI_STDIO` set to 0 and using the msvcrt.dll's family of printing functions.

Related commit in mingw-w64: https://github.com/mirror/mingw-w64/commit/bfd33f6c0ec5e652cc9911857dd1492ece8d8383