### PR TITLE
CI: Add caching and macOS job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,24 +15,38 @@ jobs:
       run: echo "CC=gcc-10" >> $GITHUB_ENV && echo "CXX=g++-10" >> $GITHUB_ENV
     - uses: actions/setup-python@v2
 
+    - name: Cache external dependencies
+      id: cache-ext
+      uses: actions/cache@v2
+      with:
+        path: ext
+        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}
     - uses: ilammy/setup-nasm@v1
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       with:
         version: 2.15.05
     - uses: seanmiddleditch/gha-setup-ninja@v3
+      if: steps.cache-ext.outputs.cache-hit != 'true'
     - run: pip install meson
+      if: steps.cache-ext.outputs.cache-hit != 'true'
     - name: Build aom
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash aom.cmd
     - name: Build dav1d
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash dav1d.cmd
     - name: Build rav1e
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash rav1e.cmd
     - name: Build libgav1
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash libgav1.cmd
     - name: Build libyuv
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash libyuv.cmd
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,38 +2,40 @@ name: CI
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-20.04
-    env:
-      CC: gcc-10
-      CXX: g++-10
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
     steps:
+    - uses: actions/checkout@v2
+    - name: Set GCC & G++ 10 compiler (on Linux)
+      if: runner.os == 'Linux'
+      run: echo "CC=gcc-10" >> $GITHUB_ENV && echo "CXX=g++-10" >> $GITHUB_ENV
     - uses: actions/setup-python@v2
-    - name: Install dependencies
-      run: |
-        DEBIAN_FRONTEND=noninteractive sudo apt-get update || true
-        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ninja-build gcc-10 g++-10
-        pip install --upgrade pip
-        pip install setuptools
-        pip install meson
+
     - uses: ilammy/setup-nasm@v1
       with:
         version: 2.15.05
-    - uses: actions/checkout@v2
-    - name: Setup aom
+    - uses: seanmiddleditch/gha-setup-ninja@v3
+    - run: pip install meson
+    - name: Build aom
       working-directory: ./ext
       run: bash aom.cmd
-    - name: Setup dav1d
+    - name: Build dav1d
       working-directory: ./ext
       run: bash dav1d.cmd
-    - name: Setup rav1e
+    - name: Build rav1e
       working-directory: ./ext
       run: bash rav1e.cmd
-    - name: Setup libgav1
+    - name: Build libgav1
       working-directory: ./ext
       run: bash libgav1.cmd
-    - name: Setup libyuv
+    - name: Build libyuv
       working-directory: ./ext
       run: bash libyuv.cmd
+
     - name: Prepare libavif (cmake)
       run: |
         mkdir build && cd build
@@ -41,6 +43,7 @@ jobs:
     - name: Build libavif (make)
       working-directory: ./build
       run: make -j $(($(nproc) + 1))
-    - name: Run AVIF Tests
+    - name: Run AVIF Tests (on Linux)
+      if: runner.os == 'Linux'
       working-directory: ./build
       run: ./aviftest ../tests/data

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -7,10 +7,10 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone https://chromium.googlesource.com/libyuv/libyuv
+git clone --single-branch https://chromium.googlesource.com/libyuv/libyuv
 
 cd libyuv
-git checkout 2525698
+git checkout 2871589
 
 mkdir build
 cd build


### PR DESCRIPTION
This PR updates the CI configuration to implement caching of all external dependencies (currently aom, dav1d, rav1e, libgav1 and libyuv), speeding up the build from 15 to 20 minutes to under 1 minute with a cache hit.

It also adds a macOS build using Xcode with Apple Clang and includes a bit of cleanup. It updates libyuv to resolve an error on macOS.

I have split the PR into 3 commits to separate each feature. You can see a run without caching [here](https://github.com/EwoutH/libavif/actions/runs/749698421) and a build with caching [here](https://github.com/EwoutH/libavif/actions/runs/749829968).
