### PR TITLE
Update the documentation for libaom sharpness param

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -120,7 +120,7 @@ static void syntax(void)
         printf("    cq-level=Q                        : Constant/Constrained Quality level (0-63, end-usage must be set to cq or q)\n");
         printf("    enable-chroma-deltaq=B            : Enable delta quantization in chroma planes (0: disable (default), 1: enable)\n");
         printf("    end-usage=MODE                    : Rate control mode (vbr, cbr, cq, or q)\n");
-        printf("    sharpness=S                       : Loop filter sharpness (0-7, default: 0)\n");
+        printf("    sharpness=S                       : Bias towards block sharpness in rate-distortion optimization of transform coefficients (0-7, default: 0)\n");
         printf("    tune=METRIC                       : Tune the encoder for distortion metric (psnr or ssim, default: psnr)\n");
         printf("    film-grain-test=TEST              : Film grain test vectors (0: none (default), 1: test-1  2: test-2, ... 16: test-16)\n");
         printf("    film-grain-table=FILENAME         : Path to file containing film grain parameters\n");

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -384,7 +384,7 @@ static const struct aomOptionDef aomOptionDefs[] = {
     { "cq-level", AOME_SET_CQ_LEVEL, AVIF_AOM_OPTION_UINT, NULL },
     // Enable delta quantization in chroma planes
     { "enable-chroma-deltaq", AV1E_SET_ENABLE_CHROMA_DELTAQ, AVIF_AOM_OPTION_INT, NULL },
-    // Loop filter sharpness
+    // Bias towards block sharpness in rate-distortion optimization of transform coefficients
     { "sharpness", AOME_SET_SHARPNESS, AVIF_AOM_OPTION_UINT, NULL },
     // Tune distortion metric
     { "tune", AOME_SET_TUNING, AVIF_AOM_OPTION_ENUM, tuningEnum },


### PR DESCRIPTION
The documentation for libaom sharpness parameter is updated to comply with the current implementation in libaom. These changes were introduced in the following CL:

https://aomedia-review.googlesource.com/c/aom/+/60901

Loop filtering does not make use of the sharpness parameter now. It is currently used to control sharpness in the block through transform coeff RD.