### PR TITLE
No need to negate alphaPass and item->alpha

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -975,7 +975,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             if ((item->metadataPayload.size == 0) && (item->encodeOutput->samples.count == 0)) {
                 continue;
             }
-            if (!alphaPass != !item->alpha) {
+            if (alphaPass != item->alpha) {
                 continue;
             }
 


### PR DESCRIPTION
alphaPass and item->alpha are of the avifBool type, so we can safely
assume they hold boolean values (0 or 1). It is not necessary to ensure
a boolean value by using the ! operator.