### PR TITLE
Print MC value when warning resetting to defaults

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -623,7 +623,8 @@ int main(int argc, char * argv[])
 
         if (cicpExplicitlySet) {
             // Only warn if someone explicitly asked for identity.
-            printf("WARNING: matrixCoefficients may not be set to identity(0) when subsampling. Resetting MC to defaults.\n");
+            printf("WARNING: matrixCoefficients may not be set to identity (0) when subsampling. Resetting MC to defaults (%d).\n",
+                   image->matrixCoefficients);
         }
     }
 


### PR DESCRIPTION
Print the default value when we warn we're restting matrix coefficients
to defaults.