### PR TITLE
Do not ignore -Wunused-macros in src/codec_svt.c

### DIFF
--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -16,9 +16,6 @@
 #define SVT_AV1_VERSION_MAJOR SVT_VERSION_MAJOR
 #define SVT_AV1_VERSION_MINOR SVT_VERSION_MINOR
 #define SVT_AV1_VERSION_PATCHLEVEL SVT_VERSION_PATCHLEVEL
-#ifdef __GNUC__ // Delete this when we start using the SVT_AV1_CHECK_VERSION macro.
-#pragma GCC diagnostic ignored "-Wunused-macros"
-#endif
 // clang-format off
 #define SVT_AV1_CHECK_VERSION(major, minor, patch)                            \
     (SVT_AV1_VERSION_MAJOR > (major) ||                                       \


### PR DESCRIPTION
Remove the temporary GCC pragma that ignores -Wunused-macros in
src/codec_svt.c. It was needed only before
commit 74a21444397e323a088fa1f274c9fc942ee7a870.