### PR TITLE
Harvest framerate from y4m headers as the "default", if present

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -221,15 +221,15 @@ int main(int argc, char * argv[])
             fprintf(stderr, "Cannot determine output file extension: %s\n", outputFilename);
             returnCode = 1;
         } else if (outputFormat == AVIF_APP_FILE_FORMAT_Y4M) {
-            if (!y4mWrite(avif, outputFilename)) {
+            if (!y4mWrite(outputFilename, avif)) {
                 returnCode = 1;
             }
         } else if (outputFormat == AVIF_APP_FILE_FORMAT_JPEG) {
-            if (!avifJPEGWrite(avif, outputFilename, jpegQuality, chromaUpsampling)) {
+            if (!avifJPEGWrite(outputFilename, avif, jpegQuality, chromaUpsampling)) {
                 returnCode = 1;
             }
         } else if (outputFormat == AVIF_APP_FILE_FORMAT_PNG) {
-            if (!avifPNGWrite(avif, outputFilename, requestedDepth, chromaUpsampling)) {
+            if (!avifPNGWrite(outputFilename, avif, requestedDepth, chromaUpsampling)) {
                 returnCode = 1;
             }
         } else {

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -39,7 +39,7 @@ static void my_error_exit(j_common_ptr cinfo)
 // longjmp. But GCC's -Wclobbered warning may have trouble figuring that out, so
 // we preemptively declare it as volatile.
 
-avifBool avifJPEGRead(avifImage * avif, const char * inputFilename, avifPixelFormat requestedFormat, uint32_t requestedDepth)
+avifBool avifJPEGRead(const char * inputFilename, avifImage * avif, avifPixelFormat requestedFormat, uint32_t requestedDepth)
 {
     volatile avifBool ret = AVIF_FALSE;
     uint8_t * volatile iccData = NULL;
@@ -137,7 +137,7 @@ static void avifRGBAToRGB(const avifRGBImage * src, avifRGBImage * dst)
 }
 #endif
 
-avifBool avifJPEGWrite(avifImage * avif, const char * outputFilename, int jpegQuality, avifChromaUpsampling chromaUpsampling)
+avifBool avifJPEGWrite(const char * outputFilename, avifImage * avif, int jpegQuality, avifChromaUpsampling chromaUpsampling)
 {
     avifBool ret = AVIF_FALSE;
     FILE * f = NULL;

--- a/apps/shared/avifjpeg.h
+++ b/apps/shared/avifjpeg.h
@@ -6,7 +6,7 @@
 
 #include "avif/avif.h"
 
-avifBool avifJPEGRead(avifImage * avif, const char * inputFilename, avifPixelFormat requestedFormat, uint32_t requestedDepth);
-avifBool avifJPEGWrite(avifImage * avif, const char * outputFilename, int jpegQuality, avifChromaUpsampling chromaUpsampling);
+avifBool avifJPEGRead(const char * inputFilename, avifImage * avif, avifPixelFormat requestedFormat, uint32_t requestedDepth);
+avifBool avifJPEGWrite(const char * outputFilename, avifImage * avif, int jpegQuality, avifChromaUpsampling chromaUpsampling);
 
 #endif // ifndef LIBAVIF_APPS_SHARED_AVIFJPEG_H

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -23,7 +23,7 @@
 // modified between setjmp and longjmp. But GCC's -Wclobbered warning may have
 // trouble figuring that out, so we preemptively declare them as volatile.
 
-avifBool avifPNGRead(avifImage * avif, const char * inputFilename, avifPixelFormat requestedFormat, uint32_t requestedDepth, uint32_t * outPNGDepth)
+avifBool avifPNGRead(const char * inputFilename, avifImage * avif, avifPixelFormat requestedFormat, uint32_t requestedDepth, uint32_t * outPNGDepth)
 {
     volatile avifBool readResult = AVIF_FALSE;
     png_structp png = NULL;
@@ -155,7 +155,7 @@ cleanup:
     return readResult;
 }
 
-avifBool avifPNGWrite(avifImage * avif, const char * outputFilename, uint32_t requestedDepth, avifChromaUpsampling chromaUpsampling)
+avifBool avifPNGWrite(const char * outputFilename, avifImage * avif, uint32_t requestedDepth, avifChromaUpsampling chromaUpsampling)
 {
     volatile avifBool writeResult = AVIF_FALSE;
     png_structp png = NULL;

--- a/apps/shared/avifpng.h
+++ b/apps/shared/avifpng.h
@@ -7,7 +7,7 @@
 #include "avif/avif.h"
 
 // if (requestedDepth == 0), do best-fit
-avifBool avifPNGRead(avifImage * avif, const char * inputFilename, avifPixelFormat requestedFormat, uint32_t requestedDepth, uint32_t * outPNGDepth);
-avifBool avifPNGWrite(avifImage * avif, const char * outputFilename, uint32_t requestedDepth, avifChromaUpsampling chromaUpsampling);
+avifBool avifPNGRead(const char * inputFilename, avifImage * avif, avifPixelFormat requestedFormat, uint32_t requestedDepth, uint32_t * outPNGDepth);
+avifBool avifPNGWrite(const char * outputFilename, avifImage * avif, uint32_t requestedDepth, avifChromaUpsampling chromaUpsampling);
 
 #endif // ifndef LIBAVIF_APPS_SHARED_AVIFPNG_H

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -36,4 +36,14 @@ typedef enum avifAppFileFormat
 
 avifAppFileFormat avifGuessFileFormat(const char * filename);
 
+// This structure holds any timing data coming from source (typically non-AVIF) inputs being fed
+// into avifenc. If either or both values are 0, the timing is "invalid" / sentinel and the values
+// should be ignored. This structure is used to override the timing defaults in avifenc when the
+// enduser doesn't provide timing on the commandline and the source content provides a framerate.
+typedef struct avifAppSourceTiming
+{
+    uint64_t duration;  // duration in time units (based on the timescale below)
+    uint64_t timescale; // timescale of the media (Hz)
+} avifAppSourceTiming;
+
 #endif // ifndef LIBAVIF_APPS_SHARED_AVIFUTIL_H

--- a/apps/shared/y4m.h
+++ b/apps/shared/y4m.h
@@ -12,7 +12,7 @@
 // The structure will always be freed upon failure or reaching EOF.
 struct y4mFrameIterator;
 
-avifBool y4mRead(avifImage * avif, const char * inputFilename, struct y4mFrameIterator ** iter);
+avifBool y4mRead(avifImage * avif, const char * inputFilename, struct y4mFrameIterator ** iter, avifImageTiming * imageTiming);
 avifBool y4mWrite(avifImage * avif, const char * outputFilename);
 
 #endif // ifndef LIBAVIF_APPS_SHARED_Y4M_H

--- a/apps/shared/y4m.h
+++ b/apps/shared/y4m.h
@@ -6,13 +6,15 @@
 
 #include "avif/avif.h"
 
+#include "avifutil.h"
+
 // Optionally pass one of these pointers (set to NULL) on a fresh input. If it successfully reads in
 // a frame and sees that there is more data to be read, it will allocate an internal structure remembering
 // the y4m header and FILE position and return it. Pass in this pointer to continue reading frames.
 // The structure will always be freed upon failure or reaching EOF.
 struct y4mFrameIterator;
 
-avifBool y4mRead(avifImage * avif, const char * inputFilename, struct y4mFrameIterator ** iter, avifImageTiming * imageTiming);
-avifBool y4mWrite(avifImage * avif, const char * outputFilename);
+avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTiming * sourceTiming, struct y4mFrameIterator ** iter);
+avifBool y4mWrite(const char * outputFilename, avifImage * avif);
 
 #endif // ifndef LIBAVIF_APPS_SHARED_Y4M_H

--- a/tests/testcase.c
+++ b/tests/testcase.c
@@ -207,7 +207,7 @@ int testCaseRun(TestCase * tc, const char * dataDir, avifBool generating)
     y4mFilename[sizeof(y4mFilename) - 1] = 0;
 
     avifImage * image = avifImageCreateEmpty();
-    if (!y4mRead(image, y4mFilename, NULL)) {
+    if (!y4mRead(image, y4mFilename, NULL, NULL)) {
         avifImageDestroy(image);
         printf("ERROR[%s]: Can't read y4m: %s\n", tc->name, y4mFilename);
         return AVIF_FALSE;

--- a/tests/testcase.c
+++ b/tests/testcase.c
@@ -207,7 +207,7 @@ int testCaseRun(TestCase * tc, const char * dataDir, avifBool generating)
     y4mFilename[sizeof(y4mFilename) - 1] = 0;
 
     avifImage * image = avifImageCreateEmpty();
-    if (!y4mRead(image, y4mFilename, NULL, NULL)) {
+    if (!y4mRead(y4mFilename, image, NULL, NULL)) {
         avifImageDestroy(image);
         printf("ERROR[%s]: Can't read y4m: %s\n", tc->name, y4mFilename);
         return AVIF_FALSE;


### PR DESCRIPTION
Change avifenc's internal defaults for duration/timescale to 0 (as a sentinel), and allow the first
source file's framerate (if detected) to override the original defaults if so.

Fixes: #497