### PR TITLE
avifIO read() should require readFlags == 0

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -27,7 +27,10 @@ static avifResult avifIOMemoryReaderRead(struct avifIO * io, uint32_t readFlags,
 {
     // printf("avifIOMemoryReaderRead offset %" PRIu64 " size %zu\n", offset, size);
 
-    (void)readFlags;
+    if (readFlags != 0) {
+        // Unsupported readFlags
+        return AVIF_RESULT_IO_ERROR;
+    }
 
     avifIOMemoryReader * reader = (avifIOMemoryReader *)io;
 
@@ -78,7 +81,10 @@ static avifResult avifIOFileReaderRead(struct avifIO * io, uint32_t readFlags, u
 {
     // printf("avifIOFileReaderRead offset %" PRIu64 " size %zu\n", offset, size);
 
-    (void)readFlags;
+    if (readFlags != 0) {
+        // Unsupported readFlags
+        return AVIF_RESULT_IO_ERROR;
+    }
 
     avifIOFileReader * reader = (avifIOFileReader *)io;
 

--- a/tests/aviftest.c
+++ b/tests/aviftest.c
@@ -265,7 +265,10 @@ static avifResult avifIOTestReaderRead(struct avifIO * io, uint32_t readFlags, u
 {
     // printf("avifIOTestReaderRead offset %" PRIu64 " size %zu\n", offset, size);
 
-    (void)readFlags;
+    if (readFlags != 0) {
+        // Unsupported readFlags
+        return AVIF_RESULT_IO_ERROR;
+    }
 
     avifIOTestReader * reader = (avifIOTestReader *)io;
 


### PR DESCRIPTION
Since no read flags are defined yet, current implementations of
avifIOReadFunc should require the readFlags parameter be 0.