### PR TITLE
Check if alpha plane is present when deciding toRGBAlphaMode

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -134,17 +134,19 @@ static avifBool avifPrepareReformatState(const avifImage * image, const avifRGBI
     }
 
     state->toRGBAlphaMode = AVIF_ALPHA_MULTIPLY_MODE_NO_OP;
-    if (!avifRGBFormatHasAlpha(rgb->format) || rgb->ignoreAlpha) {
-        // if we are converting some image with alpha into a format without alpha, we should do 'premultiply alpha' before
-        // discarding alpha plane. This has the same effect of rendering this image on a black background, which makes sense.
-        if (!image->alphaPremultiplied) {
-            state->toRGBAlphaMode = AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY;
-        }
-    } else {
-        if (!image->alphaPremultiplied && rgb->alphaPremultiplied) {
-            state->toRGBAlphaMode = AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY;
-        } else if (image->alphaPremultiplied && !rgb->alphaPremultiplied) {
-            state->toRGBAlphaMode = AVIF_ALPHA_MULTIPLY_MODE_UNMULTIPLY;
+    if (image->alphaPlane != NULL) {
+        if (!avifRGBFormatHasAlpha(rgb->format) || rgb->ignoreAlpha) {
+            // if we are converting some image with alpha into a format without alpha, we should do 'premultiply alpha' before
+            // discarding alpha plane. This has the same effect of rendering this image on a black background, which makes sense.
+            if (!image->alphaPremultiplied) {
+                state->toRGBAlphaMode = AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY;
+            }
+        } else {
+            if (!image->alphaPremultiplied && rgb->alphaPremultiplied) {
+                state->toRGBAlphaMode = AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY;
+            } else if (image->alphaPremultiplied && !rgb->alphaPremultiplied) {
+                state->toRGBAlphaMode = AVIF_ALPHA_MULTIPLY_MODE_UNMULTIPLY;
+            }
         }
     }
 


### PR DESCRIPTION
When selecting `toRGBAlphaMode `, we didn't check if the alpha plane is present.