### PR TITLE
Make image size limit configurable, expose to avifdec

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -36,6 +36,8 @@ static void syntax(void)
     printf("    -u,--upsampling U : Chroma upsampling (for 420/422). automatic (default), fastest, best, nearest, or bilinear\n");
     printf("    -i,--info         : Decode all frames and display all image information instead of saving to disk\n");
     printf("    --ignore-icc      : If the input file contains an embedded ICC profile, ignore it (no-op if absent)\n");
+    printf("    --size-limit C    : Specifies the image size limit (in total pixels) that the AV1 codec should tolerate.\n");
+    printf("                        Default: %u, set to 0 to disable. Supported codecs: dav1d.\n", AVIF_MAX_IMAGE_SIZE);
     printf("\n");
     avifPrintVersions();
 }
@@ -91,6 +93,7 @@ int main(int argc, char * argv[])
     avifBool infoOnly = AVIF_FALSE;
     avifChromaUpsampling chromaUpsampling = AVIF_CHROMA_UPSAMPLING_AUTOMATIC;
     avifBool ignoreICC = AVIF_FALSE;
+    uint32_t imageSizeLimit = AVIF_MAX_IMAGE_SIZE;
 
     if (argc < 2) {
         syntax();
@@ -161,6 +164,9 @@ int main(int argc, char * argv[])
             infoOnly = AVIF_TRUE;
         } else if (!strcmp(arg, "--ignore-icc")) {
             ignoreICC = AVIF_TRUE;
+        } else if (!strcmp(arg, "--size-limit")) {
+            NEXTARG();
+            imageSizeLimit = strtoul(arg, NULL, 10);
         } else {
             // Positional argument
             if (!inputFilename) {
@@ -205,6 +211,7 @@ int main(int argc, char * argv[])
     avifDecoder * decoder = avifDecoderCreate();
     decoder->maxThreads = jobs;
     decoder->codecChoice = codecChoice;
+    decoder->imageSizeLimit = imageSizeLimit;
     avifResult decodeResult = avifDecoderReadFile(decoder, avif, inputFilename);
     if (decodeResult == AVIF_RESULT_OK) {
         printf("Image decoded: %s\n", inputFilename);

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -76,6 +76,10 @@ typedef int avifBool;
 #define AVIF_SPEED_SLOWEST 0
 #define AVIF_SPEED_FASTEST 10
 
+// A maximum image size to avoid out-of-memory errors or integer overflow in
+// (32-bit) int or unsigned int arithmetic operations.
+#define AVIF_MAX_IMAGE_SIZE (16384 * 16384)
+
 enum avifPlanesFlags
 {
     AVIF_PLANES_YUV = (1 << 0),
@@ -700,6 +704,11 @@ typedef struct avifDecoder
     // If you don't actually leverage this data, it is best to ignore it here.
     avifBool ignoreExif;
     avifBool ignoreXMP;
+
+    // This represents the maximum size of a image (in pixel count) that the underlying AV1 decoder
+    // should attempt to decode. It defaults to AVIF_MAX_IMAGE_SIZE, and can be set to 0 to disable
+    // the limit. Currently supported codecs: dav1d.
+    uint32_t imageSizeLimit;
 
     // stats from the most recent read, possibly 0s if reading an image sequence
     avifIOStats ioStats;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -330,10 +330,6 @@ typedef struct avifSequenceHeader
 } avifSequenceHeader;
 avifBool avifSequenceHeaderParse(avifSequenceHeader * header, const avifROData * sample);
 
-// A maximum image size to avoid out-of-memory errors or integer overflow in
-// (32-bit) int or unsigned int arithmetic operations.
-#define AVIF_MAX_IMAGE_SIZE (16384 * 16384)
-
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -55,6 +55,7 @@ static avifBool dav1dCodecOpen(avifCodec * codec, avifDecoder * decoder)
         // Give all available threads to decode a single frame as fast as possible
         codec->internal->dav1dSettings.n_frame_threads = 1;
         codec->internal->dav1dSettings.n_tile_threads = AVIF_CLAMP(decoder->maxThreads, 1, DAV1D_MAX_TILE_THREADS);
+        codec->internal->dav1dSettings.frame_size_limit = decoder->imageSizeLimit;
 
         if (dav1d_open(&codec->internal->dav1dContext, &codec->internal->dav1dSettings) != 0) {
             return AVIF_FALSE;
@@ -208,9 +209,6 @@ avifCodec * avifCodecCreateDav1d(void)
     codec->internal = (struct avifCodecInternal *)avifAlloc(sizeof(struct avifCodecInternal));
     memset(codec->internal, 0, sizeof(struct avifCodecInternal));
     dav1d_default_settings(&codec->internal->dav1dSettings);
-
-    // Set a maximum frame size limit to avoid OOM'ing fuzzers.
-    codec->internal->dav1dSettings.frame_size_limit = AVIF_MAX_IMAGE_SIZE;
 
     // Ensure that we only get the "highest spatial layer" as a single frame
     // for each input sample, instead of getting each spatial layer as its own


### PR DESCRIPTION
This should resolve #263 .

@wantehchang:

* Should we make the default 0 (no limit) and manually set the limit in our fuzzer (and possibly Chrome), or should we keep the constant `AVIF_MAX_IMAGE_SIZE` (perhaps renamed to have DEFAULT somewhere in it?) and force people to opt into no limit?

* Does libaom have a similar size limit we can use? It'd be nice to not have to caveat "dav1d only" in various places.