### PR TITLE
Print the item type in two diagnostic messages

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -917,14 +917,17 @@ static avifResult avifDecoderItemValidateAV1(const avifDecoderItem * item, avifD
     const avifProperty * av1CProp = avifPropertyArrayFind(&item->properties, "av1C");
     if (!av1CProp) {
         // An av1C box is mandatory in all valid AVIF configurations. Bail out.
-        avifDiagnosticsPrintf(diag, "Item ID %u is missing mandatory av1C property", item->id);
+        avifDiagnosticsPrintf(diag, "Item ID %u of type '%.4s' is missing mandatory av1C property", item->id, (const char *)item->type);
         return AVIF_RESULT_BMFF_PARSE_FAILED;
     }
 
     const avifProperty * pixiProp = avifPropertyArrayFind(&item->properties, "pixi");
     if (!pixiProp && (strictFlags & AVIF_STRICT_PIXI_REQUIRED)) {
         // A pixi box is mandatory in all valid AVIF configurations. Bail out.
-        avifDiagnosticsPrintf(diag, "[Strict] Item ID %u is missing mandatory pixi property", item->id);
+        avifDiagnosticsPrintf(diag,
+                              "[Strict] Item ID %u of type '%.4s' is missing mandatory pixi property",
+                              item->id,
+                              (const char *)item->type);
         return AVIF_RESULT_BMFF_PARSE_FAILED;
     }
 


### PR DESCRIPTION
Print the item type in the diagnostic messages for missing mandatory
av1C or pixi property.

Before:
 * [Strict] Item ID 8 is missing mandatory pixi property

After:
 * [Strict] Item ID 8 of type 'grid' is missing mandatory pixi property