### PR TITLE
Add man pages for command-line tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,23 @@ dist: bionic
 addons:
   apt:
     packages:
+      - docbook-xml
+      - docbook-xsl
+      - libxml2-utils
       - ninja-build
       - python3
       - python3-pip
+      - xsltproc
 
 before_script:
   - curl -L https://download.videolan.org/contrib/nasm/nasm-2.14.tar.gz | tar xvz
   - cd nasm-2.14
   - ./configure && make -j2 && sudo make install
   - nasm --version
+  - curl -L https://github.com/asciidoc/asciidoc-py3/releases/download/9.0.4/asciidoc-9.0.4.tar.gz | tar xvz
+  - cd asciidoc-9.0.4
+  - ./configure && sudo make install
+  - a2x --version
   - pip3 --disable-pip-version-check install setuptools
   - pip3 --disable-pip-version-check install meson
   - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -30,7 +38,7 @@ before_script:
   - mkdir build
   - cd build
 script:
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=$config -DBUILD_SHARED_LIBS=OFF -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=ON -DAVIF_CODEC_LIBGAV1=ON -DAVIF_LOCAL_LIBGAV1=ON -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON -DAVIF_LOCAL_LIBYUV=ON -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON -DAVIF_BUILD_TESTS=ON ..
+  - cmake -G Ninja -DCMAKE_BUILD_TYPE=$config -DBUILD_SHARED_LIBS=OFF -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=ON -DAVIF_CODEC_LIBGAV1=ON -DAVIF_LOCAL_LIBGAV1=ON -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON -DAVIF_LOCAL_LIBYUV=ON -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON -DAVIF_BUILD_MAN=ON -DAVIF_BUILD_TESTS=ON ..
   - ninja
 
 matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,3 +590,4 @@ if(WIN32)
 endif()
 
 add_subdirectory(contrib)
+add_subdirectory(docs)

