### PR TITLE
Remove an avifImageFreePlanes call for alpha plane

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3874,9 +3874,8 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
         }
     }
 
-    if (decoder->data->alphaTileCount == 0) {
-        avifImageFreePlanes(decoder->image, AVIF_PLANES_A); // no alpha
-    } else if (decoder->data->decodedAlphaTileCount > oldDecodedAlphaTileCount) {
+    if (decoder->data->decodedAlphaTileCount > oldDecodedAlphaTileCount) {
+        assert(decoder->data->alphaTileCount > 0);
         // There is at least one newly decoded alpha tile.
         if ((decoder->data->alphaGrid.rows > 0) && (decoder->data->alphaGrid.columns > 0)) {
             if (!avifDecoderDataFillImageGrid(decoder->data,


### PR DESCRIPTION
decoder->image is initially created as an empty image. If
decoder->data->alphaTileCount is 0, we will never allocate the alpha
plane of decoder->image or steal the alpha plane from the only "tile".
So we don't need to free the alpha plane of decoder->image in this case.