### PR TITLE
No need to use the & operator with an array

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -27,7 +27,7 @@ uint16_t avifHTONS(uint16_t s)
 uint16_t avifNTOHS(uint16_t s)
 {
     uint8_t data[2];
-    memcpy(&data, &s, sizeof(data));
+    memcpy(data, &s, sizeof(data));
 
     return (uint16_t)((data[1] << 0) | (data[0] << 8));
 }
@@ -47,7 +47,7 @@ uint32_t avifHTONL(uint32_t l)
 uint32_t avifNTOHL(uint32_t l)
 {
     uint8_t data[4];
-    memcpy(&data, &l, sizeof(data));
+    memcpy(data, &l, sizeof(data));
 
     return ((uint32_t)data[3] << 0) | ((uint32_t)data[2] << 8) | ((uint32_t)data[1] << 16) | ((uint32_t)data[0] << 24);
 }
@@ -71,7 +71,7 @@ uint64_t avifHTON64(uint64_t l)
 uint64_t avifNTOH64(uint64_t l)
 {
     uint8_t data[8];
-    memcpy(&data, &l, sizeof(data));
+    memcpy(data, &l, sizeof(data));
 
     return ((uint64_t)data[7] << 0) | ((uint64_t)data[6] << 8) | ((uint64_t)data[5] << 16) | ((uint64_t)data[4] << 24) |
            ((uint64_t)data[3] << 32) | ((uint64_t)data[2] << 40) | ((uint64_t)data[1] << 48) | ((uint64_t)data[0] << 56);


### PR DESCRIPTION
The name of an array can be used as a pointer to the first element of
the array, so it is not necessary to use the & operator with an array.
In other words, if `data` is an array, then `data` can be used as
`&data[0]`.