### PR TITLE
Update handling of 'lsel' and progressive decoding

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -170,7 +170,7 @@ typedef struct avifDecoderItem
     uint32_t premByID;             // if non-zero, this item is premultiplied by Item #{premByID}
     avifBool hasUnsupportedEssentialProperty; // If true, this item cites a property flagged as 'essential' that libavif doesn't support (yet). Ignore the item, if so.
     avifBool ipmaSeen;    // if true, this item already received a property association
-    avifBool progressive; // if true, this item has progressive layers (a1lx), but does not select a specific layer (lsel)
+    avifBool progressive; // if true, this item has progressive layers (a1lx), but does not select a specific layer (the layer_id value in lsel is set to 0xFFFF)
 } avifDecoderItem;
 AVIF_ARRAY_DECLARE(avifDecoderItemArray, avifDecoderItem, item);
 
@@ -535,8 +535,9 @@ static avifBool avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput * d
     }
 
     const avifProperty * lselProp = avifPropertyArrayFind(&item->properties, "lsel");
-    item->progressive = (a1lxProp && !lselProp); // Progressive images offer layers via the a1lxProp, but don't specify a layer selection with lsel.
-    if (lselProp) {
+    // Progressive images offer layers via the a1lxProp, but don't specify a layer selection with lsel.
+    item->progressive = (a1lxProp && lselProp && (lselProp->u.lsel.layerID == 0xFFFF));
+    if (lselProp && (lselProp->u.lsel.layerID != 0xFFFF)) {
         // Layer selection. This requires that the underlying AV1 codec decodes all layers,
         // and then only returns the requested layer as a single frame. To the user of libavif,
         // this appears to be a single frame.
@@ -1866,7 +1867,7 @@ static avifBool avifParseLayerSelectorProperty(avifProperty * prop, const uint8_
 
     avifLayerSelectorProperty * lsel = &prop->u.lsel;
     CHECK(avifROStreamReadU16(&s, &lsel->layerID));
-    if (lsel->layerID >= MAX_AV1_LAYER_COUNT) {
+    if ((lsel->layerID != 0xFFFF) && (lsel->layerID >= MAX_AV1_LAYER_COUNT)) {
         avifDiagnosticsPrintf(diag, "Box[lsel] contains an unsupported layer [%u]", lsel->layerID);
         return AVIF_FALSE;
     }


### PR DESCRIPTION
Previously, progressive decoding of a layered image was allowed if
'lsel' was absent. Now, progressivg decoding is allowed if the layer_id
value in 'lsel' is set to 0xFFFF.

Fix https://github.com/AOMediaCodec/libavif/issues/826.