### PR TITLE
Make external library subdir configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,26 @@ option(AVIF_CODEC_SVT "Use the SVT-AV1 codec for encoding" OFF)
 option(AVIF_CODEC_AOM_DECODE "if AVIF_CODEC_AOM is on, use/offer libaom's decoder" ON)
 option(AVIF_CODEC_AOM_ENCODE "if AVIF_CODEC_AOM is on, use/offer libaom's encoder" ON)
 
-option(AVIF_LOCAL_AOM "Build the AOM codec by providing your own copy of the repo in ext/aom (see Local Builds in README)" OFF)
-option(AVIF_LOCAL_DAV1D "Build the dav1d codec by providing your own copy of the repo in ext/dav1d (see Local Builds in README)" OFF)
-option(AVIF_LOCAL_LIBGAV1 "Build the libgav1 codec by providing your own copy of the repo in ext/libgav1 (see Local Builds in README)" OFF)
-option(AVIF_LOCAL_RAV1E "Build the rav1e codec by providing your own copy of the repo in ext/rav1e (see Local Builds in README)" OFF)
-option(AVIF_LOCAL_SVT "Build the SVT-AV1 codec by providing your own copy of the repo in ext/SVT-AV1 (see Local Builds in README)" OFF)
+option(AVIF_LOCAL_AOM "Build the AOM codec by providing your own copy of the repo (see Local Builds in README)" OFF)
+option(AVIF_LOCAL_DAV1D "Build the dav1d codec by providing your own copy of the repo (see Local Builds in README)" OFF)
+option(AVIF_LOCAL_LIBGAV1 "Build the libgav1 codec by providing your own copy of the repo (see Local Builds in README)" OFF)
+option(AVIF_LOCAL_RAV1E "Build the rav1e codec by providing your own copy of the repo (see Local Builds in README)" OFF)
+option(AVIF_LOCAL_SVT "Build the SVT-AV1 codec by providing your own copy of the repo (see Local Builds in README)" OFF)
+
+set(AVIF_LOCAL_AOM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom" CACHE PATH "Source directory of your own copy of AOM codec")
+set(AVIF_LOCAL_AOM_LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom/build.libavif" CACHE PATH "Library directory of your own copy of AOM codec")
+set(AVIF_LOCAL_DAV1D_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/usr/include" CACHE PATH "Source directory of your own copy of dav1d codec")
+set(AVIF_LOCAL_DAV1D_LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/usr/lib" CACHE PATH "Library directory of your own copy of dav1d codec")
+set(AVIF_LOCAL_LIBGAV1_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libgav1/src" CACHE PATH "Source directory of your own copy of libgav1 codec")
+set(AVIF_LOCAL_LIBGAV1_LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libgav1/build" CACHE PATH "Library directory of your own copy of libgav1 codec")
+set(AVIF_LOCAL_RAV1E_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/include/rav1e" CACHE PATH "Source directory of your own copy of rav1e codec")
+set(AVIF_LOCAL_RAV1E_LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/lib" CACHE PATH "Library directory of your own copy of rav1e codec")
+set(AVIF_LOCAL_SVT_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/SVT-AV1/include" CACHE PATH "Source directory of your own copy of SVT-AV1 codec")
+set(AVIF_LOCAL_SVT_LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/SVT-AV1/Bin/Release" CACHE PATH "Library directory of your own copy of SVT-AV1 codec")
+
+option(AVIF_LOCAL_LIBYUV "Build libyuv by providing your own copy inside the ext subdir." OFF)
+set(AVIF_LOCAL_LIBYUV_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/include" CACHE PATH "Source directory of your own copy of libyuv")
+set(AVIF_LOCAL_LIBYUV_LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/build" CACHE PATH "Library directory of your own copy of libyuv")
 
 if(AVIF_LOCAL_LIBGAV1)
     enable_language(CXX)
@@ -91,20 +106,6 @@ if(AVIF_LOCAL_JPEG)
     else()
         set(JPEG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libjpeg" PARENT_SCOPE)
         set(JPEG_LIBRARY jpeg PARENT_SCOPE)
-    endif()
-endif()
-option(AVIF_LOCAL_LIBYUV "Build libyuv by providing your own copy inside the ext subdir." OFF)
-if(AVIF_LOCAL_LIBYUV)
-    set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/build/${CMAKE_STATIC_LIBRARY_PREFIX}yuv${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    if(NOT EXISTS "${LIB_FILENAME}")
-        message(FATAL_ERROR "libavif(AVIF_LOCAL_LIBYUV): ${LIB_FILENAME} is missing, bailing out")
-    endif()
-    if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
-        set(LIBYUV_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/include")
-        set(LIBYUV_LIBRARY ${LIB_FILENAME})
-    else()
-        set(LIBYUV_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/include" PARENT_SCOPE)
-        set(LIBYUV_LIBRARY ${LIB_FILENAME} PARENT_SCOPE)
     endif()
 endif()
 # ---------------------------------------------------------------------------------------
@@ -232,6 +233,12 @@ endif()
 
 find_package(libyuv QUIET) # not required
 if(libyuv_FOUND)
+    if(AVIF_LOCAL_LIBYUV)
+        if(NOT "${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+            set(LIBYUV_INCLUDE_DIR ${LIBYUV_INCLUDE_DIR} PARENT_SCOPE)
+            set(LIBYUV_LIBRARY ${LIBYUV_LIBRARY} PARENT_SCOPE)
+        endif()
+    endif()
     # libyuv 1755 exposed all of the I*Matrix() functions, which libavif relies on.
     if(NOT LIBYUV_VERSION)
         message(STATUS "libavif: libyuv found, but version unknown; libyuv-based fast paths disabled.")
@@ -252,96 +259,60 @@ set(AVIF_CODEC_INCLUDES)
 set(AVIF_CODEC_LIBRARIES)
 
 if(AVIF_CODEC_DAV1D)
-    message(STATUS "libavif: Codec enabled: dav1d (decode)")
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_DAV1D=1)
     set(AVIF_SRCS ${AVIF_SRCS}
         src/codec_dav1d.c
     )
 
-    if(AVIF_LOCAL_DAV1D)
-        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/src/libdav1d.a")
-        if(NOT EXISTS "${LIB_FILENAME}")
-            message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
-        endif()
-
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build"
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include"
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include/dav1d"
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/include"
-        )
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
-    else()
-        # Check to see if dav1d is independently being built by the outer CMake project
-        if(NOT TARGET dav1d)
-            find_package(dav1d REQUIRED)
-            set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${DAV1D_INCLUDE_DIR})
-        endif()
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${DAV1D_LIBRARY})
+    # Check to see if dav1d is independently being built by the outer CMake project
+    if(NOT TARGET dav1d)
+        find_package(dav1d REQUIRED)
+        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${DAV1D_INCLUDE_DIR})
     endif()
+    set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${DAV1D_LIBRARY})
 
     if(UNIX AND NOT APPLE)
         set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${CMAKE_DL_LIBS}) # for dlsym
     endif()
+
+    message(STATUS "libavif: Codec enabled: dav1d (decode)")
 endif()
 
 if(AVIF_CODEC_LIBGAV1)
-    message(STATUS "libavif: Codec enabled: libgav1 (decode)")
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_LIBGAV1=1)
     set(AVIF_SRCS ${AVIF_SRCS}
         src/codec_libgav1.c
     )
 
     if(AVIF_LOCAL_LIBGAV1)
-        set (AVIF_LIBGAV1_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libgav1/build")
         # If ${ANDROID_ABI} is set, look for the library under that subdirectory.
         if (DEFINED ANDROID_ABI)
-            set(AVIF_LIBGAV1_BUILD_DIR "${AVIF_LIBGAV1_BUILD_DIR}/${ANDROID_ABI}")
+            set(AVIF_LOCAL_LIBGAV1_LIBRARY_DIR "${AVIF_LIBGAV1_BUILD_DIR}/${ANDROID_ABI}")
         endif()
-        set(LIB_FILENAME "${AVIF_LIBGAV1_BUILD_DIR}/libgav1${CMAKE_STATIC_LIBRARY_SUFFIX}")
-        if(NOT EXISTS "${LIB_FILENAME}")
-            message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
-        endif()
-
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/libgav1/src"
-        )
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
-    else()
-        # Check to see if libgav1 is independently being built by the outer CMake project
-        if(NOT TARGET libgav1)
-            find_package(libgav1 REQUIRED)
-            set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${LIBGAV1_INCLUDE_DIR})
-        endif()
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIBGAV1_LIBRARY})
     endif()
+
+    # Check to see if libgav1 is independently being built by the outer CMake project
+    if(NOT TARGET libgav1)
+        find_package(libgav1 REQUIRED)
+        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${LIBGAV1_INCLUDE_DIR})
+    endif()
+    set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIBGAV1_LIBRARY})
+
+    message(STATUS "libavif: Codec enabled: libgav1 (decode)")
 endif()
 
 if(AVIF_CODEC_RAV1E)
-    message(STATUS "libavif: Codec enabled: rav1e (encode)")
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_RAV1E=1)
     set(AVIF_SRCS ${AVIF_SRCS}
         src/codec_rav1e.c
     )
 
-    if(AVIF_LOCAL_RAV1E)
-        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/lib/${CMAKE_STATIC_LIBRARY_PREFIX}rav1e${CMAKE_STATIC_LIBRARY_SUFFIX}")
-        if(NOT EXISTS "${LIB_FILENAME}")
-            message(FATAL_ERROR "libavif: compiled rav1e library is missing (in ext/rav1e/build.libavif/usr/lib), bailing out")
-        endif()
-
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/include/rav1e"
-        )
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
-    else()
-        # Check to see if rav1e is independently being built by the outer CMake project
-        if(NOT TARGET rav1e)
-            find_package(rav1e REQUIRED)
-            set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${RAV1E_INCLUDE_DIR})
-        endif()
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${RAV1E_LIBRARIES})
+    # Check to see if rav1e is independently being built by the outer CMake project
+    if(NOT TARGET rav1e)
+        find_package(rav1e REQUIRED)
+        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${RAV1E_INCLUDE_DIR})
     endif()
