### PR TITLE
Write ccst box in Sample Entry for animated images

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -1383,6 +1383,15 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             if (!item->alpha) {
                 avifEncoderWriteColorProperties(&s, imageMetadata, NULL, NULL);
             }
+
+            avifBoxMarker ccst = avifRWStreamWriteFullBox(&s, "ccst", AVIF_BOX_SIZE_TBD, 0, 0);
+            const uint8_t ccstValue = (0 << 7) | // unsigned int(1) all_ref_pics_intra;
+                                      (1 << 6) | // unsigned int(1) intra_pred_used;
+                                      (15 << 2); // unsigned int(4) max_ref_per_pic;
+            avifRWStreamWriteU8(&s, ccstValue);
+            avifRWStreamWriteZeros(&s, 3); // unsigned int(26) reserved; (two zero bits are written along with ccstValue).
+            avifRWStreamFinishBox(&s, ccst);
+
             avifRWStreamFinishBox(&s, av01);
             avifRWStreamFinishBox(&s, stsd);
 


### PR DESCRIPTION
Section 7.2.3 of the HEIF spec:
The CodingConstraintsBox shall be present in the sample description
entry for tracks with handler_type equal to 'pict'.

The values of the fields are chosen to be permissive rather than
figuring out the exact values by inspecting the bitstream which can be
too cumbersome. The values are as follows:
all_ref_pics_intra - 0 - all samples can use any type of reference.
intra_pred_used - 1 - intra prediction may or may not be used.
max_ref_per_pic - 15 - reserved value to indicate that any number of
                       reference images can be used.

Fixes the following Compliance Warden error:
[heif][Rule #12] Error: CodingConstraintsBox ('ccst') shall be present
once