### PR TITLE
Change avif_decode_fuzzer to be more like Chrome

### DIFF
--- a/tests/oss-fuzz/avif_decode_fuzzer.cc
+++ b/tests/oss-fuzz/avif_decode_fuzzer.cc
@@ -18,15 +18,17 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
     static size_t yuvDepthsCount = sizeof(yuvDepths) / sizeof(yuvDepths[0]);
 
     avifDecoder * decoder = avifDecoderCreate();
+    decoder->allowProgressive = AVIF_TRUE;
     // ClusterFuzz passes -rss_limit_mb=2560 to avif_decode_fuzzer. Empirically setting
     // decoder->imageSizeLimit to this value allows avif_decode_fuzzer to consume no more than
     // 2560 MB of memory.
     static_assert(11 * 1024 * 10 * 1024 <= AVIF_DEFAULT_IMAGE_SIZE_LIMIT, "");
     decoder->imageSizeLimit = 11 * 1024 * 10 * 1024;
-    avifResult result = avifDecoderSetIOMemory(decoder, Data, Size);
-    if (result == AVIF_RESULT_OK) {
-        result = avifDecoderParse(decoder);
-    }
+    avifIO * io = avifIOCreateMemoryReader(Data, Size);
+    // Similate Chrome's avifIO object, which is not persistent.
+    io->persistent = AVIF_FALSE;
+    avifDecoderSetIO(decoder, io);
+    avifResult result = avifDecoderParse(decoder);
     if (result == AVIF_RESULT_OK) {
         for (int loop = 0; loop < 2; ++loop) {
             while (avifDecoderNextImage(decoder) == AVIF_RESULT_OK) {


### PR DESCRIPTION
Allow progressive decoding and use a non-persistent avifIO object. This
allows avif_decode_fuzzer to reproduce the AddressSanitizer
heap-use-after-free error in https://crbug.com/1239472.