### PR TITLE
Don't use a non-constant expr as union initializer

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -1096,11 +1096,12 @@ static avifResult avifRGBImageToF16(avifRGBImage * rgb)
     for (uint32_t j = 0; j < rgb->height; ++j) {
         uint16_t * pixel = pixelRowBase;
         for (uint32_t i = 0; i < rgb->width * channelCount; ++i, ++pixel) {
-            const union
+            union
             {
                 float f;
                 uint32_t u32;
-            } f16 = { .f = *pixel * multiplier };
+            } f16;
+            f16.f = *pixel * multiplier;
             *pixel = (uint16_t)(f16.u32 >> 13);
         }
         pixelRowBase += stride;


### PR DESCRIPTION
Don't use a non-constant expression as a union initializer. Fix the
Visual Studio 2017 compiler warning:

..\src\reformat.c(1103): warning C4204:
nonstandard extension used: non-constant aggregate initializer

Fix https://github.com/AOMediaCodec/libavif/issues/914.