### PR TITLE
Support for progressive AVIFs and operating point selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ set(AVIF_SRCS
     src/read.c
     src/reformat.c
     src/reformat_libyuv.c
+    src/scale.c
     src/stream.c
     src/utils.c
     src/write.c

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -37,8 +37,8 @@ static void syntax(void)
     printf("    -r,--raw-color    : Output raw RGB values instead of multiplying by alpha when saving to opaque formats\n");
     printf("                        (JPEG only; not applicable to y4m)\n");
     printf("    --index           : When decoding an image sequence or progressive image, specify which frame index to decode (Default: 0)\n");
-    printf("    --progressive     : Enable progressive AVIF processing. If a progressive image is encountered, avifdec will use\n");
-    printf("                        --index to choose which layer to decode (in progressive order).\n");
+    printf("    --progressive     : Enable progressive AVIF processing. If a progressive image is encountered and --progressive is passed,\n");
+    printf("                        avifdec will use --index to choose which layer to decode (in progressive order).\n");
     printf("    --no-strict       : Disable strict decoding, which disables strict validation checks and errors\n");
     printf("    -i,--info         : Decode all frames and display all image information instead of saving to disk\n");
     printf("    --ignore-icc      : If the input file contains an embedded ICC profile, ignore it (no-op if absent)\n");

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -38,7 +38,7 @@ static void syntax(void)
     printf("                        (JPEG only; not applicable to y4m)\n");
     printf("    --index           : When decoding an image sequence or progressive image, specify which frame index to decode (Default: 0)\n");
     printf("    --progressive     : Enable progressive AVIF processing. If a progressive image is encountered, avifdec will use\n");
-    printf("                        --index to choose which variant to decode (in progressive order).\n");
+    printf("                        --index to choose which layer to decode (in progressive order).\n");
     printf("    --no-strict       : Disable strict decoding, which disables strict validation checks and errors\n");
     printf("    -i,--info         : Decode all frames and display all image information instead of saving to disk\n");
     printf("    --ignore-icc      : If the input file contains an embedded ICC profile, ignore it (no-op if absent)\n");

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -1074,7 +1074,7 @@ int main(int argc, char * argv[])
         lossyHint = " (Lossless)";
     }
     printf("AVIF to be written:%s\n", lossyHint);
-    avifImageDump(gridCells ? gridCells[0] : image, gridDims[0], gridDims[1]);
+    avifImageDump(gridCells ? gridCells[0] : image, gridDims[0], gridDims[1], AVIF_PROGRESSIVE_STATE_UNAVAILABLE);
 
     printf("Encoding with AV1 codec '%s' speed [%d], color QP [%d (%s) <-> %d (%s)], alpha QP [%d (%s) <-> %d (%s)], tileRowsLog2 [%d], tileColsLog2 [%d], %d worker thread(s), please wait...\n",
            avifCodecName(codecChoice, AVIF_CODEC_FLAG_CAN_ENCODE),

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -105,7 +105,6 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
             printf("    * imir (Mirror)        : Mode %u (%s)\n", avif->imir.mode, (avif->imir.mode == 0) ? "top-to-bottom" : "left-to-right");
         }
     }
-    printf(" * Alpha          : %s\n", alphaPresent ? (avif->alphaPremultiplied ? "Premultiplied" : "Not premultiplied") : "Absent");
     printf(" * Progressive    : %s\n", avifProgressiveStateToString(progressiveState));
 }
 

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -38,7 +38,7 @@ static void printClapFraction(const char * name, int32_t n, int32_t d)
     printf(", ");
 }
 
-static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uint32_t gridRows, avifBool alphaPresent)
+static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uint32_t gridRows, avifBool alphaPresent, avifProgressiveState progressiveState)
 {
     uint32_t width = avif->width;
     uint32_t height = avif->height;
@@ -105,17 +105,19 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
             printf("    * imir (Mirror)        : Mode %u (%s)\n", avif->imir.mode, (avif->imir.mode == 0) ? "top-to-bottom" : "left-to-right");
         }
     }
