### PR TITLE
Use procedure specified in H.273 to quantize YUV

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -520,16 +520,14 @@ typedef struct avifReformatState
     uint32_t rgbOffsetBytesA;
 
     uint32_t yuvDepth;
-    uint32_t rgbDepth;
     avifRange yuvRange;
     int yuvMaxChannel;
     int rgbMaxChannel;
-    float yuvMaxChannelF;
     float rgbMaxChannelF;
-    float yBias; // minimum y value
-    float uvBias; // the value of 0.5 for the appropriate bit depth [128, 512, 2048]
-    float yRange; // difference between max and min y
-    float uvRange; // difference between max and min uv
+    float biasY; // minimum y value
+    float biasUV; // the value of 0.5 for the appropriate bit depth [128, 512, 2048]
+    float rangeY; // difference between max and min y
+    float rangeUV; // difference between max and min uv
 
     avifPixelFormatInfo formatInfo;
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -526,7 +526,10 @@ typedef struct avifReformatState
     int rgbMaxChannel;
     float yuvMaxChannelF;
     float rgbMaxChannelF;
-    int uvBias; // the integer value of 0.5 for the appropriate bit depth [128, 512, 2048]
+    float yBias; // minimal y value
+    float uvBias; // the value of 0.5 for the appropriate bit depth [128, 512, 2048]
+    float yRange; // difference between max and min y
+    float uvRange; // difference between max and min uv
 
     avifPixelFormatInfo formatInfo;
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -526,7 +526,7 @@ typedef struct avifReformatState
     int rgbMaxChannel;
     float yuvMaxChannelF;
     float rgbMaxChannelF;
-    float yBias; // minimal y value
+    float yBias; // minimum y value
     float uvBias; // the value of 0.5 for the appropriate bit depth [128, 512, 2048]
     float yRange; // difference between max and min y
     float uvRange; // difference between max and min uv

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -133,13 +133,12 @@ avifBool avifPrepareReformatState(const avifImage * image, const avifRGBImage * 
 static int avifReformatStateYToUNorm(avifReformatState * state, float v)
 {
     int unorm = (int)avifRoundf(v * state->rangeY + state->biasY);
-    unorm = AVIF_CLAMP(unorm, 0, state->yuvMaxChannel);
-    return unorm;
+    return AVIF_CLAMP(unorm, 0, state->yuvMaxChannel);
 }
 
 static int avifReformatStateUVToUNorm(avifReformatState * state, float v)
 {
-    int unorm = 0;
+    int unorm;
 
     // YCgCo performs limited-full range adjustment on R,G,B but the current implementation performs range adjustment
     // on Y,U,V. So YCgCo with limited range is unsupported.

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -118,6 +118,7 @@ avifBool avifPrepareReformatState(const avifImage * image, const avifRGBImage * 
     for (uint32_t cp = 0; cp < cpCount; ++cp) {
         int unorm = cp;
         switch (state->mode) {
+            // review this when implementing YCgCo limited range support.
             case AVIF_REFORMAT_MODE_YCGCO:
             case AVIF_REFORMAT_MODE_YUV_COEFFICIENTS:
                 state->unormFloatTableY[cp] = ((float)unorm - state->yBias) / state->yRange;


### PR DESCRIPTION
Old `avifReformatStateYToUNorm` and `avifReformatStateUVToUNorm` functions quantize YUV value at very first without extra precision, and can introduce severer than normal banding. This PR change to follow the procedure specified in H.273, and can give better result on limited range images.

Difference example:
| Original | Old | New |
| --- | --- | --- |
| ![original](https://user-images.githubusercontent.com/13075180/103022694-7756a280-4587-11eb-8fec-56351ebb5231.png) | ![old](https://user-images.githubusercontent.com/13075180/103022713-7cb3ed00-4587-11eb-84a9-c986dc981464.png) | ![new](https://user-images.githubusercontent.com/13075180/103022720-7faedd80-4587-11eb-9ff6-76b8bd8314c3.png) |


Images are created by following command:
```
avifenc -r l --min 0 --max 0 --cicp 1/13/1 original.png output.avif
avifdec output.avif test.png
```

Updated formulas passed avifyuv test with maxDrift=1 (only tested 8bit and 10bit. 12bit is too slow).
