### PR TITLE
Support for Progressive AVIF encoding

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -243,6 +243,7 @@ typedef avifResult (*avifCodecEncodeImageFunc)(struct avifCodec * codec,
                                                avifEncoder * encoder,
                                                const avifImage * image,
                                                avifBool alpha,
+                                               int layerIndex,
                                                avifAddImageFlags addImageFlags,
                                                avifCodecEncodeOutput * output);
 typedef avifBool (*avifCodecEncodeFinishFunc)(struct avifCodec * codec, avifCodecEncodeOutput * output);

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -51,6 +51,7 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
                                         avifEncoder * encoder,
                                         const avifImage * image,
                                         avifBool alpha,
+                                        int layerIndex,
                                         uint32_t addImageFlags,
                                         avifCodecEncodeOutput * output)
 {
@@ -58,6 +59,10 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
 
     RaConfig * rav1eConfig = NULL;
     RaFrame * rav1eFrame = NULL;
+
+    if (layerIndex != 0) {
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
 
     if (!codec->internal->rav1eContext) {
         if (codec->csOptions->count > 0) {

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -28,6 +28,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
                                       avifEncoder * encoder,
                                       const avifImage * image,
                                       avifBool alpha,
+                                      int layerIndex,
                                       uint32_t addImageFlags,
                                       avifCodecEncodeOutput * output)
 {
@@ -35,6 +36,10 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
     EbColorFormat color_format = EB_YUV420;
     EbBufferHeaderType * input_buffer = NULL;
     EbErrorType res = EB_ErrorNone;
+
+    if (layerIndex != 0) {
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
 
     int y_shift = 0;
     // EbColorRange svt_range;

--- a/src/read.c
+++ b/src/read.c
@@ -37,8 +37,6 @@ static const size_t xmpContentTypeSize = sizeof(xmpContentType);
 // can't be more than 4 unique tuples right now.
 #define MAX_IPMA_VERSION_AND_FLAGS_SEEN 4
 
-#define MAX_AV1_LAYER_COUNT 4
-
 // ---------------------------------------------------------------------------
 // Box data structures
 
@@ -1534,7 +1532,7 @@ static avifBool avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw, s
             }
         }
 
-        uint16_t dataReferenceIndex;                                 // unsigned int(16) data_ref rence_index;
+        uint16_t dataReferenceIndex;                                 // unsigned int(16) data_reference_index;
         CHECK(avifROStreamReadU16(&s, &dataReferenceIndex));         //
         uint64_t baseOffset;                                         // unsigned int(base_offset_size*8) base_offset;
         CHECK(avifROStreamReadUX8(&s, &baseOffset, baseOffsetSize)); //
@@ -1827,7 +1825,7 @@ static avifBool avifParseAV1LayeredImageIndexingProperty(avifProperty * prop, co
         }
     }
 
-    // Layer sizes will be validated layer (when the item's size is known)
+    // Layer sizes will be validated later (when the item's size is known)
     return AVIF_TRUE;
 }
 


### PR DESCRIPTION
- Add support to write a1lx box for progressive AVIF, and interleave each layer of alpha and color AV1 payload when writing mdat.
- Add layer config to avifEncoder and avifCodec impl to encode scalable AV1 stream. (aom only, rav1e and SVT-AV1 simply fail.)
- New avifenc args: --progressive.

