### PR TITLE
change encoder speed in gdk-pixbuf plug-in

### DIFF
--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -467,7 +467,7 @@ static gboolean avif_image_saver(FILE          *f,
     encoder->maxQuantizer = max_quantizer;
     encoder->minQuantizerAlpha = 0;
     encoder->maxQuantizerAlpha = alpha_quantizer;
-    encoder->speed = 8;
+    encoder->speed = 7;
 
     res = avifEncoderWrite(encoder, avif, &raw);
     avifEncoderDestroy(encoder);


### PR DESCRIPTION
I chose encoder speed 8 for the plug-in in the past.

Encoders were relatively slow at that time and speed 8 gave quite acceptable waiting time.

Today, encoders get faster and the speed settings in AOM was remapped.

So I am sure we can change the 8 at least to 7 to slightly improve visual quality of the saved file.