### PR TITLE
Declare the sizeHint field of avifIO as uint64_t

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -539,7 +539,7 @@ typedef void (*avifIODestroyFunc)(struct avifIO * io);
 //   all bytes from the offset to EOF, and return AVIF_RESULT_OK.
 typedef avifResult (*avifIOReadFunc)(struct avifIO * io, uint32_t readFlags, uint64_t offset, uint64_t size, avifROData * out);
 
-typedef avifResult (*avifIOWriteFunc)(struct avifIO * io, uint32_t writeFlags, uint64_t offset, uint8_t * data, uint64_t size);
+typedef avifResult (*avifIOWriteFunc)(struct avifIO * io, uint32_t writeFlags, uint64_t offset, const uint8_t * data, uint64_t size);
 
 typedef struct avifIO
 {
@@ -554,7 +554,7 @@ typedef struct avifIO
     // can possibly be for your environment, but within your environment's memory constraints). This
     // is used for sanity checks when allocating internal buffers to protect against
     // malformed/malicious files.
-    size_t sizeHint;
+    uint64_t sizeHint;
 
     // If true, *all* memory regions returned from *all* calls to read are guaranteed to be
     // persistent and exist for the lifetime of the avifIO object. If false, libavif will make

--- a/src/io.c
+++ b/src/io.c
@@ -129,7 +129,11 @@ avifIO * avifIOCreateFileReader(const char * filename)
     }
 
     fseek(f, 0, SEEK_END);
-    size_t fileSize = (size_t)ftell(f);
+    long fileSize = ftell(f);
+    if (fileSize < 0) {
+        fclose(f);
+        return NULL;
+    }
     fseek(f, 0, SEEK_SET);
 
     avifIOFileReader * reader = avifAlloc(sizeof(avifIOFileReader));
@@ -137,7 +141,7 @@ avifIO * avifIOCreateFileReader(const char * filename)
     reader->f = f;
     reader->io.destroy = avifIOFileReaderDestroy;
     reader->io.read = avifIOFileReaderRead;
-    reader->io.sizeHint = fileSize;
+    reader->io.sizeHint = (uint64_t)fileSize;
     reader->io.persistent = AVIF_FALSE;
     avifRWDataRealloc(&reader->buffer, 1024);
     return (avifIO *)reader;

--- a/src/read.c
+++ b/src/read.c
@@ -331,7 +331,7 @@ void avifCodecDecodeInputDestroy(avifCodecDecodeInput * decodeInput)
     avifFree(decodeInput);
 }
 
-static avifBool avifCodecDecodeInputGetSamples(avifCodecDecodeInput * decodeInput, avifSampleTable * sampleTable, size_t sizeHint)
+static avifBool avifCodecDecodeInputGetSamples(avifCodecDecodeInput * decodeInput, avifSampleTable * sampleTable, uint64_t sizeHint)
 {
     uint32_t sampleSizeIndex = 0;
     for (uint32_t chunkIndex = 0; chunkIndex < sampleTable->chunks.count; ++chunkIndex) {
@@ -371,7 +371,7 @@ static avifBool avifCodecDecodeInputGetSamples(avifCodecDecodeInput * decodeInpu
             if (sampleSize > UINT64_MAX - sampleOffset) {
                 return AVIF_FALSE;
             }
-            if (sizeHint && ((sampleOffset + sampleSize) > (uint64_t)sizeHint)) {
+            if (sizeHint && ((sampleOffset + sampleSize) > sizeHint)) {
                 return AVIF_FALSE;
             }
 

--- a/tests/aviftest.c
+++ b/tests/aviftest.c
@@ -11,6 +11,7 @@
 
 #include "testcase.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -378,7 +379,7 @@ static int runIOTests(const char * dataDir)
                     retCode = 1;
                 }
 
-                printf("File: [%s @ %zu / %zu bytes, %s, %s] parse returned: %s\n",
+                printf("File: [%s @ %zu / %" PRIu64 " bytes, %s, %s] parse returned: %s\n",
                        filename,
                        io->availableBytes,
                        io->io.sizeHint,
@@ -398,7 +399,7 @@ static int runIOTests(const char * dataDir)
                         retCode = 1;
                     }
 
-                    printf("File: [%s @ %zu / %zu bytes, %s, %s] nextImage returned: %s\n",
+                    printf("File: [%s @ %zu / %" PRIu64 " bytes, %s, %s] nextImage returned: %s\n",
                            filename,
                            io->availableBytes,
                            io->io.sizeHint,


### PR DESCRIPTION
Since the sizeHint field of the avifIO struct may represent the size of
a file, it should be declared as uint64_t in order to support large
files (files larger than 2 GB). The current size_t type is 32 bits on
32-bit platforms.

Since the 'offset' parameter of the avifIO read() function is uint64_t,
sizeHint should be of the same type. In other words, file offset and
file size should have the same type. (I assume 'offset' is declared as
uint64_t in order to support large files.)

In avifIOCreateFileReader(), check for ftell() failure to avoid casting
-1 to an unsigned type (whether it's size_t or uint64_t).

Also declared the 'data' parameter of the avifIO write() function as a
const pointer.