### PR TITLE
Fix oss-fuzz coverage build failure of dav1d

### DIFF
--- a/ext/dav1d_oss_fuzz.patch
+++ b/ext/dav1d_oss_fuzz.patch
@@ -1,0 +1,19 @@
+diff --git a/meson.build b/meson.build
+index a9cfa04..085653f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -382,7 +382,13 @@ endif
+ 
+ cdata.set10('ARCH_PPC64LE', host_machine.cpu() == 'ppc64le')
+ 
+-if cc.symbols_have_underscore_prefix()
++# Meson's symbols_have_underscore_prefix() function returns true incorrectly
++# if -fprofile-instr-generate is specified in CFLAGS. This is similar to the
++# problem symbols_have_underscore_prefix() has with -flto mentioned in
++# https://github.com/mesonbuild/meson/issues/5482. Since oss-fuzz uses
++# -fprofile-instr-generate in CFLAGS only on Linux, add a special case for
++# Linux to work around this Meson bug.
++if host_machine.system() != 'linux' and cc.symbols_have_underscore_prefix()
+     cdata.set10('PREFIX', true)
+     cdata_asm.set10('PREFIX', true)
+ endif

--- a/ext/dav1d_oss_fuzz.sh
+++ b/ext/dav1d_oss_fuzz.sh
@@ -8,10 +8,10 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-# When updating the dav1d version, make the same change to dav1d_oss_fuzz.sh.
 git clone -b 0.9.2 --depth 1 https://code.videolan.org/videolan/dav1d.git
 
 cd dav1d
+patch -p1 < ../dav1d_oss_fuzz.patch
 mkdir build
 cd build
 


### PR DESCRIPTION
The cc.symbols_have_underscore_prefix() test in dav1d/meson.build
returns the incorrect value (true) if -fprofile-instr-generate is
specified in the CFLAGS environment variable. This is apparently a bug
in Meson's symbols_have_underscore_prefix() function. See
https://github.com/mesonbuild/meson/issues/5482. Work around this bug by
adding a special case for Linux in dav1d/meson.build.

Part 1 of the fix for https://crbug.com/oss-fuzz/38512. Part 2 of the
fix is to change oss-fuzz/projects/libavif/build.sh to run
"bash dav1d_oss_fuzz.sh" instead of "bash dav1d.cmd".