### PR TITLE
avifROStreamHasBytesLeft: avoid adding byteCount

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -22,7 +22,7 @@ void avifROStreamStart(avifROStream * stream, avifROData * raw)
 
 avifBool avifROStreamHasBytesLeft(const avifROStream * stream, size_t byteCount)
 {
-    return (stream->offset + byteCount) <= stream->raw->size;
+    return byteCount <= (stream->raw->size - stream->offset);
 }
 
 size_t avifROStreamRemainingBytes(const avifROStream * stream)


### PR DESCRIPTION
It is not clear whether the byteCount parameter of
avifROStreamHasBytesLeft always comes from a trusted source, so adding
byteCount to the stream offset could result in an integer overflow.
Avoid this potential risk by subtracting the stream offset from the
stream size, which is safe to do when the stream is valid.