### PR TITLE
Add avifColorPrimaries, etc. back as typedefs

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -405,9 +405,9 @@ int main(int argc, char * argv[])
     // However, if the end-user doesn't specify any CICP, we will convert to YUV using BT601
     // coefficients anyway (as MC:2 falls back to MC:5/6), so we might as well signal it explicitly.
     // See: ISO/IEC 23000-22:2019 Amendment 2, or the comment in avifCalcYUVCoefficients()
-    uint16_t colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
-    uint16_t transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
-    uint16_t matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
+    avifColorPrimaries colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
+    avifTransferCharacteristics transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
+    avifMatrixCoefficients matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
 
     int argIndex = 1;
     while (argIndex < argc) {
@@ -530,9 +530,9 @@ int main(int argc, char * argv[])
                 returnCode = 1;
                 goto cleanup;
             }
-            colorPrimaries = (uint16_t)cicp[0];
-            transferCharacteristics = (uint16_t)cicp[1];
-            matrixCoefficients = (uint16_t)cicp[2];
+            colorPrimaries = (avifColorPrimaries)cicp[0];
+            transferCharacteristics = (avifTransferCharacteristics)cicp[1];
+            matrixCoefficients = (avifMatrixCoefficients)cicp[2];
             cicpExplicitlySet = AVIF_TRUE;
         } else if (!strcmp(arg, "-r") || !strcmp(arg, "--range")) {
             NEXTARG();

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -236,10 +236,11 @@ enum
     AVIF_COLOR_PRIMARIES_SMPTE432 = 12, // DCI P3
     AVIF_COLOR_PRIMARIES_EBU3213 = 22
 };
+typedef uint16_t avifColorPrimaries; // AVIF_COLOR_PRIMARIES_*
 
 // outPrimaries: rX, rY, gX, gY, bX, bY, wX, wY
-AVIF_API void avifColorPrimariesGetValues(uint16_t acp, float outPrimaries[8]);
-AVIF_API uint16_t avifColorPrimariesFind(const float inPrimaries[8], const char ** outName);
+AVIF_API void avifColorPrimariesGetValues(avifColorPrimaries acp, float outPrimaries[8]);
+AVIF_API avifColorPrimaries avifColorPrimariesFind(const float inPrimaries[8], const char ** outName);
 
 enum
 {
@@ -264,6 +265,7 @@ enum
     AVIF_TRANSFER_CHARACTERISTICS_SMPTE428 = 17,
     AVIF_TRANSFER_CHARACTERISTICS_HLG = 18
 };
+typedef uint16_t avifTransferCharacteristics; // AVIF_TRANSFER_CHARACTERISTICS_*
 
 enum
 {
@@ -282,6 +284,7 @@ enum
     AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL = 13,
     AVIF_MATRIX_COEFFICIENTS_ICTCP = 14
 };
+typedef uint16_t avifMatrixCoefficients; // AVIF_MATRIX_COEFFICIENTS_*
 
 // ---------------------------------------------------------------------------
 // Optional transformation structs
@@ -377,14 +380,9 @@ typedef struct avifImage
     // ICC profile is not specified, these will be stored in the AVIF container's `colr` box with
     // a type of `nclx`. If your system supports ICC profiles, be sure to check for the existence
     // of one (avifImage.icc) before relying on the values listed here!
-    //
-    // Note: These are type uint16_t instead of their associated enums as additional CICP values
-    // are likely to be added to H.273 in the future, and there might exist a legal CICP value
-    // in one of these members that is not labeled by the above enums in this version of libavif.
-    // See the discussion here: https://github.com/AOMediaCodec/libavif/issues/461
-    uint16_t colorPrimaries;          // AVIF_COLOR_PRIMARIES_*
-    uint16_t transferCharacteristics; // AVIF_TRANSFER_CHARACTERISTICS_*
-    uint16_t matrixCoefficients;      // AVIF_MATRIX_COEFFICIENTS_*
+    avifColorPrimaries colorPrimaries;
+    avifTransferCharacteristics transferCharacteristics;
+    avifMatrixCoefficients matrixCoefficients;
 
     // Transformations - These metadata values are encoded/decoded when transformFlags are set
     // appropriately, but do not impact/adjust the actual pixel buffers used (images won't be

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -280,9 +280,9 @@ typedef struct avifSequenceHeader
     uint32_t bitDepth;
     avifPixelFormat yuvFormat;
     avifChromaSamplePosition chromaSamplePosition;
