### PR TITLE
reformat: Support F16 Half Float conversion in avifRGBImage

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -562,6 +562,7 @@ typedef struct avifRGBImage
     avifBool ignoreAlpha;        // Used for XRGB formats, treats formats containing alpha (such as ARGB) as if they were
                                  // RGB, treating the alpha bits as if they were all 1.
     avifBool alphaPremultiplied; // indicates if RGB value is pre-multiplied by alpha. Default: false
+    avifBool isFloat;            // indicates if RGBA values are in half float (f16) format. Valid only when depth == 16. Default: false
 
     uint8_t * pixels;
     uint32_t rowBytes;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -149,6 +149,12 @@ typedef struct avifReformatState
 avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb);
 
 // Returns:
+// * AVIF_RESULT_OK               - Converted successfully with libyuv.
+// * AVIF_RESULT_NOT_IMPLEMENTED  - The fast path for this conversion is not implemented with libyuv, use built-in conversion.
+// * AVIF_RESULT_INVALID_ARGUMENT - Return error to caller.
+avifResult avifRGBImageToF16LibYUV(avifRGBImage * rgb);
+
+// Returns:
 // * AVIF_RESULT_OK              - (Un)Premultiply successfully with libyuv
 // * AVIF_RESULT_NOT_IMPLEMENTED - The fast path for this combination is not implemented with libyuv, use built-in (Un)Premultiply
 // * [any other error]           - Return error to caller

--- a/src/avif.c
+++ b/src/avif.c
@@ -378,6 +378,7 @@ void avifRGBImageSetDefaults(avifRGBImage * rgb, const avifImage * image)
     rgb->alphaPremultiplied = AVIF_FALSE; // Most expect RGBA output to *not* be premultiplied. Those that do can opt-in by
                                           // setting this to match image->alphaPremultiplied or forcing this to true
                                           // after calling avifRGBImageSetDefaults(),
+    rgb->isFloat = AVIF_FALSE;
 }
 
 void avifRGBImageAllocatePixels(avifRGBImage * rgb)

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -22,6 +22,11 @@ avifResult avifRGBImageUnpremultiplyAlphaLibYUV(avifRGBImage * rgb)
     (void)rgb;
     return AVIF_RESULT_NOT_IMPLEMENTED;
 }
+avifResult avifRGBImageToF16LibYUV(avifRGBImage * rgb)
+{
+    (void)rgb;
+    return AVIF_RESULT_NOT_IMPLEMENTED;
+}
 unsigned int avifLibYUVVersion(void)
 {
     return 0;
@@ -497,6 +502,19 @@ avifResult avifRGBImageUnpremultiplyAlphaLibYUV(avifRGBImage * rgb)
     }
 
     return AVIF_RESULT_NOT_IMPLEMENTED;
+}
+
+avifResult avifRGBImageToF16LibYUV(avifRGBImage * rgb)
+{
+    const float scale = 1.0f / ((1 << rgb->depth) - 1);
+    const int result = HalfFloatPlane((const uint16_t *)rgb->pixels,
+                                      rgb->rowBytes,
+                                      (uint16_t *)rgb->pixels,
+                                      rgb->rowBytes,
+                                      scale,
+                                      rgb->width * avifRGBFormatChannelCount(rgb->format),
+                                      rgb->height);
+    return (result == 0) ? AVIF_RESULT_OK : AVIF_RESULT_INVALID_ARGUMENT;
 }
 
 unsigned int avifLibYUVVersion(void)


### PR DESCRIPTION
Some platforms (Android for example [1]) support only the F16 Half
Float format for images with bits-per-pixel == 16. This PR adds
support for converting the RGBA pixels into half float format.

It does so by adding a setting variable to avifRGBImage and then
doing the conversion at the end of avifImageYUVToRGB. It also
invokes libyuv if available to do the conversion with SIMD
optimizations.

While there is potential to make this even faster (instead of
doing this conversion in the end, we could potentially do it while
we do the YUV -> RGB conversion), that is a much larger change and
the performance gain from that may or may not be worth the trade
off in complicating the code paths.

[1] https://developer.android.com/reference/android/graphics/Bitmap.Config#RGBA_F16