### PR TITLE
Disallow zero grid output_width or output_height

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -983,7 +983,7 @@ static avifBool avifParseImageGridBox(avifImageGrid * grid, const uint8_t * raw,
         CHECK(avifROStreamReadU32(&s, &grid->outputWidth));  // unsigned int(FieldLength) output_width;
         CHECK(avifROStreamReadU32(&s, &grid->outputHeight)); // unsigned int(FieldLength) output_height;
     }
-    if (grid->outputWidth > AVIF_MAX_IMAGE_SIZE / grid->outputHeight) {
+    if (grid->outputWidth == 0 || grid->outputHeight == 0 || grid->outputWidth > AVIF_MAX_IMAGE_SIZE / grid->outputHeight) {
         return AVIF_FALSE;
     }
     return AVIF_TRUE;


### PR DESCRIPTION
Fix https://crbug.com/oss-fuzz/24818 and
https://crbug.com/oss-fuzz/24821. These bugs were introduced by my fix
for https://crbug.com/oss-fuzz/24728 and
https://crbug.com/oss-fuzz/24734.