### PR TITLE
Remove unneeded libs and includes for svt and aom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,15 +305,7 @@ if(AVIF_CODEC_SVT)
         endif()
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${SVT_LIBRARY})
     endif()
-
-    # Unfortunately, svt requires a few more libraries
-    if(WIN32)
-        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ws2_32.lib userenv.lib)
-    elseif(UNIX AND NOT APPLE)
-        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${CMAKE_DL_LIBS}) # for backtrace
-    endif()
 endif()
-
 
 if(AVIF_CODEC_AOM)
     message(STATUS "libavif: Codec enabled: aom (encode/decode)")
@@ -329,7 +321,6 @@ if(AVIF_CODEC_AOM)
 
         set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
             "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom"
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom/build.avif"
         )
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
         message(STATUS "LIBAOM_INCLUDE_PATH: ${CMAKE_CURRENT_SOURCE_DIR}/ext/aom")


### PR DESCRIPTION
The additional libraries for svt were apparently copied from the rav1e
section. ws2_32.lib is the Winsock library, which is unlikely to be used
in a video codec. Similarly -ldl is for functions like dlopen() and
dlsym(), which are not found in the svt source tree.

The ext/aom/build.avif pathname is incorrect. Even the correct pathname
ext/aom/build.libavif is not needed, because headers in that directory
are not public headers.