### PR TITLE
Ext: Update libgav1 to v0.16.3, abseil-cpp to lts_2021_03_24

### DIFF
--- a/ext/libgav1.cmd
+++ b/ext/libgav1.cmd
@@ -8,11 +8,10 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone --single-branch https://chromium.googlesource.com/codecs/libgav1
+git clone -b v0.16.3 --depth 1 https://chromium.googlesource.com/codecs/libgav1
 
 cd libgav1
-git checkout 4a89dc3
-git clone -b lts_2020_09_23 --depth 1 https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
+git clone -b lts_2021_03_24 --depth 1 https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
 mkdir build
 cd build
 


### PR DESCRIPTION
- Updates libgav1 to the new [v0.16.3 tag](https://chromium.googlesource.com/codecs/libgav1/+/refs/tags/v0.16.3)
- Updates abseil-cpp to the latest LTS branch, [lts_2021_03_24](https://github.com/abseil/abseil-cpp/releases/tag/20210324.0)

Because we now checkout a tag instead of a commit, `--depth 1` can be used again for a faster and smaller checkout.