### PR TITLE
Format CMakeLists.txt

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,24 @@
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section("format"):
+  # How wide to allow formatted cmake files
+  line_width = 130
+
+  # How many spaces to tab for indent
+  tab_size = 4
+
+  # If an argument group contains more than this many sub-groups (parg or kwarg
+  # groups) then force it to a vertical layout.
+  max_subgroups_hwrap = 3
+
+  # If a positional argument group contains more than this many arguments, then
+  # force it to a vertical layout.
+  max_pargs_hwrap = 10
+
+# ------------------------------------------------
+# Options affecting comment reflow and formatting.
+# ------------------------------------------------
+with section("markup"):
+  # enable comment markup parsing and reflow
+  enable_markup = False

--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -16,6 +16,10 @@ with section("format"):
   # force it to a vertical layout.
   max_pargs_hwrap = 10
 
+  # If a statement is wrapped to more than one line, than dangle the closing
+  # parenthesis on its own line.
+  dangle_parens = True
+
 # ------------------------------------------------
 # Options affecting comment reflow and formatting.
 # ------------------------------------------------

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,5 @@
+format:
+  line_width: 130
+  tab_size: 4
+markup:
+  enable_markup: false

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,5 +1,0 @@
-format:
-  line_width: 130
-  tab_size: 4
-markup:
-  enable_markup: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,7 @@ cmake_minimum_required(VERSION 3.5)
 # Specify search path for CMake modules to be loaded by include() and find_package()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
-project(
-    libavif
-    LANGUAGES C
-    VERSION 0.9.3)
+project(libavif LANGUAGES C VERSION 0.9.3)
 
 # Set C99 as the default
 set(CMAKE_C_STANDARD 99)
@@ -70,24 +67,16 @@ if(AVIF_LOCAL_ZLIBPNG)
     # Put the value of ZLIB_INCLUDE_DIR in the cache. This works around cmake behavior that has been updated by
     # cmake policy CMP0102 in cmake 3.17. Remove the CACHE workaround when we require cmake 3.17 or later. See
     # https://gitlab.kitware.com/cmake/cmake/-/issues/21343.
-    set(ZLIB_INCLUDE_DIR
-        "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib"
-        CACHE PATH "zlib include dir")
+    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib" CACHE PATH "zlib include dir")
     include_directories("${CMAKE_CURRENT_BINARY_DIR}/ext/zlib")
     set(CMAKE_DEBUG_POSTFIX "")
 
     # This is the only way I could avoid libpng going crazy if it found awk.exe, seems benign otherwise
     set(PREV_ANDROID ${ANDROID})
     set(ANDROID TRUE)
