### PR TITLE
Quiet the find_package(libyuv) call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ if(UNIX)
     set(AVIF_PLATFORM_LIBRARIES m Threads::Threads)
 endif()
 
-find_package(libyuv) # not required
+find_package(libyuv QUIET) # not required
 if(libyuv_FOUND)
     message(STATUS "libavif: libyuv found, libyuv-based fast paths enabled.")
     set(AVIF_PLATFORM_DEFINITIONS ${AVIF_PLATFORM_DEFINITIONS} -DAVIF_LIBYUV_ENABLED=1)


### PR DESCRIPTION
Get rid of the confusing error message.

Before:

-- Checking for module 'libyuv'
--   No package 'libyuv' found
-- Could NOT find libyuv (missing: LIBYUV_LIBRARY LIBYUV_LIBRARIES LIBYUV_INCLUDE_DIR) (found version "")
-- libavif: libyuv not found, libyuv-based fast paths disabled.

After:

-- Checking for module 'libyuv'
--   No package 'libyuv' found
-- libavif: libyuv not found, libyuv-based fast paths disabled.