### PR TITLE
Add multi XMP/Exif metadata encode/decode API

### DIFF
--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -64,8 +64,20 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
     printf(" * Matrix Coeffs. : %u\n", avif->matrixCoefficients);
 
     printf(" * ICC Profile    : %s (" AVIF_FMT_ZU " bytes)\n", (avif->icc.size > 0) ? "Present" : "Absent", avif->icc.size);
-    printf(" * XMP Metadata   : %s (" AVIF_FMT_ZU " bytes)\n", (avif->xmp.size > 0) ? "Present" : "Absent", avif->xmp.size);
-    printf(" * EXIF Metadata  : %s (" AVIF_FMT_ZU " bytes)\n", (avif->exif.size > 0) ? "Present" : "Absent", avif->exif.size);
+    if (avif->xmpItems && (avif->xmpItems[0].size != 0)) {
+        for (avifRWData * xmp = avif->xmpItems; (xmp->size != 0); ++xmp) {
+            printf(" * XMP Metadata  : Present (" AVIF_FMT_ZU " bytes)\n", xmp->size);
+        }
+    } else {
+        printf(" * XMP Metadata  : Absent\n");
+    }
+    if (avif->exifItems && (avif->exifItems[0].size != 0)) {
+        for (avifRWData * exif = avif->exifItems; exif && (exif->size != 0); ++exif) {
+            printf(" * EXIF Metadata  : Present (" AVIF_FMT_ZU " bytes)\n", exif->size);
+        }
+    } else {
+        printf(" * EXIF Metadata  : Absent\n");
+    }
 
     if (avif->transformFlags == AVIF_TRANSFORM_NONE) {
         printf(" * Transformations: None\n");

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -31,8 +31,8 @@ int main(int argc, char * argv[])
     // * transferCharacteristics
     // * matrixCoefficients
     // * avifImageSetProfileICC()
-    // * avifImageSetMetadataExif()
-    // * avifImageSetMetadataXMP()
+    // * avifImagePushMetadataExif()
+    // * avifImagePushMetadataXMP()
     // * yuvRange
     // * alphaRange
     // * alphaPremultiplied

--- a/src/read.c
+++ b/src/read.c
@@ -1478,7 +1478,8 @@ static avifResult avifDecoderFindMetadata(avifDecoder * decoder, avifMeta * meta
             uint32_t exifTiffHeaderOffset;
             CHECKERR(avifROStreamReadU32(&exifBoxStream, &exifTiffHeaderOffset), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) exif_tiff_header_offset;
 
-            avifResult pushResult = avifImagePushMetadataExif(image, avifROStreamCurrent(&exifBoxStream), avifROStreamRemainingBytes(&exifBoxStream));
+            avifResult pushResult =
+                avifImagePushMetadataExif(image, avifROStreamCurrent(&exifBoxStream), avifROStreamRemainingBytes(&exifBoxStream));
             if (pushResult != AVIF_RESULT_OK) {
                 return pushResult;
             }

--- a/src/write.c
+++ b/src/write.c
@@ -538,6 +538,60 @@ static void avifWriteGridPayload(avifRWData * data, uint32_t gridCols, uint32_t 
     avifRWStreamFinishWrite(&s);
 }
 
+static avifResult avifEncoderDataCreateExifItem(avifEncoderData * data, const avifRWData * exif)
+{
+    // Validate Exif payload (if any) and find TIFF header offset
+    uint32_t exifTiffHeaderOffset = 0;
+    if (exif->size < 4) {
+        // Can't even fit the TIFF header, something is wrong
+        return AVIF_RESULT_INVALID_EXIF_PAYLOAD;
+    }
+
+    const uint8_t tiffHeaderBE[4] = { 'M', 'M', 0, 42 };
+    const uint8_t tiffHeaderLE[4] = { 'I', 'I', 42, 0 };
+    for (; exifTiffHeaderOffset < (exif->size - 4); ++exifTiffHeaderOffset) {
+        if (!memcmp(&exif->data[exifTiffHeaderOffset], tiffHeaderBE, sizeof(tiffHeaderBE))) {
+            break;
+        }
+        if (!memcmp(&exif->data[exifTiffHeaderOffset], tiffHeaderLE, sizeof(tiffHeaderLE))) {
+            break;
+        }
+    }
+
+    if (exifTiffHeaderOffset >= exif->size - 4) {
+        // Couldn't find the TIFF header
+        return AVIF_RESULT_INVALID_EXIF_PAYLOAD;
+    }
+
+    avifEncoderItem * exifItem = avifEncoderDataCreateItem(data, "Exif", "Exif", 5, 0);
+    if (!exifItem) {
+        return AVIF_RESULT_OUT_OF_MEMORY;
+    }
+    exifItem->irefToID = data->primaryItemID;
+    exifItem->irefType = "cdsc";
+
+    avifRWDataRealloc(&exifItem->metadataPayload, sizeof(uint32_t) + exif->size);
+    exifTiffHeaderOffset = avifHTONL(exifTiffHeaderOffset);
+    memcpy(exifItem->metadataPayload.data, &exifTiffHeaderOffset, sizeof(uint32_t));
+    memcpy(exifItem->metadataPayload.data + sizeof(uint32_t), exif->data, exif->size);
+    return AVIF_RESULT_OK;
+}
+
+static avifResult avifEncoderDataCreateXMPItem(avifEncoderData * data, const avifRWData * xmp)
+{
+    avifEncoderItem * xmpItem = avifEncoderDataCreateItem(data, "mime", "XMP", 4, 0);
+    if (!xmpItem) {
+        return AVIF_RESULT_OUT_OF_MEMORY;
+    }
+    xmpItem->irefToID = data->primaryItemID;
+    xmpItem->irefType = "cdsc";
+
+    xmpItem->infeContentType = xmpContentType;
+    xmpItem->infeContentTypeSize = xmpContentTypeSize;
+    avifRWDataSet(&xmpItem->metadataPayload, xmp->data, xmp->size);
+    return AVIF_RESULT_OK;
+}
+
 static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
                                               uint32_t gridCols,
                                               uint32_t gridRows,
@@ -733,48 +787,32 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         // -----------------------------------------------------------------------
         // Create metadata items (Exif, XMP)
 
-        if (firstCell->exif.size > 0) {
-            // Validate Exif payload (if any) and find TIFF header offset
-            uint32_t exifTiffHeaderOffset = 0;
-            if (firstCell->exif.size < 4) {
-                // Can't even fit the TIFF header, something is wrong
-                return AVIF_RESULT_INVALID_EXIF_PAYLOAD;
+        if (!firstCell->exifItems && (firstCell->exif.size != 0)) {
+            // For retrocompatibility, encode the given single Exif item if the Exif item array is null.
+            const avifResult result = avifEncoderDataCreateExifItem(encoder->data, &firstCell->exif);
+            if (result != AVIF_RESULT_OK) {
+                return result;
             }
-
-            const uint8_t tiffHeaderBE[4] = { 'M', 'M', 0, 42 };
-            const uint8_t tiffHeaderLE[4] = { 'I', 'I', 42, 0 };
-            for (; exifTiffHeaderOffset < (firstCell->exif.size - 4); ++exifTiffHeaderOffset) {
-                if (!memcmp(&firstCell->exif.data[exifTiffHeaderOffset], tiffHeaderBE, sizeof(tiffHeaderBE))) {
-                    break;
-                }
-                if (!memcmp(&firstCell->exif.data[exifTiffHeaderOffset], tiffHeaderLE, sizeof(tiffHeaderLE))) {
-                    break;
-                }
+        }
+        for (const avifRWData * exif = firstCell->exifItems; exif && (exif->size != 0); ++exif) {
+            const avifResult result = avifEncoderDataCreateExifItem(encoder->data, exif);
+            if (result != AVIF_RESULT_OK) {
+                return result;
             }
-
-            if (exifTiffHeaderOffset >= firstCell->exif.size - 4) {
-                // Couldn't find the TIFF header
-                return AVIF_RESULT_INVALID_EXIF_PAYLOAD;
-            }
-
-            avifEncoderItem * exifItem = avifEncoderDataCreateItem(encoder->data, "Exif", "Exif", 5, 0);
-            exifItem->irefToID = encoder->data->primaryItemID;
-            exifItem->irefType = "cdsc";
-
-            avifRWDataRealloc(&exifItem->metadataPayload, sizeof(uint32_t) + firstCell->exif.size);
-            exifTiffHeaderOffset = avifHTONL(exifTiffHeaderOffset);
-            memcpy(exifItem->metadataPayload.data, &exifTiffHeaderOffset, sizeof(uint32_t));
-            memcpy(exifItem->metadataPayload.data + sizeof(uint32_t), firstCell->exif.data, firstCell->exif.size);
         }
 
-        if (firstCell->xmp.size > 0) {
-            avifEncoderItem * xmpItem = avifEncoderDataCreateItem(encoder->data, "mime", "XMP", 4, 0);
-            xmpItem->irefToID = encoder->data->primaryItemID;
-            xmpItem->irefType = "cdsc";
-
-            xmpItem->infeContentType = xmpContentType;
-            xmpItem->infeContentTypeSize = xmpContentTypeSize;
-            avifRWDataSet(&xmpItem->metadataPayload, firstCell->xmp.data, firstCell->xmp.size);
+        if (!firstCell->xmpItems && (firstCell->xmp.size != 0)) {
+            // For retrocompatibility, encode the given single XMP item if the XMP item array is null.
+            const avifResult result = avifEncoderDataCreateXMPItem(encoder->data, &firstCell->xmp);
+            if (result != AVIF_RESULT_OK) {
+                return result;
+            }
+        }
+        for (const avifRWData * xmp = firstCell->xmpItems; xmp && (xmp->size != 0); ++xmp) {
+            const avifResult result = avifEncoderDataCreateXMPItem(encoder->data, xmp);
+            if (result != AVIF_RESULT_OK) {
+                return result;
+            }
         }
     } else {
         // Another frame in an image sequence

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,13 @@ endif()
 target_link_libraries(avifincrtest avif ${AVIF_PLATFORM_LIBRARIES})
 add_test(NAME avifincrtest COMMAND avifincrtest ${CMAKE_CURRENT_SOURCE_DIR}/data/sofa_grid1x5_420.avif)
 
+add_executable(avifmetadatatest avifmetadatatest.c)
+if(AVIF_LOCAL_LIBGAV1)
+    set_target_properties(avifmetadatatest PROPERTIES LINKER_LANGUAGE "CXX")
+endif()
+target_link_libraries(avifmetadatatest avif ${AVIF_PLATFORM_LIBRARIES})
+add_test(NAME avifmetadatatest COMMAND avifmetadatatest)
+
 add_executable(avify4mtest avify4mtest.c)
 if(AVIF_LOCAL_LIBGAV1)
     set_target_properties(avify4mtest PROPERTIES LINKER_LANGUAGE "CXX")

--- a/tests/avifmetadatatest.c
+++ b/tests/avifmetadatatest.c
@@ -1,0 +1,278 @@
+// Copyright 2022 Google LLC. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//------------------------------------------------------------------------------
+
+// ICC color profiles are not checked by libavif so the content does not matter. This is a truncated widespread ICC color profile.
+static const uint8_t sampleICC[] = { 0x00, 0x00, 0x02, 0x0c, 0x6c, 0x63, 0x6d, 0x73, 0x02, 0x10, 0x00, 0x00,
+                                     0x6d, 0x6e, 0x74, 0x72, 0x52, 0x47, 0x42, 0x20, 0x58, 0x59, 0x5a, 0x20 };
+static const size_t sampleICCSize = sizeof(sampleICC) / sizeof(sampleICC[0]);
+
+// Exif bytes are partially checked by libavif. This is a truncated widespread Exif metadata chunk.
+static const uint8_t sampleExif[] = { 0xff, 0x1,  0x45, 0x78, 0x69, 0x76, 0x32, 0xff, 0xe1, 0x12, 0x5a, 0x45,
+                                      0x78, 0x69, 0x66, 0x0,  0x0,  0x49, 0x49, 0x2a, 0x0,  0x8,  0x0,  0x0 };
+static const size_t sampleExifSize = sizeof(sampleExif) / sizeof(sampleExif[0]);
+
+// XMP bytes are not checked by libavif so the content does not matter. This is a truncated widespread XMP metadata chunk.
+static const uint8_t sampleXMP[] = { 0x3c, 0x3f, 0x78, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x74, 0x20, 0x62, 0x65,
+                                     0x67, 0x69, 0x6e, 0x3d, 0x22, 0xef, 0xbb, 0xbf, 0x22, 0x20, 0x69, 0x64 };
+static const size_t sampleXMPSize = sizeof(sampleXMP) / sizeof(sampleXMP[0]);
+
+//------------------------------------------------------------------------------
+// TODO(yguyon): Move these functions to a tests/common/helper.c shared with avifgridapitest.c
+
+// Fills a plane with a repeating gradient.
+static void fillPlane(int width, int height, int depth, uint8_t * row, uint32_t rowBytes)
+{
+    assert(depth == 8 || depth == 10 || depth == 12); // Values allowed by AV1.
+    const int maxValuePlusOne = 1 << depth;
+    for (int y = 0; y < height; ++y) {
+        if (depth == 8) {
+            memset(row, y % maxValuePlusOne, width);
+        } else {
+            for (int x = 0; x < width; ++x) {
+                ((uint16_t *)row)[x] = (uint16_t)(y % maxValuePlusOne);
+            }
+        }
+        row += rowBytes;
+    }
+}
+
+// Creates an image where the pixel values are defined but do not matter.
+// Returns false in case of memory failure.
+static avifBool createImage(int width, int height, int depth, avifPixelFormat yuvFormat, avifBool createAlpha, avifImage ** image)
+{
+    *image = avifImageCreate(width, height, depth, yuvFormat);
+    if (*image == NULL) {
+        printf("ERROR: avifImageCreate() failed\n");
+        return AVIF_FALSE;
+    }
+    avifImageAllocatePlanes(*image, createAlpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV);
+
+    avifPixelFormatInfo formatInfo;
+    avifGetPixelFormatInfo((*image)->yuvFormat, &formatInfo);
+    uint32_t uvWidth = ((*image)->width + formatInfo.chromaShiftX) >> formatInfo.chromaShiftX;
+    uint32_t uvHeight = ((*image)->height + formatInfo.chromaShiftY) >> formatInfo.chromaShiftY;
+
+    const int planeCount = formatInfo.monochrome ? 1 : AVIF_PLANE_COUNT_YUV;
+    for (int plane = 0; plane < planeCount; ++plane) {
+        fillPlane((plane == AVIF_CHAN_Y) ? (*image)->width : uvWidth,
+                  (plane == AVIF_CHAN_Y) ? (*image)->height : uvHeight,
+                  (*image)->depth,
+                  (*image)->yuvPlanes[plane],
+                  (*image)->yuvRowBytes[plane]);
+    }
+
+    if (createAlpha) {
+        fillPlane((*image)->width, (*image)->height, (*image)->depth, (*image)->alphaPlane, (*image)->alphaRowBytes);
+    }
+    return AVIF_TRUE;
+}
+
+static avifBool createImage1x1(avifImage ** image)
+{
+    return createImage(/*width=*/1, /*height=*/1, /*depth=*/10, AVIF_PIXEL_FORMAT_YUV444, /*createAlpha=*/AVIF_TRUE, image);
+}
+
+//------------------------------------------------------------------------------
+
+// Encodes the image. Returns false in case of failure.
+static avifBool encode(const avifImage * image, avifRWData * output)
+{
+    avifBool success = AVIF_FALSE;
+    avifEncoder * encoder = NULL;
+
+    encoder = avifEncoderCreate();
+    if (encoder == NULL) {
+        printf("ERROR: avifEncoderCreate() failed\n");
+        goto cleanup;
+    }
+    encoder->speed = AVIF_SPEED_FASTEST;
+    if (avifEncoderWrite(encoder, image, output) != AVIF_RESULT_OK) {
+        printf("ERROR: avifEncoderWrite() failed\n");
+        goto cleanup;
+    }
+
+    success = AVIF_TRUE;
+cleanup:
+    if (encoder != NULL) {
+        avifEncoderDestroy(encoder);
+    }
+    return success;
+}
+
+// Decodes the data. Returns false in case of failure.
+static avifBool decode(const avifRWData * encodedAvif, avifImage ** image)
+{
+    avifBool success = AVIF_FALSE;
+    *image = avifImageCreateEmpty();
+    avifDecoder * const decoder = avifDecoderCreate();
+    if (*image == NULL || decoder == NULL) {
+        printf("ERROR: memory allocation failed\n");
+        goto cleanup;
+    }
+    if (avifDecoderReadMemory(decoder, *image, encodedAvif->data, encodedAvif->size) != AVIF_RESULT_OK) {
+        printf("ERROR: avifDecoderReadMemory() failed\n");
+        goto cleanup;
+    }
+    success = AVIF_TRUE;
+cleanup:
+    if (decoder != NULL) {
+        avifDecoderDestroy(decoder);
+    }
+    return success;
+}
+
+//------------------------------------------------------------------------------
+
+// Returns true if the decoded metadata matches the expected output metadata given the input metadata.
+static avifBool metadataIsEqual(avifRWData legacyInputItem, const avifRWData * inputItems, avifRWData legacyOutputItem, const avifRWData * outputItems)
+{
+    if (inputItems) {
+        // legacyInputItem should be ignored.
+        const avifRWData * inputItem = inputItems;
+        const avifRWData * outputItem = outputItems;
+        while (inputItem->size != 0) {
+            if (!outputItem || (outputItem->size != inputItem->size) ||
+                (memcmp(outputItem->data, inputItem->data, outputItem->size) != 0)) {
+                return AVIF_FALSE;
+            }
+            ++inputItem;
+            ++outputItem;
+        }
+        if (outputItem->size != 0) {
+            return AVIF_FALSE;
+        }
+    } else if (legacyInputItem.size != 0) {
+        // Legacy metadata input only.
+        if (!outputItems || (outputItems[0].size != legacyInputItem.size) ||
+            (memcmp(outputItems[0].data, legacyInputItem.data, outputItems[0].size) != 0)) {
+            return AVIF_FALSE;
+        }
+        if (outputItems[1].size != 0) {
+            return AVIF_FALSE;
+        }
+    } else {
+        // No metadata input.
+        if (outputItems) {
+            return AVIF_FALSE;
+        }
+    }
+
+    // Verify legacy decoding API is behaving according to documentation.
+    if ((legacyOutputItem.size != 0) != (outputItems && (outputItems[0].size != 0))) {
+        return AVIF_FALSE;
+    }
+    if ((legacyOutputItem.size != 0) && (memcmp(legacyOutputItem.data, outputItems[0].data, legacyOutputItem.size) != 0)) {
+        return AVIF_FALSE;
+    }
+    return AVIF_TRUE;
+}
+
+// Encodes, decodes then compares the metadata of the input and decoded images.
+static avifBool encodeDecode(const avifImage * image)
+{
+    avifBool success = AVIF_FALSE;
+    avifRWData encodedAvif = { 0 };
+    avifImage * decodedImage = NULL;
+    if (!encode(image, &encodedAvif)) {
+        goto cleanup;
+    }
+    if (!decode(&encodedAvif, &decodedImage)) {
+        goto cleanup;
+    }
+
+    if ((image->icc.size != 0) != (decodedImage->icc.size != 0)) {
+        printf("ERROR: icc mismatch\n");
+        goto cleanup;
+    }
+    if (!metadataIsEqual(image->exif, image->exifItems, decodedImage->exif, decodedImage->exifItems)) {
+        printf("ERROR: Exif metadata mismatch\n");
+        goto cleanup;
+    }
+    if (!metadataIsEqual(image->xmp, image->xmpItems, decodedImage->xmp, decodedImage->xmpItems)) {
+        printf("ERROR: XMP metadata mismatch\n");
+        goto cleanup;
+    }
+    success = AVIF_TRUE;
+cleanup:
+    avifRWDataFree(&encodedAvif);
+    if (decodedImage) {
+        avifImageDestroy(decodedImage);
+    }
+    return success;
+}
+
+//------------------------------------------------------------------------------
+
+// Encodes, decodes then verifies that the output metadata matches the input metadata defined by the arguments.
+static avifBool encodeDecodeMetadataItems(avifBool useICC, avifBool useLegacyExif, avifBool useLegacyXMP, size_t exifItemCount, size_t xmpItemCount)
+{
+    avifBool success = AVIF_FALSE;
+    avifImage * image;
+    if (!createImage1x1(&image)) {
+        goto cleanup;
+    }
+
+    if (useICC) {
+        avifImageSetProfileICC(image, sampleICC, sampleICCSize);
+    }
+
+    if (useLegacyExif) {
+        avifImageSetMetadataExif(image, sampleExif, sampleExifSize);
+        exifItemCount = (exifItemCount != 0) ? exifItemCount - 1 : 0;
+    }
+    for (size_t i = 0; i < exifItemCount; ++i) {
+        if (avifImagePushMetadataExif(image, sampleExif, sampleExifSize) != AVIF_RESULT_OK) {
+            goto cleanup;
+        }
+        image->exifItems[i].data[image->exifItems[i].size - 1] = i; // Make Exif item unique.
+    }
+
+    if (useLegacyXMP) {
+        avifImageSetMetadataXMP(image, sampleXMP, sampleXMPSize);
+        xmpItemCount = (xmpItemCount != 0) ? xmpItemCount - 1 : 0;
+    }
+    for (size_t i = 0; i < xmpItemCount; ++i) {
+        if (avifImagePushMetadataXMP(image, sampleXMP, sampleXMPSize) != AVIF_RESULT_OK) {
+            goto cleanup;
+        }
+        image->xmpItems[i].data[image->xmpItems[i].size - 1] = i; // Make XMP item unique.
+    }
+
+    if (!encodeDecode(image)) {
+        goto cleanup;
+    }
+    success = AVIF_TRUE;
+cleanup:
+    if (image) {
+        avifImageDestroy(image);
+    }
+    return success;
+}
+
+int main(void)
+{
+    for (avifBool useICC = AVIF_FALSE; useICC <= AVIF_TRUE; ++useICC) {
+        for (avifBool useLegacyExif = AVIF_FALSE; useLegacyExif <= AVIF_TRUE; ++useLegacyExif) {
+            for (avifBool useLegacyXMP = AVIF_FALSE; useLegacyXMP <= AVIF_TRUE; ++useLegacyXMP) {
+                for (size_t exifItemCount = 0; exifItemCount <= 3; ++exifItemCount) {
+                    for (size_t xmpItemCount = 0; xmpItemCount <= 3; ++xmpItemCount) {
+                        if (!encodeDecodeMetadataItems(useICC, useLegacyExif, useLegacyXMP, exifItemCount, xmpItemCount)) {
+                            return EXIT_FAILURE;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The single metadata chunk API is kept as deprecated for now.
It may be removed in a later API-breaking release.
Add test.
See bug #825.