### PR TITLE
Revert "NON-STANDARD: Allow alpha subimage items to not have an ispe …

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3101,7 +3101,7 @@ avifResult avifDecoderParse(avifDecoder * decoder)
                 avifDiagnosticsPrintf(data->diag, "Item ID [%u] size is too large [%ux%u]", item->id, item->width, item->height);
                 return AVIF_RESULT_BMFF_PARSE_FAILED;
             }
-        } else if (!item->auxForID) { // NON-STANDARD: Allow auxiliary images to not have an ispe property. See: https://crbug.com/1245673
+        } else {
             avifDiagnosticsPrintf(data->diag, "Item ID [%u] is missing a mandatory ispe property", item->id);
             return AVIF_RESULT_BMFF_PARSE_FAILED;
         }
@@ -3426,13 +3426,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         }
 
         if (alphaItem) {
-            if (!alphaItem->width && !alphaItem->height) {
-                // NON-STANDARD: Alpha subimage does not have an ispe property; adopt width/height from color item
-                // See: https://crbug.com/1245673
-                alphaItem->width = colorItem->width;
-                alphaItem->height = colorItem->height;
-            }
-
             if ((data->alphaGrid.rows > 0) && (data->alphaGrid.columns > 0)) {
                 if (!avifDecoderGenerateImageGridTiles(decoder, &data->alphaGrid, alphaItem, AVIF_TRUE)) {
                     return AVIF_RESULT_INVALID_IMAGE_GRID;


### PR DESCRIPTION
…property, infer ispe from color item"

This reverts commit efed118564495228be8af6b2a640c473375c039b. That
commit is intended for Chrome 93 only.