### PR TITLE
More cleanup for avifDecoderReadItem()

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -636,7 +636,7 @@ static avifResult avifDecoderReadItem(avifDecoder * decoder, avifDecoderItem * i
     }
 
     // Find this item's source of all extents' data, based on the construction method
-    avifRWData * idatBuffer = NULL;
+    const avifRWData * idatBuffer = NULL;
     if (item->idatID != 0) {
         // construction_method: idat(1)
 
@@ -709,10 +709,9 @@ static avifResult avifDecoderReadItem(avifDecoder * decoder, avifDecoderItem * i
             if (readResult != AVIF_RESULT_OK) {
                 return readResult;
             }
-        }
-
-        if (bytesToRead > offsetBuffer.size) {
-            return AVIF_RESULT_TRUNCATED_DATA;
+            if (bytesToRead != offsetBuffer.size) {
+                return AVIF_RESULT_TRUNCATED_DATA;
+            }
         }
 
         if (singlePersistentBuffer) {


### PR DESCRIPTION
This is a follow-up to https://github.com/AOMediaCodec/libavif/commit/610b0a1739a9d2675d1fe33d5be0c0997e7dfa55

The bytesToRead > offsetBuffer.size check only needs to be performed in
the !idatBuffer case. In the idatBuffer case, we can prove that
bytesToRead <= offsetBuffer.size is true.