### PR TITLE
Correct AVIF_PIXEL_FORMAT_NONE handling logic

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -793,11 +793,9 @@ int main(int argc, char * argv[])
 
     if ((image->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_IDENTITY) && (input.requestedFormat != AVIF_PIXEL_FORMAT_NONE) &&
         (input.requestedFormat != AVIF_PIXEL_FORMAT_YUV444)) {
-        // This protects against this code misbehaving if AVIF_APP_DEFAULT_PIXEL_FORMAT is ever changed from AVIF_PIXEL_FORMAT_YUV444
-        assert((input.requestedFormat != AVIF_PIXEL_FORMAT_NONE) || (AVIF_APP_DEFAULT_PIXEL_FORMAT == AVIF_PIXEL_FORMAT_YUV444));
-
-        // matrixCoefficients was likely set to AVIF_MATRIX_COEFFICIENTS_IDENTITY as a side effect
-        // of --lossless, and Identity is only valid with YUV444. Set this back to the default.
+        // User explicitly asked for non YUV444 yuvFormat, while matrixCoefficients was likely
+        // set to AVIF_MATRIX_COEFFICIENTS_IDENTITY as a side effect of --lossless,
+        // and Identity is only valid with YUV444. Set matrixCoefficients back to the default.
         image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
 
         if (cicpExplicitlySet) {

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -297,7 +297,10 @@ avifBool avifJPEGRead(const char * inputFilename, avifImage * avif, avifPixelFor
 
         avif->width = cinfo.output_width;
         avif->height = cinfo.output_height;
-        avif->yuvFormat = (requestedFormat == AVIF_PIXEL_FORMAT_NONE) ? AVIF_APP_DEFAULT_PIXEL_FORMAT : requestedFormat;
+        if (avif->yuvFormat == AVIF_PIXEL_FORMAT_NONE) {
+            // Identity is only valid with YUV444.
+            avif->yuvFormat = (avif->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_IDENTITY) ? AVIF_PIXEL_FORMAT_YUV444 : AVIF_APP_DEFAULT_PIXEL_FORMAT;
+        }
         avif->depth = requestedDepth ? requestedDepth : 8;
         avifRGBImageSetDefaults(&rgb, avif);
         rgb.format = AVIF_RGB_FORMAT_RGB;

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -118,7 +118,11 @@ avifBool avifPNGRead(const char * inputFilename, avifImage * avif, avifPixelForm
 
     avif->width = rawWidth;
     avif->height = rawHeight;
-    avif->yuvFormat = (requestedFormat == AVIF_PIXEL_FORMAT_NONE) ? AVIF_APP_DEFAULT_PIXEL_FORMAT : requestedFormat;
+    avif->yuvFormat = requestedFormat;
+    if (avif->yuvFormat == AVIF_PIXEL_FORMAT_NONE) {
+        // Identity is only valid with YUV444.
+        avif->yuvFormat = (avif->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_IDENTITY) ? AVIF_PIXEL_FORMAT_YUV444 : AVIF_APP_DEFAULT_PIXEL_FORMAT;
+    }
     avif->depth = requestedDepth;
     if (avif->depth == 0) {
         if (imgBitDepth == 8) {


### PR DESCRIPTION
Fix #647.

Make `avifJPEGRead` and `avifPNGRead` consider "Identity is only valid with YUV444" rule when deciding pixel format.
Remove confusing ineffective assertion in avifenc.c.