### PR TITLE
ext: Checkout libaom v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 *   - speed 0-6: no change is needed
 *   - speed 7:   change to speed 6 for the same results
 *   - speed 8-9: re-test and re-adjust speed according to your app needs
-* Update aom.cmd: v3.1.3
+* Update aom.cmd: v3.2.0
 * Update dav1d.cmd: 0.9.2
 
 ## [0.9.2] - 2021-06-23

--- a/ext/aom.cmd
+++ b/ext/aom.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b v3.1.3 --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v3.2.0 --depth 1 https://aomedia.googlesource.com/aom
 
 cd aom
 mkdir build.libavif

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -34,7 +34,7 @@ nasm --version
 
 # aom
 cd
-git clone -b v3.1.3 --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v3.2.0 --depth 1 https://aomedia.googlesource.com/aom
 cd aom
 mkdir build.avif
 cd build.avif


### PR DESCRIPTION
Updates the libaom version checked out in the ext and docker scripts
from v3.1.3 to v3.2.0.