### PR TITLE
Make avifDecoderItemMaxExtent progressive-aware

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -863,7 +863,7 @@ static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, avifDec
     uint64_t maxOffset = 0;
     for (uint32_t extentIter = 0; extentIter < item->extents.count; ++extentIter) {
         avifExtent * extent = &item->extents.extent[extentIter];
-        const size_t usedExtentSize = (extent->size > remainingBytes) ? extent->size : remainingBytes;
+        const size_t usedExtentSize = (extent->size < remainingBytes) ? extent->size : remainingBytes;
 
         if (usedExtentSize > UINT64_MAX - extent->offset) {
             return AVIF_RESULT_BMFF_PARSE_FAILED;

--- a/src/read.c
+++ b/src/read.c
@@ -828,7 +828,7 @@ static void avifDecoderDataDestroy(avifDecoderData * data)
 // This returns the max extent that has to be read in order to decode this item. If
 // the item is stored in an idat, the data has already been read during Parse() and
 // this function will return AVIF_RESULT_OK with a 0-byte extent.
-static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, avifDecodeSample * sample, avifExtent * outExtent)
+static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, const avifDecodeSample * sample, avifExtent * outExtent)
 {
     if (item->extents.count == 0) {
         return AVIF_RESULT_TRUNCATED_DATA;


### PR DESCRIPTION
This should make `avifDecoderNthImageMaxExtent()` behave correctly when in progressive mode.