### PR TITLE
Refine Premultiply alpha handling during conversion, update libyuv usage

### DIFF
--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -114,29 +114,6 @@ cleanup:
     return ret;
 }
 
-#if !defined(JCS_ALPHA_EXTENSIONS)
-// this is only for removing alpha when processing non-premultiplied image.
-static void avifRGBAToRGB(const avifRGBImage * src, avifRGBImage * dst)
-{
-    dst->width = src->width;
-    dst->height = src->height;
-    dst->format = AVIF_RGB_FORMAT_RGB;
-    dst->depth = 8;
-
-    avifRGBImageAllocatePixels(dst);
-
-    for (uint32_t j = 0; j < src->height; ++j) {
-        uint8_t * srcRow = &src->pixels[j * src->rowBytes];
-        uint8_t * dstRow = &src->pixels[j * dst->rowBytes];
-        for (uint32_t i = 0; i < src->width; ++i) {
-            uint8_t * srcPixel = &srcRow[i * 4];
-            uint8_t * dstPixel = &dstRow[i * 3];
-            memcpy(dstPixel, srcPixel, 3);
-        }
-    }
-}
-#endif
-
 avifBool avifJPEGWrite(const char * outputFilename, avifImage * avif, int jpegQuality, avifChromaUpsampling chromaUpsampling)
 {
     avifBool ret = AVIF_FALSE;
@@ -152,29 +129,14 @@ avifBool avifJPEGWrite(const char * outputFilename, avifImage * avif, int jpegQu
     avifRGBImage rgbPremultiplied;
     avifRGBImageSetDefaults(&rgb, avif);
     avifRGBImageSetDefaults(&rgbPremultiplied, avif);
-    rgb.format = avif->alphaPremultiplied ? AVIF_RGB_FORMAT_RGB : AVIF_RGB_FORMAT_RGBA;
+    rgb.format = AVIF_RGB_FORMAT_RGB;
     rgb.chromaUpsampling = chromaUpsampling;
     rgb.depth = 8;
-    // always get premultiplied result.
-    // This will give natural appearance to output JPG image.
-    rgb.alphaPremultiplied = AVIF_TRUE;
     avifRGBImageAllocatePixels(&rgb);
     if (avifImageYUVToRGB(avif, &rgb) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);
         goto cleanup;
     }
-
-    // libjpeg-turbo accepts RGBA input, so do less if possible
-#if !defined(JCS_ALPHA_EXTENSIONS)
-    if (!avif->alphaPremultiplied) {
-        if (avifRGBImagePremultiplyAlpha(&rgb) != AVIF_RESULT_OK) {
-            fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);
-            goto cleanup;
-        }
-        avifRGBAToRGB(&rgb, &rgbPremultiplied);
-        avifRGBImageFreePixels(&rgb);
-    }
-#endif
 
     f = fopen(outputFilename, "wb");
     if (!f) {
@@ -185,13 +147,8 @@ avifBool avifJPEGWrite(const char * outputFilename, avifImage * avif, int jpegQu
     jpeg_stdio_dest(&cinfo, f);
     cinfo.image_width = avif->width;
     cinfo.image_height = avif->height;
-#if defined(JCS_ALPHA_EXTENSIONS)
-    cinfo.input_components = 3;
-    cinfo.in_color_space = JCS_EXT_RGBX;
-#else
     cinfo.input_components = 3;
     cinfo.in_color_space = JCS_RGB;
-#endif
     jpeg_set_defaults(&cinfo);
     jpeg_set_quality(&cinfo, jpegQuality, TRUE);
     jpeg_start_compress(&cinfo, TRUE);
@@ -200,24 +157,10 @@ avifBool avifJPEGWrite(const char * outputFilename, avifImage * avif, int jpegQu
         write_icc_profile(&cinfo, avif->icc.data, (unsigned int)avif->icc.size);
     }
 
-#if defined(JCS_ALPHA_EXTENSIONS)
     while (cinfo.next_scanline < cinfo.image_height) {
         row_pointer[0] = &rgb.pixels[cinfo.next_scanline * rgb.rowBytes];
         (void)jpeg_write_scanlines(&cinfo, row_pointer, 1);
     }
-#else
-    if (avif->alphaPremultiplied) {
-        while (cinfo.next_scanline < cinfo.image_height) {
-            row_pointer[0] = &rgb.pixels[cinfo.next_scanline * rgb.rowBytes];
-            (void)jpeg_write_scanlines(&cinfo, row_pointer, 1);
-        }
-    } else {
-        while (cinfo.next_scanline < cinfo.image_height) {
-            row_pointer[0] = &rgbPremultiplied.pixels[cinfo.next_scanline * rgbPremultiplied.rowBytes];
-            (void)jpeg_write_scanlines(&cinfo, row_pointer, 1);
-        }
-    }
-#endif
 
     jpeg_finish_compress(&cinfo);
     ret = AVIF_TRUE;

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -140,7 +140,8 @@ typedef enum avifResult
     AVIF_RESULT_IO_ERROR,
     AVIF_RESULT_WAITING_ON_IO, // similar to EAGAIN/EWOULDBLOCK, this means the avifIO doesn't have necessary data available yet
     AVIF_RESULT_INVALID_ARGUMENT, // an argument passed into this function is invalid
-    AVIF_RESULT_NOT_IMPLEMENTED   // a requested code path is not (yet) implemented
+    AVIF_RESULT_NOT_IMPLEMENTED,  // a requested code path is not (yet) implemented
+    AVIF_RESULT_NEED_POST_PROCESS // a requested code path need post process
 } avifResult;
 
 AVIF_API const char * avifResultToString(avifResult result);
@@ -476,7 +477,8 @@ typedef struct avifRGBImage
                                            // Unused when converting to YUV. avifRGBImageSetDefaults() prefers quality over speed.
     avifBool ignoreAlpha;        // Used for XRGB formats, treats formats containing alpha (such as ARGB) as if they were
                                  // RGB, treating the alpha bits as if they were all 1.
-    avifBool alphaPremultiplied; // indicates if RGB value is pre-multiplied by alpha. Default: false
+    avifBool alphaPremultiplied; // Indicates if RGB value is pre-multiplied by alpha. Default: false
+                                 // This field has no effect for RGB formats without alpha.
 
     uint8_t * pixels;
     uint32_t rowBytes;
@@ -537,8 +539,10 @@ typedef struct avifReformatState
     float rgbMaxChannelF;
     float biasY;   // minimum Y value
     float biasUV;  // the value of 0.5 for the appropriate bit depth [128, 512, 2048]
+    float biasA;   // minimum A value
     float rangeY;  // difference between max and min Y
     float rangeUV; // difference between max and min UV
+    float rangeA;  // difference between max and min A
 
     avifPixelFormatInfo formatInfo;
 
@@ -547,6 +551,11 @@ typedef struct avifReformatState
     float unormFloatTableUV[1 << 12];
 
     avifReformatMode mode;
+
+    avifBool toRGBPremultiply;
+    avifBool toRGBUnpremultiply;
+    avifBool toYUVPremultiply;
+    avifBool toYUVUnpremultiply;
 } avifReformatState;
 AVIF_API avifBool avifPrepareReformatState(const avifImage * image, const avifRGBImage * rgb, avifReformatState * state);
 

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -93,17 +93,19 @@ avifBool avifFillAlpha(const avifAlphaParams * const params);
 avifBool avifReformatAlpha(const avifAlphaParams * const params);
 
 // Returns:
