### PR TITLE
Remove alphaRange from avifImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+There is an incompatible ABI change in this release. Members were removed from
+avifImage struct. It is necessary to recompile your code.
+
+### Removed
+* alphaRange field was removed from the avifImage struct. It it presumed that
+  alpha plane is always full range.
+
 ## [0.10.1] - 2022-04-11
 
 ### Changed

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -53,10 +53,6 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
         printf(" * Chroma Sam. Pos: %u\n", avif->yuvChromaSamplePosition);
     }
     printf(" * Alpha          : %s\n", alphaPresent ? (avif->alphaPremultiplied ? "Premultiplied" : "Not premultiplied") : "Absent");
-    if (avif->alphaRange == AVIF_RANGE_LIMITED) {
-        printf("                    Limited range\n");
-        printf("                    WARNING: Limited-range alpha is deprecated. Use full-range alpha instead.\n");
-    }
     printf(" * Range          : %s\n", (avif->yuvRange == AVIF_RANGE_FULL) ? "Full" : "Limited");
 
     printf(" * Color Primaries: %u\n", avif->colorPrimaries);

--- a/examples/avif_example_decode_file.c
+++ b/examples/avif_example_decode_file.c
@@ -49,7 +49,7 @@ int main(int argc, char * argv[])
     while (avifDecoderNextImage(decoder) == AVIF_RESULT_OK) {
         // Now available (for this frame):
         // * All decoder->image YUV pixel data (yuvFormat, yuvPlanes, yuvRange, yuvChromaSamplePosition, yuvRowBytes)
-        // * decoder->image alpha data (alphaRange, alphaPlane, alphaRowBytes)
+        // * decoder->image alpha data (alphaPlane, alphaRowBytes)
         // * this frame's sequence timing
 
         avifRGBImageSetDefaults(&rgb, decoder->image);

--- a/examples/avif_example_decode_memory.c
+++ b/examples/avif_example_decode_memory.c
@@ -71,7 +71,7 @@ int main(int argc, char * argv[])
     while (avifDecoderNextImage(decoder) == AVIF_RESULT_OK) {
         // Now available (for this frame):
         // * All decoder->image YUV pixel data (yuvFormat, yuvPlanes, yuvRange, yuvChromaSamplePosition, yuvRowBytes)
-        // * decoder->image alpha data (alphaRange, alphaPlane, alphaRowBytes)
+        // * decoder->image alpha data (alphaPlane, alphaRowBytes)
         // * this frame's sequence timing
 
         avifRGBImageSetDefaults(&rgb, decoder->image);

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -34,7 +34,6 @@ int main(int argc, char * argv[])
     // * avifImageSetMetadataExif()
     // * avifImageSetMetadataXMP()
     // * yuvRange
-    // * alphaRange
     // * alphaPremultiplied
     // * transforms (transformFlags, pasp, clap, irot, imir)
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -432,7 +432,6 @@ typedef struct avifImage
     uint32_t yuvRowBytes[AVIF_PLANE_COUNT_YUV];
     avifBool imageOwnsYUVPlanes;
 
-    avifRange alphaRange;
     uint8_t * alphaPlane;
     uint32_t alphaRowBytes;
     avifBool imageOwnsAlphaPlane;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -72,14 +72,12 @@ typedef struct avifAlphaParams
     uint32_t height;
 
     uint32_t srcDepth;
-    avifRange srcRange;
     uint8_t * srcPlane;
     uint32_t srcRowBytes;
     uint32_t srcOffsetBytes;
     uint32_t srcPixelBytes;
 
     uint32_t dstDepth;
-    avifRange dstRange;
     uint8_t * dstPlane;
     uint32_t dstRowBytes;
     uint32_t dstOffsetBytes;
@@ -127,10 +125,8 @@ typedef struct avifReformatState
     float rgbMaxChannelF;
     float biasY;   // minimum Y value
     float biasUV;  // the value of 0.5 for the appropriate bit depth [128, 512, 2048]
-    float biasA;   // minimum A value
     float rangeY;  // difference between max and min Y
     float rangeUV; // difference between max and min UV
-    float rangeA;  // difference between max and min A
 
     avifPixelFormatInfo formatInfo;
 
@@ -253,6 +249,7 @@ typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec,
                                               struct avifDecoder * decoder,
                                               const avifDecodeSample * sample,
                                               avifBool alpha,
+                                              avifBool * isLimitedRangeAlpha,
                                               avifImage * image);
 // EncodeImage and EncodeFinish are not required to always emit a sample, but when all images are
 // encoded and EncodeFinish is called, the number of samples emitted must match the number of submitted frames.

--- a/src/alpha.c
+++ b/src/alpha.c
@@ -6,19 +6,10 @@
 #include <assert.h>
 #include <string.h>
 
-static int calcMaxChannel(uint32_t depth, avifRange range)
-{
-    int maxChannel = (int)((1 << depth) - 1);
-    if (range == AVIF_RANGE_LIMITED) {
-        maxChannel = avifFullToLimitedY(depth, maxChannel);
-    }
-    return maxChannel;
-}
-
 avifBool avifFillAlpha(const avifAlphaParams * const params)
 {
     if (params->dstDepth > 8) {
-        const uint16_t maxChannel = (uint16_t)calcMaxChannel(params->dstDepth, params->dstRange);
+        const uint16_t maxChannel = (uint16_t)((1 << params->dstDepth) - 1);
         for (uint32_t j = 0; j < params->height; ++j) {
             uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
             for (uint32_t i = 0; i < params->width; ++i) {
@@ -27,7 +18,8 @@ avifBool avifFillAlpha(const avifAlphaParams * const params)
             }
         }
     } else {
-        const uint8_t maxChannel = (uint8_t)calcMaxChannel(params->dstDepth, params->dstRange);
+        // In this case, (1 << params->dstDepth) - 1 is always equal to 255.
+        const uint8_t maxChannel = 255;
         for (uint32_t j = 0; j < params->height; ++j) {
             uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
             for (uint32_t i = 0; i < params->width; ++i) {
@@ -39,8 +31,6 @@ avifBool avifFillAlpha(const avifAlphaParams * const params)
     return AVIF_TRUE;
 }
 
-// Note: The [limited -> limited] paths are here for completeness, but in practice those
-//       paths will never be used, as avifRGBImage is always full range.
 avifBool avifReformatAlpha(const avifAlphaParams * const params)
 {
     const int srcMaxChannel = (1 << params->srcDepth) - 1;
@@ -51,330 +41,75 @@ avifBool avifReformatAlpha(const avifAlphaParams * const params)
     if (params->srcDepth == params->dstDepth) {
         // no depth rescale
 
-        if ((params->srcRange == AVIF_RANGE_FULL) && (params->dstRange == AVIF_RANGE_FULL)) {
-            // no depth rescale, no range conversion
+        if (params->srcDepth > 8) {
+            // no depth rescale, uint16_t -> uint16_t
 
-            if (params->srcDepth > 8) {
-                // no depth rescale, no range conversion, uint16_t -> uint16_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                    }
-                }
-            } else {
-                // no depth rescale, no range conversion, uint8_t -> uint8_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        dstRow[i * params->dstPixelBytes] = srcRow[i * params->srcPixelBytes];
-                    }
+            for (uint32_t j = 0; j < params->height; ++j) {
+                uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
+                uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
+                for (uint32_t i = 0; i < params->width; ++i) {
+                    *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
                 }
             }
-        } else if ((params->srcRange == AVIF_RANGE_LIMITED) && (params->dstRange == AVIF_RANGE_FULL)) {
-            // limited -> full
+        } else {
+            // no depth rescale, uint8_t -> uint8_t
 
-            if (params->srcDepth > 8) {
-                // no depth rescale, limited -> full, uint16_t -> uint16_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                        int dstAlpha = avifLimitedToFullY(params->srcDepth, srcAlpha);
-                        *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
-                    }
-                }
-            } else {
-                // no depth rescale, limited -> full, uint8_t -> uint8_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = srcRow[i * params->srcPixelBytes];
-                        int dstAlpha = avifLimitedToFullY(params->srcDepth, srcAlpha);
-                        dstRow[i * params->dstPixelBytes] = (uint8_t)dstAlpha;
-                    }
-                }
-            }
-        } else if ((params->srcRange == AVIF_RANGE_FULL) && (params->dstRange == AVIF_RANGE_LIMITED)) {
-            // full -> limited
-
-            if (params->srcDepth > 8) {
-                // no depth rescale, full -> limited, uint16_t -> uint16_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                        int dstAlpha = avifFullToLimitedY(params->dstDepth, srcAlpha);
-                        *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
-                    }
-                }
-            } else {
-                // no depth rescale, full -> limited, uint8_t -> uint8_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = srcRow[i * params->srcPixelBytes];
-                        int dstAlpha = avifFullToLimitedY(params->dstDepth, srcAlpha);
-                        dstRow[i * params->dstPixelBytes] = (uint8_t)dstAlpha;
-                    }
-                }
-            }
-        } else if ((params->srcRange == AVIF_RANGE_LIMITED) && (params->dstRange == AVIF_RANGE_LIMITED)) {
-            // limited -> limited
-
-            if (params->srcDepth > 8) {
-                // no depth rescale, limited -> limited, uint16_t -> uint16_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                    }
-                }
-            } else {
-                // no depth rescale, limited -> limited, uint8_t -> uint8_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        dstRow[i * params->dstPixelBytes] = srcRow[i * params->srcPixelBytes];
-                    }
+            for (uint32_t j = 0; j < params->height; ++j) {
+                uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
+                uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
+                for (uint32_t i = 0; i < params->width; ++i) {
+                    dstRow[i * params->dstPixelBytes] = srcRow[i * params->srcPixelBytes];
                 }
             }
         }
