### PR TITLE
Use the new MIAF default image->matrixCoefficients

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ avifImage * image = avifImageCreate(width, height, depth, format);
 // matrixCoefficients to indicate how you would like YUV<->RGB conversion to be done.
 image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
 image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
-image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT709;
+image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
 image->yuvRange = AVIF_RANGE_FULL;
 
 // Option 1: Populate YUV planes


### PR DESCRIPTION
In sample code, set image->matrixCoefficients to
AVIF_MATRIX_COEFFICIENTS_BT601, the new default matrix_coefficients in
MIAF Section 7.3.6.4 (as of ISO/IEC 23000-22:2019 Amendment 2).