### PR TITLE
Don't need to disable MSVC warnings 5031 and 5032

### DIFF
--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -228,8 +228,6 @@ void avifDumpDiagnostics(const avifDiagnostics * diag)
 
 // Windows
 
-#pragma warning(disable : 5031)
-#pragma warning(disable : 5032)
 #include <windows.h>
 
 int avifQueryCPUCount(void)


### PR DESCRIPTION
Since #pragma warning(push) and #pragma warning(pop) are not used in
this file, we cannot possibly get MSVC warnings 5031 and 5032. Therefore
it is not necessary to disable these two warnings.

Fix https://github.com/AOMediaCodec/libavif/issues/679.