### PR TITLE
Fix FillImageGrid() yuvFormat assertion for alpha

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -187,7 +187,7 @@ AVIF_API void avifRWDataFree(avifRWData * raw);
 
 typedef enum avifPixelFormat
 {
-    // No pixels are present
+    // No YUV pixels are present. Alpha plane can still be present.
     AVIF_PIXEL_FORMAT_NONE = 0,
 
     AVIF_PIXEL_FORMAT_YUV444,

--- a/src/read.c
+++ b/src/read.c
@@ -1316,7 +1316,8 @@ static avifBool avifDecoderDataFillImageGrid(avifDecoderData * data,
     }
 
     if (alpha) {
-        assert(firstTile->image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400);
+        // An alpha tile does not contain any YUV pixel.
+        assert(firstTile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE);
     }
     if (!avifAreGridDimensionsValid(firstTile->image->yuvFormat,
                                     grid->outputWidth,

--- a/src/read.c
+++ b/src/read.c
@@ -1316,7 +1316,7 @@ static avifBool avifDecoderDataFillImageGrid(avifDecoderData * data,
     }
 
     if (alpha) {
-        // An alpha tile does not contain any YUV pixel.
+        // An alpha tile does not contain any YUV pixels.
         assert(firstTile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE);
     }
     if (!avifAreGridDimensionsValid(firstTile->image->yuvFormat,


### PR DESCRIPTION
Also fix AVIF_PIXEL_FORMAT_NONE comment.
Also adapt avifgridapitest to cover this use case and >8 bit depths.

An avifImage with NONE as yuvFormat means there is no YUV pixel, but
alpha samples can still be present, which is the way tiles are
decoded. See how yuvFormat is left to NONE for alpha images in
aomCodecGetNextImage() and other codec implementations.