### PR TITLE
 Ext: Update to dav1d 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-* Update dav1d.cmd to point at the 0.8.0 tag
+* Update dav1d.cmd to point at the 0.8.1 tag
 
 ## [0.8.4] - 2020-11-23
 

--- a/ext/dav1d.cmd
+++ b/ext/dav1d.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b 0.8.0 --depth 1 https://code.videolan.org/videolan/dav1d.git
+git clone -b 0.8.1 --depth 1 https://code.videolan.org/videolan/dav1d.git
 
 cd dav1d
 mkdir build


### PR DESCRIPTION
[dav1d 0.8.1 release notes](https://code.videolan.org/videolan/dav1d/-/blob/0.8.1/NEWS):
> 0.8.1 is a minor update on 0.8.0:
>  - Keep references to buffers valid after dav1d_close(). Fixes a regression
>    caused by the picture buffer pool added in 0.8.0.
>  - ARM32 optimizations for 10bit bitdepth for SGR
>  - ARM32 optimizations for 16bit bitdepth for blend/w_masl/emu_edge
>  - ARM64 optimizations for 10bit bitdepth for SGR
>  - x86 optimizations for wiener in SSE2/SSSE3/AVX2