### PR TITLE
AVIF_RESULT_NO_IO renamed AVIF_RESULT_IO_NOT_SET

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -92,7 +92,7 @@ typedef enum avifResult
     AVIF_RESULT_INVALID_IMAGE_GRID,
     AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION,
     AVIF_RESULT_TRUNCATED_DATA,
-    AVIF_RESULT_NO_IO,
+    AVIF_RESULT_IO_NOT_SET, // the avifIO field of avifDecoder is not set
     AVIF_RESULT_IO_ERROR,
     AVIF_RESULT_WAITING_ON_IO // similar to EAGAIN/EWOULDBLOCK, this means the avifIO doesn't have necessary data available yet
 } avifResult;

--- a/src/avif.c
+++ b/src/avif.c
@@ -88,7 +88,7 @@ const char * avifResultToString(avifResult result)
         case AVIF_RESULT_INVALID_IMAGE_GRID:            return "Invalid image grid";
         case AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION: return "Invalid codec-specific option";
         case AVIF_RESULT_TRUNCATED_DATA:                return "Truncated data";
-        case AVIF_RESULT_NO_IO:                         return "No IO";
+        case AVIF_RESULT_IO_NOT_SET:                    return "IO not set";
         case AVIF_RESULT_IO_ERROR:                      return "IO Error";
         case AVIF_RESULT_WAITING_ON_IO:                 return "Waiting on IO";
         case AVIF_RESULT_UNKNOWN_ERROR:

--- a/src/read.c
+++ b/src/read.c
@@ -2186,9 +2186,7 @@ void avifDecoderSetIO(avifDecoder * decoder, avifIO * io)
 avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const uint8_t * data, size_t size)
 {
     avifIO * io = avifIOCreateMemoryReader(data, size);
-    if (!io) {
-        return AVIF_RESULT_NO_IO;
-    }
+    assert(io);
     avifDecoderSetIO(decoder, io);
     return AVIF_RESULT_OK;
 }
@@ -2197,7 +2195,7 @@ avifResult avifDecoderSetIOFile(avifDecoder * decoder, const char * filename)
 {
     avifIO * io = avifIOCreateFileReader(filename);
     if (!io) {
-        return AVIF_RESULT_NO_IO;
+        return AVIF_RESULT_IO_ERROR;
     }
     avifDecoderSetIO(decoder, io);
     return AVIF_RESULT_OK;
@@ -2258,7 +2256,7 @@ static avifResult avifDecoderPrepareSample(avifDecoder * decoder, avifDecodeSamp
 avifResult avifDecoderParse(avifDecoder * decoder)
 {
     if (!decoder->io || !decoder->io->read) {
-        return AVIF_RESULT_NO_IO;
+        return AVIF_RESULT_IO_NOT_SET;
     }
 
     // Cleanup anything lingering in the decoder
@@ -2719,7 +2717,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 avifResult avifDecoderNextImage(avifDecoder * decoder)
 {
     if (!decoder->io || !decoder->io->read) {
-        return AVIF_RESULT_NO_IO;
+        return AVIF_RESULT_IO_NOT_SET;
     }
 
     uint32_t nextImageIndex = (uint32_t)(decoder->imageIndex + 1);


### PR DESCRIPTION
AVIF_RESULT_NO_IO is renamed AVIF_RESULT_IO_NOT_SET.

Change the error checking in avifDecoderSetIOMemory() to an assertion
because avifIOCreateMemoryReader() does not fail (libavif does not
report memory allocation errors).

Change avifDecoderSetIOFile() to return AVIF_RESULT_IO_ERROR on failure.
Ideally it should return a "file not found" error, but there is no such
avifResult error code.

Fix https://github.com/AOMediaCodec/libavif/issues/364.