### PR TITLE
avifIO: Remove API functions that take FILE* arguments

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -6,7 +6,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -571,7 +570,6 @@ typedef struct avifIO
 
 avifIO * avifIOCreateMemoryReader(const uint8_t * data, size_t size);
 avifIO * avifIOCreateFileReader(const char * filename);
-avifIO * avifIOCreateFilePtrReader(FILE * f, avifBool closeOnDestroy);
 void avifIODestroy(avifIO * io);
 
 // ---------------------------------------------------------------------------
@@ -701,7 +699,6 @@ avifResult avifDecoderReadFile(avifDecoder * decoder, avifImage * image, const c
 avifResult avifDecoderSetSource(avifDecoder * decoder, avifDecoderSource source);
 avifResult avifDecoderSetIO(avifDecoder * decoder, avifIO * io);
 avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const avifROData * rawInput);
-avifResult avifDecoderSetIOFilePtr(avifDecoder * decoder, FILE * f, avifBool closeOnDestroy);
 avifResult avifDecoderSetIOFile(avifDecoder * decoder, const char * filename);
 avifResult avifDecoderParse(avifDecoder * decoder);
 avifResult avifDecoderNextImage(avifDecoder * decoder);

--- a/src/read.c
+++ b/src/read.c
@@ -2163,11 +2163,6 @@ avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const avifROData * rawI
     return avifDecoderSetIO(decoder, avifIOCreateMemoryReader(rawInput->data, rawInput->size));
 }
 
-avifResult avifDecoderSetIOFilePtr(avifDecoder * decoder, FILE * f, avifBool closeOnDestroy)
-{
-    return avifDecoderSetIO(decoder, avifIOCreateFilePtrReader(f, closeOnDestroy));
-}
-
 avifResult avifDecoderSetIOFile(avifDecoder * decoder, const char * filename)
 {
     return avifDecoderSetIO(decoder, avifIOCreateFileReader(filename));


### PR DESCRIPTION
```
It is not safe to have to FILE* arguments in a public API, since
the library and caller are not necessarily built with the same
libc. This is particularily common on Windows, where things
are commonly linked against different MSVCRT versions, where
the FILE internals may differ.
```

I think this should be OK to do, since no release version has been tagged since this API was introduced.

I am unsure whether a SONAME bump is required here, given the above.