### PR TITLE
Use same code pattern to fix MS CL code analysis

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -84,8 +84,9 @@ void avifArrayCreate(void * arrayStruct, uint32_t elementSize, uint32_t initialC
     arr->elementSize = elementSize ? elementSize : 1;
     arr->count = 0;
     arr->capacity = initialCapacity;
-    arr->ptr = (uint8_t *)avifAlloc((size_t)arr->elementSize * arr->capacity);
-    memset(arr->ptr, 0, (size_t)arr->elementSize * arr->capacity);
+    size_t byteCount = (size_t)arr->elementSize * arr->capacity;
+    arr->ptr = (uint8_t *)avifAlloc(byteCount);
+    memset(arr->ptr, 0, byteCount);
 }
 
 uint32_t avifArrayPushIndex(void * arrayStruct)
@@ -93,8 +94,8 @@ uint32_t avifArrayPushIndex(void * arrayStruct)
     avifArrayInternal * arr = (avifArrayInternal *)arrayStruct;
     if (arr->count == arr->capacity) {
         uint8_t * oldPtr = arr->ptr;
-        uint32_t oldByteCount = arr->elementSize * arr->capacity;
-        arr->ptr = (uint8_t *)avifAlloc((size_t)oldByteCount * 2);
+        size_t oldByteCount = (size_t)arr->elementSize * arr->capacity;
+        arr->ptr = (uint8_t *)avifAlloc(oldByteCount * 2);
         memset(arr->ptr + oldByteCount, 0, oldByteCount);
         memcpy(arr->ptr, oldPtr, oldByteCount);
         arr->capacity *= 2;


### PR DESCRIPTION
Use the same code pattern in avifArrayCreate() and avifArrayPushIndex()
to fix Visual C++ code analysis warnings.