### PR TITLE
Check aom_codec_control(AOME_SET_CPUUSED) failure

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -664,7 +664,9 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, tileColsLog2);
         }
         if (aomCpuUsed != -1) {
-            aom_codec_control(&codec->internal->encoder, AOME_SET_CPUUSED, aomCpuUsed);
+            if (aom_codec_control(&codec->internal->encoder, AOME_SET_CPUUSED, aomCpuUsed) != AOM_CODEC_OK) {
+                return AVIF_RESULT_UNKNOWN_ERROR;
+            }
         }
         if (!avifProcessAOMOptionsPostInit(codec, alpha)) {
             return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;


### PR DESCRIPTION
The aom_codec_control(encoder, AOME_SET_CPUUSED, aomCpuUsed) call fails
if aomCpuUsed is greater than the maximum cpu-used value supported by
libaom. This should not happen if we set aomCpuUsed correctly, so this
check is intended to prevent future bugs when we attempt to use libaom's
new speed 9, which is not supported by libaom 2.0.x or older.