### PR TITLE
Disable Clang warning (drop const qualifier)

### DIFF
--- a/contrib/gdk-pixbuf/CMakeLists.txt
+++ b/contrib/gdk-pixbuf/CMakeLists.txt
@@ -14,6 +14,9 @@ if(AVIF_BUILD_GDK_PIXBUF)
 
             # This is required because glib stupidly uses invalid #define names, such as __G_LIB_H__…
             add_definitions(-Wno-reserved-id-macro)
+            if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+                add_definitions(-Wno-cast-qual)
+            endif()
             target_link_libraries(pixbufloader-avif PUBLIC ${GDK_PIXBUF_LIBRARIES} avif)
             target_include_directories(pixbufloader-avif PUBLIC ${GDK_PIXBUF_INCLUDE_DIRS})
 


### PR DESCRIPTION
This is a fix to https://github.com/AOMediaCodec/libavif/issues/251