### PR TITLE
Recognize the Y4M format string "C420mpeg2"

### DIFF
--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -36,12 +36,19 @@ static avifBool y4mColorSpaceParse(const char * formatString, struct y4mFrameIte
     if (!strcmp(formatString, "C420jpeg")) {
         frame->format = AVIF_PIXEL_FORMAT_YUV420;
         frame->depth = 8;
+        // Chroma sample position is center.
         return AVIF_TRUE;
     }
     if (!strcmp(formatString, "C420mpeg2")) {
         frame->format = AVIF_PIXEL_FORMAT_YUV420;
         frame->depth = 8;
         frame->chromaSamplePosition = AVIF_CHROMA_SAMPLE_POSITION_VERTICAL;
+        return AVIF_TRUE;
+    }
+    if (!strcmp(formatString, "C420paldv")) {
+        frame->format = AVIF_PIXEL_FORMAT_YUV420;
+        frame->depth = 8;
+        frame->chromaSamplePosition = AVIF_CHROMA_SAMPLE_POSITION_COLOCATED;
         return AVIF_TRUE;
     }
     if (!strcmp(formatString, "C444p10")) {
@@ -103,6 +110,7 @@ static avifBool y4mColorSpaceParse(const char * formatString, struct y4mFrameIte
     if (!strcmp(formatString, "C420")) {
         frame->format = AVIF_PIXEL_FORMAT_YUV420;
         frame->depth = 8;
+        // Chroma sample position is center.
         return AVIF_TRUE;
     }
     if (!strcmp(formatString, "Cmono")) {


### PR DESCRIPTION
The libavformat/yuv4mpegdec.c file in ffmpeg says:
```
        case 'C': // Color space
            if (strncmp("420jpeg", tokstart, 7) == 0) {
                pix_fmt = AV_PIX_FMT_YUV420P;
                chroma_sample_location = AVCHROMA_LOC_CENTER;
            } else if (strncmp("420mpeg2", tokstart, 8) == 0) {
                pix_fmt = AV_PIX_FMT_YUV420P;
                chroma_sample_location = AVCHROMA_LOC_LEFT;
            } else if (strncmp("420paldv", tokstart, 8) == 0) {
                pix_fmt = AV_PIX_FMT_YUV420P;
                chroma_sample_location = AVCHROMA_LOC_TOPLEFT;
            } else if ...
            ...
            } else if (strncmp("420", tokstart, 3) == 0) {
                pix_fmt = AV_PIX_FMT_YUV420P;
                chroma_sample_location = AVCHROMA_LOC_CENTER;
            } else if ...
```