### PR TITLE
Do not create AV1 codecs in avifDecoderParse()

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3342,11 +3342,6 @@ static avifCodec * avifCodecCreateInternal(avifCodecChoice choice)
     return avifCodecCreate(choice, AVIF_CODEC_FLAG_CAN_DECODE);
 }
 
-static void avifDecoderFlush(avifDecoder * decoder)
-{
-    avifDecoderDataResetCodec(decoder->data);
-}
-
 // If alpha is AVIF_FALSE, searches for the primary color item (parentItemID is ignored in this case).
 // If alpha is AVIF_TRUE, searches for the auxiliary alpha item whose parent item ID is parentItemID.
 // Returns the target item if found, or NULL.
@@ -3800,7 +3795,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         return AVIF_RESULT_BMFF_PARSE_FAILED;
     }
 
-    avifDecoderFlush(decoder);
     return AVIF_RESULT_OK;
 }
 
@@ -3812,9 +3806,7 @@ static avifResult avifDecoderPrepareTiles(avifDecoder * decoder, uint32_t nextIm
         // Ensure there's an AV1 codec available before doing anything else
         if (!tile->codec) {
             tile->codec = avifCodecCreateInternal(decoder->codecChoice);
-            if (!tile->codec) {
-                return AVIF_RESULT_NO_CODEC_AVAILABLE;
-            }
+            AVIF_CHECKERR(tile->codec, AVIF_RESULT_NO_CODEC_AVAILABLE);
             tile->codec->diag = &decoder->diag;
             tile->codec->operatingPoint = tile->operatingPoint;
             tile->codec->allLayers = tile->input->allLayers;
@@ -4110,14 +4102,18 @@ avifResult avifDecoderNthImage(avifDecoder * decoder, uint32_t frameIndex)
         }
         // The next image (decoder->imageIndex + 1) is partially decoded but
         // the previous image (decoder->imageIndex) is requested.
-        // Fall through to flush and start decoding from the nearest key frame.
+        // Fall through to resetting the decoder data and start decoding from
+        // the nearest key frame.
     }
 
     int nearestKeyFrame = (int)avifDecoderNearestKeyframe(decoder, frameIndex);
     if ((nearestKeyFrame > (decoder->imageIndex + 1)) || (requestedIndex <= decoder->imageIndex)) {
-        // If we get here, a decoder flush is necessary
+        // If we get here, we need to start decoding from the nearest key frame.
+        // So discard the unused decoder state and its previous frames. This
+        // will force the setup of a new decoder instance in
+        // avifDecoderNextImage().
         decoder->imageIndex = nearestKeyFrame - 1; // prepare to read nearest keyframe
-        avifDecoderFlush(decoder);
+        avifDecoderDataResetCodec(decoder->data);
     }
     for (;;) {
         avifResult result = avifDecoderNextImage(decoder);


### PR DESCRIPTION
The creation of AV1 codecs can be completely postponed to
avifDecoderNextImage().

This builds on top of https://github.com/AOMediaCodec/libavif/pull/794.