### PR TITLE
Use libyuv BT.709 & 2020 full range YuvConstants

### DIFF
--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -56,27 +56,53 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
     const struct YuvConstants * matrixYVU = NULL;
     if (image->yuvRange == AVIF_RANGE_FULL) {
         switch (image->matrixCoefficients) {
+            // BT.709 full range YuvConstants were added in libyuv version 1772.
+            // See https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2646472.
+            case AVIF_MATRIX_COEFFICIENTS_BT709:
+#if LIBYUV_VERSION >= 1772
+                matrixYUV = &kYuvF709Constants;
+                matrixYVU = &kYvuF709Constants;
+#endif
+                break;
             case AVIF_MATRIX_COEFFICIENTS_BT470BG:
             case AVIF_MATRIX_COEFFICIENTS_BT601:
             case AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED:
                 matrixYUV = &kYuvJPEGConstants;
                 matrixYVU = &kYvuJPEGConstants;
                 break;
+            // BT.2020 full range YuvConstants were added in libyuv version 1775.
+            // See https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2678859.
+            case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
+#if LIBYUV_VERSION >= 1775
+                matrixYUV = &kYuvV2020Constants;
+                matrixYVU = &kYvuV2020Constants;
+#endif
+                break;
             case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
                 switch (image->colorPrimaries) {
+                    case AVIF_COLOR_PRIMARIES_BT709:
+                    case AVIF_COLOR_PRIMARIES_UNSPECIFIED:
+#if LIBYUV_VERSION >= 1772
+                        matrixYUV = &kYuvF709Constants;
+                        matrixYVU = &kYvuF709Constants;
+#endif
+                        break;
                     case AVIF_COLOR_PRIMARIES_BT470BG:
                     case AVIF_COLOR_PRIMARIES_BT601:
                         matrixYUV = &kYuvJPEGConstants;
                         matrixYVU = &kYvuJPEGConstants;
                         break;
+                    case AVIF_COLOR_PRIMARIES_BT2020:
+#if LIBYUV_VERSION >= 1775
+                        matrixYUV = &kYuvV2020Constants;
+                        matrixYVU = &kYvuV2020Constants;
+#endif
+                        break;
 
-                    case AVIF_COLOR_PRIMARIES_UNSPECIFIED:
                     case AVIF_COLOR_PRIMARIES_UNKNOWN:
-                    case AVIF_COLOR_PRIMARIES_BT709:
                     case AVIF_COLOR_PRIMARIES_BT470M:
                     case AVIF_COLOR_PRIMARIES_SMPTE240:
                     case AVIF_COLOR_PRIMARIES_GENERIC_FILM:
-                    case AVIF_COLOR_PRIMARIES_BT2020:
                     case AVIF_COLOR_PRIMARIES_XYZ:
                     case AVIF_COLOR_PRIMARIES_SMPTE431:
                     case AVIF_COLOR_PRIMARIES_SMPTE432:
@@ -86,11 +112,9 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
                 break;
 
             case AVIF_MATRIX_COEFFICIENTS_IDENTITY:
-            case AVIF_MATRIX_COEFFICIENTS_BT709:
             case AVIF_MATRIX_COEFFICIENTS_FCC:
             case AVIF_MATRIX_COEFFICIENTS_SMPTE240:
             case AVIF_MATRIX_COEFFICIENTS_YCGCO:
-            case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
             case AVIF_MATRIX_COEFFICIENTS_BT2020_CL:
             case AVIF_MATRIX_COEFFICIENTS_SMPTE2085:
             case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL:


### PR DESCRIPTION
Use libyuv BT.709 and BT.2020 full range YuvConstants if they are
available.