### PR TITLE
Miscellaneous minor comment fixes

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -228,7 +228,7 @@ avifBool avifROStreamReadUX8(avifROStream * stream, uint64_t * v, uint64_t facto
 avifBool avifROStreamReadU64(avifROStream * stream, uint64_t * v);
 avifBool avifROStreamReadString(avifROStream * stream, char * output, size_t outputSize);
 avifBool avifROStreamReadBoxHeader(avifROStream * stream, avifBoxHeader * header); // This fails if the size reported by the header cannot fit in the stream
-avifBool avifROStreamReadBoxHeaderPartial(avifROStream * stream, avifBoxHeader * header); // This doesn't require that the full box can fit in the stream
+avifBool avifROStreamReadBoxHeaderPartial(avifROStream * stream, avifBoxHeader * header); // This doesn't require that the whole box can fit in the stream
 avifBool avifROStreamReadVersionAndFlags(avifROStream * stream, uint8_t * version, uint32_t * flags); // version and flags ptrs are both optional
 avifBool avifROStreamReadAndEnforceVersion(avifROStream * stream, uint8_t enforcedVersion); // currently discards flags
 

--- a/src/read.c
+++ b/src/read.c
@@ -524,7 +524,7 @@ static avifDecoderItem * avifMetaFindItem(avifMeta * meta, uint32_t itemID)
 typedef struct avifDecoderData
 {
     avifFileType ftyp;
-    avifRWData ftypData; // cloned from avifIO
+    avifRWData ftypData; // Contents of the ftyp box. Cloned from avifIO. ftyp.compatibleBrands points into ftypData.
     avifMeta * meta;     // The root-level meta box
     avifTrackArray tracks;
     avifTileArray tiles;
@@ -2026,11 +2026,10 @@ static avifBool avifParseFileTypeBox(avifFileType * ftyp, const uint8_t * raw, s
     return AVIF_TRUE;
 }
 
+// Note: this top-level function is the only avifParse*() function that returns avifResult instead of avifBool.
+// Be sure to use CHECKERR() in this function with an explicit error result instead of simply using CHECK().
 static avifResult avifParse(avifDecoder * decoder)
 {
-    // Note: this top-level function is the only avifParse*() function that returns avifResult instead of avifBool.
-    // Be sure to use CHECKERR() in this function with an explicit error result instead of simply using CHECK().
-
     avifResult readResult;
     size_t parseOffset = 0;
     avifDecoderData * data = decoder->data;
@@ -2045,7 +2044,7 @@ static avifResult avifParse(avifDecoder * decoder)
         }
         if (!headerContents.size) {
             // If we got AVIF_RESULT_OK from the reader but received 0 bytes,
-            // This we've reached the end of the file with no errors. Hooray!
+            // we've reached the end of the file with no errors. Hooray!
             break;
         }
 


### PR DESCRIPTION
include/avif/internal.h: Change "full box" to "whole box" to avoid being
misinterpreted as the FullBox type in ISO BMFF.

src/read.c: Describe how the ftypData field of avifDecoderData is used.
Move the Note for avifParse() to the outside of the function to make it
more prominent. Remove an extra "This".