### PR TITLE
Add size_t casts to fix MSVC x86 compiler warnings

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -41,7 +41,7 @@ static avifResult avifIOMemoryReaderRead(struct avifIO * io, uint32_t readFlags,
     }
     uint64_t availableSize = reader->rodata.size - offset;
     if (size > availableSize) {
-        size = availableSize;
+        size = (size_t)availableSize;
     }
 
     out->data = reader->rodata.data + offset;
@@ -95,7 +95,7 @@ static avifResult avifIOFileReaderRead(struct avifIO * io, uint32_t readFlags, u
     }
     uint64_t availableSize = reader->io.sizeHint - offset;
     if (size > availableSize) {
-        size = availableSize;
+        size = (size_t)availableSize;
     }
 
     if (size > 0) {

--- a/tests/aviftest.c
+++ b/tests/aviftest.c
@@ -279,7 +279,7 @@ static avifResult avifIOTestReaderRead(struct avifIO * io, uint32_t readFlags, u
     }
     uint64_t availableSize = reader->rodata.size - offset;
     if (size > availableSize) {
-        size = availableSize;
+        size = (size_t)availableSize;
     }
 
     if (offset > reader->availableBytes) {


### PR DESCRIPTION
In 32-bit builds, size_t is smaller than uint64_t, so assigning a
uint64_t variable to a size_t variable could result in loss of data. In
these particular cases, the conversion to size_t is safe because we have
just checked that the uint64_t variable is less than the size_t
variable.

Fix https://github.com/AOMediaCodec/libavif/issues/370.