### PR TITLE
Remove the avifCodecSpecificOptionsGet() function

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -134,7 +134,6 @@ AVIF_ARRAY_DECLARE(avifCodecSpecificOptions, avifCodecSpecificOption, entries);
 avifCodecSpecificOptions * avifCodecSpecificOptionsCreate(void);
 void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions);
 void avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const char * key, const char * value); // if(value==NULL), key is deleted
-const avifCodecSpecificOption * avifCodecSpecificOptionsGet(const avifCodecSpecificOptions * csOptions, const char * key); // Returns NULL if not found
 
 // ---------------------------------------------------------------------------
 // avifCodec (abstraction layer to use different AV1 implementations)

--- a/src/avif.c
+++ b/src/avif.c
@@ -438,17 +438,6 @@ void avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const cha
     entry->value = avifStrdup(value);
 }
 
-const avifCodecSpecificOption * avifCodecSpecificOptionsGet(const avifCodecSpecificOptions * csOptions, const char * key)
-{
-    for (uint32_t i = 0; i < csOptions->count; ++i) {
-        const avifCodecSpecificOption * entry = &csOptions->entries[i];
-        if (!strcmp(entry->key, key)) {
-            return entry;
-        }
-    }
-    return NULL;
-}
-
 // ---------------------------------------------------------------------------
 // Codec availability and versions
 


### PR DESCRIPTION
The avifCodecSpecificOptionsGet() function is not used, and the
codec_xxx.c files can just iterate over the csOptions array directly.