-// * AVIF_RESULT_OK              - Converted successfully with libyuv
-// * AVIF_RESULT_NOT_IMPLEMENTED - The fast path for this combination is not implemented with libyuv, use built-in YUV conversion
-// * [any other error]           - Return error to caller
+// * AVIF_RESULT_OK                - Converted successfully with libyuv
+// * AVIF_RESULT_NOT_IMPLEMENTED   - The fast path for this combination is not implemented with libyuv, use built-in YUV conversion
+// * AVIF_RESULT_NEED_POST_PROCESS - Only color conversion part for this combination is implemented with libyuv, use built-in alpha conversion and premultiply
+// * [any other error]             - Return error to caller
 avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb);
 
 // Returns:
-// * AVIF_RESULT_OK              - (Un)Premultiply successfully with libyuv
-// * AVIF_RESULT_NOT_IMPLEMENTED - The fast path for this combination is not implemented with libyuv, use built-in (Un)Premultiply
-// * [any other error]           - Return error to caller
+// * AVIF_RESULT_OK                - (Un)Premultiply successfully with libyuv
+// * AVIF_RESULT_NOT_IMPLEMENTED   - The fast path for this combination is not implemented with libyuv, use built-in (Un)Premultiply
+// * [any other error]             - Return error to caller
 avifResult avifRGBImagePremultiplyAlphaLibYUV(avifRGBImage * rgb);
 avifResult avifRGBImageUnpremultiplyAlphaLibYUV(avifRGBImage * rgb);
