### PR TITLE
Fix endian dependent parameters to avifRWStreamWrite

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -1180,7 +1180,19 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     // Write tracks (if an image sequence)
 
     if (encoder->data->frames.count > 1) {
-        static const uint32_t unityMatrix[9] = { 0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000 };
+        static const uint8_t unityMatrix[9][4] = {
+            /* clang-format off */
+            { 0x00, 0x01, 0x00, 0x00 },
+            { 0 },
+            { 0 },
+            { 0 },
+            { 0x00, 0x01, 0x00, 0x00 },
+            { 0 },
+            { 0 },
+            { 0 },
+            { 0x40, 0x00, 0x00, 0x00 }
+            /* clang-format on */
+        };
 
         uint64_t durationInTimescales = 0;
         for (uint32_t frameIndex = 0; frameIndex < encoder->data->frames.count; ++frameIndex) {


### PR DESCRIPTION
The ISOBMFF and MIAF spec expects the values in big endian order.

When avifRWStreamWrite is called with uint32_t pointers on little
endian machines, we will end up writing incorrect values since the bytes
in uint32_t will be stored in little endian order in those machines.

For example, without this patch the "unityMatrix" field triggers the
following errors in ComplainceWarden (we end up writing 0x00004000
instead of 0x40000000):

[miaf][Rule #14] Error: Matrix field of the TrackHeaderBox: "a" value (100) shall b
e 0x00010000 or 0xFFFF0000
[miaf][Rule #14] Error: Matrix field of the TrackHeaderBox: "d" value (0) shall be
0x00010000 or 0xFFFF0000 ("b" is 0)
[miaf][Rule #14] Error: Matrix field of the TrackHeaderBox: "w" value (40) shall be 0x40000000

With this patch, these errors no longer appear.

The fix is to convert the uint32_t array into a uint8_t array and use
the correct big endian byte order for the values.

I have audited all the other calls to avifRWStreamWrite and this is
the only place where we use endian dependent parameters. In all the
other calls, we use a uint8_t pointer where there is no endian
depdendency.