### PR TITLE
Add the allowMissingPixi decoder setting

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -734,6 +734,14 @@ typedef struct avifDecoder
     // (see comment above), and setting this to 0 disables the limit.
     uint32_t imageCountLimit;
 
+    // Allow the PixelInformationProperty ('pixi') to be missing in AV1 image items. Default to
+    // false.
+    //
+    // libheif v1.11.0 or older does not add the 'pixi' item property to AV1 image items. If you
+    // need to decode AVIF images encoded by libheif v1.11.0 or older, set allowMissingPixi to
+    // true. (This issue has been corrected in libheif v1.12.0.)
+    avifBool allowMissingPixi;
+
     // stats from the most recent read, possibly 0s if reading an image sequence
     avifIOStats ioStats;
 

--- a/src/read.c
+++ b/src/read.c
@@ -712,7 +712,7 @@ static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, avifExt
     return AVIF_RESULT_OK;
 }
 
-static avifResult avifDecoderItemValidateAV1(const avifDecoderItem * item)
+static avifResult avifDecoderItemValidateAV1(const avifDecoderItem * item, avifBool allowMissingPixi)
 {
     const avifProperty * av1CProp = avifPropertyArrayFind(&item->properties, "av1C");
     if (!av1CProp) {
@@ -724,7 +724,7 @@ static avifResult avifDecoderItemValidateAV1(const avifDecoderItem * item)
     const avifProperty * pixiProp = avifPropertyArrayFind(&item->properties, "pixi");
     if (!pixiProp) {
         // A pixi box is mandatory in all valid AVIF configurations. Bail out.
-        return AVIF_RESULT_BMFF_PARSE_FAILED;
+        return allowMissingPixi ? AVIF_RESULT_OK : AVIF_RESULT_BMFF_PARSE_FAILED;
     }
 
     for (uint8_t i = 0; i < pixiProp->u.pixi.planeCount; ++i) {
@@ -2901,12 +2901,12 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         decoder->alphaPresent = (alphaItem != NULL);
         decoder->image->alphaPremultiplied = decoder->alphaPresent && (colorItem->premByID == alphaItem->id);
 
-        avifResult colorItemValidationResult = avifDecoderItemValidateAV1(colorItem);
+        avifResult colorItemValidationResult = avifDecoderItemValidateAV1(colorItem, decoder->allowMissingPixi);
         if (colorItemValidationResult != AVIF_RESULT_OK) {
             return colorItemValidationResult;
         }
         if (alphaItem) {
-            avifResult alphaItemValidationResult = avifDecoderItemValidateAV1(alphaItem);
+            avifResult alphaItemValidationResult = avifDecoderItemValidateAV1(alphaItem, decoder->allowMissingPixi);
             if (alphaItemValidationResult != AVIF_RESULT_OK) {
                 return alphaItemValidationResult;
             }


### PR DESCRIPTION
The allowMissingPixi decoder setting allows AVIF images to not have the
PixelInformationProperty (pixi) in AV1 image items. Images encoded with
libheif v1.11.0 or older do not have the 'pixi' item property. (This bug
has been fixed in libheif v1.12.0, just released on 2021-05-05.)