### PR TITLE
Handle the new AOM_IMG_FMT_NV12 enum in switch

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -177,6 +177,11 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
                 yuvFormat = AVIF_PIXEL_FORMAT_YUV444;
                 break;
             case AOM_IMG_FMT_NONE:
+#if defined(AOM_HAVE_IMG_FMT_NV12)
+            // Although the libaom encoder supports the NV12 image format as an input format, the
+            // libaom decoder does not support NV12 as an output format.
+            case AOM_IMG_FMT_NV12:
+#endif
             case AOM_IMG_FMT_YV12:
             case AOM_IMG_FMT_AOMYV12:
             case AOM_IMG_FMT_YV1216:


### PR DESCRIPTION
Handle the new AOM_IMG_FMT_NV12 enum conditionally in a switch statement
in aomCodecGetNextImage(). This fixes a Clang -Wswitch-enum warning,
which is enabled by -Weverything.

Although the latest code on the main branch of libaom supports the NV12
image format, it is only supported as an input to the encoder. The
aomCodecGetNextImage() function is a decoder function, so it should
treat the NV12 image format as unsupported.