-    set(PNG_BUILD_ZLIB
-        "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib"
-        CACHE STRING "" FORCE)
-    set(PNG_SHARED
-        OFF
-        CACHE BOOL "")
-    set(PNG_TESTS
-        OFF
-        CACHE BOOL "")
+    set(PNG_BUILD_ZLIB "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib" CACHE STRING "" FORCE)
+    set(PNG_SHARED OFF CACHE BOOL "")
+    set(PNG_TESTS OFF CACHE BOOL "")
     add_subdirectory(ext/libpng)
     set(PNG_PNG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libpng")
     set(PNG_LIBRARY png_static)
@@ -103,12 +92,8 @@ if(AVIF_LOCAL_JPEG)
         set(JPEG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libjpeg")
         set(JPEG_LIBRARY jpeg)
     else()
-        set(JPEG_INCLUDE_DIR
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/libjpeg"
-            PARENT_SCOPE)
-        set(JPEG_LIBRARY
-            jpeg
-            PARENT_SCOPE)
+        set(JPEG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libjpeg" PARENT_SCOPE)
+        set(JPEG_LIBRARY jpeg PARENT_SCOPE)
     endif()
 endif()
 option(AVIF_LOCAL_LIBYUV "Build libyuv by providing your own copy inside the ext subdir." OFF)
@@ -122,12 +107,8 @@ if(AVIF_LOCAL_LIBYUV)
         set(LIBYUV_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/include")
         set(LIBYUV_LIBRARY ${LIB_FILENAME})
     else()
-        set(LIBYUV_INCLUDE_DIR
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/include"
-            PARENT_SCOPE)
-        set(LIBYUV_LIBRARY
-            ${LIB_FILENAME}
-            PARENT_SCOPE)
+        set(LIBYUV_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/include" PARENT_SCOPE)
+        set(LIBYUV_LIBRARY ${LIB_FILENAME} PARENT_SCOPE)
     endif()
 endif()
 # ---------------------------------------------------------------------------------------
@@ -439,30 +420,19 @@ if(AVIF_CODEC_AOM)
     message(STATUS "libavif: Codec enabled: aom (${AVIF_CODEC_AOM_ENCODE_DECODE_CONFIG})")
 endif()
 
-if(NOT AVIF_CODEC_AOM
-   AND NOT AVIF_CODEC_DAV1D
-   AND NOT AVIF_CODEC_LIBGAV1)
+if(NOT AVIF_CODEC_AOM AND NOT AVIF_CODEC_DAV1D AND NOT AVIF_CODEC_LIBGAV1)
     message(WARNING "libavif: No decoding library is enabled.")
 endif()
 
 add_library(avif ${AVIF_SRCS})
-set_target_properties(
-    avif
-    PROPERTIES VERSION ${LIBRARY_VERSION}
-               SOVERSION ${LIBRARY_SOVERSION}
-               C_VISIBILITY_PRESET hidden)
+set_target_properties(avif PROPERTIES VERSION ${LIBRARY_VERSION} SOVERSION ${LIBRARY_SOVERSION} C_VISIBILITY_PRESET hidden)
 target_compile_definitions(avif PRIVATE ${AVIF_PLATFORM_DEFINITIONS} ${AVIF_CODEC_DEFINITIONS})
 target_link_libraries(avif PRIVATE ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
-target_include_directories(
-    avif
-    PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-    PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
+target_include_directories(avif PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
+                           PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
 set(AVIF_PKG_CONFIG_EXTRA_CFLAGS "")
 if(BUILD_SHARED_LIBS)
-    target_compile_definitions(
-        avif
-        PUBLIC AVIF_DLL
-        PRIVATE AVIF_BUILDING_SHARED_LIBS)
+    target_compile_definitions(avif PUBLIC AVIF_DLL PRIVATE AVIF_BUILDING_SHARED_LIBS)
     set(AVIF_PKG_CONFIG_EXTRA_CFLAGS " -DAVIF_DLL")
     if(AVIF_LOCAL_LIBGAV1)
         set_target_properties(avif PROPERTIES LINKER_LANGUAGE "CXX")
@@ -505,10 +475,8 @@ if(AVIF_BUILD_APPS OR AVIF_BUILD_TESTS)
     add_library(avif_apps STATIC # Static so it does not have to be installed.
                 apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c apps/shared/y4m.c)
     target_link_libraries(avif_apps avif ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
-    target_include_directories(
-        avif_apps
-        PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR}
-        INTERFACE apps/shared)
+    target_include_directories(avif_apps PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> ${PNG_PNG_INCLUDE_DIR}
+                                                 ${JPEG_INCLUDE_DIR} INTERFACE apps/shared)
 endif()
 
 if(AVIF_BUILD_APPS)
@@ -550,10 +518,8 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
         install(EXPORT ${PROJECT_NAME}-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
         include(CMakePackageConfigHelpers)
-        write_basic_package_version_file(
-            ${PROJECT_NAME}-config-version.cmake
-            VERSION ${PROJECT_VERSION}
-            COMPATIBILITY SameMajorVersion)
+        write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake VERSION ${PROJECT_VERSION}
+                                         COMPATIBILITY SameMajorVersion)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
                 DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,13 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-# Specify search path for CMake modules to be loaded by include()
-# and find_package()
+# Specify search path for CMake modules to be loaded by include() and find_package()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
-project(libavif LANGUAGES C VERSION 0.9.3)
+project(
+    libavif
+    LANGUAGES C
+    VERSION 0.9.3)
 
 # Set C99 as the default
 set(CMAKE_C_STANDARD 99)
@@ -40,10 +42,14 @@ option(AVIF_CODEC_AOM_DECODE "if AVIF_CODEC_AOM is on, use/offer libaom's decode
 option(AVIF_CODEC_AOM_ENCODE "if AVIF_CODEC_AOM is on, use/offer libaom's encoder" ON)
 
 option(AVIF_LOCAL_AOM "Build the AOM codec by providing your own copy of the repo in ext/aom (see Local Builds in README)" OFF)
-option(AVIF_LOCAL_DAV1D "Build the dav1d codec by providing your own copy of the repo in ext/dav1d (see Local Builds in README)" OFF)
-option(AVIF_LOCAL_LIBGAV1 "Build the libgav1 codec by providing your own copy of the repo in ext/libgav1 (see Local Builds in README)" OFF)
-option(AVIF_LOCAL_RAV1E "Build the rav1e codec by providing your own copy of the repo in ext/rav1e (see Local Builds in README)" OFF)
-option(AVIF_LOCAL_SVT "Build the SVT-AV1 codec by providing your own copy of the repo in ext/SVT-AV1 (see Local Builds in README)" OFF)
+option(AVIF_LOCAL_DAV1D "Build the dav1d codec by providing your own copy of the repo in ext/dav1d (see Local Builds in README)"
+       OFF)
+option(AVIF_LOCAL_LIBGAV1
+       "Build the libgav1 codec by providing your own copy of the repo in ext/libgav1 (see Local Builds in README)" OFF)
+option(AVIF_LOCAL_RAV1E "Build the rav1e codec by providing your own copy of the repo in ext/rav1e (see Local Builds in README)"
+       OFF)
+option(AVIF_LOCAL_SVT
+       "Build the SVT-AV1 codec by providing your own copy of the repo in ext/SVT-AV1 (see Local Builds in README)" OFF)
 
 if(AVIF_LOCAL_LIBGAV1)
     enable_language(CXX)
@@ -64,16 +70,24 @@ if(AVIF_LOCAL_ZLIBPNG)
     # Put the value of ZLIB_INCLUDE_DIR in the cache. This works around cmake behavior that has been updated by
     # cmake policy CMP0102 in cmake 3.17. Remove the CACHE workaround when we require cmake 3.17 or later. See
     # https://gitlab.kitware.com/cmake/cmake/-/issues/21343.
-    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib" CACHE PATH "zlib include dir")
+    set(ZLIB_INCLUDE_DIR
+        "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib"
+        CACHE PATH "zlib include dir")
     include_directories("${CMAKE_CURRENT_BINARY_DIR}/ext/zlib")
     set(CMAKE_DEBUG_POSTFIX "")
 
     # This is the only way I could avoid libpng going crazy if it found awk.exe, seems benign otherwise
     set(PREV_ANDROID ${ANDROID})
     set(ANDROID TRUE)
-    set(PNG_BUILD_ZLIB "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib" CACHE STRING "" FORCE)
-    set(PNG_SHARED OFF CACHE BOOL "")
-    set(PNG_TESTS OFF CACHE BOOL "")
+    set(PNG_BUILD_ZLIB
+        "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib"
+        CACHE STRING "" FORCE)
+    set(PNG_SHARED
+        OFF
+        CACHE BOOL "")
+    set(PNG_TESTS
+        OFF
+        CACHE BOOL "")
     add_subdirectory(ext/libpng)
     set(PNG_PNG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libpng")
     set(PNG_LIBRARY png_static)
@@ -85,17 +99,22 @@ endif()
 option(AVIF_LOCAL_JPEG "Build jpeg by providing your own copy inside the ext subdir." OFF)
 if(AVIF_LOCAL_JPEG)
     add_subdirectory(ext/libjpeg)
-    if("${CMAKE_SOURCE_DIR}" STREQUAL  "${CMAKE_CURRENT_SOURCE_DIR}")
+    if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
         set(JPEG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libjpeg")
         set(JPEG_LIBRARY jpeg)
     else()
-        set(JPEG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libjpeg" PARENT_SCOPE)
-        set(JPEG_LIBRARY jpeg PARENT_SCOPE)
+        set(JPEG_INCLUDE_DIR
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/libjpeg"
+            PARENT_SCOPE)
+        set(JPEG_LIBRARY
+            jpeg
+            PARENT_SCOPE)
     endif()
 endif()
 option(AVIF_LOCAL_LIBYUV "Build libyuv by providing your own copy inside the ext subdir." OFF)
 if(AVIF_LOCAL_LIBYUV)
-    set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/build/${CMAKE_STATIC_LIBRARY_PREFIX}yuv${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    set(LIB_FILENAME
+        "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/build/${CMAKE_STATIC_LIBRARY_PREFIX}yuv${CMAKE_STATIC_LIBRARY_SUFFIX}")
     if(NOT EXISTS "${LIB_FILENAME}")
         message(FATAL_ERROR "libavif(AVIF_LOCAL_LIBYUV): ${LIB_FILENAME} is missing, bailing out")
     endif()
@@ -103,8 +122,12 @@ if(AVIF_LOCAL_LIBYUV)
         set(LIBYUV_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/include")
         set(LIBYUV_LIBRARY ${LIB_FILENAME})
     else()
-        set(LIBYUV_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/include" PARENT_SCOPE)
-        set(LIBYUV_LIBRARY ${LIB_FILENAME} PARENT_SCOPE)
+        set(LIBYUV_INCLUDE_DIR
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/include"
+            PARENT_SCOPE)
+        set(LIBYUV_LIBRARY
+            ${LIB_FILENAME}
+            PARENT_SCOPE)
     endif()
 endif()
 # ---------------------------------------------------------------------------------------
@@ -112,7 +135,7 @@ endif()
 # Enable all warnings
 include(CheckCCompilerFlag)
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    MESSAGE(STATUS "libavif: Enabling warnings for Clang")
+    message(STATUS "libavif: Enabling warnings for Clang")
     add_definitions(
         -Weverything
         -Wno-bad-function-cast
@@ -127,8 +150,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
         -Wno-missing-noreturn
         -Wno-padded
         -Wno-sign-conversion
-        -Wno-error=c11-extensions
-    )
+        -Wno-error=c11-extensions)
     # Some headers such as glib-2.0 use identifier names that start with '_' followed by a capital letter.
     # The C standard reserves names beginning with an underscore and various other combinations.
     # ISO/IEC 9899:1999 (aka C99 standard) 7.1.3 Reserved identifiers
@@ -157,12 +179,12 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
         add_definitions(-Wno-used-but-marked-unused)
     endif()
 elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
-    MESSAGE(STATUS "libavif: Enabling warnings for GCC")
+    message(STATUS "libavif: Enabling warnings for GCC")
     add_definitions(-Wall -Wextra)
 elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
-    MESSAGE(STATUS "libavif: Enabling warnings for MSVC")
+    message(STATUS "libavif: Enabling warnings for MSVC")
     add_definitions(
-        /Wall   # All warnings
+        /Wall # All warnings
         /wd4255 # Disable: no function prototype given
         /wd4324 # Disable: structure was padded due to alignment specifier
         /wd4668 # Disable: is not defined as a preprocessor macro, replacing with '0'
@@ -172,17 +194,16 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
         /wd4820 # Disable: bytes padding added after data member
         /wd4996 # Disable: potentially unsafe stdlib methods
         /wd5045 # Disable: Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
-
         # This tells MSVC to read source code as UTF-8 and assume console can only use ASCII (minimal safe).
         # libavif uses ANSI API to print to console, which is not portable between systems using different
         # languages and results in mojibake unless we only use codes shared by every code page: ASCII.
         # A C4556 warning will be generated on violation.
         # Commonly used /utf-8 flag assumes UTF-8 for both source and console, which is usually not the case.
         # Warnings can be suppressed but there will still be random characters printed to the console.
-        /source-charset:utf-8 /execution-charset:us-ascii
-    )
+        /source-charset:utf-8
+        /execution-charset:us-ascii)
 else()
-    MESSAGE(FATAL_ERROR "libavif: Unknown compiler, bailing out")
+    message(FATAL_ERROR "libavif: Unknown compiler, bailing out")
 endif()
 
 if(AVIF_ENABLE_WERROR)
@@ -192,13 +213,13 @@ if(AVIF_ENABLE_WERROR)
     elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
         add_definitions(/WX)
     else()
-        MESSAGE(FATAL_ERROR "libavif: Unknown compiler, bailing out")
+        message(FATAL_ERROR "libavif: Unknown compiler, bailing out")
     endif()
 endif()
 
 if(AVIF_ENABLE_COVERAGE)
     if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
-        MESSAGE(STATUS "libavif: Enabling coverage for Clang")
+        message(STATUS "libavif: Enabling coverage for Clang")
         add_definitions(-fprofile-instr-generate -fcoverage-mapping -O0)
         set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} "-fprofile-instr-generate -fcoverage-mapping")
     else()
@@ -222,8 +243,7 @@ set(AVIF_SRCS
     src/scale.c
     src/stream.c
     src/utils.c
-    src/write.c
-)
+    src/write.c)
 
 set(AVIF_PLATFORM_DEFINITIONS)
 set(AVIF_PLATFORM_INCLUDES)
@@ -263,9 +283,7 @@ set(AVIF_CODEC_LIBRARIES)
 
 if(AVIF_CODEC_DAV1D)
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_DAV1D=1)
-    set(AVIF_SRCS ${AVIF_SRCS}
-        src/codec_dav1d.c
-    )
+    set(AVIF_SRCS ${AVIF_SRCS} src/codec_dav1d.c)
 
     if(AVIF_LOCAL_DAV1D)
         set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/src/libdav1d.a")
@@ -273,12 +291,10 @@ if(AVIF_CODEC_DAV1D)
             message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
         endif()
 
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build"
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include"
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include/dav1d"
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/include"
-        )
+        set(AVIF_CODEC_INCLUDES
+            ${AVIF_CODEC_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build"
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include" "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include/dav1d"
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/include")
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
     else()
         # Check to see if dav1d is independently being built by the outer CMake project
@@ -298,14 +314,12 @@ endif()
 
 if(AVIF_CODEC_LIBGAV1)
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_LIBGAV1=1)
-    set(AVIF_SRCS ${AVIF_SRCS}
-        src/codec_libgav1.c
-    )
+    set(AVIF_SRCS ${AVIF_SRCS} src/codec_libgav1.c)
 
     if(AVIF_LOCAL_LIBGAV1)
-        set (AVIF_LIBGAV1_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libgav1/build")
+        set(AVIF_LIBGAV1_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libgav1/build")
         # If ${ANDROID_ABI} is set, look for the library under that subdirectory.
-        if (DEFINED ANDROID_ABI)
+        if(DEFINED ANDROID_ABI)
             set(AVIF_LIBGAV1_BUILD_DIR "${AVIF_LIBGAV1_BUILD_DIR}/${ANDROID_ABI}")
         endif()
         set(LIB_FILENAME "${AVIF_LIBGAV1_BUILD_DIR}/libgav1${CMAKE_STATIC_LIBRARY_SUFFIX}")
@@ -313,9 +327,7 @@ if(AVIF_CODEC_LIBGAV1)
             message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
         endif()
 
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/libgav1/src"
-        )
+        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/ext/libgav1/src")
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
     else()
         # Check to see if libgav1 is independently being built by the outer CMake project
@@ -331,19 +343,17 @@ endif()
 
 if(AVIF_CODEC_RAV1E)
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_RAV1E=1)
-    set(AVIF_SRCS ${AVIF_SRCS}
-        src/codec_rav1e.c
-    )
+    set(AVIF_SRCS ${AVIF_SRCS} src/codec_rav1e.c)
 
     if(AVIF_LOCAL_RAV1E)
-        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/lib/${CMAKE_STATIC_LIBRARY_PREFIX}rav1e${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        set(LIB_FILENAME
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/lib/${CMAKE_STATIC_LIBRARY_PREFIX}rav1e${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        )
         if(NOT EXISTS "${LIB_FILENAME}")
             message(FATAL_ERROR "libavif: compiled rav1e library is missing (in ext/rav1e/build.libavif/usr/lib), bailing out")
         endif()
 
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/include/rav1e"
-        )
+        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/include/rav1e")
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
     else()
         # Check to see if rav1e is independently being built by the outer CMake project
@@ -366,19 +376,17 @@ endif()
 
 if(AVIF_CODEC_SVT)
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_SVT=1)
-    set(AVIF_SRCS ${AVIF_SRCS}
-        src/codec_svt.c
-    )
+    set(AVIF_SRCS ${AVIF_SRCS} src/codec_svt.c)
 
     if(AVIF_LOCAL_SVT)
-        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/SVT-AV1/Bin/Release/${CMAKE_STATIC_LIBRARY_PREFIX}SvtAv1Enc${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        set(LIB_FILENAME
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/SVT-AV1/Bin/Release/${CMAKE_STATIC_LIBRARY_PREFIX}SvtAv1Enc${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        )
         if(NOT EXISTS "${LIB_FILENAME}")
             message(FATAL_ERROR "libavif: compiled svt library is missing (in ext/SVT-AV1/Bin/Release), bailing out")
         endif()
 
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/SVT-AV1/include"
-        )
+        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/ext/SVT-AV1/include")
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
     else()
         # Check to see if svt is independently being built by the outer CMake project
@@ -404,20 +412,20 @@ if(AVIF_CODEC_AOM)
         set(AVIF_CODEC_AOM_ENCODE_DECODE_CONFIG "decode only")
         set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_AOM_DECODE=1)
     else()
-        message(FATAL_ERROR "libavif: AVIF_CODEC_AOM is on, but both AVIF_CODEC_AOM_ENCODE and AVIF_CODEC_AOM_DECODE are off. Disable AVIF_CODEC_AOM to disable both parts of the codec.")
+        message(
+            FATAL_ERROR
+                "libavif: AVIF_CODEC_AOM is on, but both AVIF_CODEC_AOM_ENCODE and AVIF_CODEC_AOM_DECODE are off. Disable AVIF_CODEC_AOM to disable both parts of the codec."
+        )
     endif()
-    set(AVIF_SRCS ${AVIF_SRCS}
-        src/codec_aom.c
-    )
+    set(AVIF_SRCS ${AVIF_SRCS} src/codec_aom.c)
     if(AVIF_LOCAL_AOM)
-        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom/build.libavif/${CMAKE_STATIC_LIBRARY_PREFIX}aom${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        set(LIB_FILENAME
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom/build.libavif/${CMAKE_STATIC_LIBRARY_PREFIX}aom${CMAKE_STATIC_LIBRARY_SUFFIX}")
         if(NOT EXISTS "${LIB_FILENAME}")
             message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
         endif()
 
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES}
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom"
-        )
+        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom")
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
     else()
         # Check to see if aom is independently being built by the outer CMake project
@@ -431,28 +439,30 @@ if(AVIF_CODEC_AOM)
     message(STATUS "libavif: Codec enabled: aom (${AVIF_CODEC_AOM_ENCODE_DECODE_CONFIG})")
 endif()
 
-if(NOT AVIF_CODEC_AOM AND NOT AVIF_CODEC_DAV1D AND NOT AVIF_CODEC_LIBGAV1)
+if(NOT AVIF_CODEC_AOM
+   AND NOT AVIF_CODEC_DAV1D
+   AND NOT AVIF_CODEC_LIBGAV1)
     message(WARNING "libavif: No decoding library is enabled.")
 endif()
 
 add_library(avif ${AVIF_SRCS})
-set_target_properties(avif
-                      PROPERTIES
-                          VERSION ${LIBRARY_VERSION}
-                          SOVERSION ${LIBRARY_SOVERSION}
-                          C_VISIBILITY_PRESET hidden)
-target_compile_definitions(avif
-                           PRIVATE ${AVIF_PLATFORM_DEFINITIONS} ${AVIF_CODEC_DEFINITIONS})
-target_link_libraries(avif
-                      PRIVATE ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
-target_include_directories(avif
-                           PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include>
-                                  $<INSTALL_INTERFACE:include>
-                           PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
+set_target_properties(
+    avif
+    PROPERTIES VERSION ${LIBRARY_VERSION}
+               SOVERSION ${LIBRARY_SOVERSION}
+               C_VISIBILITY_PRESET hidden)
+target_compile_definitions(avif PRIVATE ${AVIF_PLATFORM_DEFINITIONS} ${AVIF_CODEC_DEFINITIONS})
+target_link_libraries(avif PRIVATE ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
+target_include_directories(
+    avif
+    PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
+    PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
 set(AVIF_PKG_CONFIG_EXTRA_CFLAGS "")
 if(BUILD_SHARED_LIBS)
-    target_compile_definitions(avif PUBLIC AVIF_DLL
-                                    PRIVATE AVIF_BUILDING_SHARED_LIBS)
+    target_compile_definitions(
+        avif
+        PUBLIC AVIF_DLL
+        PRIVATE AVIF_BUILDING_SHARED_LIBS)
     set(AVIF_PKG_CONFIG_EXTRA_CFLAGS " -DAVIF_DLL")
     if(AVIF_LOCAL_LIBGAV1)
         set_target_properties(avif PROPERTIES LINKER_LANGUAGE "CXX")
@@ -461,12 +471,7 @@ endif()
 
 option(AVIF_BUILD_EXAMPLES "Build avif Examples." OFF)
 if(AVIF_BUILD_EXAMPLES)
-    set(AVIF_EXAMPLES
-        avif_example_decode_memory
-        avif_example_decode_file
-        avif_example_decode_streaming
-        avif_example_encode
-    )
+    set(AVIF_EXAMPLES avif_example_decode_memory avif_example_decode_file avif_example_decode_streaming avif_example_encode)
 
     foreach(EXAMPLE ${AVIF_EXAMPLES})
         add_executable(${EXAMPLE} examples/${EXAMPLE}.c)
@@ -498,19 +503,12 @@ if(AVIF_BUILD_APPS OR AVIF_BUILD_TESTS)
     find_package(JPEG REQUIRED)
 
     add_library(avif_apps STATIC # Static so it does not have to be installed.
-        apps/shared/avifjpeg.c
-        apps/shared/iccjpeg.c
-        apps/shared/avifpng.c
-        apps/shared/avifutil.c
-        apps/shared/y4m.c)
+                apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c apps/shared/y4m.c)
     target_link_libraries(avif_apps avif ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
-    target_include_directories(avif_apps
-                               PRIVATE
-                                   $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES>
-                                   ${PNG_PNG_INCLUDE_DIR}
-                                   ${JPEG_INCLUDE_DIR}
-                               INTERFACE
-                                   apps/shared)
+    target_include_directories(
+        avif_apps
+        PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR}
+        INTERFACE apps/shared)
 endif()
 
 if(AVIF_BUILD_APPS)
@@ -526,11 +524,11 @@ if(AVIF_BUILD_APPS)
     target_link_libraries(avifdec avif avif_apps ${AVIF_PLATFORM_LIBRARIES})
 
     if(NOT SKIP_INSTALL_APPS AND NOT SKIP_INSTALL_ALL)
-        install(TARGETS avifenc avifdec
+        install(
+            TARGETS avifenc avifdec
             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        )
+            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     endif()
 endif()
 
@@ -540,34 +538,31 @@ if(AVIF_BUILD_TESTS)
 endif()
 
 if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
-    install(TARGETS avif
+    install(
+        TARGETS avif
         EXPORT ${PROJECT_NAME}-config
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    )
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
     # Enable CMake configs in VCPKG mode
-    if (BUILD_SHARED_LIBS OR VCPKG_TARGET_TRIPLET)
-        install(EXPORT ${PROJECT_NAME}-config
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+    if(BUILD_SHARED_LIBS OR VCPKG_TARGET_TRIPLET)
+        install(EXPORT ${PROJECT_NAME}-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
         include(CMakePackageConfigHelpers)
-        write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake
-                                         VERSION ${PROJECT_VERSION}
-                                         COMPATIBILITY SameMajorVersion)
+        write_basic_package_version_file(
+            ${PROJECT_NAME}-config-version.cmake
+            VERSION ${PROJECT_VERSION}
+            COMPATIBILITY SameMajorVersion)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
                 DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
     endif()
 
     configure_file(libavif.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libavif.pc @ONLY)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libavif.pc
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libavif.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL)
-    install(FILES include/avif/avif.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/avif"
-    )
+    install(FILES include/avif/avif.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/avif")
 endif()
 
 # ---------------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,13 +40,17 @@ option(AVIF_CODEC_AOM_ENCODE "if AVIF_CODEC_AOM is on, use/offer libaom's encode
 
 option(AVIF_LOCAL_AOM "Build the AOM codec by providing your own copy of the repo in ext/aom (see Local Builds in README)" OFF)
 option(AVIF_LOCAL_DAV1D "Build the dav1d codec by providing your own copy of the repo in ext/dav1d (see Local Builds in README)"
-       OFF)
+       OFF
+)
 option(AVIF_LOCAL_LIBGAV1
-       "Build the libgav1 codec by providing your own copy of the repo in ext/libgav1 (see Local Builds in README)" OFF)
+       "Build the libgav1 codec by providing your own copy of the repo in ext/libgav1 (see Local Builds in README)" OFF
+)
 option(AVIF_LOCAL_RAV1E "Build the rav1e codec by providing your own copy of the repo in ext/rav1e (see Local Builds in README)"
-       OFF)
+       OFF
+)
 option(AVIF_LOCAL_SVT
-       "Build the SVT-AV1 codec by providing your own copy of the repo in ext/SVT-AV1 (see Local Builds in README)" OFF)
+       "Build the SVT-AV1 codec by providing your own copy of the repo in ext/SVT-AV1 (see Local Builds in README)" OFF
+)
 
 if(AVIF_LOCAL_LIBGAV1)
     enable_language(CXX)
@@ -99,7 +103,8 @@ endif()
 option(AVIF_LOCAL_LIBYUV "Build libyuv by providing your own copy inside the ext subdir." OFF)
 if(AVIF_LOCAL_LIBYUV)
     set(LIB_FILENAME
-        "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/build/${CMAKE_STATIC_LIBRARY_PREFIX}yuv${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        "${CMAKE_CURRENT_SOURCE_DIR}/ext/libyuv/build/${CMAKE_STATIC_LIBRARY_PREFIX}yuv${CMAKE_STATIC_LIBRARY_SUFFIX}"
+    )
     if(NOT EXISTS "${LIB_FILENAME}")
         message(FATAL_ERROR "libavif(AVIF_LOCAL_LIBYUV): ${LIB_FILENAME} is missing, bailing out")
     endif()
@@ -131,7 +136,8 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
         -Wno-missing-noreturn
         -Wno-padded
         -Wno-sign-conversion
-        -Wno-error=c11-extensions)
+        -Wno-error=c11-extensions
+    )
     # Some headers such as glib-2.0 use identifier names that start with '_' followed by a capital letter.
     # The C standard reserves names beginning with an underscore and various other combinations.
     # ISO/IEC 9899:1999 (aka C99 standard) 7.1.3 Reserved identifiers
@@ -182,7 +188,8 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
         # Commonly used /utf-8 flag assumes UTF-8 for both source and console, which is usually not the case.
         # Warnings can be suppressed but there will still be random characters printed to the console.
         /source-charset:utf-8
-        /execution-charset:us-ascii)
+        /execution-charset:us-ascii
+    )
 else()
     message(FATAL_ERROR "libavif: Unknown compiler, bailing out")
 endif()
@@ -224,7 +231,8 @@ set(AVIF_SRCS
     src/scale.c
     src/stream.c
     src/utils.c
-    src/write.c)
+    src/write.c
+)
 
 set(AVIF_PLATFORM_DEFINITIONS)
 set(AVIF_PLATFORM_INCLUDES)
@@ -275,7 +283,8 @@ if(AVIF_CODEC_DAV1D)
         set(AVIF_CODEC_INCLUDES
             ${AVIF_CODEC_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build"
             "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include" "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include/dav1d"
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/include")
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/include"
+        )
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
     else()
         # Check to see if dav1d is independently being built by the outer CMake project
@@ -401,7 +410,8 @@ if(AVIF_CODEC_AOM)
     set(AVIF_SRCS ${AVIF_SRCS} src/codec_aom.c)
     if(AVIF_LOCAL_AOM)
         set(LIB_FILENAME
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom/build.libavif/${CMAKE_STATIC_LIBRARY_PREFIX}aom${CMAKE_STATIC_LIBRARY_SUFFIX}")
+            "${CMAKE_CURRENT_SOURCE_DIR}/ext/aom/build.libavif/${CMAKE_STATIC_LIBRARY_PREFIX}aom${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        )
         if(NOT EXISTS "${LIB_FILENAME}")
             message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
         endif()
@@ -428,8 +438,10 @@ add_library(avif ${AVIF_SRCS})
 set_target_properties(avif PROPERTIES VERSION ${LIBRARY_VERSION} SOVERSION ${LIBRARY_SOVERSION} C_VISIBILITY_PRESET hidden)
 target_compile_definitions(avif PRIVATE ${AVIF_PLATFORM_DEFINITIONS} ${AVIF_CODEC_DEFINITIONS})
 target_link_libraries(avif PRIVATE ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
-target_include_directories(avif PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-                           PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
+target_include_directories(
+    avif PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE ${AVIF_PLATFORM_INCLUDES}
+                                                                                                      ${AVIF_CODEC_INCLUDES}
+)
 set(AVIF_PKG_CONFIG_EXTRA_CFLAGS "")
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(avif PUBLIC AVIF_DLL PRIVATE AVIF_BUILDING_SHARED_LIBS)
@@ -472,11 +484,15 @@ if(AVIF_BUILD_APPS OR AVIF_BUILD_TESTS)
     find_package(PNG REQUIRED)
     find_package(JPEG REQUIRED)
 
-    add_library(avif_apps STATIC # Static so it does not have to be installed.
-                apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c apps/shared/y4m.c)
+    add_library(
+        avif_apps STATIC # Static so it does not have to be installed.
+        apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c apps/shared/y4m.c
+    )
     target_link_libraries(avif_apps avif ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
-    target_include_directories(avif_apps PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> ${PNG_PNG_INCLUDE_DIR}
-                                                 ${JPEG_INCLUDE_DIR} INTERFACE apps/shared)
+    target_include_directories(
+        avif_apps PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR}
+        INTERFACE apps/shared
+    )
 endif()
 
 if(AVIF_BUILD_APPS)
@@ -496,7 +512,8 @@ if(AVIF_BUILD_APPS)
             TARGETS avifenc avifdec
             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        )
     endif()
 endif()
 
@@ -511,17 +528,20 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
         EXPORT ${PROJECT_NAME}-config
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    )
 
     # Enable CMake configs in VCPKG mode
     if(BUILD_SHARED_LIBS OR VCPKG_TARGET_TRIPLET)
         install(EXPORT ${PROJECT_NAME}-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
         include(CMakePackageConfigHelpers)
-        write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake VERSION ${PROJECT_VERSION}
-                                         COMPATIBILITY SameMajorVersion)
+        write_basic_package_version_file(
+            ${PROJECT_NAME}-config-version.cmake VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion
+        )
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+        )
     endif()
 
     configure_file(libavif.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libavif.pc @ONLY)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
 # libavif [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/louquillio/libavif?branch=master&svg=true)](https://ci.appveyor.com/project/louquillio/libavif) [![Travis Build Status](https://travis-ci.com/AOMediaCodec/libavif.svg?branch=master)](https://travis-ci.com/AOMediaCodec/libavif)
 
-This library aims to be a friendly, portable C implementation of the AV1 Image File Format, as described here:
+This library aims to be a friendly, portable C implementation of the AV1 Image
+File Format, as described here:
 
 <https://aomediacodec.github.io/av1-avif/>
 
-It is a work-in-progress, but can already encode and decode all AOM supported YUV formats and bit depths (with alpha).
+It is a work-in-progress, but can already encode and decode all AOM supported
+YUV formats and bit depths (with alpha).
 
-For now, it is recommended that you checkout/use [tagged releases](https://github.com/AOMediaCodec/libavif/releases) instead of just using the master branch. I will regularly create new versions as bugfixes and features are added.
+For now, it is recommended that you check out/use
+[tagged releases](https://github.com/AOMediaCodec/libavif/releases) instead of
+just using the master branch. I will regularly create new versions as bugfixes
+and features are added.
 
 ## Usage
 
-Please see the examples in the examples directory. If you're already building `libavif`, enable the CMake option `AVIF_BUILD_EXAMPLES` in order to build and run the examples too.
+Please see the examples in the "examples" directory. If you're already building
+`libavif`, enable the CMake option `AVIF_BUILD_EXAMPLES` in order to build and
+run the examples too.
 
 ## Build Notes
 
@@ -44,7 +51,30 @@ codec.
 
 ## Prebuilt Library (Windows)
 
-If you're building on Windows with Visual Studio 2019 and want to try out libavif without going through the build process, static library builds for both Debug and Release are available on [AppVeyor](https://ci.appveyor.com/project/louquillio/libavif).
+If you're building on Windows with Visual Studio 2019 and want to try out
+libavif without going through the build process, static library builds for both
+Debug and Release are available on
+[AppVeyor](https://ci.appveyor.com/project/louquillio/libavif).
+
+## Development Notes
+
+libavif is written mainly in C99.
+
+### Formatting
+
+Use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to format the C
+sources from the top-level folder:
+
+```sh
+clang-format -i apps/*.c examples/*.c include/avif/*.h src/*.c tests/*.c
+```
+
+Use [cmake-format](https://github.com/cheshirekow/cmake_format) to format the
+CMakeLists.txt files from the top-level folder:
+
+```sh
+cmake-format -i CMakeLists.txt tests/CMakeLists.txt
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Debug and Release are available on
 
 ## Development Notes
 
-libavif is written mainly in C99.
+libavif is written in C99.
 
 ### Formatting
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,10 +42,7 @@ if(AVIF_LOCAL_LIBGAV1)
 endif()
 target_link_libraries(avifyuv avif ${AVIF_PLATFORM_LIBRARIES})
 
-add_custom_target(
-    avif_test_all
-    COMMAND $<TARGET_FILE:aviftest> ${CMAKE_CURRENT_SOURCE_DIR}/data
-    DEPENDS aviftest)
+add_custom_target(avif_test_all COMMAND $<TARGET_FILE:aviftest> ${CMAKE_CURRENT_SOURCE_DIR}/data DEPENDS aviftest)
 
 if(AVIF_ENABLE_COVERAGE)
     add_custom_target(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,18 +42,21 @@ if(AVIF_LOCAL_LIBGAV1)
 endif()
 target_link_libraries(avifyuv avif ${AVIF_PLATFORM_LIBRARIES})
 
-add_custom_target(avif_test_all
+add_custom_target(
+    avif_test_all
     COMMAND $<TARGET_FILE:aviftest> ${CMAKE_CURRENT_SOURCE_DIR}/data
-    DEPENDS aviftest
-)
+    DEPENDS aviftest)
 
 if(AVIF_ENABLE_COVERAGE)
-    add_custom_target(avif_coverage
-        COMMAND ${CMAKE_COMMAND} -E env "LLVM_PROFILE_FILE=${CMAKE_CURRENT_BINARY_DIR}/aviftest.profraw" $<TARGET_FILE:aviftest> ${CMAKE_CURRENT_SOURCE_DIR}/data
-        COMMAND ${XCRUN} llvm-profdata merge -sparse ${CMAKE_CURRENT_BINARY_DIR}/aviftest.profraw -o ${CMAKE_CURRENT_BINARY_DIR}/aviftest.profdata
+    add_custom_target(
+        avif_coverage
+        COMMAND ${CMAKE_COMMAND} -E env "LLVM_PROFILE_FILE=${CMAKE_CURRENT_BINARY_DIR}/aviftest.profraw" $<TARGET_FILE:aviftest>
+                ${CMAKE_CURRENT_SOURCE_DIR}/data
+        COMMAND ${XCRUN} llvm-profdata merge -sparse ${CMAKE_CURRENT_BINARY_DIR}/aviftest.profraw -o
+                ${CMAKE_CURRENT_BINARY_DIR}/aviftest.profdata
         COMMAND cmake -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/coverage
-        COMMAND ${XCRUN} llvm-cov show $<TARGET_FILE:aviftest> -instr-profile=${CMAKE_CURRENT_BINARY_DIR}/aviftest.profdata -project-title=libavif --format html -output-dir=${CMAKE_CURRENT_BINARY_DIR}/coverage
+        COMMAND ${XCRUN} llvm-cov show $<TARGET_FILE:aviftest> -instr-profile=${CMAKE_CURRENT_BINARY_DIR}/aviftest.profdata
+                -project-title=libavif --format html -output-dir=${CMAKE_CURRENT_BINARY_DIR}/coverage
         COMMAND echo Coverage report here: ${CMAKE_CURRENT_BINARY_DIR}/coverage/index.html
-        DEPENDS aviftest
-    )
+        DEPENDS aviftest)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,5 +55,6 @@ if(AVIF_ENABLE_COVERAGE)
         COMMAND ${XCRUN} llvm-cov show $<TARGET_FILE:aviftest> -instr-profile=${CMAKE_CURRENT_BINARY_DIR}/aviftest.profdata
                 -project-title=libavif --format html -output-dir=${CMAKE_CURRENT_BINARY_DIR}/coverage
         COMMAND echo Coverage report here: ${CMAKE_CURRENT_BINARY_DIR}/coverage/index.html
-        DEPENDS aviftest)
+        DEPENDS aviftest
+    )
 endif()


### PR DESCRIPTION
Use https://github.com/cheshirekow/cmake_format/tree/v0.6.13
Add config file .cmake-format.yaml.
Set CMakeLists.txt line width to 130 characters, as per .clang-format.
Format and add formatting instructions to README.md.