### PR TITLE
Call libyuv funcs to convert 10bpc YUV to 8bpc RGB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,14 +240,15 @@ find_package(libyuv QUIET) # not required
 if(libyuv_FOUND)
     # libyuv 1755 exposed all of the I*Matrix() functions, which libavif relies on.
     # libyuv 1774 exposed ScalePlane_12 function, which libavif can use for some additional optimizations.
+    # libyuv 1813 added the I*ToARGBMatrixFilter() functions, which libavif can use with the bilinear filter.
     if(NOT LIBYUV_VERSION)
         message(STATUS "libavif: libyuv found, but version unknown; libyuv-based fast paths disabled.")
     elseif(LIBYUV_VERSION LESS 1755)
         message(STATUS "libavif: libyuv (${LIBYUV_VERSION}) found, but is too old; libyuv-based fast paths disabled.")
     else()
         message(STATUS "libavif: libyuv (${LIBYUV_VERSION}) found; libyuv-based fast paths enabled.")
-        if(LIBYUV_VERSION LESS 1774)
-            message(STATUS "libavif: some libyuv optimizations require at least version 1774 to work.")
+        if(LIBYUV_VERSION LESS 1813)
+            message(STATUS "libavif: some libyuv optimizations require at least version 1813 to work.")
         endif()
         set(AVIF_PLATFORM_DEFINITIONS ${AVIF_PLATFORM_DEFINITIONS} -DAVIF_LIBYUV_ENABLED=1)
         set(AVIF_PLATFORM_INCLUDES ${AVIF_PLATFORM_INCLUDES} ${LIBYUV_INCLUDE_DIR})

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -34,6 +34,8 @@ unsigned int avifLibYUVVersion(void)
 
 #else
 
+#include <assert.h>
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes" // "this function declaration is not a prototype"
@@ -41,20 +43,25 @@ unsigned int avifLibYUVVersion(void)
 // in version 1813:
 // https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3183182
 // https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3527834
