### PR TITLE
Add aom-specific codec option enable-chroma-deltaq

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -99,6 +99,7 @@ static void syntax(void)
         printf("aom-specific advanced options:\n");
         printf("    aq-mode=M                         : Adaptive quantization mode (0: off (default), 1: variance, 2: complexity, 3: cyclic refresh)\n");
         printf("    cq-level=Q                        : Constant/Constrained Quality level (0-63, end-usage must be set to cq or q)\n");
+        printf("    enable-chroma-deltaq=B            : Enable delta quantization in chroma planes (0: disable (default), 1: enable)\n");
         printf("    end-usage=MODE                    : Rate control mode (vbr, cbr, cq, or q)\n");
         printf("    sharpness=S                       : Loop filter sharpness (0-7, default: 0)\n");
         printf("    tune=METRIC                       : Tune the encoder for distortion metric (psnr or ssim, default: psnr)\n");

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -300,11 +300,12 @@ static const struct aomOptionEnumList tuningEnum[] = { //
     { NULL, 0 }
 };
 
-static const struct aomOptionDef aomOptionDefs[] = { //
-    { "aq-mode", AV1E_SET_AQ_MODE, NULL },           // Adaptive quantization mode
-    { "cq-level", AOME_SET_CQ_LEVEL, NULL },         // Constant/Constrained Quality level
-    { "sharpness", AOME_SET_SHARPNESS, NULL },       // Loop filter sharpness
-    { "tune", AOME_SET_TUNING, tuningEnum },         // Tune distortion metric
+static const struct aomOptionDef aomOptionDefs[] = {                 //
+    { "aq-mode", AV1E_SET_AQ_MODE, NULL },                           // Adaptive quantization mode
+    { "cq-level", AOME_SET_CQ_LEVEL, NULL },                         // Constant/Constrained Quality level
+    { "enable-chroma-deltaq", AV1E_SET_ENABLE_CHROMA_DELTAQ, NULL }, // Enable delta quantization in chroma planes
+    { "sharpness", AOME_SET_SHARPNESS, NULL },                       // Loop filter sharpness
+    { "tune", AOME_SET_TUNING, tuningEnum },                         // Tune distortion metric
     { NULL, 0, NULL }
 };
 


### PR DESCRIPTION
The enable-chroma-deltaq option enables delta quantization in the chroma
planes by adding a delta to chroma quantizers. It is intended to be used
with the YUV 4:4:4 format.

See https://crbug.com/aomedia/2717.