### PR TITLE
Replace some memcpy calls with struct assignments

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -835,7 +835,7 @@ int main(int argc, char * argv[])
     if ((outputTiming.duration == 0) && (outputTiming.timescale == 0) && (firstSourceTiming.duration > 0) &&
         (firstSourceTiming.timescale > 0)) {
         // Set the default duration and timescale to the first image's timing.
-        memcpy(&outputTiming, &firstSourceTiming, sizeof(avifAppSourceTiming));
+        outputTiming = firstSourceTiming;
     } else {
         // Set output timing defaults to 30 fps
         if (outputTiming.duration == 0) {

--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -230,7 +230,7 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
 
     if (iter && *iter) {
         // Continue reading FRAMEs from this y4m stream
-        memcpy(&frame, *iter, sizeof(struct y4mFrameIterator));
+        frame = **iter;
     } else {
         // Open a fresh y4m and read its header
 
@@ -345,7 +345,7 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
     }
 
     if (sourceTiming) {
-        memcpy(sourceTiming, &frame.sourceTiming, sizeof(avifAppSourceTiming));
+        *sourceTiming = frame.sourceTiming;
     }
 
     avifImageFreePlanes(avif, AVIF_PLANES_YUV | AVIF_PLANES_A);
@@ -413,7 +413,7 @@ cleanup:
             if (!feof(frame.inputFile)) {
                 // Remember y4m state for next time
                 *iter = malloc(sizeof(struct y4mFrameIterator));
-                memcpy(*iter, &frame, sizeof(struct y4mFrameIterator));
+                **iter = frame;
             }
         }
     }

--- a/src/avif.c
+++ b/src/avif.c
@@ -160,10 +160,10 @@ void avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifPlanesF
     dstImage->matrixCoefficients = srcImage->matrixCoefficients;
 
     dstImage->transformFlags = srcImage->transformFlags;
-    memcpy(&dstImage->pasp, &srcImage->pasp, sizeof(dstImage->pasp));
-    memcpy(&dstImage->clap, &srcImage->clap, sizeof(dstImage->clap));
-    memcpy(&dstImage->irot, &srcImage->irot, sizeof(dstImage->irot));
-    memcpy(&dstImage->imir, &srcImage->imir, sizeof(dstImage->imir));
+    dstImage->pasp = srcImage->pasp;
+    dstImage->clap = srcImage->clap;
+    dstImage->irot = srcImage->irot;
+    dstImage->imir = srcImage->imir;
 
     avifImageSetProfileICC(dstImage, srcImage->icc.data, srcImage->icc.size);
 

--- a/src/write.c
+++ b/src/write.c
@@ -880,7 +880,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             const avifEncodeSample * firstSample = &item->encodeOutput->samples.sample[0];
             avifSequenceHeader sequenceHeader;
             if (avifSequenceHeaderParse(&sequenceHeader, (const avifROData *)&firstSample->data)) {
-                memcpy(&item->av1C, &sequenceHeader.av1C, sizeof(avifCodecConfigurationBox));
+                item->av1C = sequenceHeader.av1C;
             } else {
                 // This must be an invalid AV1 payload
                 return item->alpha ? AVIF_RESULT_ENCODE_ALPHA_FAILED : AVIF_RESULT_ENCODE_COLOR_FAILED;
@@ -1085,7 +1085,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
                 avifEncoderItem * dedupItem = &encoder->data->items.item[dedupIndex];
                 if (item->dimgFromID == dedupItem->dimgFromID) {
                     // We've already written dedup's items out. Steal their ipma indices and move on!
-                    memcpy(&item->ipma, &dedupItem->ipma, sizeof(struct ipmaArray));
+                    item->ipma = dedupItem->ipma;
                     foundPreviousCell = AVIF_TRUE;
                     break;
                 }


### PR DESCRIPTION
An advantage of struct assignments is that the compiler does type
checking. It will also avoid the potential mistake of passing an
incorrect third argument to memcpy().

To avoid conflict with a pending pull request, this pull request does
not change src/read.c.