### PR TITLE
Miscellaneous comment fixes

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2058,7 +2058,7 @@ static avifResult avifParse(avifDecoder * decoder)
         }
         if (!headerContents.size) {
             // If we got AVIF_RESULT_OK from the reader but received 0 bytes,
-            // This we've reached the end of the file with no errors. Hooray!
+            // we've reached the end of the file with no errors. Hooray!
             break;
         }
 
@@ -2210,7 +2210,7 @@ static avifResult avifDecoderPrepareSample(avifDecoder * decoder, avifDecodeSamp
             }
 
             // avifDecoderReadItem is guaranteed to already be persisted by either the underlying IO
-            // or by mergedExtents; just make reuse the buffer here.
+            // or by mergedExtents; just reuse the buffer here.
             memcpy(&sample->data, &itemContents, sizeof(avifROData));
             sample->ownsData = AVIF_FALSE;
             sample->partialData = item->partialMergedExtents;

--- a/src/write.c
+++ b/src/write.c
@@ -968,7 +968,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
         //   * Pass 1: alpha (AV1)
         //   * Pass 2: all other item data (AV1 color)
         //
-        // See here for the discussion on alpha coming first:
+        // See here for the discussion on alpha coming before color:
         // https://github.com/AOMediaCodec/libavif/issues/287
         //
         // Exif and XMP are packed first as they're required to be fully available


### PR DESCRIPTION
include/avif/avif.h:
* In the comment for the avifIODestroyFunc type, change "the reader" to
  "the avifIO object".
* In the comment for the avifIOReadFunc type, change "another call" to
  "another read call", and change the return value from AVIF_RESULT_OK
  to AVIF_RESULT_IO_ERROR when offset exceeds the size of the content
  (past EOF).
* In the comment for the 'persistent' field of the avifIO struct, change
  "the avifDecoder object" to "the avifIO object".
* In the comment for the 'io' field of the avifIO struct, change "the IO
  implementation" to "the avifIO implementation".
* In the comment for the avifDecoderRead() function, change "deestroyed"
  "destroyed".

src/read.c:
* In avifParse(), remove an extraneous "This".
* In avifDecoderPrepareSample(), change "make reuse the buffer" to
  "reuse the buffer".

src/write.c:
* In avifEncoderFinish(), change "alpha coming first" to "alpha coming
  before color" because now it is Exif and XMP that are packed first.