### PR TITLE
test/docker/build.sh: Dependency update

### DIFF
--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -55,7 +55,7 @@ cd
 git clone --single-branch https://chromium.googlesource.com/codecs/libgav1
 cd libgav1
 git checkout b712ad2
-git clone  --single-branch https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
+git clone -b lts_2020_09_23 --depth 1 https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
 mkdir build
 cd build
 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DLIBGAV1_THREADPOOL_USE_STD_MUTEX=1 ..

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -27,14 +27,14 @@ cargo install cargo-c
 
 # NASM
 cd
-curl -L https://download.videolan.org/contrib/nasm/nasm-2.14.tar.gz | tar xvz
-cd nasm-2.14
+curl -L https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.gz | tar xvz
+cd nasm-2.15.05
 ./configure --prefix=/usr && make -j2 && make install
 nasm --version
 
 # aom
 cd
-git clone -b v1.0.0-errata1-avif --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v2.0.1 --depth 1 https://aomedia.googlesource.com/aom
 cd aom
 mkdir build.avif
 cd build.avif
@@ -43,7 +43,7 @@ ninja install
 
 # dav1d
 cd
-git clone -b 0.6.0 --depth 1 https://code.videolan.org/videolan/dav1d.git
+git clone -b 0.8.0 --depth 1 https://code.videolan.org/videolan/dav1d.git
 cd dav1d
 mkdir build
 cd build
@@ -54,8 +54,8 @@ ninja install
 cd
 git clone --single-branch https://chromium.googlesource.com/codecs/libgav1
 cd libgav1
-git checkout 45a1d76
-git clone https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
+git checkout b712ad2
+git clone  --single-branch https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
 mkdir build
 cd build
 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DLIBGAV1_THREADPOOL_USE_STD_MUTEX=1 ..
@@ -63,7 +63,7 @@ ninja install
 
 # rav1e
 cd
-git clone -b v0.3.1 --depth 1 https://github.com/xiph/rav1e.git
+git clone -b 0.3 --depth 1 https://github.com/xiph/rav1e.git
 cd rav1e
 cargo cinstall --prefix=/usr --release
 


### PR DESCRIPTION
Update the dependencies of the Docker build script.
- Update nasm to 2.15.05
- Update aom to v2.0.1
- Update dav1d to 0.8.0
- Update libgav1 to commit b712ad2
- Update rav1e to the 0.3 maintenance branch