-#pragma clang diagnostic ignored "-Wnewline-eof" // "no newline at end of file"
+#pragma clang diagnostic ignored "-Wnewline-eof"       // "no newline at end of file"
 #endif
 #include <libyuv.h>
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 
+static avifResult avifImageYUVToRGBLibYUV8bpc(const avifImage * image,
+                                              avifRGBImage * rgb,
+                                              const struct YuvConstants * matrixYUV,
+                                              const struct YuvConstants * matrixYVU);
+static avifResult avifImageYUVToRGBLibYUV10bpc(const avifImage * image,
+                                               avifRGBImage * rgb,
+                                               const struct YuvConstants * matrixYUV,
+                                               const struct YuvConstants * matrixYVU);
+
 avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
 {
     // See if the current settings can be accomplished with libyuv, and use it (if possible).
-
-    if ((image->depth != 8) || (rgb->depth != 8)) {
-        return AVIF_RESULT_NOT_IMPLEMENTED;
-    }
 
     if ((rgb->chromaUpsampling != AVIF_CHROMA_UPSAMPLING_AUTOMATIC) && (rgb->chromaUpsampling != AVIF_CHROMA_UPSAMPLING_FASTEST)) {
         // We do not ensure a specific upsampling filter is used when calling libyuv, so if the end
@@ -193,6 +200,27 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
         // No YuvConstants exist for the current image; use the built-in YUV conversion
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
+
+    if ((image->depth == 8) && (rgb->depth == 8)) {
+        return avifImageYUVToRGBLibYUV8bpc(image, rgb, matrixYUV, matrixYVU);
+    }
+
+    if ((image->depth == 10) && (rgb->depth == 8)) {
+        return avifImageYUVToRGBLibYUV10bpc(image, rgb, matrixYUV, matrixYVU);
+    }
+
+    // This function didn't do anything; use the built-in YUV conversion
+    return AVIF_RESULT_NOT_IMPLEMENTED;
+}
+
+avifResult avifImageYUVToRGBLibYUV8bpc(const avifImage * image,
+                                       avifRGBImage * rgb,
+                                       const struct YuvConstants * matrixYUV,
+                                       const struct YuvConstants * matrixYVU)
+{
+    // See if the current settings can be accomplished with libyuv, and use it (if possible).
+
+    assert((image->depth == 8) && (rgb->depth == 8));
 
 #if LIBYUV_VERSION >= 1813
     enum FilterMode filter = kFilterBilinear;
@@ -537,6 +565,339 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
             }
             return AVIF_RESULT_OK;
 #endif
+        }
+    }
+
+    // This function didn't do anything; use the built-in YUV conversion
+    return AVIF_RESULT_NOT_IMPLEMENTED;
+}
+
+avifResult avifImageYUVToRGBLibYUV10bpc(const avifImage * image,
+                                        avifRGBImage * rgb,
+                                        const struct YuvConstants * matrixYUV,
+                                        const struct YuvConstants * matrixYVU)
+{
+    // See if the current settings can be accomplished with libyuv, and use it (if possible).
+
+    assert((image->depth == 10) && (rgb->depth == 8));
+
+#if LIBYUV_VERSION >= 1813
+    enum FilterMode filter = kFilterBilinear;
+    if (rgb->chromaUpsampling == AVIF_CHROMA_UPSAMPLING_FASTEST) {
+        // 'None' (Nearest neighbor) filter is faster than bilinear.
+        filter = kFilterNone;
+    }
+#endif
+
+    // This following section might be a bit complicated to audit without a bit of explanation:
+    //
+    // libavif uses byte-order when describing pixel formats, such that the R in RGBA is the lowest address,
+    // similar to PNG. libyuv orders in word-order, so libavif's RGBA would be referred to in libyuv as ABGR.
+    // In addition, swapping U and V in any of these calls, along with using the Yvu matrix instead of Yuv matrix,
+    // swaps B and R in these orderings as well. This table summarizes this block's intent:
+    //
+    // libavif format        libyuv Func     UV matrix (and UV argument ordering)
+    // --------------------  -------------   ------------------------------------
+    // AVIF_RGB_FORMAT_RGB   n/a             n/a
+    // AVIF_RGB_FORMAT_BGR   n/a             n/a
+    // AVIF_RGB_FORMAT_BGRA  *ToARGBMatrix   matrixYUV
+    // AVIF_RGB_FORMAT_RGBA  *ToARGBMatrix   matrixYVU
+    // AVIF_RGB_FORMAT_ABGR  *ToRGBAMatrix   matrixYUV
+    // AVIF_RGB_FORMAT_ARGB  *ToRGBAMatrix   matrixYVU
+
+    if (rgb->format == AVIF_RGB_FORMAT_BGRA) {
+        // AVIF_RGB_FORMAT_BGRA  *ToARGBMatrix   matrixYUV
+
+        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
+#if LIBYUV_VERSION >= 1780
+            if (I410ToARGBMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYUV,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+#endif
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
+#if LIBYUV_VERSION >= 1813
+            if (I210ToARGBMatrixFilter((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                       image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                       (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                       image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                       (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                       image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                       rgb->pixels,
+                                       rgb->rowBytes,
+                                       matrixYUV,
+                                       image->width,
+                                       image->height,
+                                       filter) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+#else
+            if (I210ToARGBMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYUV,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+#endif
+            return AVIF_RESULT_OK;
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
+#if LIBYUV_VERSION >= 1813
+            if (I010ToARGBMatrixFilter((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                       image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                       (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                       image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                       (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                       image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                       rgb->pixels,
+                                       rgb->rowBytes,
+                                       matrixYUV,
+                                       image->width,
+                                       image->height,
+                                       filter) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+#else
+            if (I010ToARGBMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYUV,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+#endif
+            return AVIF_RESULT_OK;
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
+            // This doesn't currently exist in libyuv
+        }
+    } else if (rgb->format == AVIF_RGB_FORMAT_RGBA) {
+        // AVIF_RGB_FORMAT_RGBA  *ToARGBMatrix   matrixYVU
+
+        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
+#if LIBYUV_VERSION >= 1780
+            if (I410ToARGBMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYVU,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+#endif
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
+#if LIBYUV_VERSION >= 1813
+            if (I210ToARGBMatrixFilter((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                       image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                       (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                       image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                       (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                       image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                       rgb->pixels,
+                                       rgb->rowBytes,
+                                       matrixYVU,
+                                       image->width,
+                                       image->height,
+                                       filter) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+#else
+            if (I210ToARGBMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYVU,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+#endif
+            return AVIF_RESULT_OK;
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
+#if LIBYUV_VERSION >= 1813
+            if (I010ToARGBMatrixFilter((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                       image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                       (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                       image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                       (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                       image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                       rgb->pixels,
+                                       rgb->rowBytes,
+                                       matrixYVU,
+                                       image->width,
+                                       image->height,
+                                       filter) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+#else
+            if (I010ToARGBMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYVU,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+#endif
+            return AVIF_RESULT_OK;
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
+            // This doesn't currently exist in libyuv
+        }
+    } else if (rgb->format == AVIF_RGB_FORMAT_ABGR) {
+        // AVIF_RGB_FORMAT_ABGR  *ToRGBAMatrix   matrixYUV
+
+        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
+            // This doesn't currently exist in libyuv
+#if 0
+            if (I410ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYUV,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+#endif
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
+            // This doesn't currently exist in libyuv
+#if 0
+            if (I210ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYUV,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+#endif
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
+            // This doesn't currently exist in libyuv
+#if 0
+            if (I010ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYUV,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+#endif
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
+            // This doesn't currently exist in libyuv
+        }
+    } else if (rgb->format == AVIF_RGB_FORMAT_ARGB) {
+        // AVIF_RGB_FORMAT_ARGB  *ToRGBAMatrix   matrixYVU
+
+        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
+            // This doesn't currently exist in libyuv
+#if 0
+            if (I410ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYVU,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+#endif
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
+            // This doesn't currently exist in libyuv
+#if 0
+            if (I210ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYVU,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+#endif
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
+            // This doesn't currently exist in libyuv
+#if 0
+            if (I010ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
+                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
+                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
+                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrixYVU,
+                                 image->width,
+                                 image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+#endif
+        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
+            // This doesn't currently exist in libyuv
         }
     }
 

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -43,7 +43,7 @@ unsigned int avifLibYUVVersion(void)
 // in version 1813:
 // https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3183182
 // https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3527834
-#pragma clang diagnostic ignored "-Wnewline-eof"       // "no newline at end of file"
+#pragma clang diagnostic ignored "-Wnewline-eof" // "no newline at end of file"
 #endif
 #include <libyuv.h>
 #if defined(__clang__)
@@ -776,126 +776,6 @@ avifResult avifImageYUVToRGBLibYUV10bpc(const avifImage * image,
             }
 #endif
             return AVIF_RESULT_OK;
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
-            // This doesn't currently exist in libyuv
-        }
-    } else if (rgb->format == AVIF_RGB_FORMAT_ABGR) {
-        // AVIF_RGB_FORMAT_ABGR  *ToRGBAMatrix   matrixYUV
-
-        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I410ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-#endif
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I210ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-#endif
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I010ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYUV,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-#endif
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
-            // This doesn't currently exist in libyuv
-        }
-    } else if (rgb->format == AVIF_RGB_FORMAT_ARGB) {
-        // AVIF_RGB_FORMAT_ARGB  *ToRGBAMatrix   matrixYVU
-
-        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I410ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-#endif
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I210ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-#endif
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
-            // This doesn't currently exist in libyuv
-#if 0
-            if (I010ToRGBAMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
-                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_V],
-                                 image->yuvRowBytes[AVIF_CHAN_V] / 2,
-                                 (const uint16_t *)image->yuvPlanes[AVIF_CHAN_U],
-                                 image->yuvRowBytes[AVIF_CHAN_U] / 2,
-                                 rgb->pixels,
-                                 rgb->rowBytes,
-                                 matrixYVU,
-                                 image->width,
-                                 image->height) != 0) {
-                return AVIF_RESULT_REFORMAT_FAILED;
-            }
-            return AVIF_RESULT_OK;
-#endif
         } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
             // This doesn't currently exist in libyuv
         }


### PR DESCRIPTION
In libyuv, I410 means 10 bit 444 YUV, I210 means 10 bit 422 YUV, and
I010 means 10 bit 420 YUV.

I010ToARGBMatrix() and I210ToARGBMatrix() were added (exposed) in libyuv
version 1755, which is the minimum libyuv version required by libavif:
https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2202748

I410ToARGBMatrix() was added in libyuv version 1780:
https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2707003

Fix https://github.com/AOMediaCodec/libavif/issues/822.