### PR TITLE
Compare with snapshot of AOM_EXT_PART_ABI_VERSION

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -43,10 +43,8 @@
 #endif
 
 // Speeds 7-9 were added to all intra mode in https://aomedia-review.googlesource.com/c/aom/+/140624.
-#if defined(AOM_EXT_PART_ABI_VERSION)
-#if AOM_ENCODER_ABI_VERSION >= (10 + AOM_CODEC_ABI_VERSION + AOM_EXT_PART_ABI_VERSION)
+#if AOM_ENCODER_ABI_VERSION >= (10 + AOM_CODEC_ABI_VERSION + /*AOM_EXT_PART_ABI_VERSION=*/1)
 #define ALL_INTRA_HAS_SPEEDS_7_TO_9 1
-#endif
 #endif
 #endif
 


### PR DESCRIPTION
In libaom v3.3.0, the AOM_EXT_PART_ABI_VERSION component of
AOM_ENCODER_ABI_VERSION was replaced by an old snapshot of 3. In our
feature detection test for speeds 7-9 in all intra mode, replace
AOM_EXT_PART_ABI_VERSION with a snapshot (1) when those speeds were
added.