### PR TITLE
Better handling for export headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,13 +406,11 @@ target_include_directories(avif
                            PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include>
                                   $<INSTALL_INTERFACE:include>
                            PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
-set(AVIF_PC_EXTRA_DEFINITION "")
+set(AVIF_PKG_CONFIG_EXTRA_CFLAGS "")
 if(BUILD_SHARED_LIBS)
-    target_compile_definitions(avif PRIVATE -DAVIF_BUILDING_SHARED_LIBS)
-    if(WIN32)
-        target_compile_definitions(avif INTERFACE -DAVIF_DLL)
-        set(AVIF_PC_EXTRA_DEFINITION " -DAVIF_DLL")
-    endif()
+    target_compile_definitions(avif PUBLIC AVIF_DLL)
+    target_compile_definitions(avif PRIVATE AVIF_BUILDING_SHARED_LIBS)
+    set(AVIF_PKG_CONFIG_EXTRA_CFLAGS " -DAVIF_DLL")
     if(AVIF_LOCAL_LIBGAV1)
         set_target_properties(avif PROPERTIES LINKER_LANGUAGE "CXX")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,13 +406,17 @@ target_include_directories(avif
                            PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include>
                                   $<INSTALL_INTERFACE:include>
                            PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
+set(AVIF_PC_EXTRA_DEFINITION "")
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(avif PRIVATE -DAVIF_BUILDING_SHARED_LIBS)
+    if(WIN32)
+        target_compile_definitions(avif INTERFACE -DAVIF_DLL)
+        set(AVIF_PC_EXTRA_DEFINITION " -DAVIF_DLL")
+    endif()
     if(AVIF_LOCAL_LIBGAV1)
         set_target_properties(avif PROPERTIES LINKER_LANGUAGE "CXX")
     endif()
 endif()
-
 
 option(AVIF_BUILD_EXAMPLES "Build avif Examples." OFF)
 if(AVIF_BUILD_EXAMPLES)

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -7,7 +7,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifndef AVIF_API
+// ---------------------------------------------------------------------------
+// Export macros
+
+// AVIF_BUILDING_SHARED_LIBS should only be defined when building shared
+// version of libavif library.
+// AVIF_DLL may only be defined when your project dynamically linking to libavif
+// on Windows, to allow compiler to generate more efficient function call
+// assembly. If you are using libavif as CMake dependency, through CMake
+// package config file or through pkg-config this is defined automatically.
+
 #if defined(AVIF_BUILDING_SHARED_LIBS)
 #if defined(_WIN32)
 #define AVIF_API __declspec(dllexport)
@@ -16,10 +25,11 @@
 #else
 #define AVIF_API
 #endif // if defined(_WIN32)
+#elif defined(_WIN32) && defined(AVIF_DLL)
+#define AVIF_API __declspec(dllimport)
 #else
 #define AVIF_API
 #endif // if defined(AVIF_BUILDING_SHARED_LIBS)
-#endif // ifndef AVIF_API
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -19,6 +19,13 @@ extern "C" {
 // AVIF_DLL should be defined if libavif is a shared library. If you are using
 // libavif as CMake dependency, through CMake package config file or
 // through pkg-config, this is defined automatically.
+//
+// Here's what `AVIF_API` will be defined to in shared build:
+// |       |        Windows        |                  Unix                  |
+// | Build | __declspec(dllexport) | __attribute__((visibility("default"))) |
+// |  Use  | __declspec(dllimport) |                                        |
+//
+// For static build, `AVIF_API` is always defined to nothing.
 
 #if defined(_WIN32)
 #define AVIF_HELPER_EXPORT __declspec(dllexport)

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -20,12 +20,12 @@ extern "C" {
 // libavif as CMake dependency, through CMake package config file or
 // through pkg-config, this is defined automatically.
 //
-// Here's what `AVIF_API` will be defined to in shared build:
+// Here's what AVIF_API will be defined as in shared build:
 // |       |        Windows        |                  Unix                  |
 // | Build | __declspec(dllexport) | __attribute__((visibility("default"))) |
 // |  Use  | __declspec(dllimport) |                                        |
 //
-// For static build, `AVIF_API` is always defined to nothing.
+// For static build, AVIF_API is always defined as nothing.
 
 #if defined(_WIN32)
 #define AVIF_HELPER_EXPORT __declspec(dllexport)

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -7,33 +7,39 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// ---------------------------------------------------------------------------
-// Export macros
-
-// AVIF_BUILDING_SHARED_LIBS should only be defined when building shared
-// version of libavif library.
-// AVIF_DLL may only be defined when your project dynamically linking to libavif
-// on Windows, to allow compiler to generate more efficient function call
-// assembly. If you are using libavif as CMake dependency, through CMake
-// package config file or through pkg-config this is defined automatically.
-
-#if defined(AVIF_BUILDING_SHARED_LIBS)
-#if defined(_WIN32)
-#define AVIF_API __declspec(dllexport)
-#elif defined(__GNUC__) && __GNUC__ >= 4
-#define AVIF_API __attribute__((visibility("default")))
-#else
-#define AVIF_API
-#endif // if defined(_WIN32)
-#elif defined(_WIN32) && defined(AVIF_DLL)
-#define AVIF_API __declspec(dllimport)
-#else
-#define AVIF_API
-#endif // if defined(AVIF_BUILDING_SHARED_LIBS)
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// ---------------------------------------------------------------------------
+// Export macros
+
+// AVIF_BUILDING_SHARED_LIBS should only be defined when libavif is being built
+// as a shared library.
+// AVIF_DLL should be defined if libavif is a shared library. If you are using
+// libavif as CMake dependency, through CMake package config file or
+// through pkg-config, this is defined automatically.
+
+#if defined(_WIN32)
+#define AVIF_HELPER_EXPORT __declspec(dllexport)
+#define AVIF_HELPER_IMPORT __declspec(dllimport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#define AVIF_HELPER_EXPORT __attribute__((visibility("default")))
+#define AVIF_HELPER_IMPORT
+#else
+#define AVIF_HELPER_EXPORT
+#define AVIF_HELPER_IMPORT
+#endif
+
+#if defined(AVIF_DLL)
+#if defined(AVIF_BUILDING_SHARED_LIBS)
+#define AVIF_API AVIF_HELPER_EXPORT
+#else
+#define AVIF_API AVIF_HELPER_IMPORT
+#endif // if defined(AVIF_BUILDING_SHARED_LIBS)
+#else
+#define AVIF_API
+#endif //if defined(AVIF_DLL)
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/libavif.pc.cmake
+++ b/libavif.pc.cmake
@@ -7,4 +7,4 @@ Name: @PROJECT_NAME@
 Description: Library for encoding and decoding .avif files
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lavif
-Cflags: -I${includedir}@AVIF_PC_EXTRA_DEFINITION@
+Cflags: -I${includedir}@AVIF_PKG_CONFIG_EXTRA_CFLAGS@

--- a/libavif.pc.cmake
+++ b/libavif.pc.cmake
@@ -7,4 +7,4 @@ Name: @PROJECT_NAME@
 Description: Library for encoding and decoding .avif files
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lavif
-Cflags: -I${includedir}
+Cflags: -I${includedir}@AVIF_PC_EXTRA_DEFINITION@


### PR DESCRIPTION
This solve some remaining problems in #439.

- Add case for `__declspec(dllimport)`, and macro `AVIF_DLL` to enable it.
- Add comments to explain this.
- Automatically defines `AVIF_DLL` for user if we can.

Here's what `AVIF_API` will be defined to:
| (Shared) | Windows | Unix |
| --- | --- | --- |
| Build | `__declspec(dllexport)` | `__attribute__((visibility("default")))` |
| Use | `__declspec(dllimport)`| |

For static build, `AVIF_API` always defines to nothing. 