### PR TITLE
Update rav1e.cmd and docker/build.sh to use rav1e 0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install dependencies
       run: |
         DEBIAN_FRONTEND=noninteractive sudo apt-get update || true
-        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ninja-build gcc-10 g++-10
+        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ninja-build gcc-10 g++-10 build-essential
         pip install --upgrade pip
         pip install setuptools
         pip install meson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Update dav1d.cmd to point at the 0.8.1 tag
+* Update rav1e.cmd to point at the 0.4 maintenance branch
 
 ## [0.8.4] - 2020-11-23
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,7 @@ if(AVIF_CODEC_RAV1E)
         endif()
 
         set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/target/release/include"
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/target/release"
         )
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
     else()

--- a/ext/rav1e.cmd
+++ b/ext/rav1e.cmd
@@ -11,7 +11,7 @@
 : # Also, the error that "The target windows-msvc is not supported yet" can safely be ignored provided that rav1e/target/release
 : # contains rav1e.h and rav1e.lib.
 
-git clone -b 0.3 --depth 1 https://github.com/xiph/rav1e.git
+git clone -b 0.4 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
 cargo install cbindgen

--- a/ext/rav1e.cmd
+++ b/ext/rav1e.cmd
@@ -14,8 +14,6 @@
 git clone -b 0.4 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
-cargo install cbindgen
-cbindgen -c cbindgen.toml -l C -o target/release/include/rav1e/rav1e.h --crate rav1e .
-
-cargo build --lib --release --features capi
+cargo install cargo-c
+cargo cinstall --release
 cd ..

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -3,7 +3,7 @@
 
 #include "avif/internal.h"
 
-#include "rav1e/rav1e.h"
+#include "rav1e.h"
 
 #include <string.h>
 

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -63,7 +63,7 @@ ninja install
 
 # rav1e
 cd
-git clone -b 0.3 --depth 1 https://github.com/xiph/rav1e.git
+git clone -b 0.4 --depth 1 https://github.com/xiph/rav1e.git
 cd rav1e
 cargo cinstall --prefix=/usr --release
 


### PR DESCRIPTION
Switches both rav1e.cmd and docker/build.sh to update from the rav1e 0.3 maintenance branch to the [0.4 maintenance branch](https://github.com/xiph/rav1e/tree/0.4).