-
     } else {
         // depth rescale
 
-        if ((params->srcRange == AVIF_RANGE_FULL) && (params->dstRange == AVIF_RANGE_FULL)) {
-            // depth rescale, no range conversion
-
-            if (params->srcDepth > 8) {
-                if (params->dstDepth > 8) {
-                    // depth rescale, no range conversion, uint16_t -> uint16_t
-
-                    for (uint32_t j = 0; j < params->height; ++j) {
-                        uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                        uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                        for (uint32_t i = 0; i < params->width; ++i) {
-                            int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                            float alphaF = (float)srcAlpha / srcMaxChannelF;
-                            int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                            dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                            *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
-                        }
-                    }
-                } else {
-                    // depth rescale, no range conversion, uint16_t -> uint8_t
-
-                    for (uint32_t j = 0; j < params->height; ++j) {
-                        uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                        uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                        for (uint32_t i = 0; i < params->width; ++i) {
-                            int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                            float alphaF = (float)srcAlpha / srcMaxChannelF;
-                            int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                            dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                            dstRow[i * params->dstPixelBytes] = (uint8_t)dstAlpha;
-                        }
-                    }
-                }
-            } else {
-                // depth rescale, no range conversion, uint8_t -> uint16_t
+        if (params->srcDepth > 8) {
+            if (params->dstDepth > 8) {
+                // depth rescale, uint16_t -> uint16_t
 
                 for (uint32_t j = 0; j < params->height; ++j) {
                     uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
                     uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
                     for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = srcRow[i * params->srcPixelBytes];
+                        int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
                         float alphaF = (float)srcAlpha / srcMaxChannelF;
                         int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
                         dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
                         *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
                     }
                 }
+            } else {
+                // depth rescale, uint16_t -> uint8_t
 
-                // If (srcDepth == 8), dstDepth must be >8 otherwise we'd be in the (params->srcDepth == params->dstDepth) block above.
-                // assert(params->dstDepth > 8);
+                for (uint32_t j = 0; j < params->height; ++j) {
+                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
+                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
+                    for (uint32_t i = 0; i < params->width; ++i) {
+                        int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
+                        float alphaF = (float)srcAlpha / srcMaxChannelF;
+                        int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
+                        dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
+                        dstRow[i * params->dstPixelBytes] = (uint8_t)dstAlpha;
+                    }
+                }
             }
-        } else if ((params->srcRange == AVIF_RANGE_LIMITED) && (params->dstRange == AVIF_RANGE_FULL)) {
-            // limited -> full
+        } else {
+            // If (srcDepth == 8), dstDepth must be >8 otherwise we'd be in the (params->srcDepth == params->dstDepth) block above.
+            assert(params->dstDepth > 8);
 
-            if (params->srcDepth > 8) {
-                if (params->dstDepth > 8) {
-                    // depth rescale, limited -> full, uint16_t -> uint16_t
-
-                    for (uint32_t j = 0; j < params->height; ++j) {
-                        uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                        uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                        for (uint32_t i = 0; i < params->width; ++i) {
-                            int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                            srcAlpha = avifLimitedToFullY(params->srcDepth, srcAlpha);
-                            float alphaF = (float)srcAlpha / srcMaxChannelF;
-                            int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                            dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                            *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
-                        }
-                    }
-                } else {
-                    // depth rescale, limited -> full, uint16_t -> uint8_t
-
-                    for (uint32_t j = 0; j < params->height; ++j) {
-                        uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                        uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                        for (uint32_t i = 0; i < params->width; ++i) {
-                            int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                            srcAlpha = avifLimitedToFullY(params->srcDepth, srcAlpha);
-                            float alphaF = (float)srcAlpha / srcMaxChannelF;
-                            int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                            dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                            dstRow[i * params->dstPixelBytes] = (uint8_t)dstAlpha;
-                        }
-                    }
+            // depth rescale, uint8_t -> uint16_t
+            for (uint32_t j = 0; j < params->height; ++j) {
+                uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
+                uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
+                for (uint32_t i = 0; i < params->width; ++i) {
+                    int srcAlpha = srcRow[i * params->srcPixelBytes];
+                    float alphaF = (float)srcAlpha / srcMaxChannelF;
+                    int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
+                    dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
+                    *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
                 }
-            } else {
-                // depth rescale, limited -> full, uint8_t -> uint16_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = srcRow[i * params->srcPixelBytes];
-                        srcAlpha = avifLimitedToFullY(params->srcDepth, srcAlpha);
-                        float alphaF = (float)srcAlpha / srcMaxChannelF;
-                        int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                        dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                        *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
-                    }
-                }
-
-                // If (srcDepth == 8), dstDepth must be >8 otherwise we'd be in the (params->srcDepth == params->dstDepth) block above.
-                // assert(params->dstDepth > 8);
-            }
-        } else if ((params->srcRange == AVIF_RANGE_FULL) && (params->dstRange == AVIF_RANGE_LIMITED)) {
-            // full -> limited
-
-            if (params->srcDepth > 8) {
-                if (params->dstDepth > 8) {
-                    // depth rescale, full -> limited, uint16_t -> uint16_t
-
-                    for (uint32_t j = 0; j < params->height; ++j) {
-                        uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                        uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                        for (uint32_t i = 0; i < params->width; ++i) {
-                            int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                            float alphaF = (float)srcAlpha / srcMaxChannelF;
-                            int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                            dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                            dstAlpha = avifFullToLimitedY(params->dstDepth, dstAlpha);
-                            *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
-                        }
-                    }
-                } else {
-                    // depth rescale, full -> limited, uint16_t -> uint8_t
-
-                    for (uint32_t j = 0; j < params->height; ++j) {
-                        uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                        uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                        for (uint32_t i = 0; i < params->width; ++i) {
-                            int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                            float alphaF = (float)srcAlpha / srcMaxChannelF;
-                            int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                            dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                            dstAlpha = avifFullToLimitedY(params->dstDepth, dstAlpha);
-                            dstRow[i * params->dstPixelBytes] = (uint8_t)dstAlpha;
-                        }
-                    }
-                }
-            } else {
-                // depth rescale, full -> limited, uint8_t -> uint16_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = srcRow[i * params->srcPixelBytes];
-                        float alphaF = (float)srcAlpha / srcMaxChannelF;
-                        int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                        dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                        dstAlpha = avifFullToLimitedY(params->dstDepth, dstAlpha);
-                        *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
-                    }
-                }
-
-                // If (srcDepth == 8), dstDepth must be >8 otherwise we'd be in the (params->srcDepth == params->dstDepth) block above.
-                // assert(params->dstDepth > 8);
-            }
-        } else if ((params->srcRange == AVIF_RANGE_LIMITED) && (params->dstRange == AVIF_RANGE_LIMITED)) {
-            // limited -> limited
-
-            if (params->srcDepth > 8) {
-                if (params->dstDepth > 8) {
-                    // depth rescale, limited -> limited, uint16_t -> uint16_t
-
-                    for (uint32_t j = 0; j < params->height; ++j) {
-                        uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                        uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                        for (uint32_t i = 0; i < params->width; ++i) {
-                            int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                            srcAlpha = avifLimitedToFullY(params->srcDepth, srcAlpha);
-                            float alphaF = (float)srcAlpha / srcMaxChannelF;
-                            int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                            dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                            dstAlpha = avifFullToLimitedY(params->dstDepth, dstAlpha);
-                            *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
-                        }
-                    }
-                } else {
-                    // depth rescale, limited -> limited, uint16_t -> uint8_t
-
-                    for (uint32_t j = 0; j < params->height; ++j) {
-                        uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                        uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                        for (uint32_t i = 0; i < params->width; ++i) {
-                            int srcAlpha = *((uint16_t *)&srcRow[i * params->srcPixelBytes]);
-                            srcAlpha = avifLimitedToFullY(params->srcDepth, srcAlpha);
-                            float alphaF = (float)srcAlpha / srcMaxChannelF;
-                            int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                            dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                            dstAlpha = avifFullToLimitedY(params->dstDepth, dstAlpha);
-                            dstRow[i * params->dstPixelBytes] = (uint8_t)dstAlpha;
-                        }
-                    }
-                }
-            } else {
-                // depth rescale, limited -> limited, uint8_t -> uint16_t
-
-                for (uint32_t j = 0; j < params->height; ++j) {
-                    uint8_t * srcRow = &params->srcPlane[params->srcOffsetBytes + (j * params->srcRowBytes)];
-                    uint8_t * dstRow = &params->dstPlane[params->dstOffsetBytes + (j * params->dstRowBytes)];
-                    for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = srcRow[i * params->srcPixelBytes];
-                        srcAlpha = avifLimitedToFullY(params->srcDepth, srcAlpha);
-                        float alphaF = (float)srcAlpha / srcMaxChannelF;
-                        int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
-                        dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                        dstAlpha = avifFullToLimitedY(params->dstDepth, dstAlpha);
-                        *((uint16_t *)&dstRow[i * params->dstPixelBytes]) = (uint16_t)dstAlpha;
-                    }
-                }
-
-                // If (srcDepth == 8), dstDepth must be >8 otherwise we'd be in the (params->srcDepth == params->dstDepth) block above.
-                // assert(params->dstDepth > 8);
             }
         }
     }