+    printf(" * Alpha          : %s\n", alphaPresent ? (avif->alphaPremultiplied ? "Premultiplied" : "Not premultiplied") : "Absent");
+    printf(" * Progressive    : %s\n", avifProgressiveStateToString(progressiveState));
 }
 
-void avifImageDump(avifImage * avif, uint32_t gridCols, uint32_t gridRows)
+void avifImageDump(avifImage * avif, uint32_t gridCols, uint32_t gridRows, avifProgressiveState progressiveState)
 {
     const avifBool alphaPresent = avif->alphaPlane && (avif->alphaRowBytes > 0);
-    avifImageDumpInternal(avif, gridCols, gridRows, alphaPresent);
+    avifImageDumpInternal(avif, gridCols, gridRows, alphaPresent, progressiveState);
 }
 
 void avifContainerDump(avifDecoder * decoder)
 {
-    avifImageDumpInternal(decoder->image, 0, 0, decoder->alphaPresent);
+    avifImageDumpInternal(decoder->image, 0, 0, decoder->alphaPresent, decoder->progressiveState);
 }
 
 void avifPrintVersions(void)

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -19,7 +19,7 @@
 #define AVIF_FMT_ZU "%zu"
 #endif
 
-void avifImageDump(avifImage * avif, uint32_t gridCols, uint32_t gridRows);
+void avifImageDump(avifImage * avif, uint32_t gridCols, uint32_t gridRows, avifProgressiveState progressiveState);
 void avifContainerDump(avifDecoder * decoder);
 void avifPrintVersions(void);
 void avifDumpDiagnostics(const avifDiagnostics * diag);

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -156,6 +156,12 @@ avifResult avifRGBImagePremultiplyAlphaLibYUV(avifRGBImage * rgb);
 avifResult avifRGBImageUnpremultiplyAlphaLibYUV(avifRGBImage * rgb);
 
 // ---------------------------------------------------------------------------
+// Scaling
+
+// This scales the YUV/A planes in-place.
+avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight, avifDiagnostics * diag);
+
+// ---------------------------------------------------------------------------
 // avifCodecDecodeInput
 
 typedef struct avifDecodeSample

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -255,7 +255,7 @@ typedef struct avifCodec
                                           //
     avifDiagnostics * diag;               // Shallow copy; owned by avifEncoder or avifDecoder
                                           //
-    uint8_t operatingPointIndex;          // Operating point Index, defaults to 0.
+    uint8_t operatingPoint;               // Operating point, defaults to 0.
     avifBool allLayers;                   // if true, the underlying codec must decode all layers, not just the best layer
 
     avifCodecGetNextImageFunc getNextImage;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -164,19 +164,21 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
 // ---------------------------------------------------------------------------
 // avifCodecDecodeInput
 
+// Legal spatial_id values are [0,1,2,3], so this serves as a sentinel value for "do not filter by spatial_id"
+#define AVIF_SPATIAL_ID_UNSET 0xff
+
 typedef struct avifDecodeSample
 {
     avifROData data;
     avifBool ownsData;
     avifBool partialData; // if true, data exists but doesn't have all of the sample in it
 
-    uint32_t itemID; // if non-zero, data comes from a mergedExtents buffer in an avifDecoderItem, not a file offset
-    uint64_t offset; // additional offset into data. Can be used to offset into an itemID's payload as well.
-    size_t size;     //
-    uint8_t skip;    // After feeding this sample, this is how many frames must be skipped before returning a frame
-                     // This is used in layer selection, as layer selection requires that decoders decode all
-                     // layers sequentially, but only a specific layer index is actually wanted.
-    avifBool sync;   // is sync sample (keyframe)
+    uint32_t itemID;   // if non-zero, data comes from a mergedExtents buffer in an avifDecoderItem, not a file offset
+    uint64_t offset;   // additional offset into data. Can be used to offset into an itemID's payload as well.
+    size_t size;       //
+    uint8_t spatialID; // If set to a value other than AVIF_SPATIAL_ID_UNSET, the output frame's spatial_id must match
+                       // this ID, otherwise output frames from this sample should be skipped until it does.
+    avifBool sync;     // is sync sample (keyframe)
 } avifDecodeSample;
 AVIF_ARRAY_DECLARE(avifDecodeSampleArray, avifDecodeSample, sample);
 

