### PR TITLE
adds support for PNG and JPEG reading from stdin when --stdin is specified

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -94,22 +94,6 @@ static void avifSwizzleSTDIN(void) {
     }
 }
 
-#if 0
-#define TOUPPER(x) (((x) <= 'z' && (x) >= 'a') ? ((x) - 'a'+ 'A') : (x))
-static void testme(char *buf){
-#define mymax  8
-    char outbuf[mymax] = {0};
-    for(int i=0; i<mymax;i++) {
-	sprintf(outbuf,"%02x",(unsigned char)buf[i]);
-	for (unsigned long j=0;outbuf[j];j++){
-	    outbuf[j] = TOUPPER(outbuf[j]);
-	}
-	fprintf(stderr,"%s ",outbuf);
-    }
-    fprintf(stderr,"\n");
-}
-#endif
-
 static inline avifBool avifMagicEntryTest(const avifMagicEntry *entry,
 					  char *data)
 {

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -47,7 +47,7 @@ avifBool avifJPEGRead(avifImage * avif, const char * inputFilename, avifPixelFor
     avifRGBImage rgb;
     memset(&rgb, 0, sizeof(avifRGBImage));
 
-    FILE * f = fopen(inputFilename, "rb");
+    FILE * f = inputFilename ? fopen(inputFilename, "rb") : stdin;
     if (!f) {
         fprintf(stderr, "Can't open JPEG file for read: %s\n", inputFilename);
         return ret;

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -33,7 +33,7 @@ avifBool avifPNGRead(avifImage * avif, const char * inputFilename, avifPixelForm
     avifRGBImage rgb;
     memset(&rgb, 0, sizeof(avifRGBImage));
 
-    FILE * f = fopen(inputFilename, "rb");
+    FILE * f = inputFilename ? fopen(inputFilename, "rb") : stdin;
     if (!f) {
         fprintf(stderr, "Can't open PNG file for read: %s\n", inputFilename);
         goto cleanup;


### PR DESCRIPTION
Adding this patch will allow <code>avifenc</code> to read png and jpg from stdin and so allow avifenc to participate in pipelines with imagemagick or similar image manipulation programs rather than having to write to a temp file, and then read from it.

Patch does the following:

1. sets a user defined buffer to use for stdin so we can do lookaheads on it
2. adds magic numbers for JPG and PNG headers (maybe better to use library code for doing this but I don't know those libraries) ... code is extensible to other file types simply by adding additional lines with magic numbers in the appropriate data structure.
3. when reading from stdin will check for magic numbers, and if it can recognize PNG or JPG will pass control back to the functions for reading those instead of the default 
4. if not recognizing PNG or JPG, program flow is restored to default handling
5. a bug is fixed on recognizing EOF on stdin (with the swizzled input buffer the current code couldn't recognize EOF)

