### PR TITLE
Utilize bilinear chroma upsample in libyuv when possible

### DIFF
--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -10,7 +10,7 @@
 git clone --single-branch https://chromium.googlesource.com/libyuv/libyuv
 
 cd libyuv
-git checkout 2f0cbb9
+git checkout 3aebf69
 
 mkdir build
 cd build

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -37,8 +37,10 @@ unsigned int avifLibYUVVersion(void)
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes" // "this function declaration is not a prototype"
-// The newline at the end of libyuv/version.h was accidentally deleted in version 1792:
+// The newline at the end of libyuv/version.h was accidentally deleted in version 1792 and restored
+// in version 1813:
 // https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3183182
+// https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3527834
 #pragma clang diagnostic ignored "-Wnewline-eof" // "no newline at end of file"
 #endif
 #include <libyuv.h>

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -57,8 +57,9 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
     }
 
     if ((rgb->chromaUpsampling != AVIF_CHROMA_UPSAMPLING_AUTOMATIC) && (rgb->chromaUpsampling != AVIF_CHROMA_UPSAMPLING_FASTEST)) {
-        // We do not ensure specific filter is used when calling libyuv, so if the end user chose a specific one, avoid using it.
-        // Also libyuv trade a bit of accuracy for speed, so if the end user requested best quality, avoid using it as well.
+        // We do not ensure a specific upsampling filter is used when calling libyuv, so if the end
+        // user chose a specific one, avoid using libyuv. Also libyuv trades a bit of accuracy for
+        // speed, so if the end user requested best quality, avoid using libyuv as well.
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
 

--- a/src/scale.c
+++ b/src/scale.c
@@ -22,6 +22,7 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes" // "this function declaration is not a prototype"
+#pragma clang diagnostic ignored "-Wnewline-eof" // "no newline at end of file"
 #endif
 #include <libyuv.h>
 #if defined(__clang__)

--- a/src/scale.c
+++ b/src/scale.c
@@ -22,6 +22,10 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes" // "this function declaration is not a prototype"
+// The newline at the end of libyuv/version.h was accidentally deleted in version 1792 and restored
+// in version 1813:
+// https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3183182
+// https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3527834
 #pragma clang diagnostic ignored "-Wnewline-eof" // "no newline at end of file"
 #endif
 #include <libyuv.h>


### PR DESCRIPTION
libyuv recently introduced the `I420ToARGBMatrixFilter` series functions with an extra `filter` parameter to select chroma upsampling behavior: nearest or bilinear. This PR utilize this ability when user requested bilinear upsampling.