### PR TITLE
Remove unneeded null check for decoder

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -301,11 +301,9 @@ int main(int argc, char * argv[])
     }
 
 cleanup:
-    if (decoder) {
-        if (returnCode != 0) {
-            avifDumpDiagnostics(&decoder->diag);
-        }
-        avifDecoderDestroy(decoder);
+    if (returnCode != 0) {
+        avifDumpDiagnostics(&decoder->diag);
     }
+    avifDecoderDestroy(decoder);
     return returnCode;
 }


### PR DESCRIPTION
Remove the unneeded null check for 'decoder' under the 'cleanup' label.
The 'decoder' variable is initialized as follows:

    avifDecoder * decoder = avifDecoderCreate();
    decoder->maxThreads = jobs;
    decoder->codecChoice = codecChoice;
    ...

so it cannot possibly be a null pointer.