### PR TITLE
Declare the param of avifDumpDiagnostics as const

### DIFF
--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -210,7 +210,7 @@ avifAppFileFormat avifGuessFileFormat(const char * filename)
     return AVIF_APP_FILE_FORMAT_UNKNOWN;
 }
 
-void avifDumpDiagnostics(struct avifDiagnostics * diag)
+void avifDumpDiagnostics(const avifDiagnostics * diag)
 {
     if (!*diag->error) {
         return;

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -23,7 +23,7 @@
 void avifImageDump(avifImage * avif, uint32_t gridCols, uint32_t gridRows);
 void avifContainerDump(avifDecoder * decoder);
 void avifPrintVersions(void);
-void avifDumpDiagnostics(struct avifDiagnostics * diag);
+void avifDumpDiagnostics(const avifDiagnostics * diag);
 
 typedef enum avifAppFileFormat
 {


### PR DESCRIPTION
Also omit the 'struct' keyword before avifDiagnostics.