### PR TITLE
Add #error if AVIF_CODEC_AOM_DECODE/ENCODE undefined

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -479,6 +479,8 @@ static struct AvailableCodec availableCodecs[] = {
       AVIF_CODEC_FLAG_CAN_DECODE
 #elif defined(AVIF_CODEC_AOM_ENCODE)
       AVIF_CODEC_FLAG_CAN_ENCODE
+#else
+#error AVIF_CODEC_AOM_DECODE or AVIF_CODEC_AOM_ENCODE must be defined
 #endif
     },
 #endif


### PR DESCRIPTION
Add #error if neither AVIF_CODEC_AOM_DECODE nor AVIF_CODEC_AOM_ENCODE is
defined. Although libavif's cmake build system ensures this error cannot
happen, this error may happen in a third-party build system. The #error
message is more informative than a compiler error message about a missing
initializer for 'flags'