### PR TITLE
Change 'size' param of avifIOReadFunc to size_t

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -537,9 +537,9 @@ typedef void (*avifIODestroyFunc)(struct avifIO * io);
 //   return AVIF_RESULT_OK.
 // * If (offset+size) exceeds the contents' size, it must provide a truncated buffer that provides
 //   all bytes from the offset to EOF, and return AVIF_RESULT_OK.
-typedef avifResult (*avifIOReadFunc)(struct avifIO * io, uint32_t readFlags, uint64_t offset, uint64_t size, avifROData * out);
+typedef avifResult (*avifIOReadFunc)(struct avifIO * io, uint32_t readFlags, uint64_t offset, size_t size, avifROData * out);
 
-typedef avifResult (*avifIOWriteFunc)(struct avifIO * io, uint32_t writeFlags, uint64_t offset, const uint8_t * data, uint64_t size);
+typedef avifResult (*avifIOWriteFunc)(struct avifIO * io, uint32_t writeFlags, uint64_t offset, const uint8_t * data, size_t size);
 
 typedef struct avifIO
 {

--- a/src/io.c
+++ b/src/io.c
@@ -23,9 +23,9 @@ typedef struct avifIOMemoryReader
     avifROData rodata;
 } avifIOMemoryReader;
 
-static avifResult avifIOMemoryReaderRead(struct avifIO * io, uint32_t readFlags, uint64_t offset, uint64_t size, avifROData * out)
+static avifResult avifIOMemoryReaderRead(struct avifIO * io, uint32_t readFlags, uint64_t offset, size_t size, avifROData * out)
 {
-    // printf("avifIOMemoryReaderRead offset %" PRIu64 " size %" PRIu64 "\n", offset, size);
+    // printf("avifIOMemoryReaderRead offset %" PRIu64 " size %zu\n", offset, size);
 
     (void)readFlags;
 
@@ -74,9 +74,9 @@ typedef struct avifIOFileReader
     FILE * f;
 } avifIOFileReader;
 
-static avifResult avifIOFileReaderRead(struct avifIO * io, uint32_t readFlags, uint64_t offset, uint64_t size, avifROData * out)
+static avifResult avifIOFileReaderRead(struct avifIO * io, uint32_t readFlags, uint64_t offset, size_t size, avifROData * out)
 {
-    // printf("avifIOFileReaderRead offset %" PRIu64 " size %" PRIu64 "\n", offset, size);
+    // printf("avifIOFileReaderRead offset %" PRIu64 " size %zu\n", offset, size);
 
     (void)readFlags;
 

--- a/tests/aviftest.c
+++ b/tests/aviftest.c
@@ -261,9 +261,9 @@ typedef struct avifIOTestReader
     size_t availableBytes;
 } avifIOTestReader;
 
-static avifResult avifIOTestReaderRead(struct avifIO * io, uint32_t readFlags, uint64_t offset, uint64_t size, avifROData * out)
+static avifResult avifIOTestReaderRead(struct avifIO * io, uint32_t readFlags, uint64_t offset, size_t size, avifROData * out)
 {
-    // printf("avifIOTestReaderRead offset %zu size %zu\n", offset, size);
+    // printf("avifIOTestReaderRead offset %" PRIu64 " size %zu\n", offset, size);
 
     (void)readFlags;
 


### PR DESCRIPTION
Change the 'size' parameter of avifIOReadFunc and avifIOWriteFunc to
size_t, because it represents the size of a memory buffer. Only the size
and offset of a file need to be a 64-bit type (in order to support large
files > 2 GB).

Fix https://github.com/AOMediaCodec/libavif/issues/357