### PR TITLE
Miscellaneous cleanup changes to apps/ and tests/

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -41,8 +41,13 @@ static void syntax(void)
 static int info(const char * inputFilename)
 {
     avifDecoder * decoder = avifDecoderCreate();
-    avifDecoderSetIOFile(decoder, inputFilename);
-    avifResult result = avifDecoderParse(decoder);
+    avifResult result = avifDecoderSetIOFile(decoder, inputFilename);
+    if (result != AVIF_RESULT_OK) {
+        fprintf(stderr, "Cannot open file for read: %s\n", inputFilename);
+        avifDecoderDestroy(decoder);
+        return 1;
+    }
+    result = avifDecoderParse(decoder);
     if (result == AVIF_RESULT_OK) {
         printf("Image decoded: %s\n", inputFilename);
 

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -242,11 +242,12 @@ static avifBool readEntireFile(const char * filename, avifRWData * raw)
     }
 
     fseek(f, 0, SEEK_END);
-    size_t fileSize = (size_t)ftell(f);
-    if (!fileSize) {
+    long pos = ftell(f);
+    if (pos <= 0) {
         fclose(f);
         return AVIF_FALSE;
     }
+    size_t fileSize = (size_t)pos;
     fseek(f, 0, SEEK_SET);
 
     avifRWDataRealloc(raw, fileSize);
@@ -449,14 +450,14 @@ int main(int argc, char * argv[])
         } else if (!strcmp(arg, "--exif")) {
             NEXTARG();
             if (!readEntireFile(arg, &exifOverride)) {
-                fprintf(stderr, "ERROR: Unable to read Exif content: %s\n", arg);
+                fprintf(stderr, "ERROR: Unable to read Exif metadata: %s\n", arg);
                 returnCode = 1;
                 goto cleanup;
             }
         } else if (!strcmp(arg, "--xmp")) {
             NEXTARG();
             if (!readEntireFile(arg, &xmpOverride)) {
-                fprintf(stderr, "ERROR: Unable to read XMP content: %s\n", arg);
+                fprintf(stderr, "ERROR: Unable to read XMP metadata: %s\n", arg);
                 returnCode = 1;
                 goto cleanup;
             }


### PR DESCRIPTION
apps/avifdec.c:
  * Handle avifDecoderSetIOFile() failures.

apps/avifenc.c:
  * Check for not only a zero return value (empty file) but also a
    negative return value (failure) of ftell().
  * In error messages, change "content" to "metadata" when referring to
    Exif and XMP.

tests/aviftest.c:
  * Carry over my recent changes from avifIOMemoryReaderRead() to
    avifIOTestReaderRead().
  * Declare local variables holding strlen() return values as size_t
    rather than int to avoid the casts to int.
  * Add the new --io-only option to the syntax help message.