### PR TITLE
Remove the find_package(ZLIB REQUIRED) call.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,8 @@ endif()
 
 option(AVIF_BUILD_APPS "Build avif apps." OFF)
 if(AVIF_BUILD_APPS)
-    find_package(ZLIB REQUIRED)
+    # If find_package(ZLIB) is called twice, the second call fails. Since find_package(PNG) calls
+    # find_package(ZLIB) internally, we don't call find_package(ZLIB) here.
     find_package(PNG REQUIRED)
     find_package(JPEG REQUIRED)
 


### PR DESCRIPTION
If find_package(ZLIB) is called twice, the second call fails. Since
find_package(PNG) calls find_package(ZLIB) internally, we should not
call find_package(ZLIB), otherwise the internal find_package(ZLIB) call
will fail.

Note: This is probably a bug of find_package(ZLIB) because one would
expect find_package(ZLIB) to be idempotent.

Fix https://github.com/AOMediaCodec/libavif/issues/379.