### PR TITLE
Fix y4m read/write for images of non-standard dimensions

### DIFF
--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -372,7 +372,8 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
         for (uint32_t y = 0; y < planeHeight; ++y) {
             uint32_t bytesRead = (uint32_t)fread(row, 1, rowBytes, frame.inputFile);
             if (bytesRead != rowBytes) {
-                fprintf(stderr, "Failed to read y4m plane (not enough data, wanted %d, got %d): %s\n", rowBytes, bytesRead, frame.displayFilename);
+                fprintf(stderr, "Failed to read y4m plane (not enough data, wanted %" PRIu32 ", got %" PRIu32 "): %s\n",
+                        rowBytes, bytesRead, frame.displayFilename);
                 goto cleanup;
             }
             row += avif->yuvRowBytes[plane];
@@ -384,7 +385,8 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
         for (uint32_t y = 0; y < avif->height; ++y) {
             uint32_t bytesRead = (uint32_t)fread(row, 1, rowBytes, frame.inputFile);
             if (bytesRead != rowBytes) {
-                fprintf(stderr, "Failed to read y4m plane (not enough data, wanted %d, got %d): %s\n", rowBytes, bytesRead, frame.displayFilename);
+                fprintf(stderr, "Failed to read y4m plane (not enough data, wanted %" PRIu32 ", got %" PRIu32 "): %s\n",
+                        rowBytes, bytesRead, frame.displayFilename);
                 goto cleanup;
             }
             row += avif->alphaRowBytes;

--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -523,15 +523,6 @@ avifBool y4mWrite(const char * outputFilename, const avifImage * avif)
         goto cleanup;
     }
 
-    uint8_t * planes[3];
-    uint32_t planeBytes[3];
-    planes[0] = avif->yuvPlanes[0];
-    planes[1] = avif->yuvPlanes[1];
-    planes[2] = avif->yuvPlanes[2];
-    planeBytes[0] = avif->yuvRowBytes[0] * avif->height;
-    planeBytes[1] = avif->yuvRowBytes[1] * (avif->height >> info.chromaShiftY);
-    planeBytes[2] = avif->yuvRowBytes[2] * (avif->height >> info.chromaShiftY);
-
     for (int plane = 0; plane < 3; ++plane) {
         uint32_t planeWidth = plane > 0 ? ((avif->width + info.chromaShiftX) >> info.chromaShiftX) : avif->width;
         uint32_t planeHeight = plane > 0 ? ((avif->height + info.chromaShiftY) >> info.chromaShiftY) : avif->height;

--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -364,29 +364,34 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
     avifGetPixelFormatInfo(avif->yuvFormat, &info);
 
     for (int plane = 0; plane < 3; ++plane) {
-        uint32_t planeWidth = plane > 0 ? ((avif->width + info.chromaShiftX) >> info.chromaShiftX) : avif->width;
-        uint32_t planeHeight = plane > 0 ? ((avif->height + info.chromaShiftY) >> info.chromaShiftY) : avif->height;
-        // The stride may not match the width so read row by row.
-        uint32_t rowBytes = planeWidth << (avif->depth > 8 ? 1 : 0);
-        uint8_t* row = avif->yuvPlanes[plane];
+        uint32_t planeWidth = (plane > 0) ? ((avif->width + info.chromaShiftX) >> info.chromaShiftX) : avif->width;
+        uint32_t planeHeight = (plane > 0) ? ((avif->height + info.chromaShiftY) >> info.chromaShiftY) : avif->height;
+        uint32_t rowBytes = planeWidth << (avif->depth > 8);
+        uint8_t * row = avif->yuvPlanes[plane];
         for (uint32_t y = 0; y < planeHeight; ++y) {
             uint32_t bytesRead = (uint32_t)fread(row, 1, rowBytes, frame.inputFile);
             if (bytesRead != rowBytes) {
-                fprintf(stderr, "Failed to read y4m plane (not enough data, wanted %" PRIu32 ", got %" PRIu32 "): %s\n",
-                        rowBytes, bytesRead, frame.displayFilename);
+                fprintf(stderr,
+                        "Failed to read y4m row (not enough data, wanted %" PRIu32 ", got %" PRIu32 "): %s\n",
+                        rowBytes,
+                        bytesRead,
+                        frame.displayFilename);
                 goto cleanup;
             }
             row += avif->yuvRowBytes[plane];
         }
     }
     if (frame.hasAlpha) {
-        uint32_t rowBytes = avif->width << (avif->depth > 8 ? 1 : 0);
-        uint8_t* row = avif->alphaPlane;
+        uint32_t rowBytes = avif->width << (avif->depth > 8);
+        uint8_t * row = avif->alphaPlane;
         for (uint32_t y = 0; y < avif->height; ++y) {
             uint32_t bytesRead = (uint32_t)fread(row, 1, rowBytes, frame.inputFile);
             if (bytesRead != rowBytes) {
-                fprintf(stderr, "Failed to read y4m plane (not enough data, wanted %" PRIu32 ", got %" PRIu32 "): %s\n",
-                        rowBytes, bytesRead, frame.displayFilename);
+                fprintf(stderr,
+                        "Failed to read y4m row (not enough data, wanted %" PRIu32 ", got %" PRIu32 "): %s\n",
+                        rowBytes,
+                        bytesRead,
+                        frame.displayFilename);
                 goto cleanup;
             }
             row += avif->alphaRowBytes;
@@ -524,11 +529,10 @@ avifBool y4mWrite(const char * outputFilename, const avifImage * avif)
     }
 
     for (int plane = 0; plane < 3; ++plane) {
-        uint32_t planeWidth = plane > 0 ? ((avif->width + info.chromaShiftX) >> info.chromaShiftX) : avif->width;
-        uint32_t planeHeight = plane > 0 ? ((avif->height + info.chromaShiftY) >> info.chromaShiftY) : avif->height;
-        // The stride may not match the width so write row by row.
-        uint32_t rowBytes = planeWidth << (avif->depth > 8 ? 1 : 0);
-        const uint8_t* row = avif->yuvPlanes[plane];
+        uint32_t planeWidth = (plane > 0) ? ((avif->width + info.chromaShiftX) >> info.chromaShiftX) : avif->width;
+        uint32_t planeHeight = (plane > 0) ? ((avif->height + info.chromaShiftY) >> info.chromaShiftY) : avif->height;
+        uint32_t rowBytes = planeWidth << (avif->depth > 8);
+        const uint8_t * row = avif->yuvPlanes[plane];
         for (uint32_t y = 0; y < planeHeight; ++y) {
             if (fwrite(row, 1, rowBytes, f) != rowBytes) {
                 fprintf(stderr, "Failed to write %" PRIu32 " bytes: %s\n", rowBytes, outputFilename);
@@ -539,8 +543,8 @@ avifBool y4mWrite(const char * outputFilename, const avifImage * avif)
         }
     }
     if (writeAlpha) {
-        uint32_t rowBytes = avif->width << (avif->depth > 8 ? 1 : 0);
-        const uint8_t* row = avif->alphaPlane;
+        uint32_t rowBytes = avif->width << (avif->depth > 8);
+        const uint8_t * row = avif->alphaPlane;
         for (uint32_t y = 0; y < avif->height; ++y) {
             if (fwrite(row, 1, rowBytes, f) != rowBytes) {
                 fprintf(stderr, "Failed to write %" PRIu32 " bytes: %s\n", rowBytes, outputFilename);


### PR DESCRIPTION
Previously the buffer was dumped to a file, even when it contained non-contiguous rows.

See https://github.com/AOMediaCodec/libavif/issues/801