### PR TITLE
Change avifenc default speed from 4 to 6

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -369,7 +369,7 @@ int main(int argc, char * argv[])
     int maxQuantizerAlpha = AVIF_QUANTIZER_LOSSLESS;
     int tileRowsLog2 = 0;
     int tileColsLog2 = 0;
-    int speed = 4;
+    int speed = 6;
     int paspCount = 0;
     uint32_t paspValues[8]; // only the first two are used
     int clapCount = 0;


### PR DESCRIPTION
Speed 6 is the fastest speed in libaom's good-quality usage mode. In one
testing Frank Galligan performed on 20 images, the average encoding
times for speeds 3, 4, 6, 8 are roughly:
  - Speed 3: 125 seconds
  - Speed 4:  63 seconds
  - Speed 6:  42 seconds
  - Speed 8:  11 seconds

So speed 6 is likely to save 1/3 of the encoding time compared with
speed 4.

https://github.com/AOMediaCodec/libavif/issues/440