### PR TITLE
Remove the colorRange field from avifCodecInternal

### DIFF
--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -28,7 +28,6 @@ struct avifCodecInternal
     Dav1dContext * dav1dContext;
     Dav1dPicture dav1dPicture;
     avifBool hasPicture;
-    avifRange colorRange;
     Dav1dData dav1dData;
     uint32_t inputSampleIndex;
 };
@@ -115,7 +114,6 @@ static avifBool dav1dCodecGetNextImage(avifCodec * codec, avifImage * image)
     if (gotPicture) {
         dav1d_picture_unref(&codec->internal->dav1dPicture);
         codec->internal->dav1dPicture = nextFrame;
-        codec->internal->colorRange = codec->internal->dav1dPicture.seq_hdr->color_range ? AVIF_RANGE_FULL : AVIF_RANGE_LIMITED;
         codec->internal->hasPicture = AVIF_TRUE;
     } else {
         if (codec->decodeInput->alpha && codec->internal->hasPicture) {
@@ -158,7 +156,7 @@ static avifBool dav1dCodecGetNextImage(avifCodec * codec, avifImage * image)
         image->depth = dav1dImage->p.bpc;
 
         image->yuvFormat = yuvFormat;
-        image->yuvRange = codec->internal->colorRange;
+        image->yuvRange = (avifRange)dav1dImage->seq_hdr->color_range;
 
         image->colorPrimaries = (avifColorPrimaries)dav1dImage->seq_hdr->pri;
         image->transferCharacteristics = (avifTransferCharacteristics)dav1dImage->seq_hdr->trc;
@@ -191,7 +189,7 @@ static avifBool dav1dCodecGetNextImage(avifCodec * codec, avifImage * image)
         avifImageFreePlanes(image, AVIF_PLANES_A);
         image->alphaPlane = dav1dImage->data[0];
         image->alphaRowBytes = (uint32_t)dav1dImage->stride[0];
-        image->alphaRange = codec->internal->colorRange;
+        image->alphaRange = (avifRange)dav1dImage->seq_hdr->color_range;
         image->imageOwnsAlphaPlane = AVIF_FALSE;
     }
     return AVIF_TRUE;

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -12,7 +12,6 @@ struct avifCodecInternal
     Libgav1DecoderSettings gav1Settings;
     Libgav1Decoder * gav1Decoder;
     const Libgav1DecoderBuffer * gav1Image;
-    avifRange colorRange;
     uint32_t inputSampleIndex;
 };
 
@@ -63,7 +62,6 @@ static avifBool gav1CodecGetNextImage(avifCodec * codec, avifImage * image)
 
     if (nextFrame) {
         codec->internal->gav1Image = nextFrame;
-        codec->internal->colorRange = (nextFrame->color_range == kLibgav1ColorRangeStudio) ? AVIF_RANGE_LIMITED : AVIF_RANGE_FULL;
     } else {
         if (codec->decodeInput->alpha && codec->internal->gav1Image) {
             // Special case: reuse last alpha frame
@@ -106,7 +104,7 @@ static avifBool gav1CodecGetNextImage(avifCodec * codec, avifImage * image)
         image->depth = gav1Image->bitdepth;
 
         image->yuvFormat = yuvFormat;
-        image->yuvRange = codec->internal->colorRange;
+        image->yuvRange = (avifRange)gav1Image->color_range;
 
         image->colorPrimaries = (avifColorPrimaries)gav1Image->color_primary;
         image->transferCharacteristics = (avifTransferCharacteristics)gav1Image->transfer_characteristics;
@@ -140,7 +138,7 @@ static avifBool gav1CodecGetNextImage(avifCodec * codec, avifImage * image)
         avifImageFreePlanes(image, AVIF_PLANES_A);
         image->alphaPlane = gav1Image->plane[0];
         image->alphaRowBytes = gav1Image->stride[0];
-        image->alphaRange = codec->internal->colorRange;
+        image->alphaRange = (avifRange)gav1Image->color_range;
         image->imageOwnsAlphaPlane = AVIF_FALSE;
     }
 


### PR DESCRIPTION
Remove the colorRange field from the avifCodecInternal struct. Now that
AVIF_RANGE_FULL is defined as 1 rather than 0x80, we can just cast the
color_range field in the codec's image struct to the avifRange enum type
directly. It is not necessary to convert with the ternary ? : operator
and cache the conversion result in the avifCodecInternal struct.