### PR TITLE
Redesign AVIF_DECODER_SOURCE_AUTO to honor the FileTypeBox's major brand

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -747,7 +747,9 @@ struct avifDecoderData;
 
 typedef enum avifDecoderSource
 {
-    // If a moov box is present in the .avif(s), use the tracks in it, otherwise decode the primary item.
+    // Honor the major brand signaled in the beginning of the file to pick between an AVIF sequence
+    // ('avis', tracks-based) or a single image ('avif', item-based). If the major brand is neither
+    // of these, prefer the AVIF sequence ('avis', tracks-based), if present.
     AVIF_DECODER_SOURCE_AUTO = 0,
 
     // Use the primary item and the aux (alpha) item in the avif(s).


### PR DESCRIPTION
When using AVIF_DECODER_SOURCE_AUTO, use the major_brand field in the FileTypeBox ('ftyp') in the
beginning of the file as a hint to whether or not to treat this file as an AVIF sequence or an
items-based single image.

In practice (and currently in the field), this won't change pre-existing behavior as the vast
majority of AVIFs in existence right now are single images and signal the major brand 'avif'
anyway, and sequences generated by avifenc have always used the major brand 'avis'.

This design is more in the spirit of ISO-BMFF Section 4.3's explanation of major_brand:

    Files would normally be externally identified (e.g. with a file extension or mime type) that
    identifies the ‘best use’ (major brand), or the brand that the author believes will provide the
    greatest compatibility.

This also would allow for currently unexercised use-cases such as "live photos", where an AVIF can
internally hold an image sequence recorded by a camera, but suggest (via the major brand) to only
display it as a single image, specifying one of the frame samples as an item.