### PR TITLE
Simplify the calculation of A (alpha)

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -624,13 +624,14 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
             B = AVIF_CLAMP(B, 0.0f, 1.0f);
 
             if (state->toRGBAlphaMode != AVIF_ALPHA_MULTIPLY_MODE_NO_OP) {
-                float A;
-                if (state->yuvChannelBytes > 1) {
-                    A = (AVIF_MIN(ptrA16[i], yuvMaxChannel) - state->biasA) / state->rangeA;
+                // Calculate A
+                uint16_t unormA;
+                if (image->depth == 8) {
+                    unormA = ptrA8[i];
                 } else {
-                    A = (AVIF_MIN(ptrA8[i], yuvMaxChannel) - state->biasA) / state->rangeA;
+                    unormA = AVIF_MIN(ptrA16[i], yuvMaxChannel);
                 }
-
+                float A = (unormA - state->biasA) / state->rangeA;
                 A = AVIF_CLAMP(A, 0.0f, 1.0f);
 
                 if (state->toRGBAlphaMode == AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY) {


### PR DESCRIPTION
Simplify the calculation of A (alpha) in avifImageYUVAnyToRGBAnySlow().
Make it look like the code that calculates Y, U, V in the same function.
For example, replace the state->yuvChannelBytes > 1 test with the
image->depth == 8 test (and swap the if and else branches), and omit the
clamping of ptrA8[i] because it cannot possibly be greater than
yuvMaxChannel.