+avifResult avifImageIdentity8ToRGB8ColorFullRangeLibYUV(const avifImage * image, avifRGBImage * rgb, avifReformatState * state);
 
 // ---------------------------------------------------------------------------
 // avifCodecDecodeInput

--- a/src/avif.c
+++ b/src/avif.c
@@ -93,6 +93,7 @@ const char * avifResultToString(avifResult result)
         case AVIF_RESULT_WAITING_ON_IO:                 return "Waiting on IO";
         case AVIF_RESULT_INVALID_ARGUMENT:              return "Invalid argument";
         case AVIF_RESULT_NOT_IMPLEMENTED:               return "Not implemented";
+        case AVIF_RESULT_NEED_POST_PROCESS:             return "Need post process";
         case AVIF_RESULT_UNKNOWN_ERROR:
         default:
             break;

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -12,6 +12,13 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
     (void)rgb;
     return AVIF_RESULT_NOT_IMPLEMENTED;
 }
+avifResult avifImageIdentity8ToRGB8ColorFullRangeLibYUV(const avifImage * image, avifRGBImage * rgb, avifReformatState * state)
+{
+    (void)image;
+    (void)rgb;
+    (void)state;
+    return AVIF_RESULT_NOT_IMPLEMENTED;
+}
 avifResult avifRGBImagePremultiplyAlphaLibYUV(avifRGBImage * rgb)
 {
     (void)rgb;
@@ -38,11 +45,15 @@ unsigned int avifLibYUVVersion(void)
 #pragma clang diagnostic pop
 #endif
 
+#if LIBYUV_VERSION < 1775
+#error libyuv version too old. Need at least 1775.
+#endif
+
 avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
 {
     // See if the current settings can be accomplished with libyuv, and use it (if possible).
 
-    if ((image->depth != 8) || (rgb->depth != 8)) {
+    if (rgb->depth != 8) {
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
 
@@ -62,21 +73,37 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
                 matrixYUV = &kYuvJPEGConstants;
                 matrixYVU = &kYvuJPEGConstants;
                 break;
+            case AVIF_MATRIX_COEFFICIENTS_BT709:
+                matrixYUV = &kYuvF709Constants;
+                matrixYVU = &kYvuF709Constants;
+                break;
+            case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
+                matrixYUV = &kYuvV2020Constants;
+                matrixYVU = &kYvuV2020Constants;
+                break;
             case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
                 switch (image->colorPrimaries) {
+                    case AVIF_COLOR_PRIMARIES_BT709:
+                    case AVIF_COLOR_PRIMARIES_UNSPECIFIED:
+                        matrixYUV = &kYuvF709Constants;
+                        matrixYVU = &kYvuF709Constants;
+                        break;
+
                     case AVIF_COLOR_PRIMARIES_BT470BG:
                     case AVIF_COLOR_PRIMARIES_BT601:
                         matrixYUV = &kYuvJPEGConstants;
                         matrixYVU = &kYvuJPEGConstants;
                         break;
 
-                    case AVIF_COLOR_PRIMARIES_UNSPECIFIED:
+                    case AVIF_COLOR_PRIMARIES_BT2020:
+                        matrixYUV = &kYuvV2020Constants;
+                        matrixYVU = &kYvuV2020Constants;
+                        break;
+
                     case AVIF_COLOR_PRIMARIES_UNKNOWN:
-                    case AVIF_COLOR_PRIMARIES_BT709:
                     case AVIF_COLOR_PRIMARIES_BT470M:
                     case AVIF_COLOR_PRIMARIES_SMPTE240:
                     case AVIF_COLOR_PRIMARIES_GENERIC_FILM:
-                    case AVIF_COLOR_PRIMARIES_BT2020:
                     case AVIF_COLOR_PRIMARIES_XYZ:
                     case AVIF_COLOR_PRIMARIES_SMPTE431:
                     case AVIF_COLOR_PRIMARIES_SMPTE432:
@@ -86,11 +113,9 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
                 break;
 
             case AVIF_MATRIX_COEFFICIENTS_IDENTITY:
-            case AVIF_MATRIX_COEFFICIENTS_BT709:
             case AVIF_MATRIX_COEFFICIENTS_FCC:
             case AVIF_MATRIX_COEFFICIENTS_SMPTE240:
             case AVIF_MATRIX_COEFFICIENTS_YCGCO:
-            case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
             case AVIF_MATRIX_COEFFICIENTS_BT2020_CL:
             case AVIF_MATRIX_COEFFICIENTS_SMPTE2085:
             case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL:
@@ -174,262 +199,404 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
     // AVIF_RGB_FORMAT_ABGR  *ToRGBAMatrix   matrixYUV
     // AVIF_RGB_FORMAT_ARGB  *ToRGBAMatrix   matrixYVU
 
-    if (rgb->format == AVIF_RGB_FORMAT_BGRA) {
-        // AVIF_RGB_FORMAT_BGRA  *ToARGBMatrix   matrixYUV
+    enum
+    {
+        YUV,
+        YUVA,
+        Y,
+        YUV16
+    } convertFunctionType = YUV;
 
-        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
-            if (I444ToARGBMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
+    union
+    {
+        int (*YUVToRGBA)(const uint8_t * src_y,
+                         int src_stride_y,
+                         const uint8_t * src_u,
+                         int src_stride_u,
+                         const uint8_t * src_v,
+                         int src_stride_v,
+                         uint8_t * dst_argb,
+                         int dst_stride_argb,
+                         const struct YuvConstants * yuvconstants,
+                         int width,
+                         int height);
+        int (*YUVAToRGBA)(const uint8_t * src_y,
+                          int src_stride_y,
+                          const uint8_t * src_u,
+                          int src_stride_u,
+                          const uint8_t * src_v,
+                          int src_stride_v,
+                          const uint8_t * src_a,
+                          int src_stride_a,
+                          uint8_t * dst_argb,
+                          int dst_stride_argb,
+                          const struct YuvConstants * yuvconstants,
+                          int width,
+                          int height,
+                          int attenuate);
+        int (*YToRGBA)(const uint8_t * src_y,
+                       int src_stride_y,
+                       uint8_t * dst_argb,
+                       int dst_stride_argb,
+                       const struct YuvConstants * yuvconstants,
+                       int width,
+                       int height);
+        int (*YUV16ToRGBA)(const uint16_t * src_y,
+                           int src_stride_y,
+                           const uint16_t * src_u,
+                           int src_stride_u,
+                           const uint16_t * src_v,
+                           int src_stride_v,
+                           uint8_t * dst_argb,
+                           int dst_stride_argb,
+                           const struct YuvConstants * yuvconstants,
+                           int width,
+                           int height);
+    } convertFunction = { NULL };
+
+    // If we should use the matrixYVU and flip U and V pointer
+    avifBool flipUV;
+
+    // separate post step to process alpha
+    enum
+    {
+        None = 0,
+        Multiply = 1,
+        Unmultiply = 2,
+        CopyAlpha = 4,
+    };
+    int alphaPostStep = None;
+
+    // do premultiply during conversion
+    avifBool attenuate = AVIF_FALSE;
+
+    if (rgb->format == AVIF_RGB_FORMAT_BGRA || rgb->format == AVIF_RGB_FORMAT_RGBA) {
+        flipUV = rgb->format == AVIF_RGB_FORMAT_RGBA;
+
+        if (image->depth == 8) {
+            // If source don't have alpha, or we don't need alpha (alpha is ignored, and no premultiply process is need)
+            if (image->alphaPlane == NULL || (rgb->ignoreAlpha && image->alphaPremultiplied)) {
+                switch (image->yuvFormat) {
+                    case AVIF_PIXEL_FORMAT_YUV444:
+                        convertFunctionType = YUV;
+                        convertFunction.YUVToRGBA = I444ToARGBMatrix;
+                        break;
+                    case AVIF_PIXEL_FORMAT_YUV422:
+                        convertFunctionType = YUV;
+                        convertFunction.YUVToRGBA = I422ToARGBMatrix;
+                        break;
+                    case AVIF_PIXEL_FORMAT_YUV420:
+                        convertFunctionType = YUV;
+                        convertFunction.YUVToRGBA = I420ToARGBMatrix;
+                        break;
+                    case AVIF_PIXEL_FORMAT_YUV400:
+                        convertFunctionType = Y;
+                        convertFunction.YToRGBA = I400ToARGBMatrix;
+                        break;
+                    case AVIF_PIXEL_FORMAT_NONE:
+                        // not possible. only for compiler warning
+                        return AVIF_RESULT_REFORMAT_FAILED;
+                }
+            } else {
+                switch (image->yuvFormat) {
+                    case AVIF_PIXEL_FORMAT_YUV444:
+                        convertFunctionType = YUVA;
+                        convertFunction.YUVAToRGBA = I444AlphaToARGBMatrix;
+                        break;
+                    case AVIF_PIXEL_FORMAT_YUV422:
+                        convertFunctionType = YUVA;
+                        convertFunction.YUVAToRGBA = I422AlphaToARGBMatrix;
+                        break;
+                    case AVIF_PIXEL_FORMAT_YUV420:
+                        convertFunctionType = YUVA;
+                        convertFunction.YUVAToRGBA = I420AlphaToARGBMatrix;
+                        break;
+                    case AVIF_PIXEL_FORMAT_YUV400:
+                        convertFunctionType = Y;
+                        alphaPostStep |= CopyAlpha;
+                        convertFunction.YToRGBA = I400ToARGBMatrix;
+                        break;
+                    case AVIF_PIXEL_FORMAT_NONE:
+                        // not possible. only for compiler warning
+                        return AVIF_RESULT_REFORMAT_FAILED;
+                }
             }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
-            if (I422ToARGBMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
+        } else if (image->depth == 10) {
+            convertFunctionType = YUV16;
+            switch (image->yuvFormat) {
+                case AVIF_PIXEL_FORMAT_YUV444:
+                    // This doesn't currently exist in libyuv
+#if 0
+                    convertFunctionType = YUV;
+                    convertFunction.YUVToRGBA = I410ToRGBAMatrix;
+#else
+                    return AVIF_RESULT_NOT_IMPLEMENTED;
+#endif
+
+                case AVIF_PIXEL_FORMAT_YUV422:
+                    convertFunction.YUV16ToRGBA = I210ToARGBMatrix;
+                    break;
+                case AVIF_PIXEL_FORMAT_YUV420:
+                    convertFunction.YUV16ToRGBA = I010ToARGBMatrix;
+                    break;
+                case AVIF_PIXEL_FORMAT_YUV400:
+                    // This doesn't currently exist in libyuv
+#if 0
+                    convertFunctionType = Y;
+                    convertFunction.YToRGBA = I010ToRGBAMatrix;
+#else
+                    return AVIF_RESULT_NOT_IMPLEMENTED;
+#endif
+                case AVIF_PIXEL_FORMAT_NONE:
+                    // not possible. only for compiler warning
+                    return AVIF_RESULT_REFORMAT_FAILED;
             }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
-            if (I420ToARGBMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
+
+            if (!(image->alphaPlane == NULL || (rgb->ignoreAlpha && image->alphaPremultiplied))) {
+                alphaPostStep |= CopyAlpha;
             }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
-            if (I400ToARGBMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
+        } else {
+            return AVIF_RESULT_NOT_IMPLEMENTED;
         }
-    } else if (rgb->format == AVIF_RGB_FORMAT_RGBA) {
-        // AVIF_RGB_FORMAT_RGBA  *ToARGBMatrix   matrixYVU
 
-        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
-            if (I444ToARGBMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
+    } else if (rgb->format == AVIF_RGB_FORMAT_ABGR || rgb->format == AVIF_RGB_FORMAT_ARGB) {
+        flipUV = rgb->format == AVIF_RGB_FORMAT_ARGB;
+
+        switch (image->yuvFormat) {
+            case AVIF_PIXEL_FORMAT_YUV444:
+                // This doesn't currently exist in libyuv
+#if 0
+            convertFunctionType = YUV;
+                convertFunction.YUVToRGBA = I444ToRGBAMatrix;
+#else
+                return AVIF_RESULT_NOT_IMPLEMENTED;
+#endif
+
+            case AVIF_PIXEL_FORMAT_YUV422:
+                convertFunctionType = YUV;
+                convertFunction.YUVToRGBA = I422ToRGBAMatrix;
+                break;
+            case AVIF_PIXEL_FORMAT_YUV420:
+                convertFunctionType = YUV;
+                convertFunction.YUVToRGBA = I420ToRGBAMatrix;
+                break;
+            case AVIF_PIXEL_FORMAT_YUV400:
+#if 0
+                convertFunctionType = Y;
+                convertFunction.YToRGBA = I400ToRGBAMatrix;
+#else
+                return AVIF_RESULT_NOT_IMPLEMENTED;
+#endif
+            case AVIF_PIXEL_FORMAT_NONE:
+                // not possible. only for compiler warning
                 return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
-            if (I422ToARGBMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
-            if (I420ToARGBMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
-            if (I400ToARGBMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
         }
-    } else if (rgb->format == AVIF_RGB_FORMAT_ABGR) {
-        // AVIF_RGB_FORMAT_ABGR  *ToRGBAMatrix   matrixYUV
 
-        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I444ToRGBAMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-#endif
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
-            if (I422ToRGBAMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
-            if (I420ToRGBAMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I400ToRGBAMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-#endif
+        if (!(image->alphaPlane == NULL || (rgb->ignoreAlpha && image->alphaPremultiplied))) {
+            alphaPostStep |= CopyAlpha;
         }
-    } else if (rgb->format == AVIF_RGB_FORMAT_ARGB) {
-        // AVIF_RGB_FORMAT_ARGB  *ToRGBAMatrix   matrixYVU
+    } else {
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
 
-        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I444ToRGBAMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
+    if (!image->alphaPremultiplied && rgb->alphaPremultiplied) {
+        if (convertFunctionType == YUVA) {
+            attenuate = AVIF_TRUE;
+        } else {
+            alphaPostStep |= Multiply;
+        }
+    } else if (image->alphaPremultiplied && !rgb->alphaPremultiplied) {
+        alphaPostStep |= Unmultiply;
+    }
+
+    switch (convertFunctionType) {
+        case YUV:
+            if (flipUV) {
+                if (convertFunction.YUVToRGBA(image->yuvPlanes[AVIF_CHAN_Y],
+                                              image->yuvRowBytes[AVIF_CHAN_Y],
+                                              image->yuvPlanes[AVIF_CHAN_V],
+                                              image->yuvRowBytes[AVIF_CHAN_V],
+                                              image->yuvPlanes[AVIF_CHAN_U],
+                                              image->yuvRowBytes[AVIF_CHAN_U],
+                                              rgb->pixels,
+                                              rgb->rowBytes,
+                                              matrixYVU,
+                                              image->width,
+                                              image->height) != 0) {
+                    return AVIF_RESULT_REFORMAT_FAILED;
+                }
+            } else {
+                if (convertFunction.YUVToRGBA(image->yuvPlanes[AVIF_CHAN_Y],
+                                              image->yuvRowBytes[AVIF_CHAN_Y],
+                                              image->yuvPlanes[AVIF_CHAN_U],
+                                              image->yuvRowBytes[AVIF_CHAN_U],
+                                              image->yuvPlanes[AVIF_CHAN_V],
+                                              image->yuvRowBytes[AVIF_CHAN_V],
+                                              rgb->pixels,
+                                              rgb->rowBytes,
+                                              matrixYUV,
+                                              image->width,
+                                              image->height) != 0) {
+                    return AVIF_RESULT_REFORMAT_FAILED;
+                }
+            }
+            break;
+
+        case YUVA:
+            if (flipUV) {
+                if (convertFunction.YUVAToRGBA(image->yuvPlanes[AVIF_CHAN_Y],
+                                               image->yuvRowBytes[AVIF_CHAN_Y],
+                                               image->yuvPlanes[AVIF_CHAN_V],
+                                               image->yuvRowBytes[AVIF_CHAN_V],
+                                               image->yuvPlanes[AVIF_CHAN_U],
+                                               image->yuvRowBytes[AVIF_CHAN_U],
+                                               image->alphaPlane,
+                                               image->alphaRowBytes,
+                                               rgb->pixels,
+                                               rgb->rowBytes,
+                                               matrixYVU,
+                                               image->width,
+                                               image->height,
+                                               attenuate) != 0) {
+                    return AVIF_RESULT_REFORMAT_FAILED;
+                }
+            } else {
+                if (convertFunction.YUVAToRGBA(image->yuvPlanes[AVIF_CHAN_Y],
+                                               image->yuvRowBytes[AVIF_CHAN_Y],
+                                               image->yuvPlanes[AVIF_CHAN_U],
+                                               image->yuvRowBytes[AVIF_CHAN_U],
+                                               image->yuvPlanes[AVIF_CHAN_V],
+                                               image->yuvRowBytes[AVIF_CHAN_V],
+                                               image->alphaPlane,
+                                               image->alphaRowBytes,
+                                               rgb->pixels,
+                                               rgb->rowBytes,
+                                               matrixYUV,
+                                               image->width,
+                                               image->height,
+                                               attenuate) != 0) {
+                    return AVIF_RESULT_REFORMAT_FAILED;
+                }
+            }
+            break;
+
+        case Y:
+            if (convertFunction.YToRGBA(image->yuvPlanes[AVIF_CHAN_Y],
+                                        image->yuvRowBytes[AVIF_CHAN_Y],
+                                        rgb->pixels,
+                                        rgb->rowBytes,
+                                        matrixYUV,
+                                        image->width,
+                                        image->height) != 0) {
                 return AVIF_RESULT_REFORMAT_FAILED;
             }
-            return AVIF_RESULT_OK;
-#endif
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
-            if (I422ToRGBAMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
+            break;
+        case YUV16:
+            // libyuv is expecting stride as ptrdiff_t
+            if (flipUV) {
+                if (convertFunction.YUV16ToRGBA((uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                                image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                                (uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                                image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                                (uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                                image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                                rgb->pixels,
+                                                rgb->rowBytes,
+                                                matrixYVU,
+                                                image->width,
+                                                image->height) != 0) {
+                    return AVIF_RESULT_REFORMAT_FAILED;
+                }
+            } else {
+                if (convertFunction.YUV16ToRGBA((uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                                image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                                (uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                                image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                                (uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                                image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                                rgb->pixels,
+                                                rgb->rowBytes,
+                                                matrixYUV,
+                                                image->width,
+                                                image->height) != 0) {
+                    return AVIF_RESULT_REFORMAT_FAILED;
+                }
             }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
-            if (I420ToRGBAMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V],
-                                 image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I400ToRGBAMatrix(image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y],
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-#endif
+            break;
+    }
+
+    if ((alphaPostStep & CopyAlpha) && image->depth == 8 && image->alphaRange == AVIF_RANGE_FULL &&
+        (rgb->format == AVIF_RGB_FORMAT_BGRA || rgb->format == AVIF_RGB_FORMAT_RGBA)) {
+        alphaPostStep &= ~CopyAlpha;
+        ARGBCopyYToAlpha(image->alphaPlane, image->alphaRowBytes, rgb->pixels, rgb->rowBytes, image->width, image->height);
+        if (alphaPostStep & Multiply) {
+            return avifRGBImagePremultiplyAlpha(rgb);
+        } else if (alphaPostStep & Unmultiply) {
+            return avifRGBImageUnpremultiplyAlpha(rgb);
         }
     }
 
-    // This function didn't do anything; use the built-in YUV conversion
-    return AVIF_RESULT_NOT_IMPLEMENTED;
+    if (alphaPostStep & CopyAlpha) {
+        return AVIF_RESULT_NEED_POST_PROCESS;
+    }
+
+    return AVIF_RESULT_OK;
+}
+
+avifResult avifImageIdentity8ToRGB8ColorFullRangeLibYUV(const avifImage * image, avifRGBImage * rgb, avifReformatState * state)
+{
+    const uint8_t * planePtr[4];
+    int planeRowBytes[4];
+
+    // state->rgbOffsetBytesA is 0 is RGB format doesn't have alpha.
+    // Place it first, so that it can be overwritten.
+    planePtr[state->rgbOffsetBytesA] = image->alphaPlane;
+    planeRowBytes[state->rgbOffsetBytesA] = image->alphaRowBytes;
+
+    planePtr[state->rgbOffsetBytesR] = image->yuvPlanes[AVIF_CHAN_V];
+    planeRowBytes[state->rgbOffsetBytesR] = image->yuvRowBytes[AVIF_CHAN_V];
+    planePtr[state->rgbOffsetBytesG] = image->yuvPlanes[AVIF_CHAN_Y];
+    planeRowBytes[state->rgbOffsetBytesG] = image->yuvRowBytes[AVIF_CHAN_Y];
+    planePtr[state->rgbOffsetBytesB] = image->yuvPlanes[AVIF_CHAN_U];
+    planeRowBytes[state->rgbOffsetBytesB] = image->yuvRowBytes[AVIF_CHAN_U];
+
+    // libavif uses byte-order when describing 4 bytes pixel formats, such that the R in RGBA is the lowest address,
+    // similar to PNG. libyuv orders in word-order, so libavif's OffsetBytes and libyuv's are reversed.
+
+    if (avifRGBFormatHasAlpha(rgb->format)) {
+        // Only src_a(planePtr[3]) is allowed to be NULL in MergeARGBPlane.
+        if (planePtr[0] == NULL || planePtr[1] == NULL || planePtr[2] == NULL) {
+            return AVIF_RESULT_NOT_IMPLEMENTED;
+        }
+
+        // BGRA in libavif.
+        MergeARGBPlane(planePtr[2],
+                       planeRowBytes[2],
+                       planePtr[1],
+                       planeRowBytes[1],
+                       planePtr[0],
+                       planeRowBytes[0],
+                       planePtr[3],
+                       planeRowBytes[3],
+                       rgb->pixels,
+                       rgb->rowBytes,
+                       image->width,
+                       image->height);
+    } else {
+        // RGB in libavif.
+        MergeRGBPlane(planePtr[0],
+                      planeRowBytes[0],
+                      planePtr[1],
+                      planeRowBytes[1],
+                      planePtr[2],
+                      planeRowBytes[2],
+                      rgb->pixels,
+                      rgb->rowBytes,
+                      image->width,
+                      image->height);
+    }
+
+    return AVIF_RESULT_OK;
 }
 
 avifResult avifRGBImagePremultiplyAlphaLibYUV(avifRGBImage * rgb)

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -89,8 +89,7 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
                         matrixYVU = &kYvuF709Constants;
                         break;
 
-                    case AVIF_COLOR_PRIMARIES_BT470BG:
-                    case AVIF_COLOR_PRIMARIES_BT601:
+                    case AVIF_COLOR_PRIMARIES_BT470M:
                         matrixYUV = &kYuvJPEGConstants;
                         matrixYVU = &kYvuJPEGConstants;
                         break;
@@ -101,7 +100,8 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
                         break;
 
                     case AVIF_COLOR_PRIMARIES_UNKNOWN:
-                    case AVIF_COLOR_PRIMARIES_BT470M:
+                    case AVIF_COLOR_PRIMARIES_BT470BG:
+                    case AVIF_COLOR_PRIMARIES_BT601:
                     case AVIF_COLOR_PRIMARIES_SMPTE240:
                     case AVIF_COLOR_PRIMARIES_GENERIC_FILM:
                     case AVIF_COLOR_PRIMARIES_XYZ:
@@ -145,8 +145,8 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
                         matrixYUV = &kYuvH709Constants;
                         matrixYVU = &kYvuH709Constants;
                         break;
-                    case AVIF_COLOR_PRIMARIES_BT470BG:
-                    case AVIF_COLOR_PRIMARIES_BT601:
+
+                    case AVIF_COLOR_PRIMARIES_BT470M:
                         matrixYUV = &kYuvI601Constants;
                         matrixYVU = &kYvuI601Constants;
                         break;
@@ -156,7 +156,8 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
                         break;
 
                     case AVIF_COLOR_PRIMARIES_UNKNOWN:
-                    case AVIF_COLOR_PRIMARIES_BT470M:
+                    case AVIF_COLOR_PRIMARIES_BT470BG:
+                    case AVIF_COLOR_PRIMARIES_BT601:
                     case AVIF_COLOR_PRIMARIES_SMPTE240:
                     case AVIF_COLOR_PRIMARIES_GENERIC_FILM:
                     case AVIF_COLOR_PRIMARIES_XYZ:


### PR DESCRIPTION
It turns out that handling premultiply alpha during YUV<->RGB conversion is more complicated than I thought it was, and code in #477 need some further changes.

The absent part is: if we are converting some image with alpha into a format without alpha, we should do 'premultiply alpha' before discarding alpha plane. This has the same effect of rendering this image on a black background, which makes sense.

For RGB->YUV, the logic is simpler because YUV and RGB image always both have or don't have alpha:

| ↓YUV, RGB→ | premultiplied | not-premultiplied | absent |
| --- | --- | --- | --- |
| premultiplied | no-op | premultiply | - |
| not-premultiplied | unpremultiply | no-op | - |
| absent | - | - | no-op |

And this is the logic for YUV->RGB:
| ↓YUV, RGB→ | premultiplied | not-premultiplied | absent |
| --- | --- | --- | --- |
| premultiplied | no-op | unpremultiply | no-op |
| not-premultiplied | premultiply | no-op | premultiply |
| absent | fill opaque | fill opaque | no-op |

There are two cases if RGB is absent:
1. RGB format has alpha, but ignoreAlpha is set. (XRGB)
2. RGB format doesn't have alpha. (RGB)

2 is tricky, because we were doing premultiply alpha as a post step of conversion but A channel is already discarded during conversion. I added premultiply alpha handling in `avifImageYUVAnyToRGBAnySlow`, routed any YUVA(Not premultiplied)->RGB conversion to it, and keep using the fast paths for other cases.

This PR also utilized more functions in libyuv.