### PR TITLE
Support premultiply alpha

### DIFF
--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -148,6 +148,7 @@ avifBool avifJPEGWrite(avifImage * avif, const char * outputFilename, int jpegQu
     avifRGBImage rgb;
     avifRGBImage rgbPremultiplied;
     avifRGBImageSetDefaults(&rgb, avif);
+    avifRGBImageSetDefaults(&rgbPremultiplied, avif);
     rgb.format = avif->alphaPremultiplied ? AVIF_RGB_FORMAT_RGB : AVIF_RGB_FORMAT_RGBA;
     rgb.chromaUpsampling = chromaUpsampling;
     rgb.depth = 8;

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -136,9 +136,6 @@ avifBool avifPNGRead(avifImage * avif, const char * inputFilename, avifPixelForm
         rowPointers[y] = &rgb.pixels[y * rgb.rowBytes];
     }
     png_read_image(png, rowPointers);
-    if (avif->alphaPremultiplied) {
-        avifRGBImagePremultiplyAlpha(&rgb);
-    }
     if (avifImageRGBToYUV(avif, &rgb) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to YUV failed: %s\n", inputFilename);
         goto cleanup;
@@ -182,13 +179,11 @@ avifBool avifPNGWrite(avifImage * avif, const char * outputFilename, uint32_t re
     avifRGBImageSetDefaults(&rgb, avif);
     rgb.depth = rgbDepth;
     rgb.chromaUpsampling = chromaUpsampling;
+    rgb.alphaPremultiplied = AVIF_FALSE;
     avifRGBImageAllocatePixels(&rgb);
     if (avifImageYUVToRGB(avif, &rgb) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);
         goto cleanup;
-    }
-    if (rgb.alphaPremultiplied) {
-        avifRGBImageUnpremultiplyAlpha(&rgb);
     }
 
     f = fopen(outputFilename, "wb");

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -18,7 +18,7 @@ static void avifImageDumpInternal(avifImage * avif, uint32_t gridCols, uint32_t 
     printf(" * Resolution     : %ux%u\n", width, height);
     printf(" * Bit Depth      : %u\n", avif->depth);
     printf(" * Format         : %s\n", avifPixelFormatToString(avif->yuvFormat));
-    printf(" * Alpha          : %s\n", alphaPresent ? "Present" : "Absent");
+    printf(" * Alpha          : %s\n", alphaPresent ? (avif->alphaPremultiplied ? "Premultiplied" : "Not premultiplied") : "Absent");
     printf(" * Range          : %s\n", (avif->yuvRange == AVIF_RANGE_FULL) ? "Full" : "Limited");
 
     printf(" * Color Primaries: %u\n", avif->colorPrimaries);

--- a/examples/avif_example_decode_file.c
+++ b/examples/avif_example_decode_file.c
@@ -66,6 +66,9 @@ int main(int argc, char * argv[])
 
         // Now available:
         // * RGB(A) pixel data (rgb.pixels, rgb.rowBytes)
+        //   note that if alpha is present, RGB may or may not be premultiplied by alpha.
+        //   call avifRGBImagePremultiplyAlpha() or avifRGBImageUnpremultiplyAlpha()
+        //   to convert pixel data into your desired format.
 
         if (rgb.depth > 8) {
             uint16_t * firstPixel = (uint16_t *)rgb.pixels;

--- a/examples/avif_example_decode_file.c
+++ b/examples/avif_example_decode_file.c
@@ -53,7 +53,7 @@ int main(int argc, char * argv[])
         // * this frame's sequence timing
 
         avifRGBImageSetDefaults(&rgb, decoder->image);
-        // Override YUV(A)->RGB(A) defaults here: depth, format, chromaUpsampling, ignoreAlpha, libYUVUsage, etc
+        // Override YUV(A)->RGB(A) defaults here: depth, format, chromaUpsampling, ignoreAlpha, alphaPremultiplied, libYUVUsage, etc
 
         // Alternative: set rgb.pixels and rgb.rowBytes yourself, which should match your chosen rgb.format
         // Be sure to use uint16_t* instead of uint8_t* for rgb.pixels/rgb.rowBytes if (rgb.depth > 8)
@@ -66,9 +66,6 @@ int main(int argc, char * argv[])
 
         // Now available:
         // * RGB(A) pixel data (rgb.pixels, rgb.rowBytes)
-        //   note that if alpha is present, RGB may or may not be premultiplied by alpha.
-        //   call avifRGBImagePremultiplyAlpha() or avifRGBImageUnpremultiplyAlpha()
-        //   to convert pixel data into your desired format.
 
         if (rgb.depth > 8) {
             uint16_t * firstPixel = (uint16_t *)rgb.pixels;

--- a/examples/avif_example_decode_memory.c
+++ b/examples/avif_example_decode_memory.c
@@ -75,7 +75,7 @@ int main(int argc, char * argv[])
         // * this frame's sequence timing
 
         avifRGBImageSetDefaults(&rgb, decoder->image);
-        // Override YUV(A)->RGB(A) defaults here: depth, format, chromaUpsampling, ignoreAlpha, libYUVUsage, etc
+        // Override YUV(A)->RGB(A) defaults here: depth, format, chromaUpsampling, ignoreAlpha, alphaPremultiplied, libYUVUsage, etc
 
         // Alternative: set rgb.pixels and rgb.rowBytes yourself, which should match your chosen rgb.format
         // Be sure to use uint16_t* instead of uint8_t* for rgb.pixels/rgb.rowBytes if (rgb.depth > 8)
@@ -88,9 +88,6 @@ int main(int argc, char * argv[])
 
         // Now available:
         // * RGB(A) pixel data (rgb.pixels, rgb.rowBytes)
-        //   note that if alpha is present, RGB may or may not be premultiplied by alpha.
-        //   call avifRGBImagePremultiplyAlpha() or avifRGBImageUnpremultiplyAlpha()
-        //   to convert pixel data into your desired format.
 
         if (rgb.depth > 8) {
             uint16_t * firstPixel = (uint16_t *)rgb.pixels;

--- a/examples/avif_example_decode_memory.c
+++ b/examples/avif_example_decode_memory.c
@@ -88,6 +88,9 @@ int main(int argc, char * argv[])
 
         // Now available:
         // * RGB(A) pixel data (rgb.pixels, rgb.rowBytes)
+        //   note that if alpha is present, RGB may or may not be premultiplied by alpha.
+        //   call avifRGBImagePremultiplyAlpha() or avifRGBImageUnpremultiplyAlpha()
+        //   to convert pixel data into your desired format.
 
         if (rgb.depth > 8) {
             uint16_t * firstPixel = (uint16_t *)rgb.pixels;

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -54,7 +54,7 @@ int main(int argc, char * argv[])
         printf("Encoding from converted RGBA\n");
 
         avifRGBImageSetDefaults(&rgb, image);
-        // Override RGB(A)->YUV(A) defaults here: depth, format, chromaUpsampling, ignoreAlpha, libYUVUsage, etc
+        // Override RGB(A)->YUV(A) defaults here: depth, format, chromaUpsampling, ignoreAlpha, alphaPremultiplied, libYUVUsage, etc
 
         // Alternative: set rgb.pixels and rgb.rowBytes yourself, which should match your chosen rgb.format
         // Be sure to use uint16_t* instead of uint8_t* for rgb.pixels/rgb.rowBytes if (rgb.depth > 8)
@@ -62,11 +62,6 @@ int main(int argc, char * argv[])
 
         // Fill your RGB(A) data here
         memset(rgb.pixels, 255, rgb.rowBytes * image->height);
-
-        // If your data is not premultiplied but you want to encode avif as
-        // premultiplied, set rgb.alphaPremultiplied to false, then call
-        // avifRGBImagePremultiplyAlpha() to convert your RGBA data
-        // into premultiplied format.
 
         avifResult convertResult = avifImageRGBToYUV(image, &rgb);
         if (convertResult != AVIF_RESULT_OK) {

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -35,6 +35,7 @@ int main(int argc, char * argv[])
     // * avifImageSetMetadataXMP()
     // * yuvRange
     // * alphaRange
+    // * alphaPremultiply
     // * transforms (transformFlags, pasp, clap, irot, imir)
 
     if (encodeYUVDirectly) {
@@ -61,6 +62,11 @@ int main(int argc, char * argv[])
 
         // Fill your RGB(A) data here
         memset(rgb.pixels, 255, rgb.rowBytes * image->height);
+
+        // If your data is not premultiplied but you want to encode avif as
+        // premultiplied, set rgb.alphaPremultiplied to false, then call
+        // avifRGBImagePremultiplyAlpha() to convert your RGBA data
+        // into premultiplied format.
 
         avifResult convertResult = avifImageRGBToYUV(image, &rgb);
         if (convertResult != AVIF_RESULT_OK) {

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -473,9 +473,7 @@ typedef struct avifRGBImage
                                            // Unused when converting to YUV. avifRGBImageSetDefaults() prefers quality over speed.
     avifBool ignoreAlpha; // Used for XRGB formats, treats formats containing alpha (such as ARGB) as if they were
                           // RGB, treating the alpha bits as if they were all 1.
-    avifBool alphaPremultiplied; // indicates if RGB value has been pre-multiplied by alpha
-                                 // this should always indicate the real state of RGB data
-                                 // To convert, use avifRGBImagePremultiplyAlpha() or avifRGBImageUnpremultiplyAlpha().
+    avifBool alphaPremultiplied; // indicates if RGB value is pre-multiplied by alpha
 
     uint8_t * pixels;
     uint32_t rowBytes;
@@ -493,6 +491,8 @@ AVIF_API avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rg
 AVIF_API avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb);
 
 // Premultiply handling functions.
+// (Un)premultiply is automatically done by the main conversion functions above,
+// so usually you don't need to call these. They are there for convenience.
 AVIF_API avifResult avifRGBImagePremultiplyAlpha(avifRGBImage * rgb);
 AVIF_API avifResult avifRGBImageUnpremultiplyAlpha(avifRGBImage * rgb);
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -367,6 +367,7 @@ typedef struct avifImage
     uint8_t * alphaPlane;
     uint32_t alphaRowBytes;
     avifBool imageOwnsAlphaPlane;
+    avifBool alphaPremultiplied;
 
     // ICC Profile
     avifRWData icc;
@@ -472,6 +473,9 @@ typedef struct avifRGBImage
                                            // Unused when converting to YUV. avifRGBImageSetDefaults() prefers quality over speed.
     avifBool ignoreAlpha; // Used for XRGB formats, treats formats containing alpha (such as ARGB) as if they were
                           // RGB, treating the alpha bits as if they were all 1.
+    avifBool alphaPremultiplied; // indicates if RGB value has been pre-multiplied by alpha
+                                 // this should always indicate the real state of RGB data
+                                 // To convert, use avifRGBImagePremultiplyAlpha() or avifRGBImageUnpremultiplyAlpha().
 
     uint8_t * pixels;
     uint32_t rowBytes;
@@ -487,6 +491,10 @@ AVIF_API void avifRGBImageFreePixels(avifRGBImage * rgb);
 // The main conversion functions
 AVIF_API avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb);
 AVIF_API avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb);
+
+// Premultiply handling functions.
+AVIF_API avifResult avifRGBImagePremultiplyAlpha(avifRGBImage * rgb);
+AVIF_API avifResult avifRGBImageUnpremultiplyAlpha(avifRGBImage * rgb);
 
 // ---------------------------------------------------------------------------
 // YUV Utils

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -98,6 +98,13 @@ avifBool avifReformatAlpha(const avifAlphaParams * const params);
 // * [any other error]           - Return error to caller
 avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb);
 
+// Returns:
+// * AVIF_RESULT_OK              - (Un)Premultiply successfully with libyuv
+// * AVIF_RESULT_NOT_IMPLEMENTED - The fast path for this combination is not implemented with libyuv, use built-in (Un)Premultiply
+// * [any other error]           - Return error to caller
+avifResult avifRGBImagePremultiplyAlphaLibYUV(avifRGBImage * rgb);
+avifResult avifRGBImageUnpremultiplyAlphaLibYUV(avifRGBImage * rgb);
+
 // ---------------------------------------------------------------------------
 // avifCodecDecodeInput
 

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 // Yes, clamp macros are nasty. Do not use them.
-#define AVIF_CLAMP(x, low, high) (((x) < (low))) ? (low) : (((high) < (x)) ? (high) : (x))
+#define AVIF_CLAMP(x, low, high) ((((x) < (low))) ? (low) : (((high) < (x)) ? (high) : (x)))
 #define AVIF_MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define AVIF_MAX(a, b) (((a) > (b)) ? (a) : (b))
 

--- a/src/alpha.c
+++ b/src/alpha.c
@@ -4,6 +4,7 @@
 #include "avif/internal.h"
 
 #include <string.h>
+#include <assert.h>
 
 static int calcMaxChannel(uint32_t depth, avifRange range)
 {
@@ -379,4 +380,249 @@ avifBool avifReformatAlpha(const avifAlphaParams * const params)
     }
 
     return AVIF_TRUE;
+}
+
+avifResult avifRGBImagePremultiplyAlpha(avifRGBImage * rgb) {
+    // no data
+    if (!rgb->pixels || !rgb->rowBytes) {
+        return AVIF_RESULT_REFORMAT_FAILED;
+    }
+
+    // no alpha.
+    if (!avifRGBFormatHasAlpha(rgb->format)) {
+        return AVIF_RESULT_INVALID_ARGUMENT;
+    }
+
+    // already premultiplied. No-op.
+    if (rgb->alphaPremultiplied) {
+        return AVIF_RESULT_OK;
+    }
+
+    rgb->alphaPremultiplied = AVIF_TRUE;
+
+    avifResult libyuvResult = avifRGBImagePremultiplyAlphaLibYUV(rgb);
+    if (libyuvResult != AVIF_RESULT_NOT_IMPLEMENTED) {
+        return libyuvResult;
+    }
+
+    assert(rgb->depth >= 8 && rgb->depth <= 16);
+
+    uint32_t max = (1 << rgb->depth) - 1;
+    float maxF = (float)max;
+
+    if (rgb->depth > 8) {
+        if (rgb->format == AVIF_RGB_FORMAT_RGBA || rgb->format == AVIF_RGB_FORMAT_BGRA) {
+            for (uint32_t j = 0; j < rgb->height; ++j) {
+                uint8_t * row = &rgb->pixels[j * rgb->rowBytes];
+                for (uint32_t i = 0; i < rgb->width; ++i) {
+                    uint16_t * pixel = (uint16_t *)&row[i * 8];
+                    uint16_t a = pixel[3];
+                    if (a >= max) {
+                        // opaque is no-op
+                        continue;
+                    } else if (a == 0) {
+                        // result must be zero
+                        pixel[0] = 0;
+                        pixel[1] = 0;
+                        pixel[2] = 0;
+                    } else {
+                        // a < maxF is always true now, so we don't need clamp here
+                        pixel[0] = (uint16_t)avifRoundf((float)pixel[0] * (float)a / maxF);
+                        pixel[1] = (uint16_t)avifRoundf((float)pixel[1] * (float)a / maxF);
+                        pixel[2] = (uint16_t)avifRoundf((float)pixel[2] * (float)a / maxF);
+                    }
+                }
+            }
+        } else {
+            for (uint32_t j = 0; j < rgb->height; ++j) {
+                uint8_t * row = &rgb->pixels[j * rgb->rowBytes];
+                for (uint32_t i = 0; i < rgb->width; ++i) {
+                    uint16_t * pixel = (uint16_t *)&row[i * 8];
+                    uint16_t a = pixel[0];
+                    if (a >= max) {
+                        continue;
+                    } else if (a == 0) {
+                        pixel[1] = 0;
+                        pixel[2] = 0;
+                        pixel[3] = 0;
+                    } else {
+                        pixel[1] = (uint16_t)avifRoundf((float)pixel[1] * (float)a / maxF);
+                        pixel[2] = (uint16_t)avifRoundf((float)pixel[2] * (float)a / maxF);
+                        pixel[3] = (uint16_t)avifRoundf((float)pixel[3] * (float)a / maxF);
+                    }
+                }
+            }
+        }
+    } else {
+        if (rgb->format == AVIF_RGB_FORMAT_RGBA || rgb->format == AVIF_RGB_FORMAT_BGRA) {
+            for (uint32_t j = 0; j < rgb->height; ++j) {
+                uint8_t * row = &rgb->pixels[j * rgb->rowBytes];
+                for (uint32_t i = 0; i < rgb->width; ++i) {
+                    uint8_t * pixel = &row[i * 4];
+                    uint8_t a = pixel[3];
+                    // uint8_t can't exceed 255
+                    if (a == max) {
+                        continue;
+                    } else if (a == 0) {
+                        pixel[0] = 0;
+                        pixel[1] = 0;
+                        pixel[2] = 0;
+                    } else {
+                        pixel[0] = (uint8_t)avifRoundf((float)pixel[0] * (float)a / maxF);
+                        pixel[1] = (uint8_t)avifRoundf((float)pixel[1] * (float)a / maxF);
+                        pixel[2] = (uint8_t)avifRoundf((float)pixel[2] * (float)a / maxF);
+                    }
+                }
+            }
+        } else {
+            for (uint32_t j = 0; j < rgb->height; ++j) {
+                uint8_t * row = &rgb->pixels[j * rgb->rowBytes];
+                for (uint32_t i = 0; i < rgb->width; ++i) {
+                    uint8_t * pixel = &row[i * 4];
+                    uint8_t a = pixel[0];
+                    if (a == max) {
+                        continue;
+                    } else if (a == 0) {
+                        pixel[1] = 0;
+                        pixel[2] = 0;
+                        pixel[3] = 0;
+                    } else {
+                        pixel[1] = (uint8_t)avifRoundf((float)pixel[1] * (float)a / maxF);
+                        pixel[2] = (uint8_t)avifRoundf((float)pixel[2] * (float)a / maxF);
+                        pixel[3] = (uint8_t)avifRoundf((float)pixel[3] * (float)a / maxF);
+                    }
+                }
+            }
+        }
+    }
+
+    return AVIF_RESULT_OK;
+}
+
+avifResult avifRGBImageUnpremultiplyAlpha(avifRGBImage * rgb)
+{
+    // no data
+    if (!rgb->pixels || !rgb->rowBytes) {
+        return AVIF_RESULT_REFORMAT_FAILED;
+    }
+
+    // no alpha.
+    if (!avifRGBFormatHasAlpha(rgb->format)) {
+        return AVIF_RESULT_REFORMAT_FAILED;
+    }
+
+    // already premultiplied. No-op.
+    if (!rgb->alphaPremultiplied) {
+        return AVIF_RESULT_OK;
+    }
+
+    rgb->alphaPremultiplied = AVIF_FALSE;
+
+    avifResult libyuvResult = avifRGBImageUnpremultiplyAlphaLibYUV(rgb);
+    if (libyuvResult != AVIF_RESULT_NOT_IMPLEMENTED) {
+        return libyuvResult;
+    }
+
+    assert(rgb->depth >= 8 && rgb->depth <= 16);
+
+    uint32_t max = (1 << rgb->depth) - 1;
+    float maxF = (float)max;
+
+    if (rgb->depth > 8) {
+        if (rgb->format == AVIF_RGB_FORMAT_RGBA || rgb->format == AVIF_RGB_FORMAT_BGRA) {
+            for (uint32_t j = 0; j < rgb->height; ++j) {
+                uint8_t * row = &rgb->pixels[j * rgb->rowBytes];
+                for (uint32_t i = 0; i < rgb->width; ++i) {
+                    uint16_t * pixel = (uint16_t *)&row[i * 8];
+                    uint16_t a = pixel[3];
+                    if (a >= max) {
+                        // opaque is no-op
+                        continue;
+                    } else if (a == 0) {
+                        // prevent divide by zero
+                        pixel[0] = 0;
+                        pixel[1] = 0;
+                        pixel[2] = 0;
+                    } else {
+                        float c1 = avifRoundf((float)pixel[0] * maxF / (float)a);
+                        float c2 = avifRoundf((float)pixel[1] * maxF / (float)a);
+                        float c3 = avifRoundf((float)pixel[2] * maxF / (float)a);
+                        pixel[0] = (uint16_t)AVIF_CLAMP(c1, 0, maxF);
+                        pixel[1] = (uint16_t)AVIF_CLAMP(c2, 0, maxF);
+                        pixel[2] = (uint16_t)AVIF_CLAMP(c3, 0, maxF);
+                    }
+                }
+            }
+        } else {
+            for (uint32_t j = 0; j < rgb->height; ++j) {
+                uint8_t * row = &rgb->pixels[j * rgb->rowBytes];
+                for (uint32_t i = 0; i < rgb->width; ++i) {
+                    uint16_t * pixel = (uint16_t *)&row[i * 8];
+                    uint16_t a = pixel[0];
+                    if (a >= max) {
+                        continue;
+                    } else if (a == 0) {
+                        pixel[1] = 0;
+                        pixel[2] = 0;
+                        pixel[3] = 0;
+                    } else {
+                        float c1 = avifRoundf((float)pixel[1] * maxF / (float)a);
+                        float c2 = avifRoundf((float)pixel[2] * maxF / (float)a);
+                        float c3 = avifRoundf((float)pixel[3] * maxF / (float)a);
+                        pixel[1] = (uint16_t)AVIF_CLAMP(c1, 0, maxF);
+                        pixel[2] = (uint16_t)AVIF_CLAMP(c2, 0, maxF);
+                        pixel[3] = (uint16_t)AVIF_CLAMP(c3, 0, maxF);
+                    }
+                }
+            }
+        }
+    } else {
+        if (rgb->format == AVIF_RGB_FORMAT_RGBA || rgb->format == AVIF_RGB_FORMAT_BGRA) {
+            for (uint32_t j = 0; j < rgb->height; ++j) {
+                uint8_t * row = &rgb->pixels[j * rgb->rowBytes];
+                for (uint32_t i = 0; i < rgb->width; ++i) {
+                    uint8_t * pixel = &row[i * 4];
+                    uint8_t a = pixel[3];
+                    if (a == max) {
+                        continue;
+                    } else if (a == 0) {
+                        pixel[0] = 0;
+                        pixel[1] = 0;
+                        pixel[2] = 0;
+                    } else {
+                        float c1 = avifRoundf((float)pixel[0] * maxF / (float)a);
+                        float c2 = avifRoundf((float)pixel[1] * maxF / (float)a);
+                        float c3 = avifRoundf((float)pixel[2] * maxF / (float)a);
+                        pixel[0] = (uint8_t)AVIF_CLAMP(c1, 0, maxF);
+                        pixel[1] = (uint8_t)AVIF_CLAMP(c2, 0, maxF);
+                        pixel[2] = (uint8_t)AVIF_CLAMP(c3, 0, maxF);
+                    }
+                }
+            }
+        } else {
+            for (uint32_t j = 0; j < rgb->height; ++j) {
+                uint8_t * row = &rgb->pixels[j * rgb->rowBytes];
+                for (uint32_t i = 0; i < rgb->width; ++i) {
+                    uint8_t * pixel = &row[i * 4];
+                    uint8_t a = pixel[0];
+                    if (a == max) {
+                        continue;
+                    } else if (a == 0) {
+                        pixel[1] = 0;
+                        pixel[2] = 0;
+                        pixel[3] = 0;
+                    } else {
+                        float c1 = avifRoundf((float)pixel[1] * maxF / (float)a);
+                        float c2 = avifRoundf((float)pixel[2] * maxF / (float)a);
+                        float c3 = avifRoundf((float)pixel[3] * maxF / (float)a);
+                        pixel[1] = (uint8_t)AVIF_CLAMP(c1, 0, maxF);
+                        pixel[2] = (uint8_t)AVIF_CLAMP(c2, 0, maxF);
+                        pixel[3] = (uint8_t)AVIF_CLAMP(c3, 0, maxF);
+                    }
+                }
+            }
+        }
+    }
+
+    return AVIF_RESULT_OK;
 }

--- a/src/avif.c
+++ b/src/avif.c
@@ -139,6 +139,7 @@ void avifImageCopy(avifImage * dstImage, const avifImage * srcImage, uint32_t pl
     dstImage->yuvRange = srcImage->yuvRange;
     dstImage->yuvChromaSamplePosition = srcImage->yuvChromaSamplePosition;
     dstImage->alphaRange = srcImage->alphaRange;
+    dstImage->alphaPremultiplied = srcImage->alphaPremultiplied;
 
     dstImage->colorPrimaries = srcImage->colorPrimaries;
     dstImage->transferCharacteristics = srcImage->transferCharacteristics;
@@ -360,6 +361,7 @@ void avifRGBImageSetDefaults(avifRGBImage * rgb, const avifImage * image)
     rgb->ignoreAlpha = AVIF_FALSE;
     rgb->pixels = NULL;
     rgb->rowBytes = 0;
+    rgb->alphaPremultiplied = image->alphaPremultiplied;
 }
 
 void avifRGBImageAllocatePixels(avifRGBImage * rgb)

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -159,6 +159,10 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
         return AVIF_RESULT_REFORMAT_FAILED;
     }
 
+    if (image->alphaPremultiplied != rgb->alphaPremultiplied) {
+        return AVIF_RESULT_REFORMAT_FAILED;
+    }
+
     avifReformatState state;
     if (!avifPrepareReformatState(image, rgb, &state)) {
         return AVIF_RESULT_REFORMAT_FAILED;
@@ -962,6 +966,10 @@ static avifResult avifImageYUV8ToRGB8Mono(const avifImage * image, avifRGBImage 
 avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
 {
     if (!image->yuvPlanes[AVIF_CHAN_Y]) {
+        return AVIF_RESULT_REFORMAT_FAILED;
+    }
+
+    if (image->alphaPremultiplied != rgb->alphaPremultiplied) {
         return AVIF_RESULT_REFORMAT_FAILED;
     }
 

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -12,12 +12,12 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
     (void)rgb;
     return AVIF_RESULT_NOT_IMPLEMENTED;
 }
-avifResult avifRGBImagePremultiplyLibYUV(avifRGBImage * rgb)
+avifResult avifRGBImagePremultiplyAlphaLibYUV(avifRGBImage * rgb)
 {
     (void)rgb;
     return AVIF_RESULT_NOT_IMPLEMENTED;
 }
-avifResult avifRGBImageUnpremultiplyLibYUV(avifRGBImage * rgb)
+avifResult avifRGBImageUnpremultiplyAlphaLibYUV(avifRGBImage * rgb)
 {
     (void)rgb;
     return AVIF_RESULT_NOT_IMPLEMENTED;

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -12,6 +12,16 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
     (void)rgb;
     return AVIF_RESULT_NOT_IMPLEMENTED;
 }
+avifResult avifRGBImagePremultiplyLibYUV(avifRGBImage * rgb)
+{
+    (void)rgb;
+    return AVIF_RESULT_NOT_IMPLEMENTED;
+}
+avifResult avifRGBImageUnpremultiplyLibYUV(avifRGBImage * rgb)
+{
+    (void)rgb;
+    return AVIF_RESULT_NOT_IMPLEMENTED;
+}
 unsigned int avifLibYUVVersion(void)
 {
     return 0;
@@ -419,6 +429,49 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
     }
 
     // This function didn't do anything; use the built-in YUV conversion
+    return AVIF_RESULT_NOT_IMPLEMENTED;
+}
+
+avifResult avifRGBImagePremultiplyAlphaLibYUV(avifRGBImage * rgb)
+{
+    // See if the current settings can be accomplished with libyuv, and use it (if possible).
+
+    if (rgb->depth != 8) {
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
+
+    // libavif uses byte-order when describing pixel formats, such that the R in RGBA is the lowest address,
+    // similar to PNG. libyuv orders in word-order, so libavif's RGBA would be referred to in libyuv as ABGR.
+
+    // order of RGB doesn't matter here.
+    if (rgb->format == AVIF_RGB_FORMAT_RGBA || rgb->format == AVIF_RGB_FORMAT_BGRA) {
+        if (ARGBAttenuate(rgb->pixels, rgb->rowBytes, rgb->pixels, rgb->rowBytes, rgb->width, rgb->height) != 0) {
+            return AVIF_RESULT_REFORMAT_FAILED;
+        }
+        return AVIF_RESULT_OK;
+    }
+
+    return AVIF_RESULT_NOT_IMPLEMENTED;
+}
+
+avifResult avifRGBImageUnpremultiplyAlphaLibYUV(avifRGBImage * rgb)
+{
+    // See if the current settings can be accomplished with libyuv, and use it (if possible).
+
+    if (rgb->depth != 8) {
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
+
+    // libavif uses byte-order when describing pixel formats, such that the R in RGBA is the lowest address,
+    // similar to PNG. libyuv orders in word-order, so libavif's RGBA would be referred to in libyuv as ABGR.
+
+    if (rgb->format == AVIF_RGB_FORMAT_RGBA || rgb->format == AVIF_RGB_FORMAT_BGRA) {
+        if (ARGBUnattenuate(rgb->pixels, rgb->rowBytes, rgb->pixels, rgb->rowBytes, rgb->width, rgb->height) != 0) {
+            return AVIF_RESULT_REFORMAT_FAILED;
+        }
+        return AVIF_RESULT_OK;
+    }
+
     return AVIF_RESULT_NOT_IMPLEMENTED;
 }
 

--- a/src/write.c
+++ b/src/write.c
@@ -461,8 +461,8 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
 
         // Prepare all AV1 items
 
-        const char ** pColorIrefType;
-        uint16_t * pColorIrefToID;
+        const char ** pColorIrefType = NULL;
+        uint16_t * pColorIrefToID = NULL;
 
         uint16_t gridColorID = 0;
         if (cellCount > 1) {


### PR DESCRIPTION
Add support to signaling image is premultiplied, and converting between premultiply and non-premultiply RGB values.

Produced file and premultiply flag can be recognized correctly by mp4parse-rust, and can be opened by Firefox, though currently Firefox is not handling alpha correctly. (always premultiply once more than should)

Also changed JPEG writer to always output premultiplied RGB value, as it's the real appearance on black background.