### PR TITLE
Make avifImageScale function public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This part of AV1 encoder is not as thoroughly tested, so there are higher
   possibility encoder may crash when given certain configuration or input.
 * Add imageSequenceTrackPresent flag to the avifDecoder struct.
+* avifImageScale() function was made part of the public ABI.
 
 ### Changed
 * Update aom.cmd: v3.7.0

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -750,6 +750,13 @@ AVIF_API void avifImageStealPlanes(avifImage * dstImage, avifImage * srcImage, a
 // accordingly.
 
 // ---------------------------------------------------------------------------
+// Scaling
+
+// Scales the YUV/A planes in-place. dstWidth and dstHeight must both be <= AVIF_DEFAULT_IMAGE_DIMENSION_LIMIT and
+// dstWidth*dstHeight should be <= AVIF_DEFAULT_IMAGE_SIZE_LIMIT.
+AVIF_API avifResult avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight, avifDiagnostics * diag);
+
+// ---------------------------------------------------------------------------
 // Optional YUV<->RGB support
 
 // To convert to/from RGB, create an avifRGBImage on the stack, call avifRGBImageSetDefaults() on

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -251,13 +251,13 @@ void avifSetTileConfiguration(int threads, uint32_t width, uint32_t height, int 
 // ---------------------------------------------------------------------------
 // Scaling
 
-// This scales the YUV/A planes in-place.
-avifBool avifImageScale(avifImage * image,
-                        uint32_t dstWidth,
-                        uint32_t dstHeight,
-                        uint32_t imageSizeLimit,
-                        uint32_t imageDimensionLimit,
-                        avifDiagnostics * diag);
+// Scales the YUV/A planes in-place.
+avifResult avifImageScaleWithLimit(avifImage * image,
+                                   uint32_t dstWidth,
+                                   uint32_t dstHeight,
+                                   uint32_t imageSizeLimit,
+                                   uint32_t imageDimensionLimit,
+                                   avifDiagnostics * diag);
 
 // ---------------------------------------------------------------------------
 // AVIF item category

--- a/src/read.c
+++ b/src/read.c
@@ -4981,13 +4981,13 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
 
         // Scale the decoded image so that it corresponds to this tile's output dimensions
         if ((tile->width != tile->image->width) || (tile->height != tile->image->height)) {
-            if (!avifImageScale(tile->image,
-                                tile->width,
-                                tile->height,
-                                decoder->imageSizeLimit,
-                                decoder->imageDimensionLimit,
-                                &decoder->diag)) {
-                avifDiagnosticsPrintf(&decoder->diag, "avifImageScale() failed");
+            if (avifImageScaleWithLimit(tile->image,
+                                        tile->width,
+                                        tile->height,
+                                        decoder->imageSizeLimit,
+                                        decoder->imageDimensionLimit,
+                                        &decoder->diag) != AVIF_RESULT_OK) {
+                avifDiagnosticsPrintf(&decoder->diag, "avifImageScaleWithLimit() failed");
                 return avifGetErrorForItemCategory(tile->input->itemCategory);
             }
         }


### PR DESCRIPTION
This is useful for apps to scale images (without having to
worry about bitdepth, subsampling, etc).

This commit renames avifImageScale to avifImageScaleWithLimit. The
latter would remain an internal only function while the former is
now part of the public ABI (moved to avif.h)

Potential workaround for issue #1484.