### PR TITLE
Simpler check for fully decoded image in NextImage

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3907,8 +3907,8 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
         }
     }
 
-    if ((decoder->data->decodedColorTileCount < decoder->data->colorTileCount) ||
-        (decoder->data->decodedAlphaTileCount < decoder->data->alphaTileCount)) {
+    if ((decoder->data->decodedColorTileCount != decoder->data->colorTileCount) ||
+        (decoder->data->decodedAlphaTileCount != decoder->data->alphaTileCount)) {
         assert(decoder->allowIncremental);
         // The image is not completely decoded. There should be no error unrelated to missing bytes,
         // and at least some missing bytes.
@@ -3926,8 +3926,6 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
     decoder->imageIndex = nextImageIndex;
     // The decoded tile counts will be reset to 0 the next time avifDecoderNextImage() is called,
     // for avifDecoderDecodedRowCount() to work until then.
-    assert(decoder->data->decodedColorTileCount == decoder->data->colorTileCount);
-    assert(decoder->data->decodedAlphaTileCount == decoder->data->alphaTileCount);
     if (decoder->data->sourceSampleTable) {
         // Decoding from a track! Provide timing information.
 

--- a/src/read.c
+++ b/src/read.c
@@ -3907,9 +3907,11 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
         }
     }
 
-    if (avifDecoderDecodedRowCount(decoder) < decoder->image->height) {
+    if ((decoder->data->decodedColorTileCount < decoder->data->colorTileCount) ||
+        (decoder->data->decodedAlphaTileCount < decoder->data->alphaTileCount)) {
         assert(decoder->allowIncremental);
-        // Rows are missing. There should be no error unrelated to missing bytes, and at least some missing bytes.
+        // The image is not completely decoded. There should be no error unrelated to missing bytes,
+        // and at least some missing bytes.
         assert((prepareColorTileResult == AVIF_RESULT_OK) || (prepareColorTileResult == AVIF_RESULT_WAITING_ON_IO));
         assert((prepareAlphaTileResult == AVIF_RESULT_OK) || (prepareAlphaTileResult == AVIF_RESULT_WAITING_ON_IO));
         assert((prepareColorTileResult != AVIF_RESULT_OK) || (prepareAlphaTileResult != AVIF_RESULT_OK));


### PR DESCRIPTION
Simplify the check for a completely decoded image in
avifDecoderNextImage(). We only need a yes/no answer; we don't need to
know how many rows are available if the image is not completely decoded.