### PR TITLE
Add four more aom-specific options

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -94,6 +94,10 @@ static void syntax(void)
     printf("\n");
     if (avifCodecName(AVIF_CODEC_CHOICE_AOM, 0)) {
         printf("aom-specific advanced options:\n");
+        printf("    aq-mode=M                         : Adaptive quantization mode (0: off (default), 1: variance, 2: complexity, 3: cyclic refresh)\n");
+        printf("    cq-level=Q                        : Constant/Constrained Quality level (0-63, end-usage must be set to cq or q)\n");
+        printf("    end-usage=MODE                    : Rate control mode (vbr, cbr, cq, or q)\n");
+        printf("    sharpness=S                       : Loop filter sharpness (0-7, default: 0)\n");
         printf("    tune=METRIC                       : Tune the encoder for distortion metric (psnr or ssim, default: psnr)\n");
         printf("\n");
     }

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -25,6 +25,8 @@
 #pragma clang diagnostic ignored "-Wassign-enum"
 #endif
 
+#include <limits.h>
+#include <stdlib.h>
 #include <string.h>
 
 struct avifCodecInternal
@@ -219,22 +221,127 @@ static aom_img_fmt_t avifImageCalcAOMFmt(const avifImage * image, avifBool alpha
     return fmt;
 }
 
-static avifBool avifProcessAOMSpecificOptions(avifCodec * codec)
+static avifBool aomOptionParseInt(const char * str, int * val)
+{
+    char * endptr;
+    const long rawval = strtol(str, &endptr, 10);
+
+    if (str[0] != '\0' && endptr[0] == '\0' && rawval >= INT_MIN && rawval <= INT_MAX) {
+        *val = (int)rawval;
+        return AVIF_TRUE;
+    }
+
+    return AVIF_FALSE;
+}
+
+struct aomOptionEnumList
+{
+    const char * name;
+    int val;
+};
+
+static avifBool aomOptionParseEnum(const char * str, const struct aomOptionEnumList * enums, int * val)
+{
+    const struct aomOptionEnumList * listptr;
+    long int rawval;
+    char * endptr;
+
+    // First see if the value can be parsed as a raw value.
+    rawval = strtol(str, &endptr, 10);
+    if (str[0] != '\0' && endptr[0] == '\0') {
+        // Got a raw value, make sure it's valid.
+        for (listptr = enums; listptr->name; listptr++)
+            if (listptr->val == rawval) {
+                *val = (int)rawval;
+                return AVIF_TRUE;
+            }
+    }
+
+    // Next see if it can be parsed as a string.
+    for (listptr = enums; listptr->name; listptr++) {
+        if (!strcmp(str, listptr->name)) {
+            *val = listptr->val;
+            return AVIF_TRUE;
+        }
+    }
+
+    return AVIF_FALSE;
+}
+
+static const struct aomOptionEnumList endUsageEnum[] = { //
+    { "vbr", AOM_VBR },                                  // Variable Bit Rate (VBR) mode
+    { "cbr", AOM_CBR },                                  // Constant Bit Rate (CBR) mode
+    { "cq", AOM_CQ },                                    // Constrained Quality (CQ)  mode
+    { "q", AOM_Q },                                      // Constrained Quality (CQ)  mode
+    { NULL, 0 }
+};
+
+static avifBool avifProcessAOMOptionsPreInit(avifCodec * codec, struct aom_codec_enc_cfg * cfg)
 {
     for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
         avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
-        if (!strcmp(entry->key, "tune")) {
-            // Tune distortion metric.
-            int tuneMetric = -1;
-            if (!strcmp(entry->value, "psnr")) {
-                tuneMetric = AOM_TUNE_PSNR;
-            } else if (!strcmp(entry->value, "ssim")) {
-                tuneMetric = AOM_TUNE_SSIM;
-            } else {
+        int val;
+        if (!strcmp(entry->key, "end-usage")) { // Rate control mode
+            if (!aomOptionParseEnum(entry->value, endUsageEnum, &val)) {
                 return AVIF_FALSE;
             }
-            aom_codec_control(&codec->internal->encoder, AOME_SET_TUNING, tuneMetric);
-        } else {
+            cfg->rc_end_usage = val;
+        }
+    }
+    return AVIF_TRUE;
+}
+
+struct aomOptionDef
+{
+    const char * name;
+    int controlId;
+    const struct aomOptionEnumList * enums;
+};
+
+static const struct aomOptionEnumList tuningEnum[] = { //
+    { "psnr", AOM_TUNE_PSNR },                         //
+    { "ssim", AOM_TUNE_SSIM },                         //
+    { NULL, 0 }
+};
+
+static const struct aomOptionDef aomOptionDefs[] = { //
+    { "aq-mode", AV1E_SET_AQ_MODE, NULL },           // Adaptive quantization mode
+    { "cq-level", AOME_SET_CQ_LEVEL, NULL },         // Constant/Constrained Quality level
+    { "sharpness", AOME_SET_SHARPNESS, NULL },       // Loop filter sharpness
+    { "tune", AOME_SET_TUNING, tuningEnum },         // Tune distortion metric
+    { NULL, 0, NULL }
+};
+
+static avifBool avifProcessAOMOptionsPostInit(avifCodec * codec)
+{
+    for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
+        avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
+        // Skip options processed by avifProcessAOMOptionsPreInit.
+        if (!strcmp(entry->key, "end-usage")) {
+            continue;
+        }
+
+        avifBool match = AVIF_FALSE;
+        for (int j = 0; aomOptionDefs[j].name; ++j) {
+            if (!strcmp(entry->key, aomOptionDefs[j].name)) {
+                match = AVIF_TRUE;
+                int val;
+                avifBool parsed;
+                if (aomOptionDefs[j].enums) {
+                    parsed = aomOptionParseEnum(entry->value, aomOptionDefs[j].enums, &val);
+                } else {
+                    parsed = aomOptionParseInt(entry->value, &val);
+                }
+                if (!parsed) {
+                    return AVIF_FALSE;
+                }
+                if (aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, val) != AOM_CODEC_OK) {
+                    return AVIF_FALSE;
+                }
+                break;
+            }
+        }
+        if (!match) {
             return AVIF_FALSE;
         }
     }
