### PR TITLE
avifDecoderReset() should not return AVIF_FALSE

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3444,7 +3444,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                                                          decoder->imageCountLimit,
                                                          decoder->io->sizeHint,
                                                          &decoder->diag)) {
-                return AVIF_FALSE;
+                return AVIF_RESULT_BMFF_PARSE_FAILED;
             }
             data->colorTileCount = 1;
 
@@ -3483,7 +3483,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                                                              decoder->imageCountLimit,
                                                              decoder->io->sizeHint,
                                                              &decoder->diag)) {
-                    return AVIF_FALSE;
+                    return AVIF_RESULT_BMFF_PARSE_FAILED;
                 }
                 alphaTile->input->alpha = AVIF_TRUE;
                 data->alphaTileCount = 1;


### PR DESCRIPTION
The return type of avifDecoderReset() is avifResult, so it should not
return AVIF_FALSE on failure, because AVIF_FALSE has the same value (0)
as AVIF_RESULT_OK.