### PR TITLE
android_jni: Support RGBA_F16 Bitmaps

### DIFF
--- a/android_jni/avifandroidjni/src/main/java/org/aomedia/avif/android/AvifDecoder.java
+++ b/android_jni/avifandroidjni/src/main/java/org/aomedia/avif/android/AvifDecoder.java
@@ -20,10 +20,11 @@ public class AvifDecoder {
   // This is a utility class and cannot be instantiated.
   private AvifDecoder() {}
 
-  /** Contains information about the AVIF Image dimensions. */
+  /** Contains information about the AVIF Image. */
   public static class Info {
     public int width;
     public int height;
+    public int depth;
   }
 
   /**


### PR DESCRIPTION
libavif now supports conversion of RGBA pixels into F16 formats
for AVIF images with depths 10 and 12. Make use of that feature to
support RGBA_F16 bitmaps on the android JNI wrapper.

Note that apps can still pass an ARGB_8888 Bitmap for 10/12 bit
images and the wrapper will merely downscale them to 8 bits in that
case (existing behavior).