--- a/LICENSE
+++ b/LICENSE
@@ -168,3 +168,32 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+
+Files: docs/CMakeLists.txt
+       docs/man/man1/*
+       docs/man/man1/include/*.adoc
+
+Copyright 2020 Shun Sakai. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright 2020 Shun Sakai. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+if(UNIX OR NOT MSVC)
+    add_subdirectory(man/man1)
+endif()

--- a/docs/man/man1/CMakeLists.txt
+++ b/docs/man/man1/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright 2020 Shun Sakai. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+option(AVIF_BUILD_MAN "Build man page" OFF)
+if(AVIF_BUILD_MAN)
+    find_program(ASCIIDOCTOR_EXE asciidoctor)
+    find_program(A2X_EXE a2x)
+    if(NOT (ASCIIDOCTOR_EXE OR A2X_EXE))
+        message(FATAL_ERROR "man page: asciidoctor or a2x is required to build")
+    endif()
+
+    set(MAN_PAGES avifenc.1 avifdec.1)
+
+    set(ASCIIDOC_ATTRIBUTES -a manversion=${PROJECT_VERSION})
+    # For codec option
+    if(AVIF_CODEC_AOM)
+        # This is also for the AOM-Specific Advanced options
+        list(APPEND ASCIIDOC_ATTRIBUTES -a available-aom)
+    endif()
+    if(AVIF_CODEC_DAV1D)
+        list(APPEND ASCIIDOC_ATTRIBUTES -a available-dav1d)
+    endif()
+    if(AVIF_CODEC_LIBGAV1)
+        list(APPEND ASCIIDOC_ATTRIBUTES -a available-libgav1)
+    endif()
+    if(AVIF_CODEC_RAV1E)
+        list(APPEND ASCIIDOC_ATTRIBUTES -a available-rav1e)
+    endif()
+    if(AVIF_CODEC_SVT)
+        list(APPEND ASCIIDOC_ATTRIBUTES -a available-svt)
+    endif()
+
+    if(ASCIIDOCTOR_EXE)
+        message(STATUS "using asciidoctor: ${ASCIIDOCTOR_EXE}")
+
+        foreach(MAN_PAGE IN LISTS MAN_PAGES)
+            add_custom_command(OUTPUT ${MAN_PAGE}
+                COMMAND ${ASCIIDOCTOR_EXE} -D "${CMAKE_CURRENT_BINARY_DIR}" -b manpage ${ASCIIDOC_ATTRIBUTES} "${CMAKE_CURRENT_SOURCE_DIR}/${MAN_PAGE}.adoc"
+                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${MAN_PAGE}.adoc"
+                VERBATIM)
+        endforeach()
+    else()
+        message(STATUS "using a2x: ${A2X_EXE}")
+
+        foreach(MAN_PAGE IN LISTS MAN_PAGES)
+            add_custom_command(OUTPUT ${MAN_PAGE}
+                COMMAND ${A2X_EXE} -D "${CMAKE_CURRENT_BINARY_DIR}" -f manpage ${ASCIIDOC_ATTRIBUTES} "${CMAKE_CURRENT_SOURCE_DIR}/${MAN_PAGE}.adoc"
+                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${MAN_PAGE}.adoc"
+                VERBATIM)
+        endforeach()
+    endif()
+    add_custom_target(man ALL DEPENDS ${MAN_PAGES})
+
+    foreach(MAN_PAGE IN LISTS MAN_PAGES)
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${MAN_PAGE}"
+            DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
+    endforeach()
+endif()

--- a/docs/man/man1/avifdec.1.adoc
+++ b/docs/man/man1/avifdec.1.adoc
@@ -1,0 +1,92 @@
+// Copyright 2020 Shun Sakai. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+= avifdec(1)
+:docdate: 2020-11-07
+ifndef::asciidoctor[]
+:revdate: {docdate}
+endif::[]
+:doctype: manpage
+ifdef::asciidoctor[]
+:mansource: libavif {manversion}
+endif::[]
+ifndef::asciidoctor[]
+:mansource: libavif
+endif::[]
+:manmanual: General Commands Manual
+
+== NAME
+avifdec - decompress an AVIF file to an image file
+
+== SYNOPSIS
+ifdef::asciidoctor[]
+[%hardbreaks]
+endif::[]
+ifndef::asciidoctor[]
+[verse]
+endif::[]
+*{manname}* [_OPTION_...] _INPUT-FILE.avif_ _OUTPUT-FILE_
+*{manname} --info* _INPUT-FILE.avif_
+
+== DESCRIPTION
+*{manname}* decompress an AV1 Image File Format (AVIF) file to an image file.
+Output format can be either JPEG, PNG or YUV4MPEG2.
+
+This is part of the libavif, the reference implementation for AVIF.
+
+== OPTIONS
+*-h*, *--help*::
+  Show help information.
+
+*-V*, *--version*::
+  Show the version number of both libavif and available AV1 codecs.
+
+*-c*, *--codec* _C_::
+  Specify the AV1 codec to use.
+  Choose _C_ from codecs list below.
+ifdef::available-aom[]
+  - *aom*
+endif::[]
+ifdef::available-dav1d[]
+  - *dav1d*
+endif::[]
+ifdef::available-libgav1[]
+  - *libgav1*
+endif::[]
+
+*-d*, *--depth* _D_::
+  Specify the output depth.
+  _D_ are either *8* or *16*.
+  This option is only available when the output format is PNG.
+
+*-q*, *--quality* _Q_::
+  Specify the output quality between *0* and *100*.
+  This option is only available when the output format is JPEG.
+  (default: *90*)
+
+*-u*, *--upsampling* _U_::
+  Specify the chroma upsampling for 420/422.
+  _U_ are either *automatic*, *fastest*, *best*, *nearest* or *bilinear*.
+  (default: *automatic*)
+
+*-i*, *--info*::
+  Decode all frames and display all image information instead of saving to disk.
+
+*--ignore-icc*::
+  If the input file contains an embedded ICC profile, ignore it.
+
+include::include/section-notes.adoc[]
+
+== EXAMPLES
+Decompress an AVIF file to a PNG file::
+  $ *{manname} input.avif output.png*
+
+Decompress to a JPEG file with the specified output quality::
+  $ *{manname} -q 50 input.avif output.jpg*
+
+include::include/section-reporting-bugs.adoc[]
+
+include::include/section-copyright.adoc[]
+
+== SEE ALSO
+*avifenc*(1)

--- a/docs/man/man1/avifenc.1.adoc
+++ b/docs/man/man1/avifenc.1.adoc
@@ -1,0 +1,217 @@
+// Copyright 2020 Shun Sakai. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+= avifenc(1)
+:docdate: 2020-11-07
+ifndef::asciidoctor[]
+:revdate: {docdate}
+endif::[]
+:doctype: manpage
+ifdef::asciidoctor[]
+:mansource: libavif {manversion}
+endif::[]
+ifndef::asciidoctor[]
+:mansource: libavif
+endif::[]
+:manmanual: General Commands Manual
+
+== NAME
+avifenc - compress an image file to an AVIF file
+
+== SYNOPSIS
+*{manname}* [_OPTION_...] _INPUT-FILE_ _OUTPUT-FILE.avif_
+
+== DESCRIPTION
+*{manname}* compress an image file to an AV1 Image File Format (AVIF) file.
+Input format can be either JPEG, PNG or YUV4MPEG2.
+
+This is part of the libavif, the reference implementation for AVIF.
+
+== OPTIONS
+*-h*, *--help*::
+  Show help information.
+
+*-V*, *--version*::
+  Show the version number of both libavif and available AV1 codecs.
+
+*-j*, *--jobs* _J_::
+  Specify the number of worker threads to use.
+  (default: *1*)
+
+*-o*, *--output* _FILENAME_::
+  Specify the name of the output AVIF file.
+
+*-l*, *--lossless*::
+  Set all defaults to encode losslessly, and emit warnings when settings/input do not allow for it.
+
+*-d*, *--depth* _D_::
+  Specify the output depth.
+  _D_ are either *8*, *10* or *12*.
+  This option is only available when the output format is JPEG or PNG.
+
+*-y*, *--yuv* _FORMAT_::
+  Specify the output format.
+  _FORMAT_ are either *444*, *422*, *420* or *400*.
+  This option is only available when the output format is JPEG or PNG.
+  (default: *444*)
+
+*--stdin*::
+  Read y4m frames from standard input instead of files.
+  No input filenames allowed, must set before offering output filename.
+
+*--cicp*, *--nclx* _P_/_T_/_M_::
+  Set CICP values.
+  Use *-r* to set range flag, and use *2* for any you wish to leave unspecified.
+  - _P_ = *enum avifColorPrimaries*
+  - _T_ = *enum avifTransferCharacteristics*
+  - _M_ = *enum avifMatrixCoefficients*
+
+*-r*, *--range* _RANGE_::
+  Specify the YUV range.
+  _RANGE_ are either *limited*/*l* or *full*/*f*.
+  This option is only available when the output format is JPEG or PNG.
+  (default: *full*)
+
+*--min* _Q_::
+  Set minimum quantizer for color.
+  _Q_ are between *0* and *63*, where *0* is lossless.
+
+*--max* _Q_::
+  Set maximum quantizer for color.
+  _Q_ are between *0* and *63*, where *0* is lossless.
+
+*--minalpha* _Q_::
+  Set minimum quantizer for alpha.
+  _Q_ are between *0* and *63*, where *0* is lossless.
+
+*--maxalpha* _Q_::
+  Set maximum quantizer for alpha.
+  _Q_ are between *0* and *63*, where *0* is lossless.
+
+*--tilerowslog2* _R_::
+  Set log2 of number of tile rows.
+  _R_ are between *0* and *6*.
+  (default: *0*)
+
+*--tilecolslog2* _C_::
+  Set log2 of number of tile columns.
+  _C_ are between *0* and *6*.
+  (default: *0*)
+
+*-s*, *--speed* _S_::
+  Specify the encoder speed.
+  _S_ are between *0* (slowest) and *10* (fastest), and *default*/*d* for codec internal defaults.
+  (default: *8*)
+
+*-c*, *--codec* _C_::
+  Specify the AV1 codec to use.
+  Choose _C_ from codecs list below.
+ifdef::available-aom[]
+  - *aom*
+endif::[]
+ifdef::available-rav1e[]
+  - *rav1e*
+endif::[]
+ifdef::available-svt[]
+  - *svt*
+endif::[]
+
+*--exif* _FILENAME_::
+  Provide an Exif metadata payload to be associated with the primary item.
+
+*--xmp* _FILENAME_::
+  Provide an XMP metadata payload to be associated with the primary item.
+
+*--icc* _FILENAME_::
+  Provide an ICC profile payload to be associated with the primary item.
+
+*-a*, *--advanced* _KEY_[_=VALUE_]::
+  Pass an advanced, codec-specific key/value string pair directly to the codec.
+  *{manname}* will warn on any not used by the codec.
+
+*--duration* _D_::
+  Set all following frame durations in timescales.
+  Can be set multiple times before supplying each filename.
+  (default: *1*)
+
+*--timescale*, *--fps* _V_::
+  Set the timescale.
+  If all frames are 1 timescale in length, this is equivalent to frames per second.
+
+*-k*, *--keyframe* _INTERVAL_::
+  Set the forced keyframe interval (maximum frames between keyframes).
+  Set to *0* to disable.
+  (default: *0*)
+
+*--ignore-icc*::
+  If the input file contains an embedded ICC profile, ignore it.
+
+*--pasp* _H_,_V_::
+  Add pasp property (aspect ratio).
+  _H_ is horizontal spacing and _V_ is vertical spacing.
+
+*--clap* _WN_,_WD_,_HN_,_HD_,_HON_,_HOD_,_VON_,_VOD_::
+  Add clap property (clean aperture).
+  - _WN_ = Width in num
+  - _WD_ = Width in denom
+  - _HN_ = Height in num
+  - _HD_ = Height in denom
+  - _HON_ = HOffset in num
+  - _HOD_ = HOffset in denom
+  - _VON_ = VOffset in num
+  - _VOD_ = VOffset in denom
+
+*--irot* _ANGLE_::
+  Add irot property (rotation).
+  _ANGLE_ are between *0* and *3*, and makes (90 * _ANGLE_) degree rotation anti-clockwise.
+
+*--imir* _AXIS_::
+  Add imir property (mirroring).
+  _AXIS_ are either *0* (vertical) or *1* (horizontal).
+
+ifdef::available-aom[]
+=== AOM-Specific Advanced options
+*aq-mode*=_M_::
+  Adaptive quantization mode.
+  _M_ are either *0* (off), *1* (variance), *2* (complexity) or *3* (cyclic refresh).
+  (default: *0*)
+
+*cq-level*=_Q_::
+  Constant/Constrained Quality level.
+  _Q_ are between *0* and *63*, and *end-usage* must be set to *cq* or *q*.
+
+*enable-chroma-deltaq*=_B_::
+  Enable delta quantization in chroma planes.
+  _B_ are either *0* (disable) or *1* (enable).
+  (default: *0*)
+
+*end-usage*=_MODE_::
+  Rate control mode.
+  _MODE_ are either *vbr*, *cbr*, *cq* or *q*.
+
+*sharpness*=_S_::
+  Loop filter sharpness.
+  _S_ are between *0* and *7*.
+  (default: *0*)
+
+*tune*=_METRIC_::
+  Tune the encoder for distortion metric.
+  _METRIC_ are either *psnr* or *ssim*.
+  (default: *psnr*)
+endif::[]
+
+include::include/section-notes.adoc[]
+
+== EXAMPLES
+Compress a PNG file to an AVIF file::
+  $ *{manname} input.png output.avif*
+
+Compress to an AVIF file without any loss::
+  $ *{manname} -l input.png output.avif*
+
+include::include/section-reporting-bugs.adoc[]
+
+include::include/section-copyright.adoc[]
+
+== SEE ALSO
+*avifdec*(1)

