### PR TITLE
Convert color range by using casts instead of ? :

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -144,7 +144,7 @@ static avifBool aomCodecGetNextImage(avifCodec * codec, avifImage * image)
         image->depth = codec->internal->image->bit_depth;
 
         image->yuvFormat = yuvFormat;
-        image->yuvRange = (codec->internal->image->range == AOM_CR_STUDIO_RANGE) ? AVIF_RANGE_LIMITED : AVIF_RANGE_FULL;
+        image->yuvRange = (avifRange)codec->internal->image->range;
 
         image->colorPrimaries = (avifColorPrimaries)codec->internal->image->cp;
         image->transferCharacteristics = (avifTransferCharacteristics)codec->internal->image->tc;
@@ -178,7 +178,7 @@ static avifBool aomCodecGetNextImage(avifCodec * codec, avifImage * image)
         avifImageFreePlanes(image, AVIF_PLANES_A);
         image->alphaPlane = codec->internal->image->planes[0];
         image->alphaRowBytes = codec->internal->image->stride[0];
-        image->alphaRange = (codec->internal->image->range == AOM_CR_STUDIO_RANGE) ? AVIF_RANGE_LIMITED : AVIF_RANGE_FULL;
+        image->alphaRange = (avifRange)codec->internal->image->range;
         image->imageOwnsAlphaPlane = AVIF_FALSE;
     }
 
@@ -372,7 +372,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
     avifBool monochromeRequested = AVIF_FALSE;
 
     if (alpha) {
-        aomImage->range = (image->alphaRange == AVIF_RANGE_FULL) ? AOM_CR_FULL_RANGE : AOM_CR_STUDIO_RANGE;
+        aomImage->range = (aom_color_range_t)image->alphaRange;
         aom_codec_control(&codec->internal->encoder, AV1E_SET_COLOR_RANGE, aomImage->range);
         monochromeRequested = AVIF_TRUE;
         for (uint32_t j = 0; j < image->height; ++j) {
@@ -383,7 +383,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
 
         // Ignore UV planes when monochrome
     } else {
-        aomImage->range = (image->yuvRange == AVIF_RANGE_FULL) ? AOM_CR_FULL_RANGE : AOM_CR_STUDIO_RANGE;
+        aomImage->range = (aom_color_range_t)image->yuvRange;
         aom_codec_control(&codec->internal->encoder, AV1E_SET_COLOR_RANGE, aomImage->range);
         int yuvPlaneCount = 3;
         if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -76,11 +76,11 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
         const avifBool supports400 = rav1eSupports400();
         RaPixelRange rav1eRange;
         if (alpha) {
-            rav1eRange = (image->alphaRange == AVIF_RANGE_FULL) ? RA_PIXEL_RANGE_FULL : RA_PIXEL_RANGE_LIMITED;
+            rav1eRange = (RaPixelRange)image->alphaRange;
             codec->internal->chromaSampling = supports400 ? RA_CHROMA_SAMPLING_CS400 : RA_CHROMA_SAMPLING_CS420;
             codec->internal->yShift = 1;
         } else {
-            rav1eRange = (image->yuvRange == AVIF_RANGE_FULL) ? RA_PIXEL_RANGE_FULL : RA_PIXEL_RANGE_LIMITED;
+            rav1eRange = (RaPixelRange)image->yuvRange;
             codec->internal->yShift = 0;
             switch (image->yuvFormat) {
                 case AVIF_PIXEL_FORMAT_YUV444:


### PR DESCRIPTION
Now that AVIF_RANGE_FULL is defined as 1 instead of 0x80, we can convert
avifRange to/from the codec's color range type by using casts instead of
the ternary ? : operator.