### PR TITLE
Cleanup related to avifDiagnosticsClearError()

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -543,6 +543,8 @@ avifBool avifCropRectConvertCleanApertureBox(avifCropRect * cropRect,
                                              avifPixelFormat yuvFormat,
                                              avifDiagnostics * diag)
 {
+    avifDiagnosticsClearError(diag);
+
     // ISO/IEC 14496-12:2020, Section 12.1.4.1:
     //   For horizOff and vertOff, D shall be strictly positive and N may be
     //   positive or negative. For cleanApertureWidth and cleanApertureHeight,
@@ -646,6 +648,8 @@ avifBool avifCleanApertureBoxConvertCropRect(avifCleanApertureBox * clap,
                                              avifPixelFormat yuvFormat,
                                              avifDiagnostics * diag)
 {
+    avifDiagnosticsClearError(diag);
+
     if (!avifCropRectIsValid(cropRect, imageW, imageH, yuvFormat, diag)) {
         return AVIF_FALSE;
     }

--- a/src/diag.c
+++ b/src/diag.c
@@ -9,7 +9,7 @@
 
 void avifDiagnosticsClearError(avifDiagnostics * diag)
 {
-    memset(diag->error, 0, AVIF_DIAGNOSTICS_ERROR_BUFFER_SIZE);
+    *diag->error = '\0';
 }
 
 #ifdef __clang__


### PR DESCRIPTION
1. Have avifCropRectConvertCleanApertureBox() and
avifCleanApertureBoxConvertCropRect() call avifDiagnosticsClearError()
on entry.

2. avifDiagnosticsClearError() just needs to set the first character of
the diag->error buffer to '\0' rather than memset the entire buffer.