### PR TITLE
tile_rows/columns in EbSvtAv1EncConfiguration log2

### DIFF
--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -121,12 +121,10 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
         }
 
         if (encoder->tileRowsLog2 != 0) {
-            int tileRowsLog2 = AVIF_CLAMP(encoder->tileRowsLog2, 0, 6);
-            svt_config->tile_rows = 1 << tileRowsLog2;
+            svt_config->tile_rows = AVIF_CLAMP(encoder->tileRowsLog2, 0, 6);
         }
         if (encoder->tileColsLog2 != 0) {
-            int tileColsLog2 = AVIF_CLAMP(encoder->tileColsLog2, 0, 6);
-            svt_config->tile_columns = 1 << tileColsLog2;
+            svt_config->tile_columns = AVIF_CLAMP(encoder->tileColsLog2, 0, 6);
         }
         if (encoder->speed != AVIF_SPEED_DEFAULT) {
             int speed = AVIF_CLAMP(encoder->speed, 0, 8);


### PR DESCRIPTION
The tile_rows and tile_columns members of the EbSvtAv1EncConfiguration
struct are log2 of tile rows and columns.