### PR TITLE
Let developers know they can ignore avifIO.write

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -613,6 +613,8 @@ typedef struct avifIO
 {
     avifIODestroyFunc destroy;
     avifIOReadFunc read;
+    
+    // This is reserved for further use - but currently ignored. Set it to a null pointer.
     avifIOWriteFunc write;
 
     // If non-zero, this is a hint to internal structures of the max size offered by the content


### PR DESCRIPTION
Add comment so that developers know that avifIO's `write` member is currently unused. They can simply set it to a null pointer.