### PR TITLE
Simplify the assertion in avifROStreamStart()

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -24,7 +24,7 @@ void avifROStreamStart(avifROStream * stream, avifROData * raw, avifDiagnostics 
     stream->diagContext = diagContext;
 
     // If diag is non-NULL, diagContext must also be non-NULL
-    assert(!stream->diag || (stream->diag && stream->diagContext));
+    assert(!stream->diag || stream->diagContext);
 }
 
 avifBool avifROStreamHasBytesLeft(const avifROStream * stream, size_t byteCount)


### PR DESCRIPTION
P => Q is equivalent to !P || Q. So it is not necessary to test P again
in !P || (P && Q).