### PR TITLE
Update dav1d_oss_fuzz.patch to the upstream commit

### DIFF
--- a/ext/dav1d_oss_fuzz.patch
+++ b/ext/dav1d_oss_fuzz.patch
@@ -1,19 +1,17 @@
 diff --git a/meson.build b/meson.build
-index a9cfa04..085653f 100644
+index 1bf69ab..1a7c409 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -382,7 +382,13 @@ endif
+@@ -382,7 +382,11 @@ endif
  
  cdata.set10('ARCH_PPC64LE', host_machine.cpu() == 'ppc64le')
  
 -if cc.symbols_have_underscore_prefix()
-+# Meson's symbols_have_underscore_prefix() function returns true incorrectly
-+# if -fprofile-instr-generate is specified in CFLAGS. This is similar to the
-+# problem symbols_have_underscore_prefix() has with -flto mentioned in
-+# https://github.com/mesonbuild/meson/issues/5482. Since oss-fuzz uses
-+# -fprofile-instr-generate in CFLAGS only on Linux, add a special case for
-+# Linux to work around this Meson bug.
-+if host_machine.system() != 'linux' and cc.symbols_have_underscore_prefix()
++# meson's cc.symbols_have_underscore_prefix() is unfortunately unrelieably
++# when additional flags like '-fprofile-instr-generate' are passed via CFLAGS
++# see following meson issue https://github.com/mesonbuild/meson/issues/5482
++if (host_machine.system() == 'darwin' or
++   (host_machine.system() == 'windows' and host_machine.cpu_family() == 'x86'))
      cdata.set10('PREFIX', true)
      cdata_asm.set10('PREFIX', true)
  endif


### PR DESCRIPTION
Update part 1 of the fix for https://crbug.com/oss-fuzz/38512. Use the
upstream dav1d commit
https://code.videolan.org/videolan/dav1d/-/commit/c6a08b3aa1ee99dade53e5e32033bc1d14455a22