### PR TITLE
Expose chroma sample position in decoded images

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -160,6 +160,7 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec, const avifDecodeS
 
         image->yuvFormat = yuvFormat;
         image->yuvRange = (codec->internal->image->range == AOM_CR_STUDIO_RANGE) ? AVIF_RANGE_LIMITED : AVIF_RANGE_FULL;
+        image->yuvChromaSamplePosition = (avifChromaSamplePosition)codec->internal->image->csp;
 
         image->colorPrimaries = (avifColorPrimaries)codec->internal->image->cp;
         image->transferCharacteristics = (avifTransferCharacteristics)codec->internal->image->tc;

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -149,6 +149,7 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec, const avifDecod
 
         image->yuvFormat = yuvFormat;
         image->yuvRange = codec->internal->colorRange;
+        image->yuvChromaSamplePosition = (avifChromaSamplePosition)dav1dImage->seq_hdr->chr;
 
         image->colorPrimaries = (avifColorPrimaries)dav1dImage->seq_hdr->pri;
         image->transferCharacteristics = (avifTransferCharacteristics)dav1dImage->seq_hdr->trc;

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -98,6 +98,7 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec, const avifDecode
 
         image->yuvFormat = yuvFormat;
         image->yuvRange = codec->internal->colorRange;
+        image->yuvChromaSamplePosition = (avifChromaSamplePosition)gav1Image->chroma_sample_position;
 
         image->colorPrimaries = (avifColorPrimaries)gav1Image->color_primary;
         image->transferCharacteristics = (avifTransferCharacteristics)gav1Image->transfer_characteristics;


### PR DESCRIPTION
Have codecs expose the chroma sample position from the sequence header
OBU of the AV1 bitstream in the decoded images.

Right now avifDecoderParse() exposes the chroma sample position from the
av1C property and this value is left unchanged in the decoded images. It
would be useful (or at least more consistent with the other fields in
avifImage) to also expose the chroma sample position in the sequence
header OBU, in case it differs from the value in the av1C property.