+    set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${RAV1E_LIBRARIES})
 
     # Unfortunately, rav1e requires a few more libraries
     if(WIN32)
@@ -349,45 +320,36 @@ if(AVIF_CODEC_RAV1E)
     elseif(UNIX AND NOT APPLE)
         set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${CMAKE_DL_LIBS}) # for backtrace
     endif()
+
+    message(STATUS "libavif: Codec enabled: rav1e (encode)")
 endif()
 
 if(AVIF_CODEC_SVT)
-    message(STATUS "libavif: Codec enabled: svt (encode)")
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_SVT=1)
     set(AVIF_SRCS ${AVIF_SRCS}
         src/codec_svt.c
     )
 
-    if(AVIF_LOCAL_SVT)
-        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/SVT-AV1/Bin/Release/${CMAKE_STATIC_LIBRARY_PREFIX}SvtAv1Enc${CMAKE_STATIC_LIBRARY_SUFFIX}")
-        if(NOT EXISTS "${LIB_FILENAME}")
-            message(FATAL_ERROR "libavif: compiled svt library is missing (in ext/SVT-AV1/Bin/Release), bailing out")
-        endif()
-
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/SVT-AV1/include"
-        )
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
-    else()
-        # Check to see if svt is independently being built by the outer CMake project
-        if(NOT TARGET svt)
-            find_package(svt REQUIRED)
-            set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${SVT_INCLUDE_DIR})
-        endif()
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${SVT_LIBRARY})
+    # Check to see if svt is independently being built by the outer CMake project
+    if(NOT TARGET svt)
+        find_package(svt REQUIRED)
+        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${SVT_INCLUDE_DIR})
     endif()