-    uint16_t colorPrimaries;
-    uint16_t transferCharacteristics;
-    uint16_t matrixCoefficients;
+    avifColorPrimaries colorPrimaries;
+    avifTransferCharacteristics transferCharacteristics;
+    avifMatrixCoefficients matrixCoefficients;
     avifRange range;
     avifCodecConfigurationBox av1C;
 } avifSequenceHeader;

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -167,9 +167,9 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec, const avifDecodeS
         image->yuvRange = (codec->internal->image->range == AOM_CR_STUDIO_RANGE) ? AVIF_RANGE_LIMITED : AVIF_RANGE_FULL;
         image->yuvChromaSamplePosition = (avifChromaSamplePosition)codec->internal->image->csp;
 
-        image->colorPrimaries = (uint16_t)codec->internal->image->cp;
-        image->transferCharacteristics = (uint16_t)codec->internal->image->tc;
-        image->matrixCoefficients = (uint16_t)codec->internal->image->mc;
+        image->colorPrimaries = (avifColorPrimaries)codec->internal->image->cp;
+        image->transferCharacteristics = (avifTransferCharacteristics)codec->internal->image->tc;
+        image->matrixCoefficients = (avifMatrixCoefficients)codec->internal->image->mc;
 
         avifPixelFormatInfo formatInfo;
         avifGetPixelFormatInfo(yuvFormat, &formatInfo);

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -155,9 +155,9 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec, const avifDecod
         image->yuvRange = codec->internal->colorRange;
         image->yuvChromaSamplePosition = (avifChromaSamplePosition)dav1dImage->seq_hdr->chr;
 
-        image->colorPrimaries = (uint16_t)dav1dImage->seq_hdr->pri;
-        image->transferCharacteristics = (uint16_t)dav1dImage->seq_hdr->trc;
-        image->matrixCoefficients = (uint16_t)dav1dImage->seq_hdr->mtrx;
+        image->colorPrimaries = (avifColorPrimaries)dav1dImage->seq_hdr->pri;
+        image->transferCharacteristics = (avifTransferCharacteristics)dav1dImage->seq_hdr->trc;
+        image->matrixCoefficients = (avifMatrixCoefficients)dav1dImage->seq_hdr->mtrx;
 
         avifPixelFormatInfo formatInfo;
         avifGetPixelFormatInfo(yuvFormat, &formatInfo);

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -102,9 +102,9 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec, const avifDecode
         image->yuvRange = codec->internal->colorRange;
         image->yuvChromaSamplePosition = (avifChromaSamplePosition)gav1Image->chroma_sample_position;
 
-        image->colorPrimaries = (uint16_t)gav1Image->color_primary;
-        image->transferCharacteristics = (uint16_t)gav1Image->transfer_characteristics;
-        image->matrixCoefficients = (uint16_t)gav1Image->matrix_coefficients;
+        image->colorPrimaries = (avifColorPrimaries)gav1Image->color_primary;
+        image->transferCharacteristics = (avifTransferCharacteristics)gav1Image->transfer_characteristics;
+        image->matrixCoefficients = (avifMatrixCoefficients)gav1Image->matrix_coefficients;
 
         avifPixelFormatInfo formatInfo;
         avifGetPixelFormatInfo(yuvFormat, &formatInfo);

--- a/src/colr.c
+++ b/src/colr.c
@@ -8,7 +8,7 @@
 
 struct avifColorPrimariesTable
 {
-    uint16_t colorPrimariesEnum;
+    avifColorPrimaries colorPrimariesEnum;
     const char * name;
     float primaries[8]; // rX, rY, gX, gY, bX, bY, wX, wY
 };
@@ -27,7 +27,7 @@ static const struct avifColorPrimariesTable avifColorPrimariesTables[] = {
 };
 static const int avifColorPrimariesTableSize = sizeof(avifColorPrimariesTables) / sizeof(avifColorPrimariesTables[0]);
 
