### PR TITLE
Fix GCC -Wclobbered warnings

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -158,7 +158,7 @@ avifBool avifPNGWrite(avifImage * avif, const char * outputFilename, uint32_t re
     png_structp png = NULL;
     png_infop info = NULL;
     png_bytep * volatile rowPointers = NULL;
-    FILE * f = NULL;
+    FILE * volatile f = NULL;
 
     avifRGBImage rgb;
     memset(&rgb, 0, sizeof(avifRGBImage));
@@ -210,7 +210,7 @@ avifBool avifPNGWrite(avifImage * avif, const char * outputFilename, uint32_t re
     png_set_option(png, PNG_SKIP_sRGB_CHECK_PROFILE, 1);
 
     png_set_IHDR(
-        png, info, avif->width, avif->height, rgbDepth, PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+        png, info, avif->width, avif->height, rgb.depth, PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
     if (avif->icc.data && (avif->icc.size > 0)) {
         png_set_iCCP(png, info, "libavif", 0, avif->icc.data, (png_uint_32)avif->icc.size);
     }
@@ -221,7 +221,7 @@ avifBool avifPNGWrite(avifImage * avif, const char * outputFilename, uint32_t re
         rowPointers[y] = &rgb.pixels[y * rgb.rowBytes];
     }
 
-    if (rgbDepth > 8) {
+    if (rgb.depth > 8) {
         png_set_swap(png);
     }
 


### PR DESCRIPTION
GCC 9.3.0 warns that the variables 'f' and 'rgbDepth' in avifPNGWrite()
might be clobbered by 'longjmp' or 'vfork'. I am not familiar with
'vfork', but I believe these are false positives for 'longjmp' because
those two variables are not modified after the 'setjmp' call.

Fix the warning by declaring the variable 'f' as volatile and by
replacing 'rgbDepth' with 'rgb.depth' after we set 'rgb.depth' equal to
'rgbDepth'.

Fix https://github.com/AOMediaCodec/libavif/issues/326.