### PR TITLE
Compute maxFixedValueWidth in 64-bit operation

### DIFF
--- a/src/scale.c
+++ b/src/scale.c
@@ -17,6 +17,8 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
 
 #else
 
+#include <limits.h>
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes" // "this function declaration is not a prototype"
@@ -70,14 +72,14 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
 
     if (srcYUVPlanes[0]) {
         const int fixedPointDivWidth = (int)(((int64_t)(srcWidth) << 16) / dstWidth);
-        const int64_t maxFixedValueWidth = fixedPointDivWidth * (dstWidth - 1);
-        if (maxFixedValueWidth > 0x7fffffff) {
+        const int64_t maxFixedValueWidth = (int64_t)fixedPointDivWidth * (dstWidth - 1);
+        if (maxFixedValueWidth > INT_MAX) {
             avifDiagnosticsPrintf(diag, "avifImageScale requested invalid width scale for libyuv [%u -> %u]", srcWidth, dstWidth);
             return AVIF_FALSE;
         }
         const int fixedPointDivHeight = (int)(((int64_t)(srcHeight) << 16) / dstHeight);
-        const int64_t maxFixedValueHeight = fixedPointDivHeight * (dstHeight - 1);
-        if (maxFixedValueHeight > 0x7fffffff) {
+        const int64_t maxFixedValueHeight = (int64_t)fixedPointDivHeight * (dstHeight - 1);
+        if (maxFixedValueHeight > INT_MAX) {
             avifDiagnosticsPrintf(diag, "avifImageScale requested invalid height scale for libyuv [%u -> %u]", srcHeight, dstHeight);
             return AVIF_FALSE;
         }
@@ -121,14 +123,14 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
 
     if (srcAlphaPlane) {
         const int fixedPointDivWidth = (int)(((int64_t)(srcWidth) << 16) / dstWidth);
-        const int64_t maxFixedValueWidth = fixedPointDivWidth * (dstWidth - 1);
-        if (maxFixedValueWidth > 0x7fffffff) {
+        const int64_t maxFixedValueWidth = (int64_t)fixedPointDivWidth * (dstWidth - 1);
+        if (maxFixedValueWidth > INT_MAX) {
             avifDiagnosticsPrintf(diag, "avifImageScale requested invalid width scale for libyuv [%u -> %u]", srcWidth, dstWidth);
             return AVIF_FALSE;
         }
         const int fixedPointDivHeight = (int)(((int64_t)(srcHeight) << 16) / dstHeight);
-        const int64_t maxFixedValueHeight = fixedPointDivHeight * (dstHeight - 1);
-        if (maxFixedValueHeight > 0x7fffffff) {
+        const int64_t maxFixedValueHeight = (int64_t)fixedPointDivHeight * (dstHeight - 1);
+        if (maxFixedValueHeight > INT_MAX) {
             avifDiagnosticsPrintf(diag, "avifImageScale requested invalid height scale for libyuv [%u -> %u]", srcHeight, dstHeight);
             return AVIF_FALSE;
         }


### PR DESCRIPTION
Improve the check added in
https://github.com/AOMediaCodec/libavif/pull/735.

Compute maxFixedValueWidth and maxFixedValueHeight in 64-bit
multiplication by casting the first operand to int64_t. Otherwise, the
first operand is an int and the second operand is a uint32_t, so the
multiplication is 32-bit.

Replace 0x7fffffff with the symbolic constant INT_MAX because the
product will be stored in an int variable.