### PR TITLE
ext: Checkout libaom v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+* Update aom.cmd: v3.3.0
+
 ## [0.9.3] - 2021-10-20
 
 ### Added

--- a/ext/aom.cmd
+++ b/ext/aom.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b v3.2.0 --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v3.3.0 --depth 1 https://aomedia.googlesource.com/aom
 
 cd aom
 mkdir build.libavif

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -34,7 +34,7 @@ nasm --version
 
 # aom
 cd
-git clone -b v3.2.0 --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v3.3.0 --depth 1 https://aomedia.googlesource.com/aom
 cd aom
 mkdir build.avif
 cd build.avif


### PR DESCRIPTION
Updates the libaom version checked out in the ext and docker scripts
from v3.2.0 to v3.3.0.