### PR TITLE
Skip YUV/RGB conversion tests except first image

### DIFF
--- a/tests/oss-fuzz/avif_decode_fuzzer.cc
+++ b/tests/oss-fuzz/avif_decode_fuzzer.cc
@@ -25,6 +25,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
     if (result == AVIF_RESULT_OK) {
         for (int loop = 0; loop < 2; ++loop) {
             while (avifDecoderNextImage(decoder) == AVIF_RESULT_OK) {
+                if ((loop != 0) || (decoder->imageIndex != 0)) {
+                    // Skip the YUV<->RGB conversion tests, which are time-consuming for large
+                    // images. It suffices to run these tests only for loop == 0 and only for the
+                    // first image of an image sequence.
+                    continue;
+                }
                 avifRGBImage rgb;
                 avifRGBImageSetDefaults(&rgb, decoder->image);
 


### PR DESCRIPTION
Skip the YUV<->RGB conversion tests except for the first loop iteration
(loop == 0) and the first image of an image sequence. The YUV<->RGB
conversion tests are time-consuming for large images, so we should try
to avoid duplicate tests.