### PR TITLE
Set g_lag_in_frames to 1 if encoding single image

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -420,6 +420,10 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             // libaom to set still_picture and reduced_still_picture_header to
             // 1 in AV1 sequence headers.
             cfg.g_limit = 1;
+            // Set g_lag_in_frames to 1 to reduce the number of frame buffers
+            // (from 20 to 2) in libaom's lookahead structure. This reduces
+            // memory consumption when encoding a single image.
+            cfg.g_lag_in_frames = 1;
         }
         if (encoder->maxThreads > 1) {
             cfg.g_threads = encoder->maxThreads;


### PR DESCRIPTION
The default value of g_lag_in_frames in libaom's "good quality" usage
mode is 19. In libaom's lookahead structure (struct lookahead_ctx) there
is an array of frame buffers. The number of frame buffers in that array
is max(1, g_lag_in_frames) + 1. Therefore this change reduces the number
of frame buffers from 20 to 2. This results in significant saving in
memory consumption for a large image, such as a photo taken on a
smartphone (typical resolutions are 3264x2448 and 4032x3024).

This change is suggested by Ranjit Kumar Tulabandu.