### PR TITLE
In 32-bit builds set frame_size_limit to 8192*8192

### DIFF
--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -215,8 +215,10 @@ avifCodec * avifCodecCreateDav1d(void)
     memset(codec->internal, 0, sizeof(struct avifCodecInternal));
     dav1d_default_settings(&codec->internal->dav1dSettings);
 
-    // Set a maximum frame size limit to avoid OOM'ing fuzzers.
-    codec->internal->dav1dSettings.frame_size_limit = AVIF_MAX_IMAGE_SIZE;
+    // Set a maximum frame size limit to avoid OOM'ing fuzzers. In 32-bit builds, if
+    // frame_size_limit > 8192 * 8192, dav1d reduces frame_size_limit to 8192 * 8192 and logs a
+    // message, so we set frame_size_limit to 8192 * 8192 to avoid the dav1d_log message.
+    codec->internal->dav1dSettings.frame_size_limit = (sizeof(size_t) < 8) ? (8192 * 8192) : AVIF_MAX_IMAGE_SIZE;
 
     // Ensure that we only get the "highest spatial layer" as a single frame
     // for each input sample, instead of getting each spatial layer as its own


### PR DESCRIPTION
This avoids the following dav1d_log() message in 32-bit builds:
    Frame size limit reduced from 268435456 to 67108864.