### PR TITLE
Add iso8 to compatible_brands for animated images

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -915,6 +915,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     if (encoder->data->frames.count > 1) {                                 //
         avifRWStreamWriteChars(&s, "avis", 4);                             // ... compatible_brands[]
         avifRWStreamWriteChars(&s, "msf1", 4);                             // ... compatible_brands[]
+        avifRWStreamWriteChars(&s, "iso8", 4);                             // ... compatible_brands[]
     }                                                                      //
     avifRWStreamWriteChars(&s, "mif1", 4);                                 // ... compatible_brands[]
     avifRWStreamWriteChars(&s, "miaf", 4);                                 // ... compatible_brands[]


### PR DESCRIPTION
Section 10.3.1.1. of the HEIF spec:
It is required that 'iso8' is present among the compatible brands array.

Fixes the Compliance Warden error:
[heif][Rule #31] Error: 'msf1' brand: 'iso8' shall be present among the compatible brands array