### PR TITLE
Improve message for avifInputReadImage failure

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -615,7 +615,7 @@ int main(int argc, char * argv[])
     uint32_t sourceDepth = 0;
     avifAppFileFormat inputFormat = avifInputReadImage(&input, image, &sourceDepth);
     if (inputFormat == AVIF_APP_FILE_FORMAT_UNKNOWN) {
-        fprintf(stderr, "Cannot determine input file format: %s\n", firstFile->filename);
+        fprintf(stderr, "Cannot determine input file format or read input file into avifImage: %s\n", firstFile->filename);
         returnCode = 1;
         goto cleanup;
     }


### PR DESCRIPTION
Improve the error message for avifInputReadImage failure. The current
message is "Cannot determine input file format", but that is not the
only reason for avifInputReadImage failure. For example,
avifInputReadImage() fails if the CICP in 'image' is not supported.

Apparently we try to address this issue by having avifJPEGRead() print
an error message if its avifImageRGBToYUV() call fails. But I was still
confused by the "Cannot determine input file format" message when I
passed an unsupported --cicp option to avifenc.