### PR TITLE
Simplify avifCodecConfigurationBoxGetFormat

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -290,9 +290,9 @@ static avifPixelFormat avifCodecConfigurationBoxGetFormat(const avifCodecConfigu
 {
     if (av1C->monochrome) {
         return AVIF_PIXEL_FORMAT_YUV400;
-    } else if ((av1C->chromaSubsamplingX == 1) && (av1C->chromaSubsamplingY == 1)) {
+    } else if (av1C->chromaSubsamplingY == 1) {
         return AVIF_PIXEL_FORMAT_YUV420;
-    } else if ((av1C->chromaSubsamplingX == 1) && (av1C->chromaSubsamplingY == 0)) {
+    } else if (av1C->chromaSubsamplingX == 1) {
         return AVIF_PIXEL_FORMAT_YUV422;
     }
     return AVIF_PIXEL_FORMAT_YUV444;


### PR DESCRIPTION
Simplify the conditionals in avifCodecConfigurationBoxGetFormat(). Once
monochrome has been eliminated, YUV 4:2:0 is the only one with
subsampling_y == 1. And the remaining two can be differentiated by
testing subsampling_x.