--- a/docs/man/man1/include/section-copyright.adoc
+++ b/docs/man/man1/include/section-copyright.adoc
@@ -1,0 +1,7 @@
+// Copyright 2020 Shun Sakai. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+== COPYRIGHT
+Copyright 2019 Joe Drago. All rights reserved.
+
+This program is released under the BSD 2-Clause "Simplified" License.

--- a/docs/man/man1/include/section-notes.adoc
+++ b/docs/man/man1/include/section-notes.adoc
@@ -1,0 +1,9 @@
+// Copyright 2020 Shun Sakai. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+== NOTES
+*AVIF specification*::
+  https://aomediacodec.github.io/av1-avif/
+
+*Git repository*::
+  https://github.com/AOMediaCodec/libavif.git

--- a/docs/man/man1/include/section-reporting-bugs.adoc
+++ b/docs/man/man1/include/section-reporting-bugs.adoc
@@ -1,0 +1,5 @@
+// Copyright 2020 Shun Sakai. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+== REPORTING BUGS
+Bugs and feature requests can be reported at https://github.com/AOMediaCodec/libavif/issues.


### PR DESCRIPTION
Add man pages for command-line tools (`avifenc` and `avifdec`). It is written in AsciiDoc, so it is required [Asciidoctor](https://asciidoctor.org/) or [AsciiDoc](https://asciidoc.org/) as dependencies at build-time on Unix-like systems.