### PR TITLE
Remove a change from the 0.9.2 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Declare the param of avifDumpDiagnostics as const (#633)
 * Adjust gdk-pixbuf loader for new API change (#668)
 * Fix gdk-pixbuf loader install path (#615)
-* Don't need to disable MSVC warnings 5031 and 5032 (#681)
 
 ## [0.9.1] - 2021-05-19
 


### PR DESCRIPTION
The change "Don't need to disable MSVC warnings 5031 and 5032 (#681)"
is a change to commit 5a987902f04ff5070349ed928f80d43c7c466c82 (the
"-j all" option of avifenc and avifdec), which was added during the
0.9.2 development cycle. So this change is not a change to older
releases and does not need to be documented as a change in 0.9.2.