### PR TITLE
Fix avifpng.c for libpng 1.4

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -12,9 +12,9 @@
 
 // See libpng-manual.txt, section XI.
 #if PNG_LIBPNG_VER_MAJOR > 1 || (PNG_LIBPNG_VER_MAJOR == 1 && PNG_LIBPNG_VER_MINOR >= 5)
-typedef png_bytep avifIccpDataP;
+typedef png_bytep png_iccp_datap;
 #else
-typedef png_charp avifIccpDataP;
+typedef png_charp png_iccp_datap;
 #endif
 
 // Note on setjmp() and volatile variables:
@@ -82,7 +82,7 @@ avifBool avifPNGRead(const char * inputFilename, avifImage * avif, avifPixelForm
     int iccpCompression = 0;
     unsigned char * iccpData = NULL;
     png_uint_32 iccpDataLen = 0;
-    if (png_get_iCCP(png, info, &iccpProfileName, &iccpCompression, (avifIccpDataP *)&iccpData, &iccpDataLen) == PNG_INFO_iCCP) {
+    if (png_get_iCCP(png, info, &iccpProfileName, &iccpCompression, (png_iccp_datap *)&iccpData, &iccpDataLen) == PNG_INFO_iCCP) {
         avifImageSetProfileICC(avif, iccpData, iccpDataLen);
     }
 
@@ -233,7 +233,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
 
     png_set_IHDR(png, info, avif->width, avif->height, rgb.depth, PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
     if (avif->icc.data && (avif->icc.size > 0)) {
-        png_set_iCCP(png, info, "libavif", 0, (avifIccpDataP)avif->icc.data, (png_uint_32)avif->icc.size);
+        png_set_iCCP(png, info, "libavif", 0, (png_iccp_datap)avif->icc.data, (png_uint_32)avif->icc.size);
     }
     png_write_info(png, info);
 

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -10,6 +10,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+// See libpng-manual.txt, section XI.
+#if PNG_LIBPNG_VER_MAJOR > 1 || (PNG_LIBPNG_VER_MAJOR == 1 && PNG_LIBPNG_VER_MINOR >= 5)
+#define png_iccp_datap png_bytep
+#else
+#define png_iccp_datap png_charp
+#endif
+
 // Note on setjmp() and volatile variables:
 //
 // K & R, The C Programming Language 2nd Ed, p. 254 says:
@@ -75,7 +82,7 @@ avifBool avifPNGRead(const char * inputFilename, avifImage * avif, avifPixelForm
     int iccpCompression = 0;
     unsigned char * iccpData = NULL;
     png_uint_32 iccpDataLen = 0;
-    if (png_get_iCCP(png, info, &iccpProfileName, &iccpCompression, &iccpData, &iccpDataLen) == PNG_INFO_iCCP) {
+    if (png_get_iCCP(png, info, &iccpProfileName, &iccpCompression, (png_iccp_datap *)&iccpData, &iccpDataLen) == PNG_INFO_iCCP) {
         avifImageSetProfileICC(avif, iccpData, iccpDataLen);
     }
 
@@ -216,7 +223,9 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
 
     // Don't bother complaining about ICC profile's contents when transferring from AVIF to PNG.
     // It is up to the enduser to decide if they want to keep their ICC profiles or not.
-    png_set_option(png, PNG_SKIP_sRGB_CHECK_PROFILE, 1);
+#if defined(PNG_SKIP_sRGB_CHECK_PROFILE) && defined(PNG_SET_OPTION_SUPPORTED) // See libpng-manual.txt, section XII.
+    png_set_option(png, PNG_SKIP_sRGB_CHECK_PROFILE, PNG_OPTION_ON);
+#endif
 
     if (compressionLevel >= 0) {
         png_set_compression_level(png, compressionLevel);
@@ -224,7 +233,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
 
     png_set_IHDR(png, info, avif->width, avif->height, rgb.depth, PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
     if (avif->icc.data && (avif->icc.size > 0)) {
-        png_set_iCCP(png, info, "libavif", 0, avif->icc.data, (png_uint_32)avif->icc.size);
+        png_set_iCCP(png, info, "libavif", 0, (png_iccp_datap)avif->icc.data, (png_uint_32)avif->icc.size);
     }
     png_write_info(png, info);
 

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -12,9 +12,9 @@
 
 // See libpng-manual.txt, section XI.
 #if PNG_LIBPNG_VER_MAJOR > 1 || (PNG_LIBPNG_VER_MAJOR == 1 && PNG_LIBPNG_VER_MINOR >= 5)
-#define png_iccp_datap png_bytep
+typedef png_bytep avifIccpDataP;
 #else
-#define png_iccp_datap png_charp
+typedef png_charp avifIccpDataP;
 #endif
 
 // Note on setjmp() and volatile variables:
@@ -82,7 +82,7 @@ avifBool avifPNGRead(const char * inputFilename, avifImage * avif, avifPixelForm
     int iccpCompression = 0;
     unsigned char * iccpData = NULL;
     png_uint_32 iccpDataLen = 0;
-    if (png_get_iCCP(png, info, &iccpProfileName, &iccpCompression, (png_iccp_datap *)&iccpData, &iccpDataLen) == PNG_INFO_iCCP) {
+    if (png_get_iCCP(png, info, &iccpProfileName, &iccpCompression, (avifIccpDataP *)&iccpData, &iccpDataLen) == PNG_INFO_iCCP) {
         avifImageSetProfileICC(avif, iccpData, iccpDataLen);
     }
 
@@ -233,7 +233,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
 
     png_set_IHDR(png, info, avif->width, avif->height, rgb.depth, PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
     if (avif->icc.data && (avif->icc.size > 0)) {
-        png_set_iCCP(png, info, "libavif", 0, (png_iccp_datap)avif->icc.data, (png_uint_32)avif->icc.size);
+        png_set_iCCP(png, info, "libavif", 0, (avifIccpDataP)avif->icc.data, (png_uint_32)avif->icc.size);
     }
     png_write_info(png, info);
 


### PR DESCRIPTION
The current default macOS CI version of libpng is 1.4; Ubuntu is 1.6.
`apps/shared/avifpng.c` is not built on the current macOS CI setup but will be in #865.
See log at https://github.com/y-guyon/libavif/runs/5393667489?check_suite_focus=true