### PR TITLE
Change avifDecoderSetIO() to return void

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -697,7 +697,11 @@ avifResult avifDecoderReadFile(avifDecoder * decoder, avifImage * image, const c
 // items in a file containing both, but switch between sources without having to
 // Parse again. Normally AVIF_DECODER_SOURCE_AUTO is enough for the common path.
 avifResult avifDecoderSetSource(avifDecoder * decoder, avifDecoderSource source);
-avifResult avifDecoderSetIO(avifDecoder * decoder, avifIO * io);
+// Note: When avifDecoderSetIO() is called, whether 'decoder' takes ownership of 'io' depends on
+// whether io->destroy is set. avifDecoderDestroy(decoder) calls avifIODestroy(io), which calls
+// io->destroy(io) if io->destroy is set. Therefore, if io->destroy is not set, then
+// avifDecoderDestroy(decoder) has no effects on 'io'.
+void avifDecoderSetIO(avifDecoder * decoder, avifIO * io);
 avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const uint8_t * data, size_t size);
 avifResult avifDecoderSetIOFile(avifDecoder * decoder, const char * filename);
 avifResult avifDecoderParse(avifDecoder * decoder);

--- a/src/read.c
+++ b/src/read.c
@@ -2177,11 +2177,10 @@ avifResult avifDecoderSetSource(avifDecoder * decoder, avifDecoderSource source)
     return avifDecoderReset(decoder);
 }
 
-avifResult avifDecoderSetIO(avifDecoder * decoder, avifIO * io)
+void avifDecoderSetIO(avifDecoder * decoder, avifIO * io)
 {
     avifIODestroy(decoder->io);
     decoder->io = io;
-    return AVIF_RESULT_OK;
 }
 
 avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const uint8_t * data, size_t size)
@@ -2190,7 +2189,8 @@ avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const uint8_t * data, s
     if (!io) {
         return AVIF_RESULT_NO_IO;
     }
-    return avifDecoderSetIO(decoder, io);
+    avifDecoderSetIO(decoder, io);
+    return AVIF_RESULT_OK;
 }
 
 avifResult avifDecoderSetIOFile(avifDecoder * decoder, const char * filename)
@@ -2199,7 +2199,8 @@ avifResult avifDecoderSetIOFile(avifDecoder * decoder, const char * filename)
     if (!io) {
         return AVIF_RESULT_NO_IO;
     }
-    return avifDecoderSetIO(decoder, io);
+    avifDecoderSetIO(decoder, io);
+    return AVIF_RESULT_OK;
 }
 
 static avifResult avifDecoderPrepareSample(avifDecoder * decoder, avifDecodeSample * sample, size_t partialByteCount)


### PR DESCRIPTION
avifDecoderSetIO() always succeeds, so it can return void.

Also add a comment to clarify whether 'decoder' takes ownership of 'io'
in a avifDecoderSetIO() call.

Fix https://github.com/AOMediaCodec/libavif/issues/359.