### PR TITLE
Fix -Wmissing-prototypes and -Wcast-qual warnings

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -272,7 +272,7 @@ static avifBool readEntireFile(const char * filename, avifRWData * raw)
     return AVIF_TRUE;
 }
 
-avifBool avifImageSplitGrid(const avifImage * gridSplitImage, uint32_t gridCols, uint32_t gridRows, avifImage ** gridCells)
+static avifBool avifImageSplitGrid(const avifImage * gridSplitImage, uint32_t gridCols, uint32_t gridRows, avifImage ** gridCells)
 {
     if ((gridSplitImage->width % gridCols) != 0) {
         fprintf(stderr, "ERROR: Can't split image width (%u) evenly into %u columns.\n", gridSplitImage->width, gridCols);
@@ -994,7 +994,7 @@ int main(int argc, char * argv[])
 
     if (gridDimsCount > 0) {
         avifResult addImageResult = avifEncoderAddImageGrid(
-            encoder, (uint8_t)gridDims[0], (uint8_t)gridDims[1], (const avifImage **)gridCells, AVIF_ADD_IMAGE_FLAG_SINGLE);
+            encoder, (uint8_t)gridDims[0], (uint8_t)gridDims[1], (const avifImage * const *)gridCells, AVIF_ADD_IMAGE_FLAG_SINGLE);
         if (addImageResult != AVIF_RESULT_OK) {
             fprintf(stderr, "ERROR: Failed to encode image: %s\n", avifResultToString(addImageResult));
             returnCode = 1;

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -865,7 +865,11 @@ enum avifAddImageFlags
 //
 
 AVIF_API avifResult avifEncoderAddImage(avifEncoder * encoder, const avifImage * image, uint64_t durationInTimescales, uint32_t addImageFlags);
-AVIF_API avifResult avifEncoderAddImageGrid(avifEncoder * encoder, uint8_t gridCols, uint8_t gridRows, const avifImage ** cellImages, uint32_t addImageFlags);
+AVIF_API avifResult avifEncoderAddImageGrid(avifEncoder * encoder,
+                                            uint8_t gridCols,
+                                            uint8_t gridRows,
+                                            const avifImage * const * cellImages,
+                                            uint32_t addImageFlags);
 AVIF_API avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output);
 
 // Codec-specific, optional "advanced" tuning settings, in the form of string key/value pairs. These

--- a/src/write.c
+++ b/src/write.c
@@ -382,7 +382,7 @@ static void avifWriteGridPayload(avifRWData * data, uint8_t gridCols, uint8_t gr
 static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
                                               uint8_t gridCols,
                                               uint8_t gridRows,
-                                              const avifImage ** cellImages,
+                                              const avifImage * const * cellImages,
                                               uint64_t durationInTimescales,
                                               uint32_t addImageFlags)
 {
@@ -626,13 +626,13 @@ avifResult avifEncoderAddImage(avifEncoder * encoder, const avifImage * image, u
     return avifEncoderAddImageInternal(encoder, 1, 1, &image, durationInTimescales, addImageFlags);
 }
 
-avifResult avifEncoderAddImageGrid(avifEncoder * encoder, uint8_t gridCols, uint8_t gridRows, const avifImage ** cellImages, uint32_t addImageFlags)
+avifResult avifEncoderAddImageGrid(avifEncoder * encoder, uint8_t gridCols, uint8_t gridRows, const avifImage * const * cellImages, uint32_t addImageFlags)
 {
     return avifEncoderAddImageInternal(
         encoder, gridCols, gridRows, cellImages, 1, addImageFlags | AVIF_ADD_IMAGE_FLAG_SINGLE); // only single image grids are supported
 }
 
-size_t avifEncoderFindExistingChunk(avifRWStream * s, size_t mdatStartOffset, const uint8_t * data, size_t size)
+static size_t avifEncoderFindExistingChunk(avifRWStream * s, size_t mdatStartOffset, const uint8_t * data, size_t size)
 {
     const size_t mdatCurrentOffset = avifRWStreamOffset(s);
     const size_t mdatSearchSize = mdatCurrentOffset - mdatStartOffset;


### PR DESCRIPTION
Add 'static' to function signatures of avifImageSplitGrid() and
avifEncoderFindExistingChunk(). This fix was suggested by Pascal
Massimino.

Change the type of the cellImages parameter of avifEncoderAddImageGrid()
from:
    const avifImage ** cellImages
to
    const avifImage * const * cellImages
so that we can cast an avifImage ** pointer to the new type without the
-Wcast-qual warning. This fix was suggested by Yuan Tong.

Fix https://crbug.com/oss-fuzz/28622.