### PR TITLE
Remove an unneeded test and duplicate code

### DIFF
--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -291,9 +291,6 @@ avifBool avifJPEGRead(const char * inputFilename, avifImage * avif, avifPixelFor
         cinfo.out_color_space = JCS_RGB;
         jpeg_start_decompress(&cinfo);
 
-        avif->width = cinfo.output_width;
-        avif->height = cinfo.output_height;
-
         int row_stride = cinfo.output_width * cinfo.output_components;
         JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo, JPOOL_IMAGE, row_stride, 1);
 


### PR DESCRIPTION
Remove an unneeded test for YUV 444, 422, and 420 in avifJPEGReadCopy().
That test always evaluates to true.

Remove two lines of duplicate code in avifJPEGRead().