### PR TITLE
Better message for unsupported file extension

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -296,7 +296,7 @@ int main(int argc, char * argv[])
             returnCode = 1;
         }
     } else {
-        fprintf(stderr, "Unrecognized file extension: %s\n", outputFilename);
+        fprintf(stderr, "Unsupported output file extension: %s\n", outputFilename);
         returnCode = 1;
     }
 


### PR DESCRIPTION
Improve the error message for an unsupported output file extension. If
we reach here, we recognize the file extension (currently only .avif),
but the file cannot be the output from avifdec. So the error message
"Unrecognized file extension" is a little confusing.