### PR TITLE
Fix box name of avifParseChunkOffsetBox

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2084,7 +2084,7 @@ static avifBool avifParseMediaHeaderBox(avifTrack * track, const uint8_t * raw, 
 
 static avifBool avifParseChunkOffsetBox(avifSampleTable * sampleTable, avifBool largeOffsets, const uint8_t * raw, size_t rawLen, avifDiagnostics * diag)
 {
-    BEGIN_STREAM(s, raw, rawLen, diag, "Box[stco]");
+    BEGIN_STREAM(s, raw, rawLen, diag, largeOffsets ? "Box[co64]" : "Box[stco]");
 
     CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 


### PR DESCRIPTION
The box name of avifParseChunkOffsetBox depends on largeOffsets.