### PR TITLE
Add the avifContainerDump() function

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -52,23 +52,18 @@ static int info(const char * inputFilename)
     result = avifDecoderParse(decoder);
     if (result == AVIF_RESULT_OK) {
         printf("Image decoded: %s\n", inputFilename);
+        avifContainerDump(decoder);
+
+        printf(" * %" PRIu64 " timescales per second, %2.2f seconds (%" PRIu64 " timescales), %d frame%s\n",
+               decoder->timescale,
+               decoder->duration,
+               decoder->durationInTimescales,
+               decoder->imageCount,
+               (decoder->imageCount == 1) ? "" : "s");
+        printf(" * Frames:\n");
 
         int frameIndex = 0;
-        avifBool firstImage = AVIF_TRUE;
         while (avifDecoderNextImage(decoder) == AVIF_RESULT_OK) {
-            if (firstImage) {
-                firstImage = AVIF_FALSE;
-                avifImageDump(decoder->image);
-
-                printf(" * %" PRIu64 " timescales per second, %2.2f seconds (%" PRIu64 " timescales), %d frame%s\n",
-                       decoder->timescale,
-                       decoder->duration,
-                       decoder->durationInTimescales,
-                       decoder->imageCount,
-                       (decoder->imageCount == 1) ? "" : "s");
-                printf(" * Frames:\n");
-            }
-
             printf("   * Decoded frame [%d] [pts %2.2f (%" PRIu64 " timescales)] [duration %2.2f (%" PRIu64 " timescales)]\n",
                    frameIndex,
                    decoder->imageTiming.pts,

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -7,12 +7,12 @@
 #include <stdio.h>
 #include <string.h>
 
-void avifImageDump(avifImage * avif)
+static void avifImageDumpInternal(avifImage * avif, avifBool alphaPresent)
 {
     printf(" * Resolution     : %dx%d\n", avif->width, avif->height);
     printf(" * Bit Depth      : %d\n", avif->depth);
     printf(" * Format         : %s\n", avifPixelFormatToString(avif->yuvFormat));
-    printf(" * Alpha          : %s\n", (avif->alphaPlane && (avif->alphaRowBytes > 0)) ? "Present" : "Absent");
+    printf(" * Alpha          : %s\n", alphaPresent ? "Present" : "Absent");
     printf(" * Range          : %s\n", (avif->yuvRange == AVIF_RANGE_FULL) ? "Full" : "Limited");
 
     printf(" * Color Primaries: %d\n", avif->colorPrimaries);
@@ -49,6 +49,17 @@ void avifImageDump(avifImage * avif)
             printf("    * imir (Mirror)        : %u (%s)\n", avif->imir.axis, (avif->imir.axis == 0) ? "Vertical" : "Horizontal");
         }
     }
+}
+
+void avifImageDump(avifImage * avif)
+{
+    const avifBool alphaPresent = avif->alphaPlane && (avif->alphaRowBytes > 0);
+    avifImageDumpInternal(avif, alphaPresent);
+}
+
+void avifContainerDump(avifDecoder * decoder)
+{
+    avifImageDumpInternal(decoder->image, decoder->alphaPresent);
 }
 
 void avifPrintVersions(void)

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -21,6 +21,7 @@
 #endif
 
 void avifImageDump(avifImage * avif);
+void avifContainerDump(avifDecoder * decoder);
 void avifPrintVersions(void);
 
 typedef enum avifAppFileFormat


### PR DESCRIPTION
Use the avifContainerDump() function in the info() function in avifdec.c
to dump the container info instead of the first frame's info.

I noticed this issue while trying to debug monochrome images encoded
with libaom before commit 2172ed05169f08b20245221a7e95619a65884fd7.
The container yuvFormat was YUV400 but the first frame's yuvFormat was
YUV420. avifdec -i printed YUV420, so I could not see the container
yuvFormat was wrong. Obviously it would be best to dump both the
container info and every frame's info, but that could be confusing to
average users, or at least too verbose.