### PR TITLE
Fix memcpy/sizeof typo in avifImageCopy

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -149,7 +149,7 @@ void avifImageCopy(avifImage * dstImage, const avifImage * srcImage, uint32_t pl
     memcpy(&dstImage->pasp, &srcImage->pasp, sizeof(dstImage->pasp));
     memcpy(&dstImage->clap, &srcImage->clap, sizeof(dstImage->clap));
     memcpy(&dstImage->irot, &srcImage->irot, sizeof(dstImage->irot));
-    memcpy(&dstImage->imir, &srcImage->imir, sizeof(dstImage->pasp));
+    memcpy(&dstImage->imir, &srcImage->imir, sizeof(dstImage->imir));
 
     avifImageSetProfileICC(dstImage, srcImage->icc.data, srcImage->icc.size);
 


### PR DESCRIPTION
I stumbled across this typo while trying to debug i686 CI failures for python-pillow/Pillow#5201.

`sizeof(dstImage->pasp)` is 8, but `sizeof(dstImage->imir)` is 1. On 32-bit architectures that meant that the `avifImage->exif` pointer was fully copied to `dstImage`. This resulted in a double free abort, because both `avifEncoderDataDestroy` and `avifImageDestroy` were doing a `free` of the same location in memory (of `encoder->data->metadataImage->exif` and `image->exif`, respectively).