### PR TITLE
avifDecoderReadItem callers can rely on contract

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2485,10 +2485,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                 if (readResult != AVIF_RESULT_OK) {
                     return readResult;
                 }
-                if ((readData.data == NULL) || (readData.size != item->size)) {
-                    return AVIF_RESULT_BMFF_PARSE_FAILED;
-                }
-                if (!avifParseImageGridBox(&data->colorGrid, readData.data, item->size)) {
+                if (!avifParseImageGridBox(&data->colorGrid, readData.data, readData.size)) {
                     return AVIF_RESULT_INVALID_IMAGE_GRID;
                 }
             }
@@ -2531,10 +2528,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                     if (readResult != AVIF_RESULT_OK) {
                         return readResult;
                     }
-                    if ((readData.data == NULL) || (readData.size != item->size)) {
-                        return AVIF_RESULT_BMFF_PARSE_FAILED;
-                    }
-                    if (!avifParseImageGridBox(&data->alphaGrid, readData.data, item->size)) {
+                    if (!avifParseImageGridBox(&data->alphaGrid, readData.data, readData.size)) {
                         return AVIF_RESULT_INVALID_IMAGE_GRID;
                     }
                 }


### PR DESCRIPTION
The callers of avifDecoderReadItem() with partialByteCount=0 can rely on
the API contract and assume that outData is valid (i.e., outData->data
is not NULL) and full (i.e., outData->size == item->size) when
avifDecoderReadItem() returns AVIF_RESULT_OK.