### PR TITLE
Cleanup related to avifCodecGetNextImageFunc

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -155,7 +155,7 @@ struct avifCodec;
 struct avifCodecInternal;
 
 typedef avifBool (*avifCodecOpenFunc)(struct avifCodec * codec);
-typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec, avifDecodeSample * sample, avifBool alpha, avifImage * image);
+typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec, const avifDecodeSample * sample, avifBool alpha, avifImage * image);
 // EncodeImage and EncodeFinish are not required to always emit a sample, but when all images are
 // encoded and EncodeFinish is called, the number of samples emitted must match the number of submitted frames.
 // avifCodecEncodeImageFunc may return AVIF_RESULT_UNKNOWN_ERROR to automatically emit the appropriate

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -73,7 +73,7 @@ static avifBool aomCodecOpen(struct avifCodec * codec)
     return AVIF_TRUE;
 }
 
-static avifBool aomCodecGetNextImage(struct avifCodec * codec, avifDecodeSample * sample, avifBool alpha, avifImage * image)
+static avifBool aomCodecGetNextImage(struct avifCodec * codec, const avifDecodeSample * sample, avifBool alpha, avifImage * image)
 {
     aom_image_t * nextFrame = NULL;
     for (;;) {
@@ -82,13 +82,12 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec, avifDecodeSample 
             // Got an image!
             break;
         } else if (sample) {
-            // Feed another sample
             codec->internal->iter = NULL;
             if (aom_codec_decode(&codec->internal->decoder, sample->data.data, sample->data.size, NULL)) {
                 return AVIF_FALSE;
             }
+            sample = NULL;
         } else {
-            // No more samples to feed
             break;
         }
     }

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -59,7 +59,7 @@ static avifBool dav1dCodecOpen(avifCodec * codec)
     return AVIF_TRUE;
 }
 
-static avifBool dav1dCodecGetNextImage(struct avifCodec * codec, avifDecodeSample * sample, avifBool alpha, avifImage * image)
+static avifBool dav1dCodecGetNextImage(struct avifCodec * codec, const avifDecodeSample * sample, avifBool alpha, avifImage * image)
 {
     avifBool gotPicture = AVIF_FALSE;
     Dav1dPicture nextFrame;

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -33,28 +33,24 @@ static avifBool gav1CodecOpen(avifCodec * codec)
     return AVIF_TRUE;
 }
 
-static avifBool gav1CodecGetNextImage(struct avifCodec * codec, avifDecodeSample * sample, avifBool alpha, avifImage * image)
+static avifBool gav1CodecGetNextImage(struct avifCodec * codec, const avifDecodeSample * sample, avifBool alpha, avifImage * image)
 {
-    const Libgav1DecoderBuffer * nextFrame = NULL;
-    // Check if there are more samples to feed
-    if (sample) {
-        // Feed another sample
-        if (Libgav1DecoderEnqueueFrame(codec->internal->gav1Decoder,
-                                       sample->data.data,
-                                       sample->data.size,
-                                       /*user_private_data=*/0,
-                                       /*buffer_private_data=*/NULL) != kLibgav1StatusOk) {
-            return AVIF_FALSE;
-        }
-        // Each Libgav1DecoderDequeueFrame() call invalidates the output frame
-        // returned by the previous Libgav1DecoderDequeueFrame() call. Clear
-        // our pointer to the previous output frame.
-        codec->internal->gav1Image = NULL;
-        if (Libgav1DecoderDequeueFrame(codec->internal->gav1Decoder, &nextFrame) != kLibgav1StatusOk) {
-            return AVIF_FALSE;
-        }
-        // Got an image!
+    if (Libgav1DecoderEnqueueFrame(codec->internal->gav1Decoder,
+                                   sample->data.data,
+                                   sample->data.size,
+                                   /*user_private_data=*/0,
+                                   /*buffer_private_data=*/NULL) != kLibgav1StatusOk) {
+        return AVIF_FALSE;
     }
+    // Each Libgav1DecoderDequeueFrame() call invalidates the output frame
+    // returned by the previous Libgav1DecoderDequeueFrame() call. Clear
+    // our pointer to the previous output frame.
+    codec->internal->gav1Image = NULL;
+    const Libgav1DecoderBuffer * nextFrame = NULL;
+    if (Libgav1DecoderDequeueFrame(codec->internal->gav1Decoder, &nextFrame) != kLibgav1StatusOk) {
+        return AVIF_FALSE;
+    }
+    // Got an image!
 
     if (nextFrame) {
         codec->internal->gav1Image = nextFrame;

--- a/src/read.c
+++ b/src/read.c
@@ -2736,11 +2736,11 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
         }
     }
 
-    // Decode decode all frames now that the sample data is ready.
+    // Decode all frames now that the sample data is ready.
     for (unsigned int tileIndex = 0; tileIndex < decoder->data->tiles.count; ++tileIndex) {
         avifTile * tile = &decoder->data->tiles.tile[tileIndex];
 
-        avifDecodeSample * sample = &tile->input->samples.sample[nextImageIndex];
+        const avifDecodeSample * sample = &tile->input->samples.sample[nextImageIndex];
 
         if (!tile->codec->getNextImage(tile->codec, sample, tile->input->alpha, tile->image)) {
             if (tile->input->alpha) {


### PR DESCRIPTION
Declare the 'sample' input parameter as const.

The avifCodecGetNextImageFunc implementations can assume the 'sample'
input parameter is not NULL.

The for (;;) loop in aomCodecGetNextImage() needs to set 'sample' to
NULL after 'sample' has been passed to a successful aom_codec_decode()
call.

Delete comments like "Check if there are more samples to feed" and
"Feed another sample" because they describe the following check in the
original code:
 codec->internal->inputSampleIndex < codec->decodeInput->samples.count
which has been deleted.