### PR TITLE
Use "C420" as default Y4M color space parameter

### DIFF
--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -215,9 +215,10 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
     struct y4mFrameIterator frame;
     frame.width = -1;
     frame.height = -1;
-    frame.depth = -1;
+    // Default to the color space "C420" to match the defaults of aomenc and ffmpeg.
+    frame.depth = 8;
     frame.hasAlpha = AVIF_FALSE;
-    frame.format = AVIF_PIXEL_FORMAT_NONE;
+    frame.format = AVIF_PIXEL_FORMAT_YUV420;
     frame.range = AVIF_RANGE_LIMITED;
     frame.chromaSamplePosition = AVIF_CHROMA_SAMPLE_POSITION_UNKNOWN;
     memset(&frame.sourceTiming, 0, sizeof(avifAppSourceTiming));
@@ -338,8 +339,7 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
         goto cleanup;
     }
 
-    if ((frame.width < 1) || (frame.height < 1) || ((frame.depth != 8) && (frame.depth != 10) && (frame.depth != 12)) ||
-        (frame.format == AVIF_PIXEL_FORMAT_NONE)) {
+    if ((frame.width < 1) || (frame.height < 1) || ((frame.depth != 8) && (frame.depth != 10) && (frame.depth != 12))) {
         fprintf(stderr, "Failed to parse y4m header (not enough information): %s\n", frame.displayFilename);
         goto cleanup;
     }


### PR DESCRIPTION
If the Y4M header does not have a 'C' (color space) parameter, default
to "C420". This matches the defaults of libaom's aomenc and ffmpeg.

1. aom/common/y4minput.c:

static int parse_tags(y4m_input *y4m_ctx, FILE *file) {
  ...
  snprintf(y4m_ctx->chroma_type, sizeof(y4m_ctx->chroma_type), "420");

2. ffmpeg/libavformat/yuv4mpegdec.c:

static int yuv4_read_header(AVFormatContext *s)
{
    ...
    enum AVPixelFormat pix_fmt = AV_PIX_FMT_NONE, alt_pix_fmt = AV_PIX_FMT_NONE;
    ...
    if (pix_fmt == AV_PIX_FMT_NONE) {
        if (alt_pix_fmt == AV_PIX_FMT_NONE)
            pix_fmt = AV_PIX_FMT_YUV420P;
        else
            pix_fmt = alt_pix_fmt;
    }