### PR TITLE
Clarify the help message for -r,--raw-color

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -34,7 +34,8 @@ static void syntax(void)
     printf("    -d,--depth D      : Output depth [8,16]. (PNG only; For y4m, depth is retained, and JPEG is always 8bpc)\n");
     printf("    -q,--quality Q    : Output quality [0-100]. (JPEG only, default: %d)\n", DEFAULT_JPEG_QUALITY);
     printf("    -u,--upsampling U : Chroma upsampling (for 420/422). automatic (default), fastest, best, nearest, or bilinear\n");
-    printf("    -r,--raw-color    : Output raw values instead of multiplying alpha when saving to opaque formats (JPEG only; always true for y4m)\n");
+    printf("    -r,--raw-color    : Output raw RGB values instead of multiplying by alpha when saving to opaque formats\n");
+    printf("                        (JPEG only; not applicable to y4m)\n");
     printf("    -i,--info         : Decode all frames and display all image information instead of saving to disk\n");
     printf("    --ignore-icc      : If the input file contains an embedded ICC profile, ignore it (no-op if absent)\n");
     printf("\n");


### PR DESCRIPTION
Explicitly say the raw values are RGB, which helps explain why this
option is not applicable to Y4M.