--- a/src/avif.c
+++ b/src/avif.c
@@ -120,7 +120,6 @@ static void avifImageSetDefaults(avifImage * image)
 {
     memset(image, 0, sizeof(avifImage));
     image->yuvRange = AVIF_RANGE_FULL;
-    image->alphaRange = AVIF_RANGE_FULL;
     image->colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
     image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
     image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
@@ -151,7 +150,6 @@ static void avifImageCopyNoAlloc(avifImage * dstImage, const avifImage * srcImag
     dstImage->yuvFormat = srcImage->yuvFormat;
     dstImage->yuvRange = srcImage->yuvRange;
     dstImage->yuvChromaSamplePosition = srcImage->yuvChromaSamplePosition;
-    dstImage->alphaRange = srcImage->alphaRange;
     dstImage->alphaPremultiplied = srcImage->alphaPremultiplied;
 
     dstImage->colorPrimaries = srcImage->colorPrimaries;

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -95,6 +95,7 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
                                      struct avifDecoder * decoder,
                                      const avifDecodeSample * sample,
                                      avifBool alpha,
+                                     avifBool * isLimitedRangeAlpha,
                                      avifImage * image)
 {
     if (!codec->internal->decoderInitialized) {
@@ -239,7 +240,7 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
         avifImageFreePlanes(image, AVIF_PLANES_A);
         image->alphaPlane = codec->internal->image->planes[0];
         image->alphaRowBytes = codec->internal->image->stride[0];
-        image->alphaRange = (codec->internal->image->range == AOM_CR_STUDIO_RANGE) ? AVIF_RANGE_LIMITED : AVIF_RANGE_FULL;
+        *isLimitedRangeAlpha = (codec->internal->image->range == AOM_CR_STUDIO_RANGE);
         image->imageOwnsAlphaPlane = AVIF_FALSE;
     }
 
@@ -782,7 +783,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
     avifBool monochromeRequested = AVIF_FALSE;
 
     if (alpha) {
-        aomImage.range = (image->alphaRange == AVIF_RANGE_FULL) ? AOM_CR_FULL_RANGE : AOM_CR_STUDIO_RANGE;
+        aomImage.range = AOM_CR_FULL_RANGE;
         aom_codec_control(&codec->internal->encoder, AV1E_SET_COLOR_RANGE, aomImage.range);
         monochromeRequested = AVIF_TRUE;
         if (aomImageAllocated) {

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -53,6 +53,7 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
                                        struct avifDecoder * decoder,
                                        const avifDecodeSample * sample,
                                        avifBool alpha,
+                                       avifBool * isLimitedRangeAlpha,
                                        avifImage * image)
 {
     if (codec->internal->dav1dContext == NULL) {
@@ -204,7 +205,7 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
         avifImageFreePlanes(image, AVIF_PLANES_A);
         image->alphaPlane = dav1dImage->data[0];
         image->alphaRowBytes = (uint32_t)dav1dImage->stride[0];
-        image->alphaRange = codec->internal->colorRange;
+        *isLimitedRangeAlpha = (codec->internal->colorRange == AVIF_RANGE_LIMITED);
         image->imageOwnsAlphaPlane = AVIF_FALSE;
     }
     return AVIF_TRUE;

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -27,6 +27,7 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec,
                                       struct avifDecoder * decoder,
                                       const avifDecodeSample * sample,
                                       avifBool alpha,
+                                      avifBool * isLimitedRangeAlpha,
                                       avifImage * image)
 {
     if (codec->internal->gav1Decoder == NULL) {
@@ -144,7 +145,7 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec,
         avifImageFreePlanes(image, AVIF_PLANES_A);
         image->alphaPlane = gav1Image->plane[0];
         image->alphaRowBytes = gav1Image->stride[0];
-        image->alphaRange = codec->internal->colorRange;
+        *isLimitedRangeAlpha = (codec->internal->colorRange == AVIF_RANGE_LIMITED);
         image->imageOwnsAlphaPlane = AVIF_FALSE;
     }
 

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -68,7 +68,7 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
         const avifBool supports400 = rav1eSupports400();
         RaPixelRange rav1eRange;
         if (alpha) {
-            rav1eRange = (image->alphaRange == AVIF_RANGE_FULL) ? RA_PIXEL_RANGE_FULL : RA_PIXEL_RANGE_LIMITED;
+            rav1eRange = RA_PIXEL_RANGE_FULL;
             codec->internal->chromaSampling = supports400 ? RA_CHROMA_SAMPLING_CS400 : RA_CHROMA_SAMPLING_CS420;
             codec->internal->yShift = 1;
         } else {

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -57,7 +57,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
     int y_shift = 0;
     // EbColorRange svt_range;
     if (alpha) {
-        // svt_range = (image->alphaRange == AVIF_RANGE_FULL) ? EB_CR_FULL_RANGE : EB_CR_STUDIO_RANGE;
+        // svt_range = EB_CR_FULL_RANGE;
         y_shift = 1;
     } else {
         // svt_range = (image->yuvRange == AVIF_RANGE_FULL) ? EB_CR_FULL_RANGE : EB_CR_STUDIO_RANGE;

--- a/src/read.c
+++ b/src/read.c
@@ -3728,16 +3728,17 @@ static avifResult avifDecoderPrepareTiles(avifDecoder * decoder,
 
 static avifResult avifImageLimitedToFullAlpha(avifImage * image)
 {
-    uint8_t * alphaPlane = image->alphaPlane;
-    const uint32_t alphaRowBytes = image->alphaRowBytes;
-
     if (image->imageOwnsAlphaPlane) {
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
 
+    uint8_t * alphaPlane = image->alphaPlane;
+    const uint32_t alphaRowBytes = image->alphaRowBytes;
+
     // We cannot do the range conversion in place since it will modify the
     // codec's internal frame buffers. Allocate memory for the conversion.
     image->alphaPlane = NULL;
+    image->alphaRowBytes = 0;
     avifImageAllocatePlanes(image, AVIF_PLANES_A);
 
     if (image->depth > 8) {
@@ -3792,10 +3793,10 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder,
         // specification. To allow such files, simply convert the alpha plane to
         // full range.
         if (tile->input->alpha && isLimitedRangeAlpha) {
-            avifResult res = avifImageLimitedToFullAlpha(tile->image);
-            if (res != AVIF_RESULT_OK) {
+            avifResult result = avifImageLimitedToFullAlpha(tile->image);
+            if (result != AVIF_RESULT_OK) {
                 avifDiagnosticsPrintf(&decoder->diag, "avifImageLimitedToFullAlpha failed");
-                return res;
+                return result;
             }
         }
 

--- a/src/write.c
+++ b/src/write.c
@@ -589,7 +589,7 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             (cellImage->depth != firstCell->depth) || (cellImage->yuvFormat != firstCell->yuvFormat) ||
             (cellImage->yuvRange != firstCell->yuvRange) || (cellImage->colorPrimaries != firstCell->colorPrimaries) ||
             (cellImage->transferCharacteristics != firstCell->transferCharacteristics) ||
-            (cellImage->matrixCoefficients != firstCell->matrixCoefficients) || (cellImage->alphaRange != firstCell->alphaRange) ||
+            (cellImage->matrixCoefficients != firstCell->matrixCoefficients) ||
             (!!cellImage->alphaPlane != !!firstCell->alphaPlane) || (cellImage->alphaPremultiplied != firstCell->alphaPremultiplied)) {
             return AVIF_RESULT_INVALID_IMAGE_GRID;
         }

--- a/tests/avifincrtest.c
+++ b/tests/avifincrtest.c
@@ -75,7 +75,7 @@ static avifBool comparePartialYUVA(const avifImage * image1, const avifImage * i
     }
 
     if (image1->alphaPlane) {
-        if (!image2->alphaPlane || (image1->alphaRange != image2->alphaRange) ||
+        if (!image2->alphaPlane ||
             (image1->alphaPremultiplied != image2->alphaPremultiplied)) {
             printf("ERROR: input mismatch\n");
             return AVIF_FALSE;
@@ -301,7 +301,6 @@ static avifBool encodeRectAsIncremental(const avifImage * image,
         }
         subImage->alphaPlane = image->yuvPlanes[AVIF_CHAN_Y];
         subImage->alphaRowBytes = image->yuvRowBytes[AVIF_CHAN_Y];
-        subImage->alphaRange = AVIF_RANGE_FULL;
         subImage->alphaPremultiplied = AVIF_FALSE;
         subImage->imageOwnsAlphaPlane = AVIF_FALSE;
     }

--- a/tests/avify4mtest.c
+++ b/tests/avify4mtest.c
@@ -46,7 +46,7 @@ static avifBool compareYUVA(const avifImage * image1, const avifImage * image2)
     }
 
     if (image1->alphaPlane != NULL || image2->alphaPlane != NULL) {
-        if (image1->alphaPlane == NULL || image2->alphaPlane == NULL || image1->alphaRange != image2->alphaRange ||
+        if (image1->alphaPlane == NULL || image2->alphaPlane == NULL ||
             image1->alphaPremultiplied != image2->alphaPremultiplied) {
             printf("ERROR: input mismatch\n");
             return AVIF_FALSE;
@@ -94,7 +94,6 @@ static void fillPlanes(avifImage * image)
         }
     }
     if (image->alphaPlane != NULL) {
-        assert(image->alphaRange == AVIF_RANGE_FULL);
         const uint16_t alphaValue = (1 << image->depth) - 1;
         for (uint32_t y = 0; y < image->height; ++y) {
             uint8_t * const row = image->alphaPlane + y * image->alphaRowBytes;
@@ -130,7 +129,6 @@ static avifBool encodeDecodeY4m(uint32_t width,
     image->depth = depth;
     image->yuvFormat = yuvFormat;
     image->yuvRange = yuvRange;
-    image->alphaRange = AVIF_RANGE_FULL; // Unused by y4mRead() and y4mWrite().
     avifImageAllocatePlanes(image, createAlpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV);
     fillPlanes(image);
 

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -340,7 +340,6 @@ int main(int argc, char * argv[])
                         avifImageFreePlanes(image, AVIF_PLANES_ALL);
                         image->depth = yuvDepth;
                         image->yuvRange = yuvRange;
-                        image->alphaRange = AVIF_RANGE_FULL;
                         avifImageRGBToYUV(image, &srcRGB);
 
                         avifRGBImage intermediateRGB;


### PR DESCRIPTION
The AVIF draft specification disallows limited range alpha and it
will eventually be in the specification once AOM ratifies it [1] [2].

Even though the default value of alphaRange is set to
AVIF_RANGE_FULL, it is possible for applications to override it
and set it to AVIF_RANGE_LIMITED thereby producing AVIF images
that will eventually be invalid.

On the encoder side, This PR prevents such images from being
produced by libavif.

On the decoder side, if we encounter an image with limited range
alpha, we always convert it to full range alpha and the applications
can assume that alpha plane is always in full range (as it will be
required by the spec eventually).

This change breaks the ABI and a note has been added to CHANGELOG.md
in the "Unreleased" section to document that.

[1] https://github.com/AOMediaCodec/av1-avif/pull/101
[2] https://aomediacodec.github.io/av1-avif/#auxiliary-images