### PR TITLE
Remove disableGridImages from avifDecoder

### DIFF
--- a/examples/avif_example_decode_file.c
+++ b/examples/avif_example_decode_file.c
@@ -20,7 +20,7 @@ int main(int argc, char * argv[])
     memset(&rgb, 0, sizeof(rgb));
 
     avifDecoder * decoder = avifDecoderCreate();
-    // Override decoder defaults here (codecChoice, requestedSource, disableGridImages, ignoreExif, ignoreXMP, etc)
+    // Override decoder defaults here (codecChoice, requestedSource, ignoreExif, ignoreXMP, etc)
 
     avifResult result = avifDecoderSetIOFile(decoder, inputFilename);
     if (result != AVIF_RESULT_OK) {

--- a/examples/avif_example_decode_memory.c
+++ b/examples/avif_example_decode_memory.c
@@ -21,7 +21,7 @@ int main(int argc, char * argv[])
     memset(&rgb, 0, sizeof(rgb));
 
     avifDecoder * decoder = avifDecoderCreate();
-    // Override decoder defaults here (codecChoice, requestedSource, disableGridImages, ignoreExif, ignoreXMP, etc)
+    // Override decoder defaults here (codecChoice, requestedSource, ignoreExif, ignoreXMP, etc)
 
     // Read entire file into fileBuffer
     FILE * f = NULL;

--- a/examples/avif_example_decode_streaming.c
+++ b/examples/avif_example_decode_streaming.c
@@ -129,7 +129,7 @@ int main(int argc, char * argv[])
 
     int returnCode = 1;
     avifDecoder * decoder = avifDecoderCreate();
-    // Override decoder defaults here (codecChoice, requestedSource, disableGridImages, ignoreExif, ignoreXMP, etc)
+    // Override decoder defaults here (codecChoice, requestedSource, ignoreExif, ignoreXMP, etc)
 
     // Read entire file into fileBuffer
     FILE * f = NULL;

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -667,9 +667,6 @@ typedef struct avifDecoder
     // avifDecoderNextImage() or avifDecoderNthImage(), as decoder->image->alphaPlane won't exist yet.
     avifBool alphaPresent;
 
-    // Set this to true to disable support of grid images. If a grid image is encountered, AVIF_RESULT_BMFF_PARSE_FAILED will be returned.
-    avifBool disableGridImages;
-
     // Enable any of these to avoid reading and surfacing specific data to the decoded avifImage.
     // These can be useful if your avifIO implementation heavily uses AVIF_RESULT_WAITING_ON_IO for
     // streaming data, as some of these payloads are (unfortunately) packed at the end of the file,

--- a/src/read.c
+++ b/src/read.c
@@ -2510,10 +2510,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             }
 
             if (isGrid) {
-                if (decoder->disableGridImages) {
-                    return AVIF_RESULT_BMFF_PARSE_FAILED;
-                }
-
                 avifROData readData;
                 avifResult readResult = avifDecoderReadItem(decoder, item, &readData, 0);
                 if (readResult != AVIF_RESULT_OK) {
@@ -2553,10 +2549,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             const avifProperty * auxCProp = avifPropertyArrayFind(&item->properties, "auxC");
             if (auxCProp && isAlphaURN(auxCProp->u.auxC.auxType) && (item->auxForID == colorItem->id)) {
                 if (isGrid) {
-                    if (decoder->disableGridImages) {
-                        return AVIF_RESULT_BMFF_PARSE_FAILED;
-                    }
-
                     avifROData readData;
                     avifResult readResult = avifDecoderReadItem(decoder, item, &readData, 0);
                     if (readResult != AVIF_RESULT_OK) {


### PR DESCRIPTION
Remove the disableGridImages field from the avifDecoder struct. The
disableGridImages decoder setting was added as a temporary security
measure while we were reviewing the newly-written grid image code. That
code has since been carefully reviewed and fuzzed.