@@ -348,6 +455,10 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             }
         }
 
+        if (!avifProcessAOMOptionsPreInit(codec, &cfg)) {
+            return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
+        }
+
         aom_codec_flags_t encoderFlags = 0;
         if (image->depth > 8) {
             encoderFlags |= AOM_CODEC_USE_HIGHBITDEPTH;
@@ -372,7 +483,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
         if (aomCpuUsed != -1) {
             aom_codec_control(&codec->internal->encoder, AOME_SET_CPUUSED, aomCpuUsed);
         }
-        if (!avifProcessAOMSpecificOptions(codec)) {
+        if (!avifProcessAOMOptionsPostInit(codec)) {
             return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
         }
     }


### PR DESCRIPTION
Add the aom-specific options aq-mode, cq-level, end-usage, and
sharpness.

Adapt some of the command-line argument processing code in libaom for
use in src/codec_aom.c. Git history shows that the libaom code that I
adapted was all written by Google employees, originally by John Koleszar
in 2012. Here is a table of the libaom code that I adapted:
    libaom                           src/codec_aom.c
    =========================================================
    The "arg" prefix                 The "aomOption" prefix
    struct arg_enum_list             struct aomOptionEnumList
    end_usage_enum                   endUsageEnum
    tuning_enum                      tuningEnum
    struct arg_def                   struct aomOptionDef
    av1_args and av1_arg_ctrl_map    aomOptionDefs
    arg_parse_int()                  aomOptionParseInt()
    arg_parse_enum()                 aomOptionParseEnum()