### PR TITLE
findrav1e: add LDFLAGS to LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,7 @@ if(AVIF_CODEC_RAV1E)
 
     # Unfortunately, rav1e requires a few more libraries
     if(WIN32)
-        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ws2_32.lib userenv.lib)
+        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ws2_32.lib bcrypt.lib userenv.lib)
     elseif(UNIX AND NOT APPLE)
         set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${CMAKE_DL_LIBS}) # for backtrace
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ if(AVIF_CODEC_RAV1E)
             find_package(rav1e REQUIRED)
             set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${RAV1E_INCLUDE_DIR})
         endif()
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${RAV1E_LIBRARY})
+        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${RAV1E_LIBRARIES})
     endif()
 
     # Unfortunately, rav1e requires a few more libraries

--- a/cmake/Modules/Findrav1e.cmake
+++ b/cmake/Modules/Findrav1e.cmake
@@ -36,11 +36,10 @@ find_library(RAV1E_LIBRARY
              PATHS ${_RAV1E_LIBDIR})
 endif()
 
-if (RAV1E_LIBRARY)
-    set(RAV1E_LIBRARIES
-        ${RAV1E_LIBRARIES}
-        ${RAV1E_LIBRARY})
-endif (RAV1E_LIBRARY)
+set(RAV1E_LIBRARIES
+    ${RAV1E_LIBRARIES}
+    ${RAV1E_LIBRARY}
+    ${_RAV1E_LDFLAGS})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(rav1e


### PR DESCRIPTION
matches findaom's behavior

fixes static linking of librav1e.a on windows since it requires bcrypt

As requested at https://github.com/AOMediaCodec/libavif/pull/802#issuecomment-995200877