### PR TITLE
Set codec-specific options for color or alpha only

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -104,6 +104,13 @@ static void syntax(void)
     printf("\n");
     if (avifCodecName(AVIF_CODEC_CHOICE_AOM, 0)) {
         printf("aom-specific advanced options:\n");
+        printf("    1. <key>=<value> applies to both the color sub-image and the alpha sub-image (if present).\n");
+        printf("    2. color:<key>=<value> or c:<key>=<value> applies only to the color sub-image.\n");
+        printf("    3. alpha:<key>=<value> or a:<key>=<value> applies only to the alpha sub-image (if present).\n");
+        printf("       Since the alpha sub-image is a monochrome image, the options that refer to the chrome planes, such as\n");
+        printf("       enable-chroma-deltaq=B, should not be used with the alpha sub-image. In addition, the film grain options\n");
+        printf("       are unlikely to make sense for the alpha sub-image.\n");
+        printf("\n");
         printf("    aq-mode=M                         : Adaptive quantization mode (0: off (default), 1: variance, 2: complexity, 3: cyclic refresh)\n");
         printf("    cq-level=Q                        : Constant/Constrained Quality level (0-63, end-usage must be set to cq or q)\n");
         printf("    enable-chroma-deltaq=B            : Enable delta quantization in chroma planes (0: disable (default), 1: enable)\n");


### PR DESCRIPTION
Set codec-specific options for color or alpha only
  
Add a new syntax for codec-specific options so that they can be applied
to the color or alpha sub-image only.

1. `<key>=<value>` applies to both color and alpha (if present).
2. `color:<key>=<value>` or `c:<key>=<value>` applies only to color.
3. `alpha:<key>=<value>` or `a:<key>=<value>` applies only to alpha (if
   present).

In the syntax message of avifenc, describe the libaom codec-specific
options that should not be used with the alpha-subimage.

Remove the special handling of the film-grain-test and film-grain-table
options for the alpha sub-image.

Fix https://github.com/AOMediaCodec/libavif/issues/533.