### PR TITLE
Reorder cmake options

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ skip_commits:
     - '*.md'
 
 install:
- # install Rust
+ # Install Rust
  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
  - rustup-init -yv --default-toolchain stable --default-host x86_64-pc-windows-msvc
  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
@@ -36,7 +36,7 @@ install:
  - mkdir build
  - cd build
  - cmake --version
- - cmake .. -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_RAV1E=ON -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_DAV1D=ON -DBUILD_SHARED_LIBS=OFF -DAVIF_LOCAL_JPEG=1 -DAVIF_LOCAL_ZLIBPNG=1 -DAVIF_BUILD_APPS=ON
+ - cmake .. -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=ON -DBUILD_SHARED_LIBS=OFF -DAVIF_LOCAL_JPEG=1 -DAVIF_LOCAL_ZLIBPNG=1 -DAVIF_BUILD_APPS=ON
 
 build:
   project: build/libavif.sln


### PR DESCRIPTION
In commit f8b2362be78aafe732a7023e1dae8d0ac60fae86, the two cmake
options for dav1d were inadvertently separated by the new cmake options
for rav1e.