### PR TITLE
Generalize the "no alpha, no premultiply" handling

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -264,6 +264,11 @@ static avifAppFileFormat avifInputReadImage(avifInput * input, avifImage * image
         return AVIF_APP_FILE_FORMAT_UNKNOWN;
     }
 
+    // The image doesn't have alpha. Prevent confusion.
+    if (!image->alphaPlane) {
+        image->alphaPremultiplied = AVIF_FALSE;
+    }
+
     if (!input->frameIter) {
         ++input->fileIndex;
     }

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -276,8 +276,6 @@ avifBool avifJPEGRead(const char * inputFilename, avifImage * avif, avifPixelFor
 
     avif->yuvFormat = requestedFormat; // This may be AVIF_PIXEL_FORMAT_NONE, which is "auto" to avifJPEGReadCopy()
     avif->depth = requestedDepth ? requestedDepth : 8;
-    // JPEG doesn't have alpha. Prevent confusion.
-    avif->alphaPremultiplied = AVIF_FALSE;
 
     if (avifJPEGReadCopy(avif, &cinfo)) {
         // JPEG pixels were successfully copied without conversion. Notify the enduser.


### PR DESCRIPTION
Move the "JPEG doesn't have alpha. Prevent confusion." code in
avifJPEGRead() to avifInputReadImage() so that it applies to all input
image formats.