### PR TITLE
Remove alphaPremultiplied line in avifJPEGWrite

### DIFF
--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -128,7 +128,6 @@ avifBool avifJPEGWrite(const char * outputFilename, avifImage * avif, int jpegQu
     rgb.format = AVIF_RGB_FORMAT_RGB;
     rgb.chromaUpsampling = chromaUpsampling;
     rgb.depth = 8;
-    rgb.alphaPremultiplied = AVIF_TRUE;
     avifRGBImageAllocatePixels(&rgb);
     if (avifImageYUVToRGB(avif, &rgb) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);


### PR DESCRIPTION
Remove the "rgb.alphaPremultiplied = AVIF_TRUE" line in avifJPEGWrite().
Commit b9158fa128d036f05b7611416c097e6c45c77870 missed this line.