+    set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${SVT_LIBRARY})
+
+    message(STATUS "libavif: Codec enabled: svt (encode)")
 endif()
 
 if(AVIF_CODEC_AOM)
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_AOM=1)
     if(AVIF_CODEC_AOM_ENCODE AND AVIF_CODEC_AOM_DECODE)
-        message(STATUS "libavif: Codec enabled: aom (encode/decode)")
+        set(AVIF_CODEC_AOM_ENCODE_DECODE_CONFIG "encode/decode")
         set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_AOM_ENCODE=1 -DAVIF_CODEC_AOM_DECODE=1)
     elseif(AVIF_CODEC_AOM_ENCODE)
-        message(STATUS "libavif: Codec enabled: aom (encode only)")
+        set(AVIF_CODEC_AOM_ENCODE_DECODE_CONFIG "encode only")
         set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_AOM_ENCODE=1)
     elseif(AVIF_CODEC_AOM_DECODE)
-        message(STATUS "libavif: Codec enabled: aom (decode only)")
+        set(AVIF_CODEC_AOM_ENCODE_DECODE_CONFIG "decode only")
         set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_AOM_DECODE=1)
     else()
         message(FATAL_ERROR "libavif: AVIF_CODEC_AOM is on, but both AVIF_CODEC_AOM_ENCODE and AVIF_CODEC_AOM_DECODE are off. Disable AVIF_CODEC_AOM to disable both parts of the codec.")
