### PR TITLE
Change prototypes of functions for memory avifIO

### DIFF
--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -59,13 +59,14 @@ static gboolean avif_context_try_load(struct avif_context * context, GError ** e
     avifDecoder * decoder = context->decoder;
     avifImage * image;
     avifRGBImage rgb;
-    avifROData raw;
+    const uint8_t * data;
+    size_t size;
     int width, height;
     GdkPixbuf *output;
 
-    raw.data = g_bytes_get_data(context->bytes, &raw.size);
+    data = g_bytes_get_data(context->bytes, &size);
 
-    ret = avifDecoderSetIOMemory(decoder, &raw);
+    ret = avifDecoderSetIOMemory(decoder, data, size);
     if (ret != AVIF_RESULT_OK) {
         g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
                     "Couldn’t decode image: %s", avifResultToString(ret));

--- a/examples/avif_example1.c
+++ b/examples/avif_example1.c
@@ -72,7 +72,7 @@ int main(int argc, char * argv[])
     // Decode it
     avifImage * decoded = avifImageCreateEmpty();
     avifDecoder * decoder = avifDecoderCreate();
-    avifResult decodeResult = avifDecoderReadMemory(decoder, decoded, (avifROData *)&raw);
+    avifResult decodeResult = avifDecoderReadMemory(decoder, decoded, raw.data, raw.size);
     avifDecoderDestroy(decoder);
 
     if (decodeResult != AVIF_RESULT_OK) {
@@ -114,7 +114,7 @@ encodeCleanup:
     avifImageDestroy(image);
     avifRGBImageFreePixels(&srcRGB);
     avifRGBImageFreePixels(&dstRGB);
-#else  /* if 1 */
+#else /* if 1 */
 
     FILE * f = fopen("test.avif", "rb");
     if (!f)

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -674,7 +674,7 @@ void avifDecoderDestroy(avifDecoder * decoder);
 
 // Simple interfaces to decode a single image, independent of the decoder afterwards (decoder may be destroyed).
 avifResult avifDecoderRead(avifDecoder * decoder, avifImage * image); // call avifDecoderSetIO*() first
-avifResult avifDecoderReadMemory(avifDecoder * decoder, avifImage * image, const avifROData * input);
+avifResult avifDecoderReadMemory(avifDecoder * decoder, avifImage * image, const uint8_t * data, size_t size);
 avifResult avifDecoderReadFile(avifDecoder * decoder, avifImage * image, const char * filename);
 
 // Multi-function alternative to avifDecoderRead() for image sequences and gaining direct access
@@ -698,7 +698,7 @@ avifResult avifDecoderReadFile(avifDecoder * decoder, avifImage * image, const c
 // Parse again. Normally AVIF_DECODER_SOURCE_AUTO is enough for the common path.
 avifResult avifDecoderSetSource(avifDecoder * decoder, avifDecoderSource source);
 avifResult avifDecoderSetIO(avifDecoder * decoder, avifIO * io);
-avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const avifROData * rawInput);
+avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const uint8_t * data, size_t size);
 avifResult avifDecoderSetIOFile(avifDecoder * decoder, const char * filename);
 avifResult avifDecoderParse(avifDecoder * decoder);
 avifResult avifDecoderNextImage(avifDecoder * decoder);

--- a/src/read.c
+++ b/src/read.c
@@ -2184,14 +2184,22 @@ avifResult avifDecoderSetIO(avifDecoder * decoder, avifIO * io)
     return AVIF_RESULT_OK;
 }
 
-avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const avifROData * rawInput)
+avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const uint8_t * data, size_t size)
 {
-    return avifDecoderSetIO(decoder, avifIOCreateMemoryReader(rawInput->data, rawInput->size));
+    avifIO * io = avifIOCreateMemoryReader(data, size);
+    if (!io) {
+        return AVIF_RESULT_NO_IO;
+    }
+    return avifDecoderSetIO(decoder, io);
 }
 
 avifResult avifDecoderSetIOFile(avifDecoder * decoder, const char * filename)
 {
-    return avifDecoderSetIO(decoder, avifIOCreateFileReader(filename));
+    avifIO * io = avifIOCreateFileReader(filename);
+    if (!io) {
+        return AVIF_RESULT_NO_IO;
+    }
+    return avifDecoderSetIO(decoder, io);
 }
 
 static avifResult avifDecoderPrepareSample(avifDecoder * decoder, avifDecodeSample * sample, size_t partialByteCount)
@@ -2938,9 +2946,9 @@ avifResult avifDecoderRead(avifDecoder * decoder, avifImage * image)
     return AVIF_RESULT_OK;
 }
 
-avifResult avifDecoderReadMemory(avifDecoder * decoder, avifImage * image, const avifROData * input)
+avifResult avifDecoderReadMemory(avifDecoder * decoder, avifImage * image, const uint8_t * data, size_t size)
 {
-    avifResult result = avifDecoderSetIOMemory(decoder, input);
+    avifResult result = avifDecoderSetIOMemory(decoder, data, size);
     if (result != AVIF_RESULT_OK) {
         return result;
     }

--- a/tests/testcase.c
+++ b/tests/testcase.c
@@ -225,7 +225,7 @@ int testCaseRun(TestCase * tc, const char * dataDir, avifBool generating)
 
     decoder = avifDecoderCreate();
     decoder->codecChoice = tc->decodeChoice;
-    avifDecoderSetIOMemory(decoder, (avifROData *)&encodedData);
+    avifDecoderSetIOMemory(decoder, encodedData.data, encodedData.size);
     avifResult decodeResult = avifDecoderParse(decoder);
     if (decodeResult != AVIF_RESULT_OK) {
         printf("ERROR[%s]: Decode failed\n", tc->name);


### PR DESCRIPTION
Change the prototypes of avifDecoderReadMemory() and
avifDecoderSetIOMemory() to represent the input memory buffer by a
buffer data pointer and buffer size, instead of an avifROData pointer.
This makes their prototypes consistent with the prototype of
avifIOCreateMemoryReader(), fixing
https://github.com/AOMediaCodec/libavif/issues/344.

Also add error checking to avifDecoderSetIOMemory() and
avifDecoderSetIOFile(): check for the failure of
avifIOCreateMemoryReader() and avifIOCreateFileReader(), respectively.