### PR TITLE
gdk-pixbuf/loader.c: Include stdlib.h for strtol

### DIFF
--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -3,6 +3,7 @@
 */
 
 #include <avif/avif.h>
+#include <stdlib.h>
 
 #define GDK_PIXBUF_ENABLE_BACKEND
 #include <gdk-pixbuf/gdk-pixbuf-io.h>


### PR DESCRIPTION
Add stdlib.h for strtol(3) used in .contrib/gdk-pixbuf/loader.c file.