### PR TITLE
Remove unnecessary memcpy() calls in src/utils.c

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -17,7 +17,7 @@ float avifRoundf(float v)
 uint16_t avifHTONS(uint16_t s)
 {
     uint16_t result;
-    uint8_t* data = (uint8_t*)&result;
+    uint8_t * data = (uint8_t *)&result;
     data[0] = (s >> 8) & 0xff;
     data[1] = (s >> 0) & 0xff;
     return result;
@@ -25,14 +25,14 @@ uint16_t avifHTONS(uint16_t s)
 
 uint16_t avifNTOHS(uint16_t s)
 {
-    uint8_t* data = (uint8_t*)&s;
+    const uint8_t * data = (const uint8_t *)&s;
     return (uint16_t)((data[1] << 0) | (data[0] << 8));
 }
 
 uint32_t avifHTONL(uint32_t l)
 {
     uint32_t result;
-    uint8_t* data = (uint8_t*)&result;
+    uint8_t * data = (uint8_t *)&result;
     data[0] = (l >> 24) & 0xff;
     data[1] = (l >> 16) & 0xff;
     data[2] = (l >> 8) & 0xff;
@@ -42,14 +42,14 @@ uint32_t avifHTONL(uint32_t l)
 
 uint32_t avifNTOHL(uint32_t l)
 {
-    uint8_t* data = (uint8_t*)&l;
+    const uint8_t * data = (const uint8_t *)&l;
     return ((uint32_t)data[3] << 0) | ((uint32_t)data[2] << 8) | ((uint32_t)data[1] << 16) | ((uint32_t)data[0] << 24);
 }
 
 uint64_t avifHTON64(uint64_t l)
 {
     uint64_t result;
-    uint8_t* data = (uint8_t*)&result;
+    uint8_t * data = (uint8_t *)&result;
     data[0] = (l >> 56) & 0xff;
     data[1] = (l >> 48) & 0xff;
     data[2] = (l >> 40) & 0xff;
@@ -63,7 +63,7 @@ uint64_t avifHTON64(uint64_t l)
 
 uint64_t avifNTOH64(uint64_t l)
 {
-    uint8_t* data = (uint8_t*)&l;
+    const uint8_t * data = (const uint8_t *)&l;
     return ((uint64_t)data[7] << 0) | ((uint64_t)data[6] << 8) | ((uint64_t)data[5] << 16) | ((uint64_t)data[4] << 24) |
            ((uint64_t)data[3] << 32) | ((uint64_t)data[2] << 40) | ((uint64_t)data[1] << 48) | ((uint64_t)data[0] << 56);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -16,45 +16,40 @@ float avifRoundf(float v)
 
 uint16_t avifHTONS(uint16_t s)
 {
-    uint8_t data[2];
+    uint16_t result;
+    uint8_t* data = (uint8_t*)&result;
     data[0] = (s >> 8) & 0xff;
     data[1] = (s >> 0) & 0xff;
-    uint16_t result;
-    memcpy(&result, data, sizeof(uint16_t));
     return result;
 }
 
 uint16_t avifNTOHS(uint16_t s)
 {
-    uint8_t data[2];
-    memcpy(data, &s, sizeof(data));
-
+    uint8_t* data = (uint8_t*)&s;
     return (uint16_t)((data[1] << 0) | (data[0] << 8));
 }
 
 uint32_t avifHTONL(uint32_t l)
 {
-    uint8_t data[4];
+    uint32_t result;
+    uint8_t* data = (uint8_t*)&result;
     data[0] = (l >> 24) & 0xff;
     data[1] = (l >> 16) & 0xff;
     data[2] = (l >> 8) & 0xff;
     data[3] = (l >> 0) & 0xff;
-    uint32_t result;
-    memcpy(&result, data, sizeof(uint32_t));
     return result;
 }
 
 uint32_t avifNTOHL(uint32_t l)
 {
-    uint8_t data[4];
-    memcpy(data, &l, sizeof(data));
-
+    uint8_t* data = (uint8_t*)&l;
     return ((uint32_t)data[3] << 0) | ((uint32_t)data[2] << 8) | ((uint32_t)data[1] << 16) | ((uint32_t)data[0] << 24);
 }
 
 uint64_t avifHTON64(uint64_t l)
 {
-    uint8_t data[8];
+    uint64_t result;
+    uint8_t* data = (uint8_t*)&result;
     data[0] = (l >> 56) & 0xff;
     data[1] = (l >> 48) & 0xff;
     data[2] = (l >> 40) & 0xff;
@@ -63,16 +58,12 @@ uint64_t avifHTON64(uint64_t l)
     data[5] = (l >> 16) & 0xff;
     data[6] = (l >> 8) & 0xff;
     data[7] = (l >> 0) & 0xff;
-    uint64_t result;
-    memcpy(&result, data, sizeof(uint64_t));
     return result;
 }
 
 uint64_t avifNTOH64(uint64_t l)
 {
-    uint8_t data[8];
-    memcpy(data, &l, sizeof(data));
-
+    uint8_t* data = (uint8_t*)&l;
     return ((uint64_t)data[7] << 0) | ((uint64_t)data[6] << 8) | ((uint64_t)data[5] << 16) | ((uint64_t)data[4] << 24) |
            ((uint64_t)data[3] << 32) | ((uint64_t)data[2] << 40) | ((uint64_t)data[1] << 48) | ((uint64_t)data[0] << 56);
 }


### PR DESCRIPTION
See https://en.cppreference.com/w/c/language/object#Strict_aliasing

Following https://github.com/AOMediaCodec/libavif/pull/882#discussion_r827426932