### PR TITLE
Remove const from non-pointer function parameters

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -385,15 +385,15 @@ typedef struct avifCropRect
 // values are not guaranteed to be complete or correct and should not be used.
 avifBool avifCropRectConvertCleanApertureBox(avifCropRect * cropRect,
                                              const avifCleanApertureBox * clap,
-                                             const uint32_t imageW,
-                                             const uint32_t imageH,
-                                             const avifPixelFormat yuvFormat,
+                                             uint32_t imageW,
+                                             uint32_t imageH,
+                                             avifPixelFormat yuvFormat,
                                              avifDiagnostics * diag);
 avifBool avifCleanApertureBoxConvertCropRect(avifCleanApertureBox * clap,
                                              const avifCropRect * cropRect,
-                                             const uint32_t imageW,
-                                             const uint32_t imageH,
-                                             const avifPixelFormat yuvFormat,
+                                             uint32_t imageW,
+                                             uint32_t imageH,
+                                             avifPixelFormat yuvFormat,
                                              avifDiagnostics * diag);
 
 // ---------------------------------------------------------------------------

--- a/src/avif.c
+++ b/src/avif.c
@@ -474,11 +474,7 @@ static clapFraction clapFractionSub(clapFraction a, clapFraction b)
     return result;
 }
 
-static avifBool avifCropRectIsValid(const avifCropRect * cropRect,
-                                    const uint32_t imageW,
-                                    const uint32_t imageH,
-                                    const avifPixelFormat yuvFormat,
-                                    avifDiagnostics * diag)
+static avifBool avifCropRectIsValid(const avifCropRect * cropRect, uint32_t imageW, uint32_t imageH, avifPixelFormat yuvFormat, avifDiagnostics * diag)
 
 {
     // ISO/IEC 23000-22:2019/DAM 2:2021, Section 7.3.6.7:
@@ -518,9 +514,9 @@ static avifBool avifCropRectIsValid(const avifCropRect * cropRect,
 
 avifBool avifCropRectConvertCleanApertureBox(avifCropRect * cropRect,
                                              const avifCleanApertureBox * clap,
-                                             const uint32_t imageW,
-                                             const uint32_t imageH,
-                                             const avifPixelFormat yuvFormat,
+                                             uint32_t imageW,
+                                             uint32_t imageH,
+                                             avifPixelFormat yuvFormat,
                                              avifDiagnostics * diag)
 {
     // ISO/IEC 14496-12:2020, Section 12.1.4.1:
@@ -595,9 +591,9 @@ avifBool avifCropRectConvertCleanApertureBox(avifCropRect * cropRect,
 
 avifBool avifCleanApertureBoxConvertCropRect(avifCleanApertureBox * clap,
                                              const avifCropRect * cropRect,
-                                             const uint32_t imageW,
-                                             const uint32_t imageH,
-                                             const avifPixelFormat yuvFormat,
+                                             uint32_t imageW,
+                                             uint32_t imageH,
+                                             avifPixelFormat yuvFormat,
                                              avifDiagnostics * diag)
 {
     if (!avifCropRectIsValid(cropRect, imageW, imageH, yuvFormat, diag)) {


### PR DESCRIPTION
Using 'const' on non-pointer function parameters means the function
cannot modify the parameters. This could be useful in function
implementations, but should be avoided in function declarations.

C++ allows the function declaration and definition to differ in the
constness of the parameters. Unfortunately C doesn't allow this, even
though gcc and clang allow this as a language extension.