### PR TITLE
Do not add AVIF_CODEC_LIBRARIES to avifenc/avifdec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,6 @@ if(AVIF_CODEC_LIBRARIES MATCHES vmaf)
     enable_language(CXX)
 endif()
 
-
 option(AVIF_BUILD_APPS "Build avif apps." OFF)
 if(AVIF_BUILD_APPS)
     find_package(ZLIB REQUIRED)
@@ -476,7 +475,7 @@ if(AVIF_BUILD_APPS)
     if(AVIF_LOCAL_LIBGAV1 OR AVIF_CODEC_LIBRARIES MATCHES vmaf)
         set_target_properties(avifenc PROPERTIES LINKER_LANGUAGE "CXX")
     endif()
-    target_link_libraries(avifenc avif ${AVIF_PLATFORM_LIBRARIES} ${AVIF_CODEC_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
+    target_link_libraries(avifenc avif ${AVIF_PLATFORM_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
     target_include_directories(avifenc
                                PRIVATE
                                    $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES>
@@ -495,7 +494,7 @@ if(AVIF_BUILD_APPS)
     if(AVIF_LOCAL_LIBGAV1 OR AVIF_CODEC_LIBRARIES MATCHES vmaf)
         set_target_properties(avifdec PROPERTIES LINKER_LANGUAGE "CXX")
     endif()
-    target_link_libraries(avifdec avif ${AVIF_PLATFORM_LIBRARIES} ${AVIF_CODEC_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
+    target_link_libraries(avifdec avif ${AVIF_PLATFORM_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
     target_include_directories(avifdec
                                PRIVATE
                                    $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES>

--- a/cmake/Modules/Findaom.cmake
+++ b/cmake/Modules/Findaom.cmake
@@ -34,7 +34,7 @@ find_library(AOM_LIBRARY
 set(AOM_LIBRARIES
     ${AOM_LIBRARIES}
     ${AOM_LIBRARY}
-    ${_AOM_LIBRARIES})
+    ${_AOM_LDFLAGS})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(aom


### PR DESCRIPTION
Do not add ${AVIF_CODEC_LIBRARIES} to the target_link_libraries of
avifenc and avifdec. avifenc and avifdec should get
${AVIF_CODEC_LIBRARIES} via the avif target.

Fix https://github.com/AOMediaCodec/libavif/issues/598.