### PR TITLE
Fix a crash in avifJPEGRead() on fopen() failure

### DIFF
--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -50,7 +50,7 @@ avifBool avifJPEGRead(avifImage * avif, const char * inputFilename, avifPixelFor
     FILE * f = fopen(inputFilename, "rb");
     if (!f) {
         fprintf(stderr, "Can't open JPEG file for read: %s\n", inputFilename);
-        goto cleanup;
+        return ret;
     }
 
     struct my_error_mgr jerr;


### PR DESCRIPTION
If the fopen() call in avifJPEGRead() fails, the local variable cinfo is
not initialized yet, so we can't goto cleanup.

Note: In fact, the local variable cinfo is not even declared at that
point. I don't know why the compiler does not warn about that.