### PR TITLE
Fix a spelling error: Similate => Simulate

### DIFF
--- a/tests/oss-fuzz/avif_decode_fuzzer.cc
+++ b/tests/oss-fuzz/avif_decode_fuzzer.cc
@@ -25,7 +25,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
     static_assert(11 * 1024 * 10 * 1024 <= AVIF_DEFAULT_IMAGE_SIZE_LIMIT, "");
     decoder->imageSizeLimit = 11 * 1024 * 10 * 1024;
     avifIO * io = avifIOCreateMemoryReader(Data, Size);
-    // Similate Chrome's avifIO object, which is not persistent.
+    // Simulate Chrome's avifIO object, which is not persistent.
     io->persistent = AVIF_FALSE;
     avifDecoderSetIO(decoder, io);
     avifResult result = avifDecoderParse(decoder);


### PR DESCRIPTION
Reported by Pascal Massimino.