### PR TITLE
Free codec->internal outside #if block

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -64,8 +64,9 @@ static void aomCodecDestroyInternal(avifCodec * codec)
     if (codec->internal->encoderInitialized) {
         aom_codec_destroy(&codec->internal->encoder);
     }
-    avifFree(codec->internal);
 #endif
+
+    avifFree(codec->internal);
 }
 
 #if defined(AVIF_CODEC_AOM_DECODE)


### PR DESCRIPTION
aomCodecDestroyInternal() should call avifFree(codec->internal) outside
the #if defined(AVIF_CODEC_AOM_ENCODE) block. Otherwise, codec->internal
will not be freed if AVIF_CODEC_AOM_DECODE is defined but
AVIF_CODEC_AOM_ENCODE is not defined.