### PR TITLE
Add MA1B brand for 8 or 10-bit monochrome images

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -748,7 +748,8 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     avifRWStreamWriteChars(&s, "mif1", 4);                                 // ... compatible_brands[]
     avifRWStreamWriteChars(&s, "miaf", 4);                                 // ... compatible_brands[]
     if ((imageMetadata->depth == 8) || (imageMetadata->depth == 10)) {     //
-        if (imageMetadata->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {        //
+        if ((imageMetadata->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) ||      //
+            (imageMetadata->yuvFormat == AVIF_PIXEL_FORMAT_YUV400)) {      //
             avifRWStreamWriteChars(&s, "MA1B", 4);                         // ... compatible_brands[]
         } else if (imageMetadata->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) { //
             avifRWStreamWriteChars(&s, "MA1A", 4);                         // ... compatible_brands[]


### PR DESCRIPTION
See the following sections in the AV1 Specification, Version 1.0.0 with
Errata 1:

Section 6.4.1. General sequence header OBU semantics, pages 112-113. The
table for seq_profile, bit depth, monochrome support, and chroma
subsampling.

A.2. Profiles, page 638. The Note says:
  Note: The Main profile supports YUV 4:2:0 or monochrome bitstreams
  with bit depth equal to 8 or 10. The High profile further adds support
  for 4:4:4 bitstreams with the same bit depth constraints. ...