### PR TITLE
ext: Update SVT-AV1 repo to GitLab

### DIFF
--- a/ext/svt.cmd
+++ b/ext/svt.cmd
@@ -11,7 +11,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #    "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b v0.8.6 --depth 1 https://github.com/AOMediaCodec/SVT-AV1.git
+git clone -b v0.8.6 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 
 cd SVT-AV1
 cd Build/windows

--- a/ext/svt.sh
+++ b/ext/svt.sh
@@ -2,7 +2,7 @@
 # then enable CMake's AVIF_CODEC_SVT and AVIF_LOCAL_SVT options.
 # cmake and ninja must be in your PATH.
 
-git clone --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v0.8.6 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 
 cd SVT-AV1
 cd Build/linux

--- a/ext/svt.sh
+++ b/ext/svt.sh
@@ -2,7 +2,7 @@
 # then enable CMake's AVIF_CODEC_SVT and AVIF_LOCAL_SVT options.
 # cmake and ninja must be in your PATH.
 
-git clone --depth 1 https://github.com/AOMediaCodec/SVT-AV1.git
+git clone --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 
 cd SVT-AV1
 cd Build/linux


### PR DESCRIPTION
Updates the SVT-AV1 repository from GitHub to GitLab.

See: https://github.com/AOMediaCodec/SVT-AV1/issues/1679

I also noticed that `ext/svt.cmd` is cloning the `v0.8.6` tag, while `ext/svt.sh` is checking out the default (master) branch. Should that be the case?