### PR TITLE
Miscellaneous minor cleanups

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -700,12 +700,12 @@ enum avifAddImageFlags
 avifResult avifEncoderAddImage(avifEncoder * encoder, const avifImage * image, uint64_t durationInTimescales, uint32_t addImageFlags);
 avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output);
 
-// Codec-specific, optional "advanced" settings tuning, in form of string key/value pairs. These
+// Codec-specific, optional "advanced" tuning settings, in the form of string key/value pairs. These
 // should be set as early as possible, preferably just after creating avifEncoder but before
 // performing any other actions.
 // key must be non-NULL, but passing a NULL value will delete that key, if it exists.
 // Setting an incorrect or unknown option for the current codec will cause errors of type
-// AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION.
+// AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION from avifEncoderWrite() or avifEncoderAddImage().
 void avifEncoderSetCodecSpecificOption(avifEncoder * encoder, const char * key, const char * value);
 
 // Helpers

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -123,7 +123,7 @@ void avifCodecEncodeOutputAddSample(avifCodecEncodeOutput * encodeOutput, const 
 void avifCodecEncodeOutputDestroy(avifCodecEncodeOutput * encodeOutput);
 
 // ---------------------------------------------------------------------------
-// avifCodecSpecificOptions (KV string pairs for advanced tuning)
+// avifCodecSpecificOptions (key/value string pairs for advanced tuning)
 
 typedef struct avifCodecSpecificOption
 {
@@ -161,7 +161,7 @@ typedef struct avifCodec
 {
     avifCodecDecodeInput * decodeInput;
     avifCodecConfigurationBox configBox;  // Pre-populated by avifEncoderWrite(), available and overridable by codec impls
-    avifCodecSpecificOptions * csOptions; // Contains codec-specific KV pairs for advanced tuning.
+    avifCodecSpecificOptions * csOptions; // Contains codec-specific key/value pairs for advanced tuning.
                                           // If a codec uses a value, it must mark it as used.
                                           // This array is NOT owned by avifCodec.
     struct avifCodecInternal * internal;  // up to each codec to use how it wants

--- a/src/write.c
+++ b/src/write.c
@@ -175,9 +175,9 @@ avifEncoder * avifEncoderCreate(void)
     encoder->tileRowsLog2 = 0;
     encoder->tileColsLog2 = 0;
     encoder->speed = AVIF_SPEED_DEFAULT;
-    encoder->data = avifEncoderDataCreate();
-    encoder->timescale = 1;
     encoder->keyframeInterval = 0;
+    encoder->timescale = 1;
+    encoder->data = avifEncoderDataCreate();
     encoder->csOptions = avifCodecSpecificOptionsCreate();
     return encoder;
 }


### PR DESCRIPTION
include/avif/avif.h: Fix the comments for
avifEncoderSetCodecSpecificOption().

include/avif/internal.h: Change "KV" to "key/value" in comments.

src/write.c: Make avifEncoderCreate() initialize members of avifEncoder
in declaration order, for easier comparison with the avifEncoder struct
definition.