### PR TITLE
Test gdk-pixbuf on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ matrix:
           sudo pkg install -y llvm10
         fi
     before_script:
-      - sudo pkg install -y aom dav1d librav1e ninja
-      - $WRAPPER cmake -B build -G Ninja -DAVIF_{CODEC_{AOM,DAV1D,RAV1E},BUILD_{APPS,TESTS}}=ON
+      - sudo pkg install -y aom dav1d gdk-pixbuf2 librav1e ninja
+      - $WRAPPER cmake -B build -G Ninja -DAVIF_{CODEC_{AOM,DAV1D,RAV1E},BUILD_{APPS,GDK_PIXBUF,TESTS}}=ON
     script:
       - $WRAPPER cmake --build build
   - <<: *freebsd_common

--- a/contrib/gdk-pixbuf/CMakeLists.txt
+++ b/contrib/gdk-pixbuf/CMakeLists.txt
@@ -18,6 +18,7 @@ if(AVIF_BUILD_GDK_PIXBUF)
                 add_definitions(-Wno-cast-qual)
             endif()
             target_link_libraries(pixbufloader-avif PUBLIC ${GDK_PIXBUF_LIBRARIES} avif)
+            target_link_directories(pixbufloader-avif PUBLIC ${GDK_PIXBUF_LIBRARY_DIRS})
             target_include_directories(pixbufloader-avif PUBLIC ${GDK_PIXBUF_INCLUDE_DIRS})
 
             pkg_get_variable(GDK_PIXBUF_MODULEDIR gdk-pixbuf-2.0 gdk_pixbuf_moduledir)


### PR DESCRIPTION
gdk-pixbuf isn't tested on CI yet but Arch, Fedora (separate), FreeBSD, Gentoo (USE), MSYS2 already expose it downstream. This PR only covers FreeBSD as I'm not familar with other systems.