### PR TITLE
Make avifCodecSpecificOptionsGet a const function

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -134,7 +134,7 @@ AVIF_ARRAY_DECLARE(avifCodecSpecificOptions, avifCodecSpecificOption, entries);
 avifCodecSpecificOptions * avifCodecSpecificOptionsCreate(void);
 void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions);
 void avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const char * key, const char * value); // if(value==NULL), key is deleted
-avifCodecSpecificOption * avifCodecSpecificOptionsGet(avifCodecSpecificOptions * csOptions, const char * key); // Returns NULL if not found
+const avifCodecSpecificOption * avifCodecSpecificOptionsGet(const avifCodecSpecificOptions * csOptions, const char * key); // Returns NULL if not found
 
 // ---------------------------------------------------------------------------
 // avifCodec (abstraction layer to use different AV1 implementations)

--- a/src/avif.c
+++ b/src/avif.c
@@ -438,10 +438,10 @@ void avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const cha
     entry->value = avifStrdup(value);
 }
 
-avifCodecSpecificOption * avifCodecSpecificOptionsGet(avifCodecSpecificOptions * csOptions, const char * key)
+const avifCodecSpecificOption * avifCodecSpecificOptionsGet(const avifCodecSpecificOptions * csOptions, const char * key)
 {
     for (uint32_t i = 0; i < csOptions->count; ++i) {
-        avifCodecSpecificOption * entry = &csOptions->entries[i];
+        const avifCodecSpecificOption * entry = &csOptions->entries[i];
         if (!strcmp(entry->key, key)) {
             return entry;
         }


### PR DESCRIPTION
Originally the avifCodecSpecificValue struct had a boolean "used" field
and a codec needed to mark the codec-specific values it supported as
used. Therefore avifCodecSpecificValueArrayGet() had to return a
non-const avifCodecSpecificValue pointer. The "unsed" field has been
removed from the avifCodecSpecificOption struct. Therefore
avifCodecSpecificOptionsGet can return a const avifCodecSpecificOption
pointer.