### PR TITLE
Add docker build CI pipeline

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,20 @@
+name: Docker Build
+on:
+  push:
+    branches:
+    tags:
+    paths:
+      - "!**.md"
+  pull_request:
+    paths:
+      - "!**.md"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: build docker image
+        run: docker build  ./tests/docker


### PR DESCRIPTION
As discussed in #620, this PR adds docker build CI pipeline. Here is the pipeline run in my repo: https://github.com/paskal/libavif/runs/3429529148

The next step I propose to take after this change will be merged is to start publishing resulting images so that users could benefit from the pre-build library.