### PR TITLE
Remove unneeded cast for grid->rows, grid->columns

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -794,7 +794,7 @@ static avifResult avifDecoderItemRead(avifDecoderItem * item, avifIO * io, avifR
 
 static avifBool avifDecoderDataGenerateImageGridTiles(avifDecoderData * data, avifImageGrid * grid, avifDecoderItem * gridItem, avifBool alpha)
 {
-    unsigned int tilesRequested = (unsigned int)grid->rows * (unsigned int)grid->columns;
+    unsigned int tilesRequested = grid->rows * grid->columns;
 
     // Count number of dimg for this item, bail out if it doesn't match perfectly
     unsigned int tilesAvailable = 0;


### PR DESCRIPTION
Remove unneeded unsigned int cast for grid->rows and grid->columns.
These two fields are of the uint32_t type now (was uint8_t).