### PR TITLE
No need to include ${ZLIB_INCLUDE_DIR}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,7 +392,6 @@ if(AVIF_BUILD_APPS)
                                PRIVATE
                                    $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES>
                                    ${CMAKE_CURRENT_SOURCE_DIR}/apps/shared
-                                   ${ZLIB_INCLUDE_DIR}
                                    ${PNG_PNG_INCLUDE_DIR}
                                    ${JPEG_INCLUDE_DIR})
     add_executable(avifdec
@@ -412,7 +411,6 @@ if(AVIF_BUILD_APPS)
                                PRIVATE
                                    $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES>
                                    ${CMAKE_CURRENT_SOURCE_DIR}/apps/shared
-                                   ${ZLIB_INCLUDE_DIR}
                                    ${PNG_PNG_INCLUDE_DIR}
                                    ${JPEG_INCLUDE_DIR})
 


### PR DESCRIPTION
From the libpng home page (http://www.libpng.org/pub/png/libpng.html):

    The 1.5.x and later series ... On the other hand, they no longer
    internally include the zlib.h header file, so applications that
    formerly depended on png.h to provide that will now need to include
    it explicitly.

Since libpng 1.5.0 was released on January 6, 2011, we can safely assume
we are using a newer version than libpng 1.5.0 and therefore do not need
to include ${ZLIB_INCLUDE_DIR} for the libpng public headers.

NOTE: Because of https://github.com/AOMediaCodec/libavif/issues/379,
${ZLIB_INCLUDE_DIR} is cleared to an empty string when we build zlib and
libpng from source code (e.g., on Windows). That's how I noticed this
issue and another evidence that we don't need to include
${ZLIB_INCLUDE_DIR}.