### PR TITLE
Cleanup in avifPrepareReformatState()

### DIFF
--- a/src/colr.c
+++ b/src/colr.c
@@ -87,7 +87,7 @@ static const struct avifMatrixCoefficientsTable matrixCoefficientsTables[] = {
     { AVIF_MATRIX_COEFFICIENTS_SMPTE240, "SMPTE ST 240", 0.212f, 0.087f },
     { AVIF_MATRIX_COEFFICIENTS_BT2020_NCL, "BT.2020 (non-constant luminance)", 0.2627f, 0.0593f },
     //{ AVIF_MATRIX_COEFFICIENTS_BT2020_CL, "BT.2020 (constant luminance)", 0.2627f, 0.0593f }, // FIXME: It is not an linear transformation.
-    //{ AVIF_MATRIX_COEFFICIENTS_ST2085, "ST 2085", 0.0f, 0.0f }, // FIXME: ST2085 can't represent using Kr and Kb.
+    //{ AVIF_MATRIX_COEFFICIENTS_SMPTE2085, "ST 2085", 0.0f, 0.0f }, // FIXME: ST2085 can't represent using Kr and Kb.
     //{ AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL, "Chromaticity-derived constant luminance system", 0.0f, 0.0f } // FIXME: It is not an linear transformation.
     //{ AVIF_MATRIX_COEFFICIENTS_ICTCP, "BT.2100-0 ICtCp", 0.0f, 0.0f }, // FIXME: This can't represent using Kr and Kb.
 };

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -25,6 +25,7 @@ avifBool avifPrepareReformatState(const avifImage * image, const avifRGBImage * 
     // These matrix coefficients values are currently unsupported. Revise this list as more support is added.
     if ((image->matrixCoefficients == 3 /* CICP reserved */) || (image->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_YCGCO) ||
         (image->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_BT2020_CL) ||
+        (image->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_SMPTE2085) ||
         (image->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL) ||
         (image->matrixCoefficients >= AVIF_MATRIX_COEFFICIENTS_ICTCP)) { // Note the >= catching "future" CICP values here too
         return AVIF_FALSE;
@@ -101,15 +102,7 @@ avifBool avifPrepareReformatState(const avifImage * image, const avifRGBImage * 
     state->rgbMaxChannel = (1 << rgb->depth) - 1;
     state->yuvMaxChannelF = (float)state->yuvMaxChannel;
     state->rgbMaxChannelF = (float)state->rgbMaxChannel;
-    if (image->depth == 8) {
-        state->uvBias = 128;
-    } else if (image->depth == 10) {
-        state->uvBias = 512;
-    } else if (image->depth == 12) {
-        state->uvBias = 2048;
-    } else {
-        return AVIF_FALSE;
-    }
+    state->uvBias = 1 << (image->depth - 1);
 
     uint32_t cpCount = 1 << image->depth;
     for (uint32_t cp = 0; cp < cpCount; ++cp) {


### PR DESCRIPTION
Return AVIF_FALSE if image->matrixCoefficients is
AVIF_MATRIX_COEFFICIENTS_SMPTE2085. Calculate state->uvBias using the
formula 1 << (image->depth - 1).

Also update a comment in matrixCoefficientsTables to use the correct
enum name AVIF_MATRIX_COEFFICIENTS_SMPTE2085.