-void avifColorPrimariesGetValues(uint16_t acp, float outPrimaries[8])
+void avifColorPrimariesGetValues(avifColorPrimaries acp, float outPrimaries[8])
 {
     for (int i = 0; i < avifColorPrimariesTableSize; ++i) {
         if (avifColorPrimariesTables[i].colorPrimariesEnum == acp) {
@@ -52,7 +52,7 @@ static avifBool primariesMatch(const float p1[8], const float p2[8])
            matchesTo3RoundedPlaces(p1[5], p2[5]) && matchesTo3RoundedPlaces(p1[6], p2[6]) && matchesTo3RoundedPlaces(p1[7], p2[7]);
 }
 
-uint16_t avifColorPrimariesFind(const float inPrimaries[8], const char ** outName)
+avifColorPrimaries avifColorPrimariesFind(const float inPrimaries[8], const char ** outName)
 {
     if (outName) {
         *outName = NULL;
@@ -71,7 +71,7 @@ uint16_t avifColorPrimariesFind(const float inPrimaries[8], const char ** outNam
 
 struct avifMatrixCoefficientsTable
 {
-    uint16_t matrixCoefficientsEnum;
+    avifMatrixCoefficients matrixCoefficientsEnum;
     const char * name;
     const float kr;
     const float kb;

--- a/src/obu.c
+++ b/src/obu.c
@@ -261,9 +261,9 @@ static avifBool parseSequenceHeader(avifBits * bits, avifSequenceHeader * header
     header->av1C.monochrome = (uint8_t)mono_chrome;
     uint32_t color_description_present_flag = avifBitsRead(bits, 1);
     if (color_description_present_flag) {
-        header->colorPrimaries = (uint16_t)avifBitsRead(bits, 8);          // color_primaries
-        header->transferCharacteristics = (uint16_t)avifBitsRead(bits, 8); // transfer_characteristics
-        header->matrixCoefficients = (uint16_t)avifBitsRead(bits, 8);      // matrix_coefficients
+        header->colorPrimaries = (avifColorPrimaries)avifBitsRead(bits, 8);                   // color_primaries
+        header->transferCharacteristics = (avifTransferCharacteristics)avifBitsRead(bits, 8); // transfer_characteristics
+        header->matrixCoefficients = (avifMatrixCoefficients)avifBitsRead(bits, 8);           // matrix_coefficients
     } else {
         header->colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
         header->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;

--- a/src/read.c
+++ b/src/read.c
@@ -72,9 +72,9 @@ typedef struct avifColourInformationBox
     size_t iccSize;
 
     avifBool hasNCLX;
-    uint16_t colorPrimaries;
-    uint16_t transferCharacteristics;
-    uint16_t matrixCoefficients;
+    avifColorPrimaries colorPrimaries;
+    avifTransferCharacteristics transferCharacteristics;
+    avifMatrixCoefficients matrixCoefficients;
     avifRange range;
 } avifColourInformationBox;
 
@@ -1257,7 +1257,6 @@ static avifBool avifParseColourInformationBox(avifProperty * prop, const uint8_t
         CHECK(avifROStreamReadU16(&s, &colr->colorPrimaries));          // unsigned int(16) colour_primaries;
         CHECK(avifROStreamReadU16(&s, &colr->transferCharacteristics)); // unsigned int(16) transfer_characteristics;
         CHECK(avifROStreamReadU16(&s, &colr->matrixCoefficients));      // unsigned int(16) matrix_coefficients;
-
         // unsigned int(1) full_range_flag;
         // unsigned int(7) reserved = 0;
         uint8_t tmp8;

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -108,15 +108,15 @@ int main(int argc, char * argv[])
                     continue;
                 }
 
-                const uint16_t matrixCoeffsList[] = { AVIF_MATRIX_COEFFICIENTS_BT709,
-                                                      AVIF_MATRIX_COEFFICIENTS_BT601,
-                                                      AVIF_MATRIX_COEFFICIENTS_BT2020_NCL,
-                                                      AVIF_MATRIX_COEFFICIENTS_IDENTITY,
-                                                      AVIF_MATRIX_COEFFICIENTS_YCGCO };
+                const avifMatrixCoefficients matrixCoeffsList[] = { AVIF_MATRIX_COEFFICIENTS_BT709,
+                                                                    AVIF_MATRIX_COEFFICIENTS_BT601,
+                                                                    AVIF_MATRIX_COEFFICIENTS_BT2020_NCL,
+                                                                    AVIF_MATRIX_COEFFICIENTS_IDENTITY,
+                                                                    AVIF_MATRIX_COEFFICIENTS_YCGCO };
                 const int matrixCoeffsCount = (int)(sizeof(matrixCoeffsList) / sizeof(matrixCoeffsList[0]));
 
                 for (int matrixCoeffsIndex = 0; matrixCoeffsIndex < matrixCoeffsCount; ++matrixCoeffsIndex) {
-                    uint16_t matrixCoeffs = matrixCoeffsList[matrixCoeffsIndex];
+                    avifMatrixCoefficients matrixCoeffs = matrixCoeffsList[matrixCoeffsIndex];
 
                     int dim = 1 << rgbDepth;
                     int maxDrift = 0;


### PR DESCRIPTION
Add the avifColorPrimaries, avifTransferCharacteristics. and
avifMatrixCoefficients types back as typedefs (aliases of uint16_t). The
typedefs make the code more readable. They also avoid breaking source
compatibility of libavif client code.