### PR TITLE
Read fails if offset is past end of buffer/fil

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3,6 +3,7 @@
 
 #include "avif/internal.h"
 
+#include <assert.h>
 #include <string.h>
 
 #define AUXTYPE_SIZE 64
@@ -694,6 +695,9 @@ static avifResult avifDecoderReadItem(avifDecoder * decoder, avifDecoderItem * i
         } else {
             // construction_method: file(0)
 
+            if ((decoder->io->sizeHint > 0) && (extent->offset > decoder->io->sizeHint)) {
+                return AVIF_RESULT_BMFF_PARSE_FAILED;
+            }
             avifResult readResult = decoder->io->read(decoder->io, 0, extent->offset, bytesToRead, &offsetBuffer);
             if (readResult != AVIF_RESULT_OK) {
                 return readResult;
@@ -2039,6 +2043,9 @@ static avifResult avifParse(avifDecoder * decoder)
     for (;;) {
         // Read just enough to get the next box header (a max of 32 bytes)
         avifROData headerContents;
+        if ((decoder->io->sizeHint > 0) && (parseOffset > decoder->io->sizeHint)) {
+            return AVIF_RESULT_BMFF_PARSE_FAILED;
+        }
         readResult = decoder->io->read(decoder->io, 0, parseOffset, 32, &headerContents);
         if (readResult != AVIF_RESULT_OK) {
             return readResult;
@@ -2054,6 +2061,7 @@ static avifResult avifParse(avifDecoder * decoder)
         avifBoxHeader header;
         CHECKERR(avifROStreamReadBoxHeaderPartial(&headerStream, &header), AVIF_RESULT_BMFF_PARSE_FAILED);
         parseOffset += headerStream.offset;
+        assert((decoder->io->sizeHint == 0) || (parseOffset <= decoder->io->sizeHint));
 
         // Try to get the remainder of the box, if necessary
         avifROData boxContents = AVIF_DATA_EMPTY;
@@ -2205,6 +2213,9 @@ static avifResult avifDecoderPrepareSample(avifDecoder * decoder, avifDecodeSamp
             }
 
             avifROData sampleContents;
+            if ((decoder->io->sizeHint > 0) && (sample->offset > decoder->io->sizeHint)) {
+                return AVIF_RESULT_BMFF_PARSE_FAILED;
+            }
             avifResult readResult = decoder->io->read(decoder->io, 0, sample->offset, bytesToRead, &sampleContents);
             if (readResult != AVIF_RESULT_OK) {
                 return readResult;


### PR DESCRIPTION
Change avifIOMemoryReaderRead() and avifIOFileReaderRead() to return the
AVIF_RESULT_BMFF_PARSE_FAILED error if offset is past the end of the
buffer or file, because this can only happen if the size field of some
box (which we encountered but did not read the contents of) is too big.

In avifIOMemoryReaderRead(), if offset is exactly at the end of the
buffer, set out->data equal to the end of the buffer rather than the
beginning of the buffer. This is just for convenience and should not
matter because out->size is set equal to 0.

Also restructure avifIOMemoryReaderRead() and avifIOFileReaderRead() to
make the two functions as similar as possible. This minimizes the
behavior differences between the two functions.