### PR TITLE
Remove extra comma warning in avif.h

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -764,7 +764,7 @@ typedef enum avifDecoderSource
 
     // Use the chunks inside primary/aux tracks in the moov block.
     // This is where avifs image sequences store their images.
-    AVIF_DECODER_SOURCE_TRACKS,
+    AVIF_DECODER_SOURCE_TRACKS
 
     // Decode the thumbnail item. Currently unimplemented.
     // AVIF_DECODER_SOURCE_THUMBNAIL_ITEM


### PR DESCRIPTION
It is triggered by -Wc++98-compat-pedantic when compiling a C++ target
including include/avif/avif.h with -Weverything set for Clang.