### PR TITLE
Declare gridCols and gridRows as uint32_t

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -939,7 +939,7 @@ int main(int argc, char * argv[])
         }
 
         if (gridCellIndex == 0) {
-            printf("Single image input for a grid image. Attempting split into %u cells...\n", gridCellCount);
+            printf("Single image input for a grid image. Attempting to split into %u cells...\n", gridCellCount);
             gridSplitImage = image;
             gridCells[0] = NULL;
 
@@ -950,12 +950,10 @@ int main(int argc, char * argv[])
             gridCellIndex = gridCellCount - 1;
         }
 
-        for (uint32_t i = 0; i < gridCellCount; ++i) {
-            if (!gridCells[i]) {
-                fprintf(stderr, "ERROR: Not enough input files for grid image! (expecting %u, or a single image to be split)\n", gridCellCount);
-                returnCode = 1;
-                goto cleanup;
-            }
+        if (gridCellIndex != gridCellCount - 1) {
+            fprintf(stderr, "ERROR: Not enough input files for grid image! (expecting %u, or a single image to be split)\n", gridCellCount);
+            returnCode = 1;
+            goto cleanup;
         }
     }
 
@@ -994,7 +992,7 @@ int main(int argc, char * argv[])
 
     if (gridDimsCount > 0) {
         avifResult addImageResult = avifEncoderAddImageGrid(
-            encoder, (uint8_t)gridDims[0], (uint8_t)gridDims[1], (const avifImage * const *)gridCells, AVIF_ADD_IMAGE_FLAG_SINGLE);
+            encoder, gridDims[0], gridDims[1], (const avifImage * const *)gridCells, AVIF_ADD_IMAGE_FLAG_SINGLE);
         if (addImageResult != AVIF_RESULT_OK) {
             fprintf(stderr, "ERROR: Failed to encode image: %s\n", avifResultToString(addImageResult));
             returnCode = 1;
@@ -1016,9 +1014,7 @@ int main(int argc, char * argv[])
             returnCode = 1;
             goto cleanup;
         }
-    }
 
-    if (!gridDimsCount) {
         // Not generating a single-image grid: Use all remaining input files as subsequent frames.
 
         avifInputFile * nextFile;

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -889,8 +889,8 @@ enum avifAddImageFlags
 
 AVIF_API avifResult avifEncoderAddImage(avifEncoder * encoder, const avifImage * image, uint64_t durationInTimescales, uint32_t addImageFlags);
 AVIF_API avifResult avifEncoderAddImageGrid(avifEncoder * encoder,
-                                            uint8_t gridCols,
-                                            uint8_t gridRows,
+                                            uint32_t gridCols,
+                                            uint32_t gridRows,
                                             const avifImage * const * cellImages,
                                             uint32_t addImageFlags);
 AVIF_API avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output);

--- a/src/write.c
+++ b/src/write.c
@@ -89,8 +89,8 @@ typedef struct avifEncoderItem
     uint16_t irefToID; // if non-zero, make an iref from this id -> irefToID
     const char * irefType;
 
-    uint8_t gridCols; // if non-zero, this is a grid item
-    uint8_t gridRows; // if non-zero, this is a grid item
+    uint32_t gridCols; // if non-zero (legal range [1-256]), this is a grid item
+    uint32_t gridRows; // if non-zero (legal range [1-256]), this is a grid item
 
     uint16_t dimgFromID; // if non-zero, make an iref from dimgFromID -> this id
 
@@ -344,7 +344,7 @@ static void avifEncoderWriteTrackMetaBox(avifEncoder * encoder, avifRWStream * s
     avifRWStreamFinishBox(s, meta);
 }
 
-static void avifWriteGridPayload(avifRWData * data, uint8_t gridCols, uint8_t gridRows, const avifImage * firstCell)
+static void avifWriteGridPayload(avifRWData * data, uint32_t gridCols, uint32_t gridRows, const avifImage * firstCell)
 {
     // ISO/IEC 23008-12 6.6.2.3.2
     // aligned(8) class ImageGrid {
@@ -380,8 +380,8 @@ static void avifWriteGridPayload(avifRWData * data, uint8_t gridCols, uint8_t gr
 }
 
 static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
-                                              uint8_t gridCols,
-                                              uint8_t gridRows,
+                                              uint32_t gridCols,
+                                              uint32_t gridRows,
                                               const avifImage * const * cellImages,
                                               uint64_t durationInTimescales,
                                               uint32_t addImageFlags)
@@ -627,8 +627,11 @@ avifResult avifEncoderAddImage(avifEncoder * encoder, const avifImage * image, u
     return avifEncoderAddImageInternal(encoder, 1, 1, &image, durationInTimescales, addImageFlags);
 }
 
-avifResult avifEncoderAddImageGrid(avifEncoder * encoder, uint8_t gridCols, uint8_t gridRows, const avifImage * const * cellImages, uint32_t addImageFlags)
+avifResult avifEncoderAddImageGrid(avifEncoder * encoder, uint32_t gridCols, uint32_t gridRows, const avifImage * const * cellImages, uint32_t addImageFlags)
 {
+    if ((gridCols == 0) || (gridCols > 256) || (gridRows == 0) || (gridRows > 256)) {
+        return AVIF_RESULT_INVALID_IMAGE_GRID;
+    }
     return avifEncoderAddImageInternal(
         encoder, gridCols, gridRows, cellImages, 1, addImageFlags | AVIF_ADD_IMAGE_FLAG_SINGLE); // only single image grids are supported
 }


### PR DESCRIPTION
Declare gridCols and gridRows as uint32_t (instead of uint8_t) so that
256 (the maximum legal value) can be represented.

Also make some cleanup changes.