### PR TITLE
Detect file read error by calling ferror()

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -104,6 +104,9 @@ static avifResult avifIOFileReaderRead(struct avifIO * io, uint32_t readFlags, u
         }
         size_t bytesRead = fread(reader->buffer.data, 1, size, reader->f);
         if (size != bytesRead) {
+            if (ferror(reader->f)) {
+                return AVIF_RESULT_IO_ERROR;
+            }
             size = bytesRead;
         }
     }


### PR DESCRIPTION
If fread() returns a byte count less than 'size', distinguish between
the error and end-of-file conditions by calling ferror().