### PR TITLE
Some straightforward changes to clapFraction code

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -400,8 +400,8 @@ static clapFraction calcCenter(int32_t dim)
     clapFraction f;
     f.n = dim >> 1;
     f.d = 1;
-    if ((dim % 2) == 1) {
-        f.n = (f.n * 2) + 1;
+    if ((dim % 2) != 0) {
+        f.n = dim;
         f.d = 2;
     }
     return f;
@@ -443,9 +443,9 @@ static void clapFractionCD(clapFraction * a, clapFraction * b)
     if ((a->d != b->d)) {
         const int32_t ad = a->d;
         const int32_t bd = b->d;
-        a->n = a->n * bd;
+        a->n *= bd;
         a->d *= bd;
-        b->n = b->n * ad;
+        b->n *= ad;
         b->d *= ad;
     }
 }


### PR DESCRIPTION
In calcCenter(), set the numerator to dim directly if dim is odd, rather
than calculate it from dim >> 1.

In clapFractionCD(), use *= whenever possible.

In avifCropRectConvertCleanApertureBox(), reduce halfW and halfH
immediately because the fractions widthN / widthD and heightN / heightD
have been verified to be integers.