### PR TITLE
Make AVIF_ENABLE_WERROR enable -Werror or /WX only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(LIBRARY_SOVERSION ${LIBRARY_VERSION_MAJOR})
 
 option(BUILD_SHARED_LIBS "Build shared avif library" ON)
 
-option(AVIF_ENABLE_WERROR "Enable all C compiler warnings and fail the build if any warning is emitted" ON)
+option(AVIF_ENABLE_WERROR "Treat all compiler warnings as errors" ON)
 
 option(AVIF_CODEC_AOM "Use the AOM codec for encoding (and decoding if no other decoder is present)" OFF)
 option(AVIF_CODEC_DAV1D "Use the dav1d codec for decoding (overrides AOM decoding if also enabled)" OFF)
@@ -81,51 +81,58 @@ endif()
 # ---------------------------------------------------------------------------------------
 
 # Enable all warnings
-if(AVIF_ENABLE_WERROR)
-    include(CheckCCompilerFlag)
-    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-        MESSAGE(STATUS "libavif: Enabling warnings for Clang")
-        add_definitions(
-          -Weverything
-          -Werror
-          -Wno-bad-function-cast
-          -Wno-cast-align
-          -Wno-conversion
-          -Wno-covered-switch-default
-          -Wno-disabled-macro-expansion
-          -Wno-documentation
-          -Wno-documentation-unknown-command
-          -Wno-double-promotion
-          -Wno-float-equal
-          -Wno-missing-noreturn
-          -Wno-padded
-          -Wno-sign-conversion
-          -Wno-error=c11-extensions
-        )
+include(CheckCCompilerFlag)
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    MESSAGE(STATUS "libavif: Enabling warnings for Clang")
+    add_definitions(
+        -Weverything
+        -Wno-bad-function-cast
+        -Wno-cast-align
+        -Wno-conversion
+        -Wno-covered-switch-default
+        -Wno-disabled-macro-expansion
+        -Wno-documentation
+        -Wno-documentation-unknown-command
+        -Wno-double-promotion
+        -Wno-float-equal
+        -Wno-missing-noreturn
+        -Wno-padded
+        -Wno-sign-conversion
+        -Wno-error=c11-extensions
+    )
     # The detection of cross compilation by -Wpoison-system-directories has false positives on macOS because
     # --sysroot is implicitly added. Turn the warning off.
     check_c_compiler_flag(-Wpoison-system-directories HAVE_POISON_SYSTEM_DIRECTORIES_WARNING)
     if(HAVE_POISON_SYSTEM_DIRECTORIES_WARNING)
         add_definitions(-Wno-poison-system-directories)
     endif()
-    elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
-        MESSAGE(STATUS "libavif: Enabling warnings for GCC")
-        add_definitions(-Werror -Wall -Wextra)
+elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
+    MESSAGE(STATUS "libavif: Enabling warnings for GCC")
+    add_definitions(-Wall -Wextra)
+elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+    MESSAGE(STATUS "libavif: Enabling warnings for MS CL")
+    add_definitions(
+        /Wall   # All warnings
+        /wd4255 # Disable: no function prototype given
+        /wd4324 # Disable: structure was padded due to alignment specifier
+        /wd4668 # Disable: is not defined as a preprocessor macro, replacing with '0'
+        /wd4710 # Disable: function not inlined
+        /wd4711 # Disable: function selected for inline expansion
+        /wd4738 # Disable: storing 32-bit float result in memory, possible loss of performance
+        /wd4820 # Disable: bytes padding added after data member
+        /wd4996 # Disable: potentially unsafe stdlib methods
+        /wd5045 # Disable: Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+    )
+else()
+    MESSAGE(FATAL_ERROR "libavif: Unknown compiler, bailing out")
+endif()
+
+if(AVIF_ENABLE_WERROR)
+    # Warnings as errors
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
+        add_definitions(-Werror)
     elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
-        MESSAGE(STATUS "libavif: Enabling warnings for MS CL")
-        add_definitions(
-          /Wall   # All warnings
-          /WX     # Warnings as errors
-          /wd4255 # Disable: no function prototype given
-          /wd4324 # Disable: structure was padded due to alignment specifier
-          /wd4668 # Disable: is not defined as a preprocessor macro, replacing with '0'
-          /wd4710 # Disable: function not inlined
-          /wd4711 # Disable: function selected for inline expansion
-          /wd4738 # Disable: storing 32-bit float result in memory, possible loss of performance
-          /wd4820 # Disable: bytes padding added after data member
-          /wd4996 # Disable: potentially unsafe stdlib methods
-          /wd5045 # Disable: Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
-        )
+        add_definitions(/WX)
     else()
         MESSAGE(FATAL_ERROR "libavif: Unknown compiler, bailing out")
     endif()


### PR DESCRIPTION
Always enable compiler warnings. Change AVIF_ENABLE_WERROR to enable
-Werror or /WX only (whether or not to treat compiler warnings as
errors).