### PR TITLE
Fail if a tile is completely outside grid bounds

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -753,7 +753,13 @@ static avifBool avifDecoderDataFillImageGrid(avifDecoderData * data,
 
             // Y and A channels
             size_t yaColOffset = colIndex * firstTile->image->width;
+            if (yaColOffset >= grid->outputWidth) {
+                return AVIF_FALSE;
+            }
             size_t yaRowOffset = rowIndex * firstTile->image->height;
+            if (yaRowOffset >= grid->outputHeight) {
+                return AVIF_FALSE;
+            }
             size_t yaRowBytes = widthToCopy * pixelBytes;
 
             if (alpha) {


### PR DESCRIPTION
avifDecoderDataFillImageGrid() should return AVIF_FALSE if a tile is
completely outside the grid boundaries.