### PR TITLE
Expose AOM specific film grain advanced options

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -107,8 +107,8 @@ static void syntax(void)
         printf("    end-usage=MODE                    : Rate control mode (vbr, cbr, cq, or q)\n");
         printf("    sharpness=S                       : Loop filter sharpness (0-7, default: 0)\n");
         printf("    tune=METRIC                       : Tune the encoder for distortion metric (psnr or ssim, default: psnr)\n");
-        printf("    film-grain-test=FV                : Film grain test vectors (0: none (default), 1: test-1  2: test-2, ... 16: test-16)\n");
-        printf("    film-grain-table=FT               : Path to file containing film grain parameters\n");
+        printf("    film-grain-test=TEST              : Film grain test vectors (0: none (default), 1: test-1  2: test-2, ... 16: test-16)\n");
+        printf("    film-grain-table=FILENAME         : Path to file containing film grain parameters\n");
         printf("\n");
     }
     avifPrintVersions();

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -107,6 +107,8 @@ static void syntax(void)
         printf("    end-usage=MODE                    : Rate control mode (vbr, cbr, cq, or q)\n");
         printf("    sharpness=S                       : Loop filter sharpness (0-7, default: 0)\n");
         printf("    tune=METRIC                       : Tune the encoder for distortion metric (psnr or ssim, default: psnr)\n");
+        printf("    film-grain-test=FV                : Film grain test vectors (0: none (default), 1: test-1  2: test-2, ... 16: test-16)\n");
+        printf("    film-grain-table=FT               : Path to file containing film grain parameters\n");
         printf("\n");
     }
     avifPrintVersions();

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -380,30 +380,30 @@ static avifBool avifProcessAOMOptionsPostInit(avifCodec * codec)
         for (int j = 0; aomOptionDefs[j].name; ++j) {
             if (!strcmp(entry->key, aomOptionDefs[j].name)) {
                 match = AVIF_TRUE;
-                avifBool parsed = AVIF_FALSE;
-                int val_int = 0;
-                unsigned int val_uint = 0;
+                avifBool success = AVIF_FALSE;
+                int valInt;
+                unsigned int valUInt;
                 switch (aomOptionDefs[j].type) {
                     case AOM_OPTION_NUL:
-                        parsed = AVIF_FALSE;
+                        success = AVIF_FALSE;
                         break;
                     case AOM_OPTION_STR:
-                        parsed = aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, entry->value) == AOM_CODEC_OK;
+                        success = aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, entry->value) == AOM_CODEC_OK;
                         break;
                     case AOM_OPTION_INT:
-                        parsed = aomOptionParseInt(entry->value, &val_int) &&
-                                 aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, val_int) == AOM_CODEC_OK;
+                        success = aomOptionParseInt(entry->value, &valInt) &&
+                                  aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, valInt) == AOM_CODEC_OK;
                         break;
                     case AOM_OPTION_UINT:
-                        parsed = aomOptionParseUInt(entry->value, &val_uint) &&
-                                 aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, val_uint) == AOM_CODEC_OK;
+                        success = aomOptionParseUInt(entry->value, &valUInt) &&
+                                  aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, valUInt) == AOM_CODEC_OK;
                         break;
                     case AOM_OPTION_ENUM:
-                        parsed = aomOptionParseEnum(entry->value, aomOptionDefs[j].enums, &val_int) &&
-                                 aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, val_int) == AOM_CODEC_OK;
+                        success = aomOptionParseEnum(entry->value, aomOptionDefs[j].enums, &valInt) &&
+                                  aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, valInt) == AOM_CODEC_OK;
                         break;
                 }
