### PR TITLE
Ext: Update aom to v3.1.0, libyuv to 2f0cbb9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-* Update aom.cmd: v3.0.0
+* Update aom.cmd: v3.1.0
+* Update libgav1: v0.16.3
+* Update libyuv.cmd: 2f0cbb9
 
 ## [0.9.0] - 2021-02-22
 

--- a/ext/aom.cmd
+++ b/ext/aom.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b v3.0.0 --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v3.1.0 --depth 1 https://aomedia.googlesource.com/aom
 
 cd aom
 mkdir build.libavif

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -10,7 +10,7 @@
 git clone --single-branch https://chromium.googlesource.com/libyuv/libyuv
 
 cd libyuv
-git checkout 2871589
+git checkout 2f0cbb9
 
 mkdir build
 cd build

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -34,7 +34,7 @@ nasm --version
 
 # aom
 cd
-git clone -b v3.0.0 --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v3.1.0 --depth 1 https://aomedia.googlesource.com/aom
 cd aom
 mkdir build.avif
 cd build.avif
@@ -52,10 +52,9 @@ ninja install
 
 # libgav1
 cd
-git clone --single-branch https://chromium.googlesource.com/codecs/libgav1
+git clone -b v0.16.3 --depth 1 https://chromium.googlesource.com/codecs/libgav1
 cd libgav1
-git checkout 4a89dc3
-git clone -b lts_2020_09_23 --depth 1 https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
+git clone -b lts_2021_03_24 --depth 1 https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
 mkdir build
 cd build
 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DLIBGAV1_THREADPOOL_USE_STD_MUTEX=1 ..


### PR DESCRIPTION
Updates the external dependencies used in the build and CI scripts.
 - Updates aom from [v3.0.0](https://aomedia.googlesource.com/aom/+/refs/tags/v3.0.0) to [v3.1.0](https://aomedia.googlesource.com/aom/+/refs/tags/v3.1.0) "Celestia" in aom.cmd
 - Updates libyuv from [2871589](https://chromium.googlesource.com/libyuv/libyuv/+/287158925b0e03ea4499a18b4e08478c5781541b) to [2f0cbb9](https://chromium.googlesource.com/libyuv/libyuv/+/2f0cbb9ede2525b8a1db3bce2501a0819140108b) in libyuv.com
 - Updates docker/build.sh to match libgav1.cmd
 - Add changelog entries