### PR TITLE
Cleanup avifutil.h comment to match libavif style

### DIFF
--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -6,14 +6,13 @@
 
 #include "avif/avif.h"
 
-/*
- * The %z format specifier is not available with Visual Studios before 2013 and
- * mingw-w64 toolchains with `__USE_MINGW_ANSI_STDIO` not set to 1.
- * Hence the %I format specifier must be used instead to print out `size_t`.
- * Newer Visual Studios and mingw-w64 toolchains built with the commit
- * mentioned with c99 set as the standard supports the %z specifier properly.
- * Related mingw-w64 commit: bfd33f6c0ec5e652cc9911857dd1492ece8d8383
- */
+// The %z format specifier is not available with Visual Studios before 2013 and mingw-w64 toolchains
+// with `__USE_MINGW_ANSI_STDIO` not set to 1. Hence the %I format specifier must be used instead
+// to print out `size_t`. Newer Visual Studios and mingw-w64 toolchains built with the commit
+// mentioned with c99 set as the standard supports the %z specifier properly.
+//
+// Related mingw-w64 commit: bfd33f6c0ec5e652cc9911857dd1492ece8d8383
+
 #if (defined(_MSVC) && _MSVC < 1800) || (defined(__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO == 0)
 #define AVIF_FMT_ZU "%Iu"
 #else


### PR DESCRIPTION
Minor: I noticed this C89-style block comment when adding `-j all` and wanted to have it match the other block comments in the codebase.