### PR TITLE
Allocate alpha alongside YUV (if necessary) during y4m decode to avoid incorrect alphaRowBytes math

### DIFF
--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -356,6 +356,9 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
     avif->yuvRange = frame.range;
     avif->yuvChromaSamplePosition = frame.chromaSamplePosition;
     avifImageAllocatePlanes(avif, AVIF_PLANES_YUV);
+    if (frame.hasAlpha) {
+        avifImageAllocatePlanes(avif, AVIF_PLANES_A);
+    }
 
     avifPixelFormatInfo info;
     avifGetPixelFormatInfo(avif->yuvFormat, &info);
@@ -378,7 +381,6 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
         }
     }
     if (frame.hasAlpha) {
-        avifImageAllocatePlanes(avif, AVIF_PLANES_A);
         if (fread(avif->alphaPlane, 1, planeBytes[3], frame.inputFile) != planeBytes[3]) {
             fprintf(stderr, "Failed to read y4m plane (not enough data): %s\n", frame.displayFilename);
             goto cleanup;


### PR DESCRIPTION
There is code later in the function that relies on `alphaRowBytes` being correct, but it isn't set until the alpha plane  is allocated. This simply moves the alpha plane allocation a bit earlier, and fixes `yuva444p` decoding.