--- a/src/avif.c
+++ b/src/avif.c
@@ -101,6 +101,20 @@ const char * avifResultToString(avifResult result)
     return "Unknown Error";
 }
 
+const char * avifProgressiveStateToString(avifProgressiveState progressiveState)
+{
+    // clang-format off
+    switch (progressiveState) {
+        case AVIF_PROGRESSIVE_STATE_UNAVAILABLE: return "Unavailable";
+        case AVIF_PROGRESSIVE_STATE_AVAILABLE:   return "Available";
+        case AVIF_PROGRESSIVE_STATE_ACTIVE:      return "Active";
+        default:
+            break;
+    }
+    // clang-format on
+    return "Unknown";
+}
+
 // This function assumes nothing in this struct needs to be freed; use avifImageClear() externally
 static void avifImageSetDefaults(avifImage * image)
 {

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -114,13 +114,15 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
         codec->internal->iter = NULL;
     }
 
-    uint8_t skipRemaining = sample->skip;
     aom_image_t * nextFrame = NULL;
     for (;;) {
         nextFrame = aom_codec_get_frame(&codec->internal->decoder, &codec->internal->iter);
         if (nextFrame) {
-            if (skipRemaining) {
-                --skipRemaining;
+            if (sample->spatialID != AVIF_SPATIAL_ID_UNSET) {
+                if (sample->spatialID == nextFrame->spatial_id) {
+                    // Found the correct spatial_id.
+                    break;
+                }
             } else {
                 // Got an image!
                 break;

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -107,7 +107,7 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
         if (aom_codec_control(&codec->internal->decoder, AV1D_SET_OUTPUT_ALL_LAYERS, codec->allLayers)) {
             return AVIF_FALSE;
         }
-        if (aom_codec_control(&codec->internal->decoder, AV1D_SET_OPERATING_POINT, codec->operatingPointIndex)) {
+        if (aom_codec_control(&codec->internal->decoder, AV1D_SET_OPERATING_POINT, codec->operatingPoint)) {
             return AVIF_FALSE;
         }
 

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -115,11 +115,12 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
     }
 
     aom_image_t * nextFrame = NULL;
+    uint8_t spatialID = AVIF_SPATIAL_ID_UNSET;
     for (;;) {
         nextFrame = aom_codec_get_frame(&codec->internal->decoder, &codec->internal->iter);
         if (nextFrame) {
-            if (sample->spatialID != AVIF_SPATIAL_ID_UNSET) {
-                if (sample->spatialID == nextFrame->spatial_id) {
+            if (spatialID != AVIF_SPATIAL_ID_UNSET) {
+                if (spatialID == nextFrame->spatial_id) {
                     // Found the correct spatial_id.
                     break;
                 }
@@ -132,6 +133,7 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
             if (aom_codec_decode(&codec->internal->decoder, sample->data.data, sample->data.size, NULL)) {
                 return AVIF_FALSE;
             }
+            spatialID = sample->spatialID;
             sample = NULL;
         } else {
             break;

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -76,7 +76,6 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
         return AVIF_FALSE;
     }
 
-    uint8_t skipRemaining = sample->skip;
     for (;;) {
         if (dav1dData.data) {
             int res = dav1d_send_data(codec->internal->dav1dContext, &dav1dData);
@@ -101,10 +100,9 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
             return AVIF_FALSE;
         } else {
             // Got a picture!
-            if (skipRemaining) {
+            if ((sample->spatialID != AVIF_SPATIAL_ID_UNSET) && (sample->spatialID != nextFrame.frame_hdr->spatial_id)) {
                 // Layer selection: skip this unwanted layer
                 dav1d_picture_unref(&nextFrame);
-                --skipRemaining;
             } else {
                 gotPicture = AVIF_TRUE;
                 break;

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -59,7 +59,7 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
         // Give all available threads to decode a single frame as fast as possible
         codec->internal->dav1dSettings.n_frame_threads = 1;
         codec->internal->dav1dSettings.n_tile_threads = AVIF_CLAMP(decoder->maxThreads, 1, DAV1D_MAX_TILE_THREADS);
-        codec->internal->dav1dSettings.operating_point = codec->operatingPointIndex;
+        codec->internal->dav1dSettings.operating_point = codec->operatingPoint;
         codec->internal->dav1dSettings.all_layers = codec->allLayers;
 
         if (dav1d_open(&codec->internal->dav1dContext, &codec->internal->dav1dSettings) != 0) {

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -31,6 +31,8 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec,
 {
     if (codec->internal->gav1Decoder == NULL) {
         codec->internal->gav1Settings.threads = decoder->maxThreads;
+        codec->internal->gav1Settings.operating_point = codec->operatingPointIndex;
+        codec->internal->gav1Settings.output_all_layers = codec->allLayers;
 
         if (Libgav1DecoderCreate(&codec->internal->gav1Settings, &codec->internal->gav1Decoder) != kLibgav1StatusOk) {
             return AVIF_FALSE;
@@ -48,9 +50,19 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec,
     // returned by the previous Libgav1DecoderDequeueFrame() call. Clear
     // our pointer to the previous output frame.
     codec->internal->gav1Image = NULL;
+
     const Libgav1DecoderBuffer * nextFrame = NULL;
-    if (Libgav1DecoderDequeueFrame(codec->internal->gav1Decoder, &nextFrame) != kLibgav1StatusOk) {
-        return AVIF_FALSE;
+    uint8_t skipRemaining = sample->skip;
+    for (;;) {
+        if (Libgav1DecoderDequeueFrame(codec->internal->gav1Decoder, &nextFrame) != kLibgav1StatusOk) {
+            return AVIF_FALSE;
+        }
+        if (nextFrame && skipRemaining) {
+            nextFrame = NULL;
+            --skipRemaining;
+        } else {
+            break;
+        }
     }
     // Got an image!
 

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -31,7 +31,7 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec,
 {
     if (codec->internal->gav1Decoder == NULL) {
         codec->internal->gav1Settings.threads = decoder->maxThreads;
-        codec->internal->gav1Settings.operating_point = codec->operatingPointIndex;
+        codec->internal->gav1Settings.operating_point = codec->operatingPoint;
         codec->internal->gav1Settings.output_all_layers = codec->allLayers;
 
         if (Libgav1DecoderCreate(&codec->internal->gav1Settings, &codec->internal->gav1Decoder) != kLibgav1StatusOk) {

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -52,14 +52,12 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec,
     codec->internal->gav1Image = NULL;
 
     const Libgav1DecoderBuffer * nextFrame = NULL;
-    uint8_t skipRemaining = sample->skip;
     for (;;) {
         if (Libgav1DecoderDequeueFrame(codec->internal->gav1Decoder, &nextFrame) != kLibgav1StatusOk) {
             return AVIF_FALSE;
         }
-        if (nextFrame && skipRemaining) {
+        if (nextFrame && (sample->spatialID != AVIF_SPATIAL_ID_UNSET) && (nextFrame->spatial_id != sample->spatialID)) {
             nextFrame = NULL;
-            --skipRemaining;
         } else {
             break;
         }

--- a/src/read.c
+++ b/src/read.c
@@ -440,8 +440,8 @@ static avifBool avifCodecDecodeInputFillFromSampleTable(avifCodecDecodeInput * d
             avifDecodeSample * sample = (avifDecodeSample *)avifArrayPushPtr(&decodeInput->samples);
             sample->offset = sampleOffset;
             sample->size = sampleSize;
-            sample->skip = 0;          // Never skip frames when decoding tracks (skip is for layer selection)
-            sample->sync = AVIF_FALSE; // to potentially be set to true following the outer loop
+            sample->spatialID = AVIF_SPATIAL_ID_UNSET; // Not filtering by spatial_id
+            sample->sync = AVIF_FALSE;                 // to potentially be set to true following the outer loop
 
             if (sampleSize > UINT64_MAX - sampleOffset) {
                 avifDiagnosticsPrintf(diag,
@@ -552,7 +552,7 @@ static avifBool avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput * d
         assert(lselProp->u.lsel.layerID < MAX_AV1_LAYER_COUNT);
         sample->offset = 0;
         sample->size = sampleSize;
-        sample->skip = (uint8_t)lselProp->u.lsel.layerID;
+        sample->spatialID = (uint8_t)lselProp->u.lsel.layerID;
         sample->sync = AVIF_TRUE;
     } else if (allowProgressive && a1lxProp) {
         // Progressive image. Decode all layers and expose them all to the user.
@@ -570,7 +570,7 @@ static avifBool avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput * d
             sample->itemID = item->id;
             sample->offset = offset;
             sample->size = layerSizes[i];
-            sample->skip = 0;
+            sample->spatialID = AVIF_SPATIAL_ID_UNSET;
             sample->sync = (i == 0); // Assume all layers depend on the first layer
 
             offset += layerSizes[i];
@@ -582,7 +582,7 @@ static avifBool avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput * d
         sample->itemID = item->id;
         sample->offset = 0;
         sample->size = item->size;
-        sample->skip = 0;
+        sample->spatialID = AVIF_SPATIAL_ID_UNSET;
         sample->sync = AVIF_TRUE;
     }
     return AVIF_TRUE;

--- a/src/read.c
+++ b/src/read.c
@@ -554,7 +554,7 @@ static avifBool avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput * d
         sample->size = sampleSize;
         sample->spatialID = (uint8_t)lselProp->u.lsel.layerID;
         sample->sync = AVIF_TRUE;
-    } else if (allowProgressive && a1lxProp) {
+    } else if (allowProgressive && item->progressive) {
         // Progressive image. Decode all layers and expose them all to the user.
 
         if (imageCountLimit && (layerCount > imageCountLimit)) {
@@ -954,7 +954,12 @@ static avifResult avifDecoderItemRead(avifDecoderItem * item,
 {
     if (item->mergedExtents.data && !item->partialMergedExtents) {
         // Multiple extents have already been concatenated for this item, just return it
-        memcpy(outData, &item->mergedExtents, sizeof(avifROData));
+        if (offset >= item->mergedExtents.size) {
+            avifDiagnosticsPrintf(diag, "Item ID %u read has overflowing offset", item->id);
+            return AVIF_RESULT_TRUNCATED_DATA;
+        }
+        outData->data = item->mergedExtents.data + offset;
+        outData->size = item->mergedExtents.size - offset;
         return AVIF_RESULT_OK;
     }
 

--- a/src/read.c
+++ b/src/read.c
@@ -626,7 +626,7 @@ typedef struct avifTile
     avifImage * image;
     uint32_t width;  // Either avifTrack.width or avifDecoderItem.width
     uint32_t height; // Either avifTrack.height or avifDecoderItem.height
-    uint8_t operatingPointIndex;
+    uint8_t operatingPoint;
 } avifTile;
 AVIF_ARRAY_DECLARE(avifTileArray, avifTile, tile);
 
@@ -767,14 +767,14 @@ static void avifDecoderDataResetCodec(avifDecoderData * data)
     }
 }
 
-static avifTile * avifDecoderDataCreateTile(avifDecoderData * data, uint32_t width, uint32_t height, uint8_t operatingPointIndex)
+static avifTile * avifDecoderDataCreateTile(avifDecoderData * data, uint32_t width, uint32_t height, uint8_t operatingPoint)
 {
     avifTile * tile = (avifTile *)avifArrayPushPtr(&data->tiles);
     tile->image = avifImageCreateEmpty();
     tile->input = avifCodecDecodeInputCreate();
     tile->width = width;
     tile->height = height;
-    tile->operatingPointIndex = operatingPointIndex;
+    tile->operatingPoint = operatingPoint;
     return tile;
 }
 
@@ -3047,7 +3047,7 @@ static avifResult avifDecoderFlush(avifDecoder * decoder)
             return AVIF_RESULT_NO_CODEC_AVAILABLE;
         }
         tile->codec->diag = &decoder->diag;
-        tile->codec->operatingPointIndex = tile->operatingPointIndex;
+        tile->codec->operatingPoint = tile->operatingPoint;
         tile->codec->allLayers = tile->input->allLayers;
     }
     return AVIF_RESULT_OK;

--- a/src/scale.c
+++ b/src/scale.c
@@ -1,0 +1,122 @@
+// Copyright 2021 Joe Drago. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/internal.h"
+
+#if !defined(AVIF_LIBYUV_ENABLED)
+
+avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight, avifDiagnostics * diag)
+{
+    (void)image;
+    (void)dstWidth;
+    (void)dstHeight;
+    avifDiagnosticsPrintf(diag, "avifImageScale() called, but is unimplemented without libyuv!");
+    return AVIF_FALSE;
+}
+
+#else
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wstrict-prototypes" // "this function declaration is not a prototype"
+#endif
+#include <libyuv.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+// This should be configurable and/or smarter
+#define AVIF_LIBYUV_FILTER_MODE kFilterBox
+
+avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight, avifDiagnostics * diag)
+{
+    if ((image->width == dstWidth) && (image->height == dstHeight)) {
+        // Nothing to do
+        return AVIF_TRUE;
+    }
+
+    if ((dstWidth == 0) || (dstHeight == 0) || (dstWidth > (AVIF_MAX_IMAGE_SIZE / dstHeight))) {
+        avifDiagnosticsPrintf(diag, "avifImageScale requested invalid dst dimensions [%ux%u]", dstWidth, dstHeight);
+        return AVIF_FALSE;
+    }
+
+    uint8_t * srcYUVPlanes[AVIF_PLANE_COUNT_YUV];
+    uint32_t srcYUVRowBytes[AVIF_PLANE_COUNT_YUV];
+    for (int i = 0; i < AVIF_PLANE_COUNT_YUV; ++i) {
+        srcYUVPlanes[i] = image->yuvPlanes[i];
+        image->yuvPlanes[i] = NULL;
+        srcYUVRowBytes[i] = image->yuvRowBytes[i];
+        image->yuvRowBytes[i] = 0;
+    }
+    const avifBool srcImageOwnsYUVPlanes = image->imageOwnsYUVPlanes;
+    image->imageOwnsYUVPlanes = AVIF_FALSE;
+
+    uint8_t * srcAlphaPlane = image->alphaPlane;
+    image->alphaPlane = NULL;
+    uint32_t srcAlphaRowBytes = image->alphaRowBytes;
+    image->alphaRowBytes = 0;
+    const avifBool srcImageOwnsAlphaPlane = image->imageOwnsAlphaPlane;
+    image->imageOwnsAlphaPlane = AVIF_FALSE;
+
+    const uint32_t srcWidth = image->width;
+    image->width = dstWidth;
+    const uint32_t srcHeight = image->height;
+    image->height = dstHeight;
+
+    if (srcYUVPlanes[0]) {
+        avifImageAllocatePlanes(image, AVIF_PLANES_YUV);
+
+        avifPixelFormatInfo formatInfo;
+        avifGetPixelFormatInfo(image->yuvFormat, &formatInfo);
+        const uint32_t srcUVWidth = (srcWidth + formatInfo.chromaShiftX) >> formatInfo.chromaShiftX;
+        const uint32_t srcUVHeight = (srcHeight + formatInfo.chromaShiftY) >> formatInfo.chromaShiftY;
+        const uint32_t dstUVWidth = (dstWidth + formatInfo.chromaShiftX) >> formatInfo.chromaShiftX;
+        const uint32_t dstUVHeight = (dstHeight + formatInfo.chromaShiftY) >> formatInfo.chromaShiftY;
+
+        for (int i = 0; i < AVIF_PLANE_COUNT_YUV; ++i) {
+            if (!srcYUVPlanes[i]) {
+                continue;
+            }
+
+            const uint32_t srcW = (i == AVIF_CHAN_Y) ? srcWidth : srcUVWidth;
+            const uint32_t srcH = (i == AVIF_CHAN_Y) ? srcHeight : srcUVHeight;
+            const uint32_t dstW = (i == AVIF_CHAN_Y) ? dstWidth : dstUVWidth;
+            const uint32_t dstH = (i == AVIF_CHAN_Y) ? dstHeight : dstUVHeight;
+            if (image->depth > 8) {
+                uint16_t * srcPlane = (uint16_t *)srcYUVPlanes[i];
+                uint16_t * dstPlane = (uint16_t *)image->yuvPlanes[i];
+                ScalePlane_12(srcPlane, srcYUVRowBytes[i], srcW, srcH, dstPlane, image->yuvRowBytes[i], dstW, dstH, AVIF_LIBYUV_FILTER_MODE);
+            } else {
+                uint8_t * srcPlane = srcYUVPlanes[i];
+                uint8_t * dstPlane = image->yuvPlanes[i];
+                ScalePlane(srcPlane, srcYUVRowBytes[i], srcW, srcH, dstPlane, image->yuvRowBytes[i], dstW, dstH, AVIF_LIBYUV_FILTER_MODE);
+            }
+
+            if (srcImageOwnsYUVPlanes) {
+                avifFree(srcYUVPlanes[i]);
+            }
+        }
+    }
+
+    if (srcAlphaPlane) {
+        avifImageAllocatePlanes(image, AVIF_PLANES_A);
+
+        if (image->depth > 8) {
+            uint16_t * srcPlane = (uint16_t *)srcAlphaPlane;
+            uint16_t * dstPlane = (uint16_t *)image->alphaPlane;
+            ScalePlane_12(srcPlane, srcAlphaRowBytes, srcWidth, srcHeight, dstPlane, image->alphaRowBytes, dstWidth, dstHeight, AVIF_LIBYUV_FILTER_MODE);
+        } else {
+            uint8_t * srcPlane = srcAlphaPlane;
+            uint8_t * dstPlane = image->alphaPlane;
+            ScalePlane(srcPlane, srcAlphaRowBytes, srcWidth, srcHeight, dstPlane, image->alphaRowBytes, dstWidth, dstHeight, AVIF_LIBYUV_FILTER_MODE);
+        }
+
+        if (srcImageOwnsAlphaPlane) {
+            avifFree(srcAlphaPlane);
+        }
+    }
+
+    return AVIF_TRUE;
+}
+
+#endif


### PR DESCRIPTION
* Support for parsing boxes: a1op, a1lx, lsel
* Added operating point and "skip" support to avifCodec impls for layer selection support
* Reworked avifdec decoding to support nth image decoding and minor optimization
* New avifProgressiveState enum to expose info about progressive AVIFs to users of libavif
* New avifdec args: --progressive, --index

@wantehchang Do not merge this yet -- There are still outstanding issues with a few of the Apple example files. It is unclear if they are issues with the file itself (`animals_00_multilayer_grid_a1lx.avif`), or an issue with our usage of dav1d (`animals_00_multilayer.avif`).