### PR TITLE
Cast uint8_t variable to uint32_t before << 24

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1503,7 +1503,7 @@ static avifBool avifParseItemPropertyAssociation(avifMeta * meta, const uint8_t 
     uint32_t flags;
     CHECK(avifROStreamReadVersionAndFlags(&s, &version, &flags));
     avifBool propertyIndexIsU16 = ((flags & 0x1) != 0);
-    *outVersionAndFlags = (version << 24) | flags;
+    *outVersionAndFlags = ((uint32_t)version << 24) | flags;
 
     uint32_t entryCount;
     CHECK(avifROStreamReadU32(&s, &entryCount));


### PR DESCRIPTION
In avifParseItemPropertyAssociation(), cast the uint8_t variable
'version' to uint32_t before performing the << 24 operation. Without the
cast, 'version' is automatically converted to 'int' by the C language,
so if the most significant bit of 'version' is 1, it will be shifted
into the sign bit of the 'int' value.

Fix https://crbug.com/oss-fuzz/33032.