### PR TITLE
Ignore clang -Wc11-extensions warnings on dav1d.h

### DIFF
--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -6,7 +6,14 @@
 #if defined(_MSC_VER)
 #pragma warning(disable : 4201) // nonstandard extension used: nameless struct/union
 #endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc11-extensions" // C11 extension used: nameless struct/union
+#endif
 #include "dav1d/dav1d.h"
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #include <string.h>
 


### PR DESCRIPTION
Ignore the following warnings when compiling with clang:
[1/8] Building C object CMakeFiles/avif.dir/src/codec_dav1d.c.o
In file included from ../src/codec_dav1d.c:9:
In file included from ../ext/dav1d/include/dav1d/dav1d.h:39:
In file included from ../ext/dav1d/include/dav1d/picture.h:35:
../ext/dav1d/include/dav1d/headers.h:96:9: warning: anonymous structs are a C11 extension [-Wc11-extensions]
        struct {
        ^
../ext/dav1d/include/dav1d/headers.h:95:5: warning: anonymous unions are a C11 extension [-Wc11-extensions]
    union {
    ^
2 warnings generated.