### PR TITLE
avifArrayPop() should zero the popped element

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -3,6 +3,7 @@
 
 #include "avif/internal.h"
 
+#include <assert.h>
 #include <math.h>
 #include <string.h>
 
@@ -128,6 +129,7 @@ void avifArrayPush(void * arrayStruct, void * element)
 void avifArrayPop(void * arrayStruct)
 {
     avifArrayInternal * arr = (avifArrayInternal *)arrayStruct;
+    assert(arr->count > 0);
     --arr->count;
     memset(&arr->ptr[arr->count * (size_t)arr->elementSize], 0, arr->elementSize);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -115,7 +115,7 @@ void * avifArrayPushPtr(void * arrayStruct)
 {
     uint32_t index = avifArrayPushIndex(arrayStruct);
     avifArrayInternal * arr = (avifArrayInternal *)arrayStruct;
-    return &arr->ptr[index * arr->elementSize];
+    return &arr->ptr[index * (size_t)arr->elementSize];
 }
 
 void avifArrayPush(void * arrayStruct, void * element)
@@ -129,6 +129,7 @@ void avifArrayPop(void * arrayStruct)
 {
     avifArrayInternal * arr = (avifArrayInternal *)arrayStruct;
     --arr->count;
+    memset(&arr->ptr[arr->count * (size_t)arr->elementSize], 0, arr->elementSize);
 }
 
 void avifArrayDestroy(void * arrayStruct)


### PR DESCRIPTION
avifArrayPop() should zero the memor of the popped element. If we ever
push an element to the array, the memory of the new element will be all
zeros.

Also make sure we cast arr->elementSize to size_t when we multiply it by
another uint32_t variable.