### PR TITLE
Fix GCC -Wclobbered warnings

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -158,30 +158,11 @@ avifBool avifPNGWrite(avifImage * avif, const char * outputFilename, uint32_t re
     png_structp png = NULL;
     png_infop info = NULL;
     png_bytep * volatile rowPointers = NULL;
-    FILE * f = NULL;
 
     avifRGBImage rgb;
     memset(&rgb, 0, sizeof(avifRGBImage));
 
-    int rgbDepth = requestedDepth;
-    if (rgbDepth == 0) {
-        if (avif->depth > 8) {
-            rgbDepth = 16;
-        } else {
-            rgbDepth = 8;
-        }
-    }
-
-    avifRGBImageSetDefaults(&rgb, avif);
-    rgb.depth = rgbDepth;
-    rgb.chromaUpsampling = chromaUpsampling;
-    avifRGBImageAllocatePixels(&rgb);
-    if (avifImageYUVToRGB(avif, &rgb) != AVIF_RESULT_OK) {
-        fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);
-        goto cleanup;
-    }
-
-    f = fopen(outputFilename, "wb");
+    FILE * f = fopen(outputFilename, "wb");
     if (!f) {
         fprintf(stderr, "Can't open PNG file for write: %s\n", outputFilename);
         goto cleanup;
@@ -205,6 +186,15 @@ avifBool avifPNGWrite(avifImage * avif, const char * outputFilename, uint32_t re
 
     png_init_io(png, f);
 
+    int rgbDepth = requestedDepth;
+    if (rgbDepth == 0) {
+        if (avif->depth > 8) {
+            rgbDepth = 16;
+        } else {
+            rgbDepth = 8;
+        }
+    }
+
     // Don't bother complaining about ICC profile's contents when transferring from AVIF to PNG.
     // It is up to the enduser to decide if they want to keep their ICC profiles or not.
     png_set_option(png, PNG_SKIP_sRGB_CHECK_PROFILE, 1);
@@ -216,6 +206,14 @@ avifBool avifPNGWrite(avifImage * avif, const char * outputFilename, uint32_t re
     }
     png_write_info(png, info);
 
+    avifRGBImageSetDefaults(&rgb, avif);
+    rgb.depth = rgbDepth;
+    rgb.chromaUpsampling = chromaUpsampling;
+    avifRGBImageAllocatePixels(&rgb);
+    if (avifImageYUVToRGB(avif, &rgb) != AVIF_RESULT_OK) {
+        fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);
+        goto cleanup;
+    }
     rowPointers = (png_bytep *)malloc(sizeof(png_bytep) * rgb.height);
     for (uint32_t y = 0; y < rgb.height; ++y) {
         rowPointers[y] = &rgb.pixels[y * rgb.rowBytes];


### PR DESCRIPTION
GCC 9.3.0 warns that the variables 'f' and 'rgbDepth' in avifPNGWrite()
might be clobbered by 'longjmp' or 'vfork'. I am not familiar with
'vfork', but I believe this is a false positive for 'longjmp' because
those two variables are not modified between the 'setjmp' and 'longjmp'
calls.

Fix the warnings by moving the relevant code back to where it was before
commit 6ce2d81653878e4bef5304495a2876232b1c515c.

I tested with the command:

  avifdec Chimera_10bit_cropped_to_1920x1008_with_HDR_metadata.avif output.png

and got the expected error message:

  Conversion to RGB failed: output.png

Fix https://github.com/AOMediaCodec/libavif/issues/326.