### PR TITLE
Make tests/compare.h and tests/testcase.h C++ safe

### DIFF
--- a/tests/compare.h
+++ b/tests/compare.h
@@ -6,6 +6,10 @@
 
 #include "avif/avif.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct ImageComparison
 {
     int maxDiff;
@@ -24,4 +28,8 @@ typedef struct ImageComparison
 // Returns AVIF_FALSE if they're not even worth comparing (mismatched sizes / pixel formats / etc)
 avifBool compareYUVA(ImageComparison * ic, const avifImage * image1, const avifImage * image2);
 
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // ifndef COMPARE_H

--- a/tests/testcase.h
+++ b/tests/testcase.h
@@ -8,6 +8,10 @@
 
 #include "cJSON.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct TestCase
 {
     char * name;
@@ -32,4 +36,8 @@ cJSON * testCaseToJSON(TestCase * tc);
 
 int testCaseRun(TestCase * tc, const char * dataDir, avifBool generating); // returns 0 on failure
 
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // ifndef TESTCASE_H


### PR DESCRIPTION
Add extern "C" blocks to tests/compare.h and tests/testcase.h to allow
tests written in C++ to include these two headers.