@@ -395,24 +357,15 @@ if(AVIF_CODEC_AOM)
     set(AVIF_SRCS ${AVIF_SRCS}
         src/codec_aom.c
     )
-    if(AVIF_LOCAL_AOM)
-        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom/build.libavif/${CMAKE_STATIC_LIBRARY_PREFIX}aom${CMAKE_STATIC_LIBRARY_SUFFIX}")
-        if(NOT EXISTS "${LIB_FILENAME}")
-            message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
-        endif()
 
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom"
-        )
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
-    else()
-        # Check to see if aom is independently being built by the outer CMake project
-        if(NOT TARGET aom)
-            find_package(aom REQUIRED)
-            set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${AOM_INCLUDE_DIR})
-        endif()
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${AOM_LIBRARIES})
+    # Check to see if aom is independently being built by the outer CMake project
+    if(NOT TARGET aom)
+        find_package(aom REQUIRED)
+        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${AOM_INCLUDE_DIR})
     endif()
+    set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${AOM_LIBRARIES})
+
+    message(STATUS "libavif: Codec enabled: aom (${AVIF_CODEC_AOM_ENCODE_DECODE_CONFIG})")
 endif()
 
 if(NOT AVIF_CODEC_AOM AND NOT AVIF_CODEC_DAV1D AND NOT AVIF_CODEC_LIBGAV1)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ If you want to statically link any codec into your local (static) build of
 libavif, building using one of these scripts and then enabling the associated
 `AVIF_LOCAL_*` is a convenient method, but you must make sure to disable
 `BUILD_SHARED_LIBS` in CMake to instruct it to make a static libavif library.
+Alternatively, you can place your local build to other directories, then set
+`AVIF_LOCAL_*_INCLUDE_DIR` and `AVIF_LOCAL_*_LIBRARY_DIR` to the path where
+corresponding codec's header and library files are located.
 
 If you want to build/install shared libraries for AV1 codecs, you can still
 peek inside of each script to see where the current known-good SHA is for each

--- a/cmake/Modules/Findaom.cmake
+++ b/cmake/Modules/Findaom.cmake
@@ -17,19 +17,30 @@
 #=============================================================================
 #
 
-find_package(PkgConfig QUIET)
-if (PKG_CONFIG_FOUND)
-    pkg_check_modules(_AOM aom)
-endif (PKG_CONFIG_FOUND)
+if (AVIF_LOCAL_AOM)
+    find_path(AOM_INCLUDE_DIR
+              NAMES aom/aom.h
+              PATHS ${AVIF_LOCAL_AOM_INCLUDE_DIR}
+              NO_DEFAULT_PATH)
 
-find_path(AOM_INCLUDE_DIR
-          NAMES aom/aom.h
-          PATHS ${_AOM_INCLUDEDIR}
-)
+    find_library(AOM_LIBRARY
+                 NAMES aom
+                 PATHS ${AVIF_LOCAL_AOM_LIBRARY_DIR}
+                 NO_DEFAULT_PATH)
+else ()
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(_AOM aom)
+    endif (PKG_CONFIG_FOUND)
 
