### PR TITLE
ext: Checkout libaom v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ There is an incompatible ABI change in this release. Members were removed from
 avifImage struct. It is necessary to recompile your code.
 
 ### Changed
+* Update aom.cmd: v3.4.0
 * Update svt.cmd/svt.sh: v1.1.0
 
 ### Removed

--- a/ext/aom.cmd
+++ b/ext/aom.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b v3.3.0 --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v3.4.0 --depth 1 https://aomedia.googlesource.com/aom
 
 cd aom
 mkdir build.libavif

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -36,7 +36,7 @@ nasm --version
 
 # aom
 cd
-git clone -b v3.3.0 --depth 1 https://aomedia.googlesource.com/aom
+git clone -b v3.4.0 --depth 1 https://aomedia.googlesource.com/aom
 cd aom
 mkdir build.avif
 cd build.avif


### PR DESCRIPTION
Updates the libaom version checked out in the ext and docker scripts
from v3.3.0 to v3.4.0.