### PR TITLE
Increment lastItemID first when creating an item

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -151,6 +151,7 @@ error:
 static avifEncoderItem * avifEncoderDataCreateItem(avifEncoderData * data, const char * type, const char * infeName, size_t infeNameSize, uint32_t cellIndex)
 {
     avifEncoderItem * item = (avifEncoderItem *)avifArrayPushPtr(&data->items);
+    ++data->lastItemID;
     item->id = data->lastItemID;
     memcpy(item->type, type, sizeof(item->type));
     item->infeName = infeName;
@@ -160,11 +161,11 @@ static avifEncoderItem * avifEncoderDataCreateItem(avifEncoderData * data, const
     if (!avifArrayCreate(&item->mdatFixups, sizeof(avifOffsetFixup), 4)) {
         goto error;
     }
-    ++data->lastItemID;
     return item;
 
 error:
     avifCodecEncodeOutputDestroy(item->encodeOutput);
+    --data->lastItemID;
     avifArrayPop(&data->items);
     return NULL;
 }


### PR DESCRIPTION
Fix a bug introduced in commit f732a4d240d1562151685b71e822d0ba3a352ad9.

In avifEncoderDataCreateItem(), increment data->lastItemID before
setting item->id equal to data->lastItemID. This is what the original
code did.

Bug: https://github.com/AOMediaCodec/libavif/issues/820