### PR TITLE
Fix a typo in the diagnostic context for 'ipco'

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1578,7 +1578,7 @@ static avifBool avifParsePixelInformationProperty(avifProperty * prop, const uin
 
 static avifBool avifParseItemPropertyContainerBox(avifPropertyArray * properties, const uint8_t * raw, size_t rawLen, avifDiagnostics * diag)
 {
-    BEGIN_STREAM(s, raw, rawLen, diag, "Box[iprp]");
+    BEGIN_STREAM(s, raw, rawLen, diag, "Box[ipco]");
 
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader header;


### PR DESCRIPTION
The diagnostic messages in avifParseItemPropertyContainerBox() should
say "Box[ipco]", not "Box[iprp]".