### PR TITLE
Fix the clang -Wunused-macros warning

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -35,10 +35,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(AVIF_CODEC_AOM_ENCODE)
 // Detect whether the aom_codec_set_option() function is available. See aom/aom_codec.h
 // in https://aomedia-review.googlesource.com/c/aom/+/126302.
 #if AOM_CODEC_ABI_VERSION >= (6 + AOM_IMAGE_ABI_VERSION)
 #define HAVE_AOM_CODEC_SET_OPTION 1
+#endif
 #endif
 
 struct avifCodecInternal


### PR DESCRIPTION
Fix the clang -Wunused-macros (macro is not used) warning about the
HAVE_AOM_CODEC_SET_OPTION macro when libavif is configured to use libaom
for decode only (-DAVIF_CODEC_AOM_ENCODE=OFF
-DAVIF_CODEC_AOM_DECODE=ON).