### PR TITLE
Check if avifImageYUVToRGBLibYUV can do the desired conversion

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -1081,18 +1081,22 @@ avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
         return AVIF_RESULT_REFORMAT_FAILED;
     }
 
+    avifAlphaMultiplyMode alphaMultiplyMode = state.toRGBAlphaMode;
     avifBool convertedWithLibYUV = AVIF_FALSE;
-    avifResult libyuvResult = avifImageYUVToRGBLibYUV(image, rgb);
-    if (libyuvResult == AVIF_RESULT_OK) {
-        convertedWithLibYUV = AVIF_TRUE;
-    } else {
-        if (libyuvResult != AVIF_RESULT_NOT_IMPLEMENTED) {
-            return libyuvResult;
+    avifResult libyuvResult = AVIF_RESULT_NOT_IMPLEMENTED;
+    if (alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP || avifRGBFormatHasAlpha(rgb->format)) {
+        libyuvResult = avifImageYUVToRGBLibYUV(image, rgb);
+
+        if (libyuvResult == AVIF_RESULT_OK) {
+            convertedWithLibYUV = AVIF_TRUE;
+        } else {
+            if (libyuvResult != AVIF_RESULT_NOT_IMPLEMENTED) {
+                return libyuvResult;
+            }
         }
     }
 
     // Reformat alpha, if user asks for it, or (un)multiply processing needs it.
-    avifAlphaMultiplyMode alphaMultiplyMode = state.toRGBAlphaMode;
     if (avifRGBFormatHasAlpha(rgb->format) && (!rgb->ignoreAlpha || (alphaMultiplyMode != AVIF_ALPHA_MULTIPLY_MODE_NO_OP))) {
         avifAlphaParams params;
 

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -1083,10 +1083,8 @@ avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
 
     avifAlphaMultiplyMode alphaMultiplyMode = state.toRGBAlphaMode;
     avifBool convertedWithLibYUV = AVIF_FALSE;
-    avifResult libyuvResult = AVIF_RESULT_NOT_IMPLEMENTED;
     if (alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP || avifRGBFormatHasAlpha(rgb->format)) {
-        libyuvResult = avifImageYUVToRGBLibYUV(image, rgb);
-
+        avifResult libyuvResult = avifImageYUVToRGBLibYUV(image, rgb);
         if (libyuvResult == AVIF_RESULT_OK) {
             convertedWithLibYUV = AVIF_TRUE;
         } else {


### PR DESCRIPTION
As suggested in #587, before calling `avifImageYUVToRGBLibYUV()` we should check if libyuv can do the desired conversion for us.
Utilize `I420ToRGB24Matrix()` from libyuv to convert to RGB/BGR formats.