-                if (!parsed) {
+                if (!success) {
                     return AVIF_FALSE;
                 }
                 break;

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -325,11 +325,11 @@ static avifBool avifProcessAOMOptionsPreInit(avifCodec * codec, struct aom_codec
 
 typedef enum
 {
-    AVIF_AOM_NUL_OPTION = 0,
-    AVIF_AOM_STR_OPTION,
-    AVIF_AOM_INT_OPTION,
-    AVIF_AOM_UINT_OPTION,
-    AVIF_AOM_ENUM_OPTION,
+    AOM_OPTION_NUL = 0,
+    AOM_OPTION_STR,
+    AOM_OPTION_INT,
+    AOM_OPTION_UINT,
+    AOM_OPTION_ENUM,
 } aomOptionType;
 
 struct aomOptionDef
@@ -337,7 +337,7 @@ struct aomOptionDef
     const char * name;
     int controlId;
     aomOptionType type;
-    // if type is AVIF_AOM_ENUM_OPTION, this must be set. Otherwise should be NULL
+    // If type is AOM_OPTION_ENUM, this must be set. Otherwise should be NULL.
     const struct aomOptionEnumList * enums;
 };
 
@@ -349,22 +349,22 @@ static const struct aomOptionEnumList tuningEnum[] = { //
 
 static const struct aomOptionDef aomOptionDefs[] = {
     // Adaptive quantization mode
-    { "aq-mode", AV1E_SET_AQ_MODE, AVIF_AOM_UINT_OPTION, NULL },
+    { "aq-mode", AV1E_SET_AQ_MODE, AOM_OPTION_UINT, NULL },
     // Constant/Constrained Quality level
-    { "cq-level", AOME_SET_CQ_LEVEL, AVIF_AOM_UINT_OPTION, NULL },
+    { "cq-level", AOME_SET_CQ_LEVEL, AOM_OPTION_UINT, NULL },
     // Enable delta quantization in chroma planes
-    { "enable-chroma-deltaq", AV1E_SET_ENABLE_CHROMA_DELTAQ, AVIF_AOM_INT_OPTION, NULL },
+    { "enable-chroma-deltaq", AV1E_SET_ENABLE_CHROMA_DELTAQ, AOM_OPTION_INT, NULL },
     // Loop filter sharpness
-    { "sharpness", AOME_SET_SHARPNESS, AVIF_AOM_UINT_OPTION, NULL },
+    { "sharpness", AOME_SET_SHARPNESS, AOM_OPTION_UINT, NULL },
     // Tune distortion metric
-    { "tune", AOME_SET_TUNING, AVIF_AOM_ENUM_OPTION, tuningEnum },
+    { "tune", AOME_SET_TUNING, AOM_OPTION_ENUM, tuningEnum },
     // Film grain test vector
-    { "film-grain-test", AV1E_SET_FILM_GRAIN_TEST_VECTOR, AVIF_AOM_INT_OPTION, NULL },
+    { "film-grain-test", AV1E_SET_FILM_GRAIN_TEST_VECTOR, AOM_OPTION_INT, NULL },
     // Film grain table file
-    { "film-grain-table", AV1E_SET_FILM_GRAIN_TABLE, AVIF_AOM_STR_OPTION, NULL },
+    { "film-grain-table", AV1E_SET_FILM_GRAIN_TABLE, AOM_OPTION_STR, NULL },
 
     // Sentinel
-    { NULL, 0, AVIF_AOM_NUL_OPTION, NULL }
+    { NULL, 0, AOM_OPTION_NUL, NULL }
 };
 
 static avifBool avifProcessAOMOptionsPostInit(avifCodec * codec)
@@ -384,21 +384,21 @@ static avifBool avifProcessAOMOptionsPostInit(avifCodec * codec)
                 int val_int = 0;
                 unsigned int val_uint = 0;
                 switch (aomOptionDefs[j].type) {
-                    case AVIF_AOM_NUL_OPTION:
+                    case AOM_OPTION_NUL:
                         parsed = AVIF_FALSE;
                         break;
-                    case AVIF_AOM_STR_OPTION:
+                    case AOM_OPTION_STR:
                         parsed = aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, entry->value) == AOM_CODEC_OK;
                         break;
-                    case AVIF_AOM_INT_OPTION:
+                    case AOM_OPTION_INT:
                         parsed = aomOptionParseInt(entry->value, &val_int) &&
                                  aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, val_int) == AOM_CODEC_OK;
                         break;
-                    case AVIF_AOM_UINT_OPTION:
+                    case AOM_OPTION_UINT:
                         parsed = aomOptionParseUInt(entry->value, &val_uint) &&
                                  aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, val_uint) == AOM_CODEC_OK;
                         break;
-                    case AVIF_AOM_ENUM_OPTION:
+                    case AOM_OPTION_ENUM:
                         parsed = aomOptionParseEnum(entry->value, aomOptionDefs[j].enums, &val_int) &&
                                  aom_codec_control(&codec->internal->encoder, aomOptionDefs[j].controlId, val_int) == AOM_CODEC_OK;
                         break;


### PR DESCRIPTION
Film grain is a post-decode step in AV1 which adds synthetic noise on the image. 

When encoding an image using 8 bit, limited range (this is the best choice If performance and compatibility are both the case), color banding artifact can usually appear on color gradient areas. Adding noise (dithering) can reduce such artifact, but doing such will significantly increase the file size (random data is hard to compress). Film grain uses several parameters to model the noise, so it solves banding without inflating file size.