-find_library(AOM_LIBRARY
-             NAMES aom
-             PATHS ${_AOM_LIBDIR})
+    find_path(AOM_INCLUDE_DIR
+              NAMES aom/aom.h
+              PATHS ${_AOM_INCLUDEDIR})
+
+    find_library(AOM_LIBRARY
+                 NAMES aom
+                 PATHS ${_AOM_LIBDIR})
+endif ()
 
 set(AOM_LIBRARIES
     ${AOM_LIBRARIES}

--- a/cmake/Modules/Finddav1d.cmake
+++ b/cmake/Modules/Finddav1d.cmake
@@ -17,19 +17,42 @@
 #=============================================================================
 #
 
-find_package(PkgConfig QUIET)
-if (PKG_CONFIG_FOUND)
-    pkg_check_modules(_DAV1D dav1d)
-endif (PKG_CONFIG_FOUND)
+# meson always produce libdav1d.a even on MSVC, so ask cmake to also
+# search for it.
+set(PREV_CMAKE_FIND_LIBRARY_PREFIXES ${CMAKE_FIND_LIBRARY_PREFIXES})
+set(PREV_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+set(CMAKE_FIND_LIBRARY_PREFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} "lib")
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} ".a")
 
-find_path(DAV1D_INCLUDE_DIR
-          NAMES dav1d/dav1d.h
-          PATHS ${_DAV1D_INCLUDEDIR}
-)
+if (AVIF_LOCAL_DAV1D)
+    find_path(DAV1D_INCLUDE_DIR
+              NAMES dav1d/dav1d.h
+              PATHS ${AVIF_LOCAL_DAV1D_INCLUDE_DIR}
+              PATH_SUFFIXES ${CMAKE_C_LIBRARY_ARCHITECTURE}
+              NO_DEFAULT_PATH)
 
