### PR TITLE
Docker: switch to ubuntu 20.04, fix tzdata install

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ADD build.sh /root/build.sh
 RUN apt update && apt install -y dos2unix

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -17,7 +17,7 @@
 
 # build env
 apt update
-apt install -y build-essential libjpeg-dev libpng-dev libssl-dev ninja-build cmake pkg-config git perl vim curl python3-pip
+DEBIAN_FRONTEND="noninteractive" apt install -y build-essential libjpeg-dev libpng-dev libssl-dev ninja-build cmake pkg-config git perl vim curl python3-pip
 pip3 install meson
 
 # Rust env

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 services:
   libavif:
     build: .


### PR DESCRIPTION
- Ubuntu 19.10 is not supported and I couldn't even install packages on it when I tried to run docker build
- without `DEBIAN_FRONTEND="noninteractive"` apt is asking the user for timezone choice when `tzdata` package is installed
- docker-compose v3 manifest is for swarm features that are clearly not in use there, so it's safe to decrease the version, which unblocks more docker versions on the client to run this manifest without problems