### PR TITLE
Bump of version in CMakeLists.txt was forgotten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.5)
 # and find_package()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
-project(libavif LANGUAGES C VERSION 0.9.1)
+project(libavif LANGUAGES C VERSION 0.9.2)
 
 # Set C99 as the default
 set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
Ideally should use this line and PROJECT_VERSION_* variables to generate include/avif/avif.h version info to keep things nicely in sync