### PR TITLE
libavif.pc: respect libdir setting

### DIFF
--- a/libavif.pc.cmake
+++ b/libavif.pc.cmake
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}/bin
-libdir=${prefix}/lib
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: @PROJECT_NAME@


### PR DESCRIPTION
Do not hardcode "lib" as that is often the wrong path with multilib.
On an x86_64 system for example, it should actually be "lib64".