### PR TITLE
Fix -Wformat / -Wformat-non-iso on MinGW UCRT

### DIFF
--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -6,14 +6,18 @@
 
 #include "avif/avif.h"
 
-// The %z format specifier is not available with Visual Studios before 2013 and mingw-w64 toolchains
-// with `__USE_MINGW_ANSI_STDIO` not set to 1. Hence the %I format specifier must be used instead
-// to print out `size_t`. Newer Visual Studios and mingw-w64 toolchains built with the commit
-// mentioned with c99 set as the standard supports the %z specifier properly.
+// The %z format specifier is not available in the old Windows CRT msvcrt,
+// Hence the %I format specifier must be used instead to print out `size_t`.
+// The new Windows CRT UCRT, which is used by Visual Studio from 2015, supports
+// the %z specifier properly.
+// Additionally, with c99 set as the standard mingw-w64 toolchains built with
+// the commit mentioned can patch format functions to support the %z specifier,
+// even it's using the old msvcrt, and this can be detected by
+// the `__USE_MINGW_ANSI_STDIO` macro.
 //
 // Related mingw-w64 commit: bfd33f6c0ec5e652cc9911857dd1492ece8d8383
 
-#if (defined(_MSVC) && _MSVC < 1800) || (defined(__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO == 0)
+#if !defined(_UCRT) && (defined(__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO == 0)
 #define AVIF_FMT_ZU "%Iu"
 #else
 #define AVIF_FMT_ZU "%zu"

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -7,12 +7,13 @@
 #include "avif/avif.h"
 
 // The %z format specifier is not available in the old Windows CRT msvcrt,
-// Hence the %I format specifier must be used instead to print out `size_t`.
-// The new Windows CRT UCRT, which is used by Visual Studio from 2015, supports
-// the %z specifier properly.
+// hence the %I format specifier must be used instead to print out `size_t`.
+// The new Windows CRT UCRT, which is used by Visual Studio 2015 or later,
+// supports the %z specifier properly.
+//
 // Additionally, with c99 set as the standard mingw-w64 toolchains built with
 // the commit mentioned can patch format functions to support the %z specifier,
-// even it's using the old msvcrt, and this can be detected by
+// even if it's using the old msvcrt, and this can be detected by
 // the `__USE_MINGW_ANSI_STDIO` macro.
 //
 // Related mingw-w64 commit: bfd33f6c0ec5e652cc9911857dd1492ece8d8383


### PR DESCRIPTION
MinGW can be configured to use UCRT, which is the new C runtime library for Windows. I'm moving my MinGW dev environment to the UCRT variant.

UCRT supports `"%zu"` properly so MinGW didn't patch`*printf` functions and set `__USE_MINGW_ANSI_STDIO` to 1. This makes `AVIF_FMT_ZU` defined to `"%Iu"`, and triggers warning from GCC and Clang.

Detect UCRT by check `_UCRT` macro, which MSSVC and MinGW both defines, and use `"%zu"` when using UCRT.