### PR TITLE
Set max image size to 32768 * 32768

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Set max image size to 32768 * 32768
 
 ## [0.8.2] - 2020-10-14
 ### Added

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -282,7 +282,7 @@ avifBool avifSequenceHeaderParse(avifSequenceHeader * header, const avifROData *
 
 // A maximum image size to avoid out-of-memory errors or integer overflow in
 // (32-bit) int or unsigned int arithmetic operations.
-#define AVIF_MAX_IMAGE_SIZE (16384 * 16384)
+#define AVIF_MAX_IMAGE_SIZE (32768 * 32768)
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
I've just checked and a milky way panorama (single row) shot with my 24MP camera. The image is 15286x5476 pixels. However we have cameras with 42MP (Sony a7R3) for a single photo in the meantime. So if I create the same image with that camera it would easily exceed 16384 pixels ...