### PR TITLE
Fix signed/unsigned mismatch and loss-of-data conversion warnings for CL in new avif tests

### DIFF
--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -360,12 +360,13 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
         avifImageAllocatePlanes(avif, AVIF_PLANES_A);
     }
 
-    avifPixelFormatInfo info;
-    avifGetPixelFormatInfo(avif->yuvFormat, &info);
+    avifPixelFormatInfo formatInfo;
+    avifGetPixelFormatInfo(avif->yuvFormat, &formatInfo);
 
-    for (int plane = 0; plane < (info.monochrome ? 1 : AVIF_PLANE_COUNT_YUV); ++plane) {
-        uint32_t planeWidth = (plane > 0) ? ((avif->width + info.chromaShiftX) >> info.chromaShiftX) : avif->width;
-        uint32_t planeHeight = (plane > 0) ? ((avif->height + info.chromaShiftY) >> info.chromaShiftY) : avif->height;
+    const int planeCount = formatInfo.monochrome ? 1 : AVIF_PLANE_COUNT_YUV;
+    for (int plane = 0; plane < planeCount; ++plane) {
+        uint32_t planeWidth = (plane > 0) ? ((avif->width + formatInfo.chromaShiftX) >> formatInfo.chromaShiftX) : avif->width;
+        uint32_t planeHeight = (plane > 0) ? ((avif->height + formatInfo.chromaShiftY) >> formatInfo.chromaShiftY) : avif->height;
         uint32_t rowBytes = planeWidth << (avif->depth > 8);
         uint8_t * row = avif->yuvPlanes[plane];
         for (uint32_t y = 0; y < planeHeight; ++y) {
@@ -512,8 +513,8 @@ avifBool y4mWrite(const char * outputFilename, const avifImage * avif)
         rangeString = "XCOLORRANGE=LIMITED";
     }
 
-    avifPixelFormatInfo info;
-    avifGetPixelFormatInfo(avif->yuvFormat, &info);
+    avifPixelFormatInfo formatInfo;
+    avifGetPixelFormatInfo(avif->yuvFormat, &formatInfo);
 
     FILE * f = fopen(outputFilename, "wb");
     if (!f) {
@@ -528,9 +529,10 @@ avifBool y4mWrite(const char * outputFilename, const avifImage * avif)
         goto cleanup;
     }
 
-    for (int plane = 0; plane < (info.monochrome ? 1 : AVIF_PLANE_COUNT_YUV); ++plane) {
-        uint32_t planeWidth = (plane > 0) ? ((avif->width + info.chromaShiftX) >> info.chromaShiftX) : avif->width;
-        uint32_t planeHeight = (plane > 0) ? ((avif->height + info.chromaShiftY) >> info.chromaShiftY) : avif->height;
+    const int planeCount = formatInfo.monochrome ? 1 : AVIF_PLANE_COUNT_YUV;
+    for (int plane = 0; plane < planeCount; ++plane) {
+        uint32_t planeWidth = (plane > 0) ? ((avif->width + formatInfo.chromaShiftX) >> formatInfo.chromaShiftX) : avif->width;
+        uint32_t planeHeight = (plane > 0) ? ((avif->height + formatInfo.chromaShiftY) >> formatInfo.chromaShiftY) : avif->height;
         uint32_t rowBytes = planeWidth << (avif->depth > 8);
         const uint8_t * row = avif->yuvPlanes[plane];
         for (uint32_t y = 0; y < planeHeight; ++y) {

--- a/tests/avifgridapitest.c
+++ b/tests/avifgridapitest.c
@@ -29,7 +29,8 @@ static avifBool createImage(int width, int height, int depth, avifPixelFormat yu
     uint32_t uvWidth = ((*image)->width + formatInfo.chromaShiftX) >> formatInfo.chromaShiftX;
     uint32_t uvHeight = ((*image)->height + formatInfo.chromaShiftY) >> formatInfo.chromaShiftY;
 
-    for (uint32_t plane = 0; plane < (formatInfo.monochrome ? 1 : AVIF_PLANE_COUNT_YUV); ++plane) {
+    const int planeCount = formatInfo.monochrome ? 1 : AVIF_PLANE_COUNT_YUV;
+    for (int plane = 0; plane < planeCount; ++plane) {
         const uint32_t widthByteCount = ((plane == AVIF_CHAN_Y) ? (*image)->width : uvWidth) * (((*image)->depth > 8) ? 2 : 1);
         const uint32_t planeHeight = (plane == AVIF_CHAN_Y) ? (*image)->height : uvHeight;
         uint8_t * row = (*image)->yuvPlanes[plane];
@@ -147,10 +148,11 @@ static avifBool encodeDecodeSizes(const int columnsCellWidths[][2],
     for (int i = 0; i < horizontalCombinationCount; ++i) {
         for (int j = 0; j < verticalCombinationCount; ++j) {
             if (!encodeDecode(/*columns=*/columnsCellWidths[i][0],
-                             /*rows=*/rowsCellHeights[j][0],
-                             /*cellWidth=*/columnsCellWidths[i][1],
-                             /*cellHeight=*/rowsCellHeights[j][1],
-                             yuvFormat, expected_success)) {
+                              /*rows=*/rowsCellHeights[j][0],
+                              /*cellWidth=*/columnsCellWidths[i][1],
+                              /*cellHeight=*/rowsCellHeights[j][1],
+                              yuvFormat,
+                              expected_success)) {
                 return AVIF_FALSE;
             }
         }


### PR DESCRIPTION
MS' CL emits signed/unsigned comparison warnings and `uint32_t` -> `uint16_t` conversion warnings in these places. This should fix them.

Nit: We don't really have any explicit code style conventions for libavif, but ternarys in a for loop conditional hurts readability a bit, and I'd prefer in the future if those were simply a const value on the previous line with a good self-documenting name.