### PR TITLE
Revert "Change  SVT_FULL_VERSION"

### DIFF
--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -4,8 +4,8 @@
 #include "avif/internal.h"
 
 #include "svt-av1/EbSvtAv1.h"
+
 #include "svt-av1/EbSvtAv1Enc.h"
-#include "svt-av1/EbVersion.h"
 
 #include <string.h>
 
@@ -24,6 +24,10 @@
       SVT_AV1_VERSION_PATCHLEVEL >= (patch)))
 // clang-format on
 #endif
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+#define SVT_FULL_VERSION STR(SVT_AV1_VERSION_MAJOR) "." STR(SVT_AV1_VERSION_MINOR) "." STR(SVT_AV1_VERSION_PATCHLEVEL)
 
 typedef struct avifCodecInternal
 {
@@ -215,7 +219,7 @@ static avifBool svtCodecEncodeFinish(avifCodec * codec, avifCodecEncodeOutput * 
 
 const char * avifCodecVersionSvt(void)
 {
-    return SVT_AV1_CVS_VERSION;
+    return SVT_FULL_VERSION;
 }
 
 static void svtCodecDestroyInternal(avifCodec * codec)


### PR DESCRIPTION
This reverts commit 1404989dae48e7d3cc174ee60a1ac064d52ac6a2.

The commit broke compilation of src/codec_svt.c:

  libavif/src/codec_svt.c:8:10: fatal error: 'svt-av1/EbVersion.h' file not found
  #include "svt-av1/EbVersion.h"
           ^~~~~~~~~~~~~~~~~~~~~