### PR TITLE
CI: test system libgav1 and Clang 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,6 @@ matrix:
       - sudo pkg upgrade -y gcc10-devel
   - <<: *freebsd_common
     name: "Clang Static Analyzer"
-    env: WRAPPER="scan-build10 --status-bugs"
+    env: WRAPPER="scan-build11 --status-bugs"
     before_install:
-      - sudo pkg install -y llvm10
+      - sudo pkg install -y llvm11

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ matrix:
           sudo pkg install -y llvm10
         fi
     before_script:
-      - sudo pkg install -y aom dav1d librav1e ninja
-      - $WRAPPER cmake -B build -G Ninja -DAVIF_{CODEC_{AOM,DAV1D,RAV1E},BUILD_{APPS,TESTS}}=ON
+      - sudo pkg install -y aom dav1d libgav1 librav1e ninja
+      - $WRAPPER cmake -B build -G Ninja -DAVIF_{CODEC_{AOM,DAV1D,LIBGAV1,RAV1E},BUILD_{APPS,TESTS}}=ON
     script:
       - $WRAPPER cmake --build build
   - <<: *freebsd_common


### PR DESCRIPTION
- I've [packaged](https://www.freshports.org/multimedia/libgav1) libgav1 0.16.0 which recenetly became available in (default) `/quarterly` set
- Clang 11 is approaching release. It's already used on FreeBSD 13.0 ([in development](https://www.freebsd.org/releases/13.0R/schedule.html))
