### PR TITLE
Don't clear error in avifEncoderSetCodecSpecificOp

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -210,7 +210,6 @@ void avifEncoderDestroy(avifEncoder * encoder)
 
 void avifEncoderSetCodecSpecificOption(avifEncoder * encoder, const char * key, const char * value)
 {
-    avifDiagnosticsClearError(&encoder->diag);
     avifCodecSpecificOptionsSet(encoder->csOptions, key, value);
 }
 


### PR DESCRIPTION
Remove the avifDiagnosticsClearError() call from
avifEncoderSetCodecSpecificOption() because
avifEncoderSetCodecSpecificOption() returns void and doesn't fail.