### PR TITLE
Add AVIF_MATRIX_COEFFICIENTS_YCGCO (YCgCo) support

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -456,7 +456,8 @@ int avifLimitedToFullUV(int depth, int v);
 typedef enum avifReformatMode
 {
     AVIF_REFORMAT_MODE_YUV_COEFFICIENTS = 0, // Normal YUV conversion using coefficients
-    AVIF_REFORMAT_MODE_IDENTITY              // Pack GBR directly into YUV planes (AVIF_MATRIX_COEFFICIENTS_IDENTITY)
+    AVIF_REFORMAT_MODE_IDENTITY,             // Pack GBR directly into YUV planes (AVIF_MATRIX_COEFFICIENTS_IDENTITY)
+    AVIF_REFORMAT_MODE_YCGCO                 // YUV conversion using AVIF_MATRIX_COEFFICIENTS_YCGCO
 } avifReformatMode;
 
 typedef struct avifReformatState

--- a/src/colr.c
+++ b/src/colr.c
@@ -85,6 +85,7 @@ static const struct avifMatrixCoefficientsTable matrixCoefficientsTables[] = {
     { AVIF_MATRIX_COEFFICIENTS_BT470BG, "BT.470-6 System BG", 0.299f, 0.114f },
     { AVIF_MATRIX_COEFFICIENTS_BT601, "BT.601", 0.299f, 0.114f },
     { AVIF_MATRIX_COEFFICIENTS_SMPTE240, "SMPTE ST 240", 0.212f, 0.087f },
+    //{ AVIF_MATRIX_COEFFICIENTS_YCGCO, "YCgCo", 0.0f, 0.0f, }, // Handled elsewhere
     { AVIF_MATRIX_COEFFICIENTS_BT2020_NCL, "BT.2020 (non-constant luminance)", 0.2627f, 0.0593f },
     //{ AVIF_MATRIX_COEFFICIENTS_BT2020_CL, "BT.2020 (constant luminance)", 0.2627f, 0.0593f }, // FIXME: It is not an linear transformation.
     //{ AVIF_MATRIX_COEFFICIENTS_SMPTE2085, "ST 2085", 0.0f, 0.0f }, // FIXME: ST2085 can't represent using Kr and Kb.

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -109,7 +109,8 @@ int main(int argc, char * argv[])
                 const avifMatrixCoefficients matrixCoeffsList[] = { AVIF_MATRIX_COEFFICIENTS_BT709,
                                                                     AVIF_MATRIX_COEFFICIENTS_BT601,
                                                                     AVIF_MATRIX_COEFFICIENTS_BT2020_NCL,
-                                                                    AVIF_MATRIX_COEFFICIENTS_IDENTITY };
+                                                                    AVIF_MATRIX_COEFFICIENTS_IDENTITY,
+                                                                    AVIF_MATRIX_COEFFICIENTS_YCGCO };
                 const int matrixCoeffsCount = (int)(sizeof(matrixCoeffsList) / sizeof(matrixCoeffsList[0]));
 
                 for (int matrixCoeffsIndex = 0; matrixCoeffsIndex < matrixCoeffsCount; ++matrixCoeffsIndex) {


### PR DESCRIPTION
Add AVIF_MATRIX_COEFFICIENTS_YCGCO=8 (YCgCo) support to src/reformat.c.

The YCgCo color space has the following two differences:

1. For the limited-full range conversion, the U,V planes use the same
equations as the Y plane. In this aspect, it is the same as Identity.

2. For the RGB-to-YUV conversion, it is similar to normal YUV
conversion but uses different equations (its equations do not use the Kb
and Kr coefficients).

In H.273 the equations for YCgCo also differ from the equations for
normal YUV conversion in when the Round() and Clip1Y() functions are
called. (In this aspect YCgCo is the same as Identity.) But libavif
seems to ignore these differences.

Fix https://github.com/AOMediaCodec/libavif/issues/418