-find_library(DAV1D_LIBRARY
-             NAMES dav1d
-             PATHS ${_DAV1D_LIBDIR})
+    find_library(DAV1D_LIBRARY
+                 NAMES dav1d
+                 PATHS ${AVIF_LOCAL_DAV1D_LIBRARY_DIR}
+                 PATH_SUFFIXES ${CMAKE_C_LIBRARY_ARCHITECTURE}
+                 NO_DEFAULT_PATH)
+else ()
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(_DAV1D dav1d)
+    endif (PKG_CONFIG_FOUND)
+
+    find_path(DAV1D_INCLUDE_DIR
+              NAMES dav1d/dav1d.h
+              PATHS ${_DAV1D_INCLUDEDIR})
+
+    find_library(DAV1D_LIBRARY
+                 NAMES dav1d
+                 PATHS ${_DAV1D_LIBDIR})
+endif ()
+
+set(CMAKE_FIND_LIBRARY_PREFIXES ${PREV_CMAKE_FIND_LIBRARY_PREFIXES})
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${PREV_CMAKE_FIND_LIBRARY_SUFFIXES})
 
 if (DAV1D_LIBRARY)
     set(DAV1D_LIBRARIES

--- a/cmake/Modules/Findlibgav1.cmake
+++ b/cmake/Modules/Findlibgav1.cmake
@@ -17,19 +17,30 @@
 #=============================================================================
 #
 
-find_package(PkgConfig QUIET)
-if (PKG_CONFIG_FOUND)
-    pkg_check_modules(_LIBGAV1 libgav1)
-endif (PKG_CONFIG_FOUND)
+if (AVIF_LOCAL_LIBGAV1)
+    find_path(LIBGAV1_INCLUDE_DIR
+              NAMES gav1/decoder.h
+              PATHS ${AVIF_LOCAL_LIBGAV1_INCLUDE_DIR}
+              NO_DEFAULT_PATH)
 
-find_path(LIBGAV1_INCLUDE_DIR
-          NAMES gav1/decoder.h
-          PATHS ${_LIBGAV1_INCLUDEDIR}
-)
+    find_library(LIBGAV1_LIBRARY
+                 NAMES gav1
+                 PATHS ${AVIF_LOCAL_LIBGAV1_LIBRARY_DIR}
+                 NO_DEFAULT_PATH)
+else ()
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(_LIBGAV1 libgav1)
+    endif (PKG_CONFIG_FOUND)
 
-find_library(LIBGAV1_LIBRARY
-             NAMES gav1
-             PATHS ${_LIBGAV1_LIBDIR})
+    find_path(LIBGAV1_INCLUDE_DIR
+              NAMES gav1/decoder.h
+              PATHS ${_LIBGAV1_INCLUDEDIR})
+
+    find_library(LIBGAV1_LIBRARY
+                 NAMES gav1
+                 PATHS ${_LIBGAV1_LIBDIR})
+endif ()
 
 if (LIBGAV1_LIBRARY)
     set(LIBGAV1_LIBRARIES

--- a/cmake/Modules/Findlibyuv.cmake
+++ b/cmake/Modules/Findlibyuv.cmake
@@ -17,17 +17,30 @@
 #=============================================================================
 #
 
-find_package(PkgConfig QUIET)
-if (PKG_CONFIG_FOUND)
-    pkg_check_modules(_LIBYUV libyuv)
-endif (PKG_CONFIG_FOUND)
-
-if (NOT LIBYUV_INCLUDE_DIR)
+if (AVIF_LOCAL_LIBYUV)
     find_path(LIBYUV_INCLUDE_DIR
               NAMES libyuv.h
-              PATHS ${_LIBYUV_INCLUDEDIR}
-    )
-endif()
+              PATHS ${AVIF_LOCAL_LIBYUV_INCLUDE_DIR}
+              NO_DEFAULT_PATH)
+
+    find_library(LIBYUV_LIBRARY
+                 NAMES yuv
+                 PATHS ${AVIF_LOCAL_LIBYUV_LIBRARY_DIR}
+                 NO_DEFAULT_PATH)
+else ()
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(_LIBYUV libyuv)
+    endif (PKG_CONFIG_FOUND)
+
+    find_path(LIBYUV_INCLUDE_DIR
+              NAMES libyuv.h
+              PATHS ${_LIBYUV_INCLUDEDIR})
+
+    find_library(LIBYUV_LIBRARY
+                 NAMES yuv
+                 PATHS ${_LIBYUV_LIBDIR})
+endif ()
 
 if(LIBYUV_INCLUDE_DIR AND NOT LIBYUV_VERSION)
     set(LIBYUV_VERSION_H "${LIBYUV_INCLUDE_DIR}/libyuv/version.h")
@@ -41,12 +54,6 @@ if(LIBYUV_INCLUDE_DIR AND NOT LIBYUV_VERSION)
     if(NOT LIBYUV_VERSION)
         message(STATUS "libyuv version detection failed.")
     endif()
-endif()
-
-if (NOT LIBYUV_LIBRARY)
-    find_library(LIBYUV_LIBRARY
-                 NAMES yuv
-                 PATHS ${_LIBYUV_LIBDIR})
 endif()
 
 if (LIBYUV_LIBRARY)

--- a/cmake/Modules/Findrav1e.cmake
+++ b/cmake/Modules/Findrav1e.cmake
@@ -17,24 +17,30 @@
 #=============================================================================
 #
 
-find_package(PkgConfig QUIET)
-if (PKG_CONFIG_FOUND)
-    pkg_check_modules(_RAV1E rav1e)
-endif (PKG_CONFIG_FOUND)
+if (AVIF_LOCAL_RAV1E)
+    find_path(RAV1E_INCLUDE_DIR
+              NAMES rav1e.h
+              PATHS ${AVIF_LOCAL_RAV1E_INCLUDE_DIR}
+              NO_DEFAULT_PATH)
 
-if (NOT RAV1E_INCLUDE_DIR)
-find_path(RAV1E_INCLUDE_DIR
-          NAMES rav1e.h
-          PATHS ${_RAV1E_INCLUDEDIR}
-          PATH_SUFFIXES rav1e
-)
-endif()
+    find_library(RAV1E_LIBRARY
+                 NAMES rav1e
+                 PATHS ${AVIF_LOCAL_RAV1E_LIBRARY_DIR}
+                 NO_DEFAULT_PATH)
+else ()
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(_RAV1E rav1e)
+    endif (PKG_CONFIG_FOUND)
 
-if (NOT RAV1E_LIBRARY)
-find_library(RAV1E_LIBRARY
-             NAMES rav1e
-             PATHS ${_RAV1E_LIBDIR})
-endif()
+    find_path(RAV1E_INCLUDE_DIR
+              NAMES rav1e.h
+              PATHS ${_RAV1E_INCLUDEDIR})
+
+    find_library(RAV1E_LIBRARY
+                 NAMES rav1e
+                 PATHS ${_RAV1E_LIBDIR})
+endif ()
 
 set(RAV1E_LIBRARIES
     ${RAV1E_LIBRARIES}

--- a/cmake/Modules/Findsvt.cmake
+++ b/cmake/Modules/Findsvt.cmake
@@ -17,19 +17,30 @@
 #=============================================================================
 #
 
-find_package(PkgConfig QUIET)
-if (PKG_CONFIG_FOUND)
-    pkg_check_modules(_SVT SvtAv1Enc)
-endif (PKG_CONFIG_FOUND)
+if (AVIF_LOCAL_SVT)
+    find_path(SVT_INCLUDE_DIR
+              NAMES svt-av1/EbSvtAv1Enc.h
+              PATHS ${AVIF_LOCAL_SVT_INCLUDE_DIR}
+              NO_DEFAULT_PATH)
 
-find_path(SVT_INCLUDE_DIR
-          NAMES svt-av1/EbSvtAv1Enc.h
-          PATHS ${_SVT_INCLUDEDIR}
-)
+    find_library(SVT_LIBRARY
+                 NAMES SvtAv1Enc
+                 PATHS ${AVIF_LOCAL_SVT_LIBRARY_DIR}
+                 NO_DEFAULT_PATH)
+else ()
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(_SVT SvtAv1Enc)
+    endif (PKG_CONFIG_FOUND)
 
-find_library(SVT_LIBRARY
-             NAMES SvtAv1Enc
-             PATHS ${_SVT_LIBDIR})
+    find_path(SVT_INCLUDE_DIR
+              NAMES svt-av1/EbSvtAv1Enc.h
+              PATHS ${_SVT_INCLUDEDIR})
+
+    find_library(SVT_LIBRARY
+                 NAMES SvtAv1Enc
+                 PATHS ${_SVT_LIBDIR})
+endif ()
 
 if (SVT_LIBRARY)
     set(SVT_LIBRARIES

--- a/ext/dav1d.cmd
+++ b/ext/dav1d.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-# When updating the dav1d version, make the same change to dav1d_oss_fuzz.sh.
+: # When updating the dav1d version, make the same change to dav1d_oss_fuzz.sh.
 git clone -b 0.9.2 --depth 1 https://code.videolan.org/videolan/dav1d.git
 
 cd dav1d
@@ -18,6 +18,8 @@ cd build
 : # macOS might require: -Dc_args=-fno-stack-check
 : # Build with asan: -Db_sanitize=address
 : # Build with ubsan: -Db_sanitize=undefined
-meson --default-library=static --buildtype release ..
-ninja
+: # Tell MSYS2 don't mess with local prefix, no-op for other platforms
+: ; export MSYS2_ARG_CONV_EXCL="--prefix="
+meson --default-library=static --buildtype release --prefix=/usr ..
+meson install --destdir .
 cd ../..

--- a/ext/dav1d_oss_fuzz.sh
+++ b/ext/dav1d_oss_fuzz.sh
@@ -18,6 +18,6 @@ cd build
 : # macOS might require: -Dc_args=-fno-stack-check
 : # Build with asan: -Db_sanitize=address
 : # Build with ubsan: -Db_sanitize=undefined
-meson --default-library=static --buildtype release ..
-ninja
+meson --default-library=static --buildtype release --prefix=/usr ..
+meson install --destdir .
 cd ../..


### PR DESCRIPTION
I'm mainly developing on Windows and testing on multiple toolchains (MinGW (MINGW64), MinGW (CLANG64) and MSVC). Libraries built using one toolchain can't be used in another, but they all expect external libraries in `ext/`, which means only one toolchain is buildable at one time. This is quite inconvenient, so I'm making it configurable so that they can coexist.