### PR TITLE
Use avifHTONL in avifRWStreamWriteBox()

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -289,7 +289,7 @@ avifBoxMarker avifRWStreamWriteBox(avifRWStream * stream, const char * type, siz
 
 void avifRWStreamFinishBox(avifRWStream * stream, avifBoxMarker marker)
 {
-    uint32_t noSize = avifNTOHL((uint32_t)(stream->offset - marker));
+    uint32_t noSize = avifHTONL((uint32_t)(stream->offset - marker));
     memcpy(stream->raw->data + marker, &noSize, sizeof(uint32_t));
 }
 


### PR DESCRIPTION
The noSize variable in avifRWStreamWriteBox() is in network order, so we
should use avifHTONL, not avifNTOHL.