### PR TITLE
Format C++ tests with Google style

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: RafikFarhad/clang-format-github-action@v2.1.0
         with:
           style: file
-          sources: "apps/**/*.h,apps/**/*.c,examples/*.c,includes/**/*.h,src/**/*.h,src/**/*.c,tests/**/*.h,tests/**/*.c"
+          sources: "apps/**.h,apps/**.c,examples/*.c,include/**.h,src/*.c,tests/**.h,tests/**.c,tests/**.cc"
           excludes: "apps/shared/iccjpeg.*"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to format the C
 sources from the top-level folder:
 
 ```sh
-clang-format -style=file:.clang-format -i \
+clang-format -style=file -i \
   apps/*.c apps/shared/avifjpeg.* apps/shared/avifpng.* \
   apps/shared/avifutil.* apps/shared/y4m.* examples/*.c \
   include/avif/*.h src/*.c tests/*.c tests/gtest/*.h tests/gtest/*.cc

--- a/tests/gtest/.clang-format
+++ b/tests/gtest/.clang-format
@@ -1,0 +1,4 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+...

--- a/tests/gtest/.clang-format
+++ b/tests/gtest/.clang-format
@@ -1,4 +1,5 @@
 ---
 Language: Cpp
 BasedOnStyle: Google
+DerivePointerAlignment: false
 ...

--- a/tests/gtest/.clang-format
+++ b/tests/gtest/.clang-format
@@ -2,4 +2,5 @@
 Language: Cpp
 BasedOnStyle: Google
 DerivePointerAlignment: false
+PointerAlignment: Left
 ...

--- a/tests/gtest/avifgridapitest.cc
+++ b/tests/gtest/avifgridapitest.cc
@@ -50,7 +50,7 @@ TEST_P(GridApiTest, EncodeDecode) {
   ASSERT_NE(encoder, nullptr);
   encoder->speed = AVIF_SPEED_FASTEST;
   // Just here to match libavif API.
-  std::vector<avifImage *> cellImagePtrs(cellImages.size());
+  std::vector<avifImage*> cellImagePtrs(cellImages.size());
   for (size_t i = 0; i < cellImages.size(); ++i) {
     cellImagePtrs[i] = cellImages[i].get();
   }

--- a/tests/gtest/avifgridapitest.cc
+++ b/tests/gtest/avifgridapitest.cc
@@ -1,11 +1,10 @@
 // Copyright 2022 Google LLC. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include "avif/avif.h"
-
 #include <tuple>
 #include <vector>
 
+#include "avif/avif.h"
 #include "aviftest_helpers.h"
 #include "gtest/gtest.h"
 
@@ -13,145 +12,139 @@ using testing::Combine;
 using testing::Values;
 using testing::ValuesIn;
 
-namespace libavif
-{
-namespace
-{
+namespace libavif {
+namespace {
 
 // Pair of cell count and cell size for a single dimension.
-struct Cell
-{
-    int count, size;
+struct Cell {
+  int count, size;
 };
 
 class GridApiTest
-    : public testing::TestWithParam<std::tuple</*horizontal=*/Cell, /*vertical=*/Cell, /*bitDepth=*/int, /*yuvFormat=*/avifPixelFormat, /*createAlpha=*/bool, /*expectedSuccess=*/bool>>
-{
-};
+    : public testing::TestWithParam<
+          std::tuple</*horizontal=*/Cell, /*vertical=*/Cell, /*bitDepth=*/int,
+                     /*yuvFormat=*/avifPixelFormat, /*createAlpha=*/bool,
+                     /*expectedSuccess=*/bool>> {};
 
-TEST_P(GridApiTest, EncodeDecode)
-{
-    const Cell horizontal = std::get<0>(GetParam());
-    const Cell vertical = std::get<1>(GetParam());
-    const int bitDepth = std::get<2>(GetParam());
-    const avifPixelFormat yuvFormat = std::get<3>(GetParam());
-    const bool createAlpha = std::get<4>(GetParam());
-    const bool expectedSuccess = std::get<5>(GetParam());
+TEST_P(GridApiTest, EncodeDecode) {
+  const Cell horizontal = std::get<0>(GetParam());
+  const Cell vertical = std::get<1>(GetParam());
+  const int bitDepth = std::get<2>(GetParam());
+  const avifPixelFormat yuvFormat = std::get<3>(GetParam());
+  const bool createAlpha = std::get<4>(GetParam());
+  const bool expectedSuccess = std::get<5>(GetParam());
 
-    // Construct a grid.
-    std::vector<testutil::avifImagePtr> cellImages;
-    cellImages.reserve(horizontal.count * vertical.count);
-    for (int i = 0; i < horizontal.count * vertical.count; ++i) {
-        cellImages.emplace_back(
-            testutil::createImage(horizontal.size, vertical.size, bitDepth, yuvFormat, createAlpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV));
-        ASSERT_NE(cellImages.back(), nullptr);
-        testutil::fillImageGradient(cellImages.back().get());
-    }
+  // Construct a grid.
+  std::vector<testutil::avifImagePtr> cellImages;
+  cellImages.reserve(horizontal.count * vertical.count);
+  for (int i = 0; i < horizontal.count * vertical.count; ++i) {
+    cellImages.emplace_back(testutil::createImage(
+        horizontal.size, vertical.size, bitDepth, yuvFormat,
+        createAlpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV));
+    ASSERT_NE(cellImages.back(), nullptr);
+    testutil::fillImageGradient(cellImages.back().get());
+  }
 
-    // Encode the grid image.
-    testutil::avifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
-    ASSERT_NE(encoder, nullptr);
-    encoder->speed = AVIF_SPEED_FASTEST;
-    std::vector<avifImage *> cellImagePtrs(cellImages.size()); // Just here to match libavif API.
-    for (size_t i = 0; i < cellImages.size(); ++i) {
-        cellImagePtrs[i] = cellImages[i].get();
-    }
-    const avifResult result =
-        avifEncoderAddImageGrid(encoder.get(), horizontal.count, vertical.count, cellImagePtrs.data(), AVIF_ADD_IMAGE_FLAG_SINGLE);
+  // Encode the grid image.
+  testutil::avifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  encoder->speed = AVIF_SPEED_FASTEST;
+  // Just here to match libavif API.
+  std::vector<avifImage *> cellImagePtrs(cellImages.size());
+  for (size_t i = 0; i < cellImages.size(); ++i) {
+    cellImagePtrs[i] = cellImages[i].get();
+  }
+  const avifResult result =
+      avifEncoderAddImageGrid(encoder.get(), horizontal.count, vertical.count,
+                              cellImagePtrs.data(), AVIF_ADD_IMAGE_FLAG_SINGLE);
 
-    if (expectedSuccess) {
-        ASSERT_EQ(result, AVIF_RESULT_OK);
-        testutil::avifRWDataCleaner encodedAvif;
-        ASSERT_EQ(avifEncoderFinish(encoder.get(), &encodedAvif), AVIF_RESULT_OK);
+  if (expectedSuccess) {
+    ASSERT_EQ(result, AVIF_RESULT_OK);
+    testutil::avifRWDataCleaner encodedAvif;
+    ASSERT_EQ(avifEncoderFinish(encoder.get(), &encodedAvif), AVIF_RESULT_OK);
 
-        // Decode the grid image.
-        testutil::avifImagePtr image(avifImageCreateEmpty(), avifImageDestroy);
-        ASSERT_NE(image, nullptr);
-        testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
-        ASSERT_NE(decoder, nullptr);
-        ASSERT_EQ(avifDecoderReadMemory(decoder.get(), image.get(), encodedAvif.data, encodedAvif.size), AVIF_RESULT_OK);
-    } else {
-        ASSERT_TRUE(result == AVIF_RESULT_INVALID_IMAGE_GRID || result == AVIF_RESULT_NO_CONTENT);
-    }
+    // Decode the grid image.
+    testutil::avifImagePtr image(avifImageCreateEmpty(), avifImageDestroy);
+    ASSERT_NE(image, nullptr);
+    testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+    ASSERT_NE(decoder, nullptr);
+    ASSERT_EQ(avifDecoderReadMemory(decoder.get(), image.get(),
+                                    encodedAvif.data, encodedAvif.size),
+              AVIF_RESULT_OK);
+  } else {
+    ASSERT_TRUE(result == AVIF_RESULT_INVALID_IMAGE_GRID ||
+                result == AVIF_RESULT_NO_CONTENT);
+  }
 }
 
-// A cell cannot be smaller than 64px in any dimension if there are several cells.
-// A cell cannot have an odd size in any dimension if there are several cells and chroma subsampling.
-// Image size must be a multiple of cell size.
-constexpr Cell kValidCells[] = { { 1, 64 }, { 1, 66 }, { 2, 64 }, { 3, 68 } };
-constexpr Cell kInvalidCells[] = { { 0, 0 }, { 0, 1 }, { 1, 0 }, { 2, 1 }, { 2, 2 }, { 2, 3 }, { 2, 63 } };
-constexpr int kBitDepths[] = { 8, 10, 12 };
-constexpr avifPixelFormat kPixelFormats[] = { AVIF_PIXEL_FORMAT_YUV444, AVIF_PIXEL_FORMAT_YUV422, AVIF_PIXEL_FORMAT_YUV420, AVIF_PIXEL_FORMAT_YUV400 };
+// A cell cannot be smaller than 64px in any dimension if there are several
+// cells. A cell cannot have an odd size in any dimension if there are several
+// cells and chroma subsampling. Image size must be a multiple of cell size.
+constexpr Cell kValidCells[] = {{1, 64}, {1, 66}, {2, 64}, {3, 68}};
+constexpr Cell kInvalidCells[] = {{0, 0}, {0, 1}, {1, 0}, {2, 1},
+                                  {2, 2}, {2, 3}, {2, 63}};
+constexpr int kBitDepths[] = {8, 10, 12};
+constexpr avifPixelFormat kPixelFormats[] = {
+    AVIF_PIXEL_FORMAT_YUV444, AVIF_PIXEL_FORMAT_YUV422,
+    AVIF_PIXEL_FORMAT_YUV420, AVIF_PIXEL_FORMAT_YUV400};
 
-INSTANTIATE_TEST_SUITE_P(Valid,
-                         GridApiTest,
+INSTANTIATE_TEST_SUITE_P(Valid, GridApiTest,
                          Combine(/*horizontal=*/ValuesIn(kValidCells),
                                  /*vertical=*/ValuesIn(kValidCells),
-                                 ValuesIn(kBitDepths),
-                                 ValuesIn(kPixelFormats),
+                                 ValuesIn(kBitDepths), ValuesIn(kPixelFormats),
                                  /*createAlpha=*/Values(false, true),
                                  /*expectedSuccess=*/Values(true)));
 
-INSTANTIATE_TEST_SUITE_P(InvalidVertically,
-                         GridApiTest,
+INSTANTIATE_TEST_SUITE_P(InvalidVertically, GridApiTest,
                          Combine(/*horizontal=*/ValuesIn(kValidCells),
                                  /*vertical=*/ValuesIn(kInvalidCells),
-                                 ValuesIn(kBitDepths),
-                                 ValuesIn(kPixelFormats),
+                                 ValuesIn(kBitDepths), ValuesIn(kPixelFormats),
                                  /*createAlpha=*/Values(false, true),
                                  /*expectedSuccess=*/Values(false)));
-INSTANTIATE_TEST_SUITE_P(InvalidHorizontally,
-                         GridApiTest,
+INSTANTIATE_TEST_SUITE_P(InvalidHorizontally, GridApiTest,
                          Combine(/*horizontal=*/ValuesIn(kInvalidCells),
                                  /*vertical=*/ValuesIn(kValidCells),
-                                 ValuesIn(kBitDepths),
-                                 ValuesIn(kPixelFormats),
+                                 ValuesIn(kBitDepths), ValuesIn(kPixelFormats),
                                  /*createAlpha=*/Values(false, true),
                                  /*expectedSuccess=*/Values(false)));
-INSTANTIATE_TEST_SUITE_P(InvalidBoth,
-                         GridApiTest,
+INSTANTIATE_TEST_SUITE_P(InvalidBoth, GridApiTest,
                          Combine(/*horizontal=*/ValuesIn(kInvalidCells),
                                  /*vertical=*/ValuesIn(kInvalidCells),
-                                 ValuesIn(kBitDepths),
-                                 ValuesIn(kPixelFormats),
+                                 ValuesIn(kBitDepths), ValuesIn(kPixelFormats),
                                  /*createAlpha=*/Values(false, true),
                                  /*expectedSuccess=*/Values(false)));
 
 // Special case depending on the cell count and the chroma subsampling.
-INSTANTIATE_TEST_SUITE_P(ValidOddHeight,
-                         GridApiTest,
-                         Combine(/*horizontal=*/Values(Cell { 1, 64 }),
-                                 /*vertical=*/Values(Cell { 1, 65 }, Cell { 2, 65 }),
+INSTANTIATE_TEST_SUITE_P(ValidOddHeight, GridApiTest,
+                         Combine(/*horizontal=*/Values(Cell{1, 64}),
+                                 /*vertical=*/Values(Cell{1, 65}, Cell{2, 65}),
                                  ValuesIn(kBitDepths),
-                                 Values(AVIF_PIXEL_FORMAT_YUV444, AVIF_PIXEL_FORMAT_YUV422, AVIF_PIXEL_FORMAT_YUV400),
+                                 Values(AVIF_PIXEL_FORMAT_YUV444,
+                                        AVIF_PIXEL_FORMAT_YUV422,
+                                        AVIF_PIXEL_FORMAT_YUV400),
                                  /*createAlpha=*/Values(false, true),
                                  /*expectedSuccess=*/Values(true)));
-INSTANTIATE_TEST_SUITE_P(InvalidOddHeight,
-                         GridApiTest,
-                         Combine(/*horizontal=*/Values(Cell { 1, 64 }),
-                                 /*vertical=*/Values(Cell { 2, 65 }),
+INSTANTIATE_TEST_SUITE_P(InvalidOddHeight, GridApiTest,
+                         Combine(/*horizontal=*/Values(Cell{1, 64}),
+                                 /*vertical=*/Values(Cell{2, 65}),
                                  ValuesIn(kBitDepths),
                                  Values(AVIF_PIXEL_FORMAT_YUV420),
                                  /*createAlpha=*/Values(false, true),
                                  /*expectedSuccess=*/Values(false)));
 
 // Special case depending on the cell count and the cell size.
-INSTANTIATE_TEST_SUITE_P(ValidOddDimensions,
-                         GridApiTest,
-                         Combine(/*horizontal=*/Values(Cell { 1, 1 }),
-                                 /*vertical=*/Values(Cell { 1, 65 }),
-                                 ValuesIn(kBitDepths),
-                                 ValuesIn(kPixelFormats),
+INSTANTIATE_TEST_SUITE_P(ValidOddDimensions, GridApiTest,
+                         Combine(/*horizontal=*/Values(Cell{1, 1}),
+                                 /*vertical=*/Values(Cell{1, 65}),
+                                 ValuesIn(kBitDepths), ValuesIn(kPixelFormats),
                                  /*createAlpha=*/Values(false, true),
                                  /*expectedSuccess=*/Values(true)));
-INSTANTIATE_TEST_SUITE_P(InvalidOddDimensions,
-                         GridApiTest,
-                         Combine(/*horizontal=*/Values(Cell { 2, 1 }),
-                                 /*vertical=*/Values(Cell { 1, 65 }, Cell { 2, 65 }),
-                                 ValuesIn(kBitDepths),
-                                 ValuesIn(kPixelFormats),
+INSTANTIATE_TEST_SUITE_P(InvalidOddDimensions, GridApiTest,
+                         Combine(/*horizontal=*/Values(Cell{2, 1}),
+                                 /*vertical=*/Values(Cell{1, 65}, Cell{2, 65}),
+                                 ValuesIn(kBitDepths), ValuesIn(kPixelFormats),
                                  /*createAlpha=*/Values(false, true),
                                  /*expectedSuccess=*/Values(false)));
 
-} // namespace
-} // namespace libavif
+}  // namespace
+}  // namespace libavif

--- a/tests/gtest/avifincrtest.cc
+++ b/tests/gtest/avifincrtest.cc
@@ -21,17 +21,17 @@ namespace {
 //------------------------------------------------------------------------------
 
 // Used to pass the data folder path to the GoogleTest suites.
-const char *dataPath = nullptr;
+const char* dataPath = nullptr;
 
 // Reads the file with fileName into bytes and returns them.
-testutil::avifRWDataCleaner readFile(const char *fileName) {
+testutil::avifRWDataCleaner readFile(const char* fileName) {
   std::ifstream file(std::string(dataPath) + fileName,
                      std::ios::binary | std::ios::ate);
   testutil::avifRWDataCleaner bytes;
   avifRWDataRealloc(&bytes,
                     file.good() ? static_cast<size_t>(file.tellg()) : 0);
   file.seekg(0, std::ios::beg);
-  file.read(reinterpret_cast<char *>(bytes.data),
+  file.read(reinterpret_cast<char*>(bytes.data),
             static_cast<std::streamsize>(bytes.size));
   return bytes;
 }
@@ -141,7 +141,7 @@ INSTANTIATE_TEST_SUITE_P(SinglePixel, IncrementalTest,
 }  // namespace
 }  // namespace libavif
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   if (argc < 2) {
     std::cerr

--- a/tests/gtest/avifincrtest.cc
+++ b/tests/gtest/avifincrtest.cc
@@ -1,13 +1,12 @@
 // Copyright 2022 Google LLC. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include "avif/avif.h"
-
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <tuple>
 
+#include "avif/avif.h"
 #include "avifincrtest_helpers.h"
 #include "aviftest_helpers.h"
 #include "gtest/gtest.h"
@@ -16,86 +15,97 @@ using testing::Bool;
 using testing::Combine;
 using testing::Values;
 
-namespace libavif
-{
-namespace
-{
+namespace libavif {
+namespace {
 
 //------------------------------------------------------------------------------
 
 // Used to pass the data folder path to the GoogleTest suites.
-const char * dataPath = nullptr;
+const char *dataPath = nullptr;
 
 // Reads the file with fileName into bytes and returns them.
-testutil::avifRWDataCleaner readFile(const char * fileName)
-{
-    std::ifstream file(std::string(dataPath) + fileName, std::ios::binary | std::ios::ate);
-    testutil::avifRWDataCleaner bytes;
-    avifRWDataRealloc(&bytes, file.good() ? static_cast<size_t>(file.tellg()) : 0);
-    file.seekg(0, std::ios::beg);
-    file.read(reinterpret_cast<char *>(bytes.data), static_cast<std::streamsize>(bytes.size));
-    return bytes;
+testutil::avifRWDataCleaner readFile(const char *fileName) {
+  std::ifstream file(std::string(dataPath) + fileName,
+                     std::ios::binary | std::ios::ate);
+  testutil::avifRWDataCleaner bytes;
+  avifRWDataRealloc(&bytes,
+                    file.good() ? static_cast<size_t>(file.tellg()) : 0);
+  file.seekg(0, std::ios::beg);
+  file.read(reinterpret_cast<char *>(bytes.data),
+            static_cast<std::streamsize>(bytes.size));
+  return bytes;
 }
 
 //------------------------------------------------------------------------------
 
-// Check that non-incremental and incremental decodings of a grid AVIF produce the same pixels.
-TEST(IncrementalTest, Decode)
-{
-    const testutil::avifRWDataCleaner encodedAvif = readFile("sofa_grid1x5_420.avif");
-    ASSERT_NE(encodedAvif.size, 0u);
-    testutil::avifImagePtr reference(avifImageCreateEmpty(), avifImageDestroy);
-    ASSERT_NE(reference, nullptr);
-    testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
-    ASSERT_NE(decoder, nullptr);
-    ASSERT_EQ(avifDecoderReadMemory(decoder.get(), reference.get(), encodedAvif.data, encodedAvif.size), AVIF_RESULT_OK);
+// Check that non-incremental and incremental decodings of a grid AVIF produce
+// the same pixels.
+TEST(IncrementalTest, Decode) {
+  const testutil::avifRWDataCleaner encodedAvif =
+      readFile("sofa_grid1x5_420.avif");
+  ASSERT_NE(encodedAvif.size, 0u);
+  testutil::avifImagePtr reference(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(reference, nullptr);
+  testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderReadMemory(decoder.get(), reference.get(),
+                                  encodedAvif.data, encodedAvif.size),
+            AVIF_RESULT_OK);
 
-    // Cell height is hardcoded because there is no API to extract it from an encoded payload.
-    testutil::decodeIncrementally(encodedAvif, /*isPersistent=*/true, /*giveSizeHint=*/true, /*useNthImageApi=*/false, *reference, /*cellHeight=*/154);
+  // Cell height is hardcoded because there is no API to extract it from an
+  // encoded payload.
+  testutil::decodeIncrementally(encodedAvif, /*isPersistent=*/true,
+                                /*giveSizeHint=*/true, /*useNthImageApi=*/false,
+                                *reference, /*cellHeight=*/154);
 }
 
 //------------------------------------------------------------------------------
 
-class IncrementalTest : public testing::TestWithParam<std::tuple</*width=*/uint32_t,
-                                                                 /*height=*/uint32_t,
-                                                                 /*createAlpha=*/bool,
-                                                                 /*flatCells=*/bool,
-                                                                 /*encodedAvifIsPersistent=*/bool,
-                                                                 /*giveSizeHint=*/bool,
-                                                                 /*useNthImageApi=*/bool>>
-{
-};
+class IncrementalTest
+    : public testing::TestWithParam<std::tuple</*width=*/uint32_t,
+                                               /*height=*/uint32_t,
+                                               /*createAlpha=*/bool,
+                                               /*flatCells=*/bool,
+                                               /*encodedAvifIsPersistent=*/bool,
+                                               /*giveSizeHint=*/bool,
+                                               /*useNthImageApi=*/bool>> {};
 
-// Encodes then decodes a window of width*height pixels at the middle of the image.
-// Check that non-incremental and incremental decodings produce the same pixels.
-TEST_P(IncrementalTest, EncodeDecode)
-{
-    const uint32_t width = std::get<0>(GetParam());
-    const uint32_t height = std::get<1>(GetParam());
-    const bool createAlpha = std::get<2>(GetParam());
-    const bool flatCells = std::get<3>(GetParam());
-    const bool encodedAvifIsPersistent = std::get<4>(GetParam());
-    const bool giveSizeHint = std::get<5>(GetParam());
-    const bool useNthImageApi = std::get<6>(GetParam());
+// Encodes then decodes a window of width*height pixels at the middle of the
+// image. Check that non-incremental and incremental decodings produce the same
+// pixels.
+TEST_P(IncrementalTest, EncodeDecode) {
+  const uint32_t width = std::get<0>(GetParam());
+  const uint32_t height = std::get<1>(GetParam());
+  const bool createAlpha = std::get<2>(GetParam());
+  const bool flatCells = std::get<3>(GetParam());
+  const bool encodedAvifIsPersistent = std::get<4>(GetParam());
+  const bool giveSizeHint = std::get<5>(GetParam());
+  const bool useNthImageApi = std::get<6>(GetParam());
 
-    // Load an image. It does not matter that it comes from an AVIF file.
-    testutil::avifImagePtr image(avifImageCreateEmpty(), avifImageDestroy);
-    ASSERT_NE(image, nullptr);
-    const testutil::avifRWDataCleaner imageBytes = readFile("sofa_grid1x5_420.avif");
-    ASSERT_NE(imageBytes.size, 0u);
-    testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
-    ASSERT_NE(decoder, nullptr);
-    ASSERT_EQ(avifDecoderReadMemory(decoder.get(), image.get(), imageBytes.data, imageBytes.size), AVIF_RESULT_OK);
+  // Load an image. It does not matter that it comes from an AVIF file.
+  testutil::avifImagePtr image(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(image, nullptr);
+  const testutil::avifRWDataCleaner imageBytes =
+      readFile("sofa_grid1x5_420.avif");
+  ASSERT_NE(imageBytes.size, 0u);
+  testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderReadMemory(decoder.get(), image.get(), imageBytes.data,
+                                  imageBytes.size),
+            AVIF_RESULT_OK);
 
-    // Encode then decode it.
-    testutil::avifRWDataCleaner encodedAvif;
-    uint32_t cellWidth, cellHeight;
-    testutil::encodeRectAsIncremental(*image, width, height, createAlpha, flatCells, &encodedAvif, &cellWidth, &cellHeight);
-    testutil::decodeNonIncrementallyAndIncrementally(encodedAvif, encodedAvifIsPersistent, giveSizeHint, useNthImageApi, cellHeight);
+  // Encode then decode it.
+  testutil::avifRWDataCleaner encodedAvif;
+  uint32_t cellWidth, cellHeight;
+  testutil::encodeRectAsIncremental(*image, width, height, createAlpha,
+                                    flatCells, &encodedAvif, &cellWidth,
+                                    &cellHeight);
+  testutil::decodeNonIncrementallyAndIncrementally(
+      encodedAvif, encodedAvifIsPersistent, giveSizeHint, useNthImageApi,
+      cellHeight);
 }
 
-INSTANTIATE_TEST_SUITE_P(WholeImage,
-                         IncrementalTest,
+INSTANTIATE_TEST_SUITE_P(WholeImage, IncrementalTest,
                          Combine(/*width=*/Values(1024),
                                  /*height=*/Values(770),
                                  /*createAlpha=*/Values(true),
@@ -104,9 +114,9 @@ INSTANTIATE_TEST_SUITE_P(WholeImage,
                                  /*giveSizeHint=*/Values(true),
                                  /*useNthImageApi=*/Values(false)));
 
-// avifEncoderAddImageInternal() only accepts grids of one unique cell, or grids where width and height are both at least 64.
-INSTANTIATE_TEST_SUITE_P(SingleCell,
-                         IncrementalTest,
+// avifEncoderAddImageInternal() only accepts grids of one unique cell, or grids
+// where width and height are both at least 64.
+INSTANTIATE_TEST_SUITE_P(SingleCell, IncrementalTest,
                          Combine(/*width=*/Values(1),
                                  /*height=*/Values(1),
                                  /*createAlpha=*/Bool(),
@@ -115,9 +125,9 @@ INSTANTIATE_TEST_SUITE_P(SingleCell,
                                  /*giveSizeHint=*/Bool(),
                                  /*useNthImageApi=*/Bool()));
 
-// Chroma subsampling requires even dimensions. See ISO 23000-22 section 7.3.11.4.2.
-INSTANTIATE_TEST_SUITE_P(SinglePixel,
-                         IncrementalTest,
+// Chroma subsampling requires even dimensions. See ISO 23000-22
+// section 7.3.11.4.2.
+INSTANTIATE_TEST_SUITE_P(SinglePixel, IncrementalTest,
                          Combine(/*width=*/Values(64, 66),
                                  /*height=*/Values(64, 66),
                                  /*createAlpha=*/Bool(),
@@ -128,16 +138,17 @@ INSTANTIATE_TEST_SUITE_P(SinglePixel,
 
 //------------------------------------------------------------------------------
 
-} // namespace
-} // namespace libavif
+}  // namespace
+}  // namespace libavif
 
-int main(int argc, char ** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    if (argc < 2) {
-        std::cerr << "The path to the test data folder must be provided as an argument" << std::endl;
-        return 1;
-    }
-    libavif::dataPath = argv[1];
-    return RUN_ALL_TESTS();
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc < 2) {
+    std::cerr
+        << "The path to the test data folder must be provided as an argument"
+        << std::endl;
+    return 1;
+  }
+  libavif::dataPath = argv[1];
+  return RUN_ALL_TESTS();
 }

--- a/tests/gtest/avifincrtest_helpers.cc
+++ b/tests/gtest/avifincrtest_helpers.cc
@@ -19,7 +19,7 @@ namespace {
 
 // Verifies that the first (top) rowCount rows of image1 and image2 are
 // identical.
-void comparePartialYUVA(const avifImage &image1, const avifImage &image2,
+void comparePartialYUVA(const avifImage& image1, const avifImage& image2,
                         uint32_t rowCount) {
   if (rowCount == 0) {
     return;
@@ -44,8 +44,8 @@ void comparePartialYUVA(const avifImage &image1, const avifImage &image2,
     const uint32_t width = (plane == AVIF_CHAN_Y) ? image1.width : uvWidth;
     const uint32_t widthByteCount = width * pixelByteCount;
     const uint32_t height = (plane == AVIF_CHAN_Y) ? rowCount : uvHeight;
-    const uint8_t *data1 = image1.yuvPlanes[plane];
-    const uint8_t *data2 = image2.yuvPlanes[plane];
+    const uint8_t* data1 = image1.yuvPlanes[plane];
+    const uint8_t* data2 = image2.yuvPlanes[plane];
     for (uint32_t y = 0; y < height; ++y) {
       ASSERT_EQ(std::memcmp(data1, data2, widthByteCount), 0);
       data1 += image1.yuvRowBytes[plane];
@@ -57,8 +57,8 @@ void comparePartialYUVA(const avifImage &image1, const avifImage &image2,
     ASSERT_NE(image2.alphaPlane, nullptr);
     ASSERT_EQ(image1.alphaPremultiplied, image2.alphaPremultiplied);
     const uint32_t widthByteCount = image1.width * pixelByteCount;
-    const uint8_t *data1 = image1.alphaPlane;
-    const uint8_t *data2 = image2.alphaPlane;
+    const uint8_t* data1 = image1.alphaPlane;
+    const uint8_t* data2 = image2.alphaPlane;
     for (uint32_t y = 0; y < rowCount; ++y) {
       ASSERT_EQ(std::memcmp(data1, data2, widthByteCount), 0);
       data1 += image1.alphaRowBytes;
@@ -121,9 +121,9 @@ struct avifROPartialData {
 // Implementation of avifIOReadFunc simulating a stream from an array. See
 // avifIOReadFunc documentation. io->data is expected to point to
 // avifROPartialData.
-avifResult avifIOPartialRead(struct avifIO *io, uint32_t readFlags,
-                             uint64_t offset, size_t size, avifROData *out) {
-  const avifROPartialData *data = (avifROPartialData *)io->data;
+avifResult avifIOPartialRead(struct avifIO* io, uint32_t readFlags,
+                             uint64_t offset, size_t size, avifROData* out) {
+  const avifROPartialData* data = (avifROPartialData*)io->data;
   if ((readFlags != 0) || !data || (data->fullSize < offset)) {
     return AVIF_RESULT_IO_ERROR;
   }
@@ -144,9 +144,9 @@ avifResult avifIOPartialRead(struct avifIO *io, uint32_t readFlags,
 // The cell count is reduced to fit libavif or AVIF format constraints. If
 // impossible, the encoded output is returned empty. The final cellWidth and
 // cellHeight are output.
-void encodeAsGrid(const avifImage &image, uint32_t gridCols, uint32_t gridRows,
-                  avifRWData *output, uint32_t *cellWidth,
-                  uint32_t *cellHeight) {
+void encodeAsGrid(const avifImage& image, uint32_t gridCols, uint32_t gridRows,
+                  avifRWData* output, uint32_t* cellWidth,
+                  uint32_t* cellHeight) {
   // Chroma subsampling requires even dimensions. See ISO 23000-22 - 7.3.11.4.2
   const bool needEvenWidths = ((image.yuvFormat == AVIF_PIXEL_FORMAT_YUV420) ||
                                (image.yuvFormat == AVIF_PIXEL_FORMAT_YUV422));
@@ -195,7 +195,7 @@ void encodeAsGrid(const avifImage &image, uint32_t gridCols, uint32_t gridRows,
   ASSERT_NE(encoder, nullptr);
   encoder->speed = AVIF_SPEED_FASTEST;
   // Just here to match libavif API.
-  std::vector<avifImage *> cellImagePtrs(cellImages.size());
+  std::vector<avifImage*> cellImagePtrs(cellImages.size());
   for (size_t i = 0; i < cellImages.size(); ++i) {
     cellImagePtrs[i] = cellImages[i].get();
   }
@@ -207,9 +207,9 @@ void encodeAsGrid(const avifImage &image, uint32_t gridCols, uint32_t gridRows,
 }
 
 // Encodes the image to be decoded incrementally.
-void encodeAsIncremental(const avifImage &image, bool flatCells,
-                         avifRWData *output, uint32_t *cellWidth,
-                         uint32_t *cellHeight) {
+void encodeAsIncremental(const avifImage& image, bool flatCells,
+                         avifRWData* output, uint32_t* cellWidth,
+                         uint32_t* cellHeight) {
   const uint32_t gridCols = image.width / 64;  // 64px is the min cell width.
   const uint32_t gridRows = flatCells ? 1 : (image.height / 64);
   encodeAsGrid(image, (gridCols > 1) ? gridCols : 1,
@@ -218,10 +218,10 @@ void encodeAsIncremental(const avifImage &image, bool flatCells,
 
 }  // namespace
 
-void encodeRectAsIncremental(const avifImage &image, uint32_t width,
+void encodeRectAsIncremental(const avifImage& image, uint32_t width,
                              uint32_t height, bool createAlphaIfNone,
-                             bool flatCells, avifRWData *output,
-                             uint32_t *cellWidth, uint32_t *cellHeight) {
+                             bool flatCells, avifRWData* output,
+                             uint32_t* cellWidth, uint32_t* cellHeight) {
   avifImagePtr subImage(avifImageCreateEmpty(), avifImageDestroy);
   ASSERT_NE(subImage, nullptr);
   ASSERT_LE(width, image.width);
@@ -246,9 +246,9 @@ void encodeRectAsIncremental(const avifImage &image, uint32_t width,
 
 //------------------------------------------------------------------------------
 
-void decodeIncrementally(const avifRWData &encodedAvif, bool isPersistent,
+void decodeIncrementally(const avifRWData& encodedAvif, bool isPersistent,
                          bool giveSizeHint, bool useNthImageApi,
-                         const avifImage &reference, uint32_t cellHeight) {
+                         const avifImage& reference, uint32_t cellHeight) {
   // AVIF cells are at least 64 pixels tall.
   if (cellHeight != reference.height) {
     ASSERT_GE(cellHeight, 64u);
@@ -308,7 +308,7 @@ void decodeIncrementally(const avifRWData &encodedAvif, bool isPersistent,
   comparePartialYUVA(reference, *decoder->image, reference.height);
 }
 
-void decodeNonIncrementallyAndIncrementally(const avifRWData &encodedAvif,
+void decodeNonIncrementallyAndIncrementally(const avifRWData& encodedAvif,
                                             bool isPersistent,
                                             bool giveSizeHint,
                                             bool useNthImageApi,

--- a/tests/gtest/avifincrtest_helpers.cc
+++ b/tests/gtest/avifincrtest_helpers.cc
@@ -1,301 +1,331 @@
 // Copyright 2022 Google LLC. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include "avif/avif.h"
+#include "avifincrtest_helpers.h"
 
 #include <algorithm>
 #include <cstring>
 #include <vector>
 
-#include "avifincrtest_helpers.h"
+#include "avif/avif.h"
 #include "aviftest_helpers.h"
 #include "gtest/gtest.h"
 
-namespace libavif
-{
-namespace testutil
-{
-namespace
-{
+namespace libavif {
+namespace testutil {
+namespace {
 
 //------------------------------------------------------------------------------
 
-// Verifies that the first (top) rowCount rows of image1 and image2 are identical.
-void comparePartialYUVA(const avifImage & image1, const avifImage & image2, uint32_t rowCount)
-{
-    if (rowCount == 0) {
-        return;
-    }
-    ASSERT_EQ(image1.width, image2.width);
-    ASSERT_GE(image1.height, rowCount);
-    ASSERT_GE(image2.height, rowCount);
-    ASSERT_EQ(image1.depth, image2.depth);
-    ASSERT_EQ(image1.yuvFormat, image2.yuvFormat);
-    ASSERT_EQ(image1.yuvRange, image2.yuvRange);
+// Verifies that the first (top) rowCount rows of image1 and image2 are
+// identical.
+void comparePartialYUVA(const avifImage &image1, const avifImage &image2,
+                        uint32_t rowCount) {
+  if (rowCount == 0) {
+    return;
+  }
+  ASSERT_EQ(image1.width, image2.width);
+  ASSERT_GE(image1.height, rowCount);
+  ASSERT_GE(image2.height, rowCount);
+  ASSERT_EQ(image1.depth, image2.depth);
+  ASSERT_EQ(image1.yuvFormat, image2.yuvFormat);
+  ASSERT_EQ(image1.yuvRange, image2.yuvRange);
 
-    avifPixelFormatInfo info;
-    avifGetPixelFormatInfo(image1.yuvFormat, &info);
-    const uint32_t uvWidth = (image1.width + info.chromaShiftX) >> info.chromaShiftX;
-    const uint32_t uvHeight = (rowCount + info.chromaShiftY) >> info.chromaShiftY;
-    const uint32_t pixelByteCount = (image1.depth > 8) ? sizeof(uint16_t) : sizeof(uint8_t);
+  avifPixelFormatInfo info;
+  avifGetPixelFormatInfo(image1.yuvFormat, &info);
+  const uint32_t uvWidth =
+      (image1.width + info.chromaShiftX) >> info.chromaShiftX;
+  const uint32_t uvHeight = (rowCount + info.chromaShiftY) >> info.chromaShiftY;
+  const uint32_t pixelByteCount =
+      (image1.depth > 8) ? sizeof(uint16_t) : sizeof(uint8_t);
 
-    for (uint32_t plane = 0; plane < (info.monochrome ? 1 : AVIF_PLANE_COUNT_YUV); ++plane) {
-        const uint32_t width = (plane == AVIF_CHAN_Y) ? image1.width : uvWidth;
-        const uint32_t widthByteCount = width * pixelByteCount;
-        const uint32_t height = (plane == AVIF_CHAN_Y) ? rowCount : uvHeight;
-        const uint8_t * data1 = image1.yuvPlanes[plane];
-        const uint8_t * data2 = image2.yuvPlanes[plane];
-        for (uint32_t y = 0; y < height; ++y) {
-            ASSERT_EQ(std::memcmp(data1, data2, widthByteCount), 0);
-            data1 += image1.yuvRowBytes[plane];
-            data2 += image2.yuvRowBytes[plane];
-        }
+  for (uint32_t plane = 0; plane < (info.monochrome ? 1 : AVIF_PLANE_COUNT_YUV);
+       ++plane) {
+    const uint32_t width = (plane == AVIF_CHAN_Y) ? image1.width : uvWidth;
+    const uint32_t widthByteCount = width * pixelByteCount;
+    const uint32_t height = (plane == AVIF_CHAN_Y) ? rowCount : uvHeight;
+    const uint8_t *data1 = image1.yuvPlanes[plane];
+    const uint8_t *data2 = image2.yuvPlanes[plane];
+    for (uint32_t y = 0; y < height; ++y) {
+      ASSERT_EQ(std::memcmp(data1, data2, widthByteCount), 0);
+      data1 += image1.yuvRowBytes[plane];
+      data2 += image2.yuvRowBytes[plane];
     }
+  }
 
-    if (image1.alphaPlane) {
-        ASSERT_NE(image2.alphaPlane, nullptr);
-        ASSERT_EQ(image1.alphaPremultiplied, image2.alphaPremultiplied);
-        const uint32_t widthByteCount = image1.width * pixelByteCount;
-        const uint8_t * data1 = image1.alphaPlane;
-        const uint8_t * data2 = image2.alphaPlane;
-        for (uint32_t y = 0; y < rowCount; ++y) {
-            ASSERT_EQ(std::memcmp(data1, data2, widthByteCount), 0);
-            data1 += image1.alphaRowBytes;
-            data2 += image2.alphaRowBytes;
-        }
+  if (image1.alphaPlane) {
+    ASSERT_NE(image2.alphaPlane, nullptr);
+    ASSERT_EQ(image1.alphaPremultiplied, image2.alphaPremultiplied);
+    const uint32_t widthByteCount = image1.width * pixelByteCount;
+    const uint8_t *data1 = image1.alphaPlane;
+    const uint8_t *data2 = image2.alphaPlane;
+    for (uint32_t y = 0; y < rowCount; ++y) {
+      ASSERT_EQ(std::memcmp(data1, data2, widthByteCount), 0);
+      data1 += image1.alphaRowBytes;
+      data2 += image2.alphaRowBytes;
     }
+  }
 }
 
-// Returns the expected number of decoded rows when availableByteCount out of byteCount were
-// given to the decoder, for an image of height rows, split into cells of cellHeight rows.
-uint32_t getMinDecodedRowCount(uint32_t height, uint32_t cellHeight, bool hasAlpha, size_t availableByteCount, size_t byteCount)
-{
-    // The whole image should be available when the full input is.
-    if (availableByteCount >= byteCount) {
-        return height;
-    }
-    // All but one cell should be decoded if at most 10 bytes are missing.
-    if ((availableByteCount + 10) >= byteCount) {
-        return height - cellHeight;
-    }
+// Returns the expected number of decoded rows when availableByteCount out of
+// byteCount were given to the decoder, for an image of height rows, split into
+// cells of cellHeight rows.
+uint32_t getMinDecodedRowCount(uint32_t height, uint32_t cellHeight,
+                               bool hasAlpha, size_t availableByteCount,
+                               size_t byteCount) {
+  // The whole image should be available when the full input is.
+  if (availableByteCount >= byteCount) {
+    return height;
+  }
+  // All but one cell should be decoded if at most 10 bytes are missing.
+  if ((availableByteCount + 10) >= byteCount) {
+    return height - cellHeight;
+  }
 
-    // Subtract the header because decoding it does not output any pixel.
-    // Most AVIF headers are below 500 bytes.
-    if (availableByteCount <= 500) {
-        return 0;
+  // Subtract the header because decoding it does not output any pixel.
+  // Most AVIF headers are below 500 bytes.
+  if (availableByteCount <= 500) {
+    return 0;
+  }
+  availableByteCount -= 500;
+  byteCount -= 500;
+  // Alpha, if any, is assumed to be located before the other planes and to
+  // represent at most 50% of the payload.
+  if (hasAlpha) {
+    if (availableByteCount <= (byteCount / 2)) {
+      return 0;
     }
-    availableByteCount -= 500;
-    byteCount -= 500;
-    // Alpha, if any, is assumed to be located before the other planes and to
-    // represent at most 50% of the payload.
-    if (hasAlpha) {
-        if (availableByteCount <= (byteCount / 2)) {
-            return 0;
-        }
-        availableByteCount -= byteCount / 2;
-        byteCount -= byteCount / 2;
-    }
-    // Linearly map the input availability ratio to the decoded row ratio.
-    const uint32_t minDecodedCellRowCount = (height / cellHeight) * availableByteCount / byteCount;
-    const uint32_t minDecodedPxRowCount = minDecodedCellRowCount * cellHeight;
-    // One cell is the incremental decoding granularity.
-    // It is unlikely that bytes are evenly distributed among cells. Offset two of them.
-    if (minDecodedPxRowCount <= (2 * cellHeight)) {
-        return 0;
-    }
-    return minDecodedPxRowCount - 2 * cellHeight;
+    availableByteCount -= byteCount / 2;
+    byteCount -= byteCount / 2;
+  }
+  // Linearly map the input availability ratio to the decoded row ratio.
+  const uint32_t minDecodedCellRowCount =
+      (height / cellHeight) * availableByteCount / byteCount;
+  const uint32_t minDecodedPxRowCount = minDecodedCellRowCount * cellHeight;
+  // One cell is the incremental decoding granularity.
+  // It is unlikely that bytes are evenly distributed among cells. Offset two of
+  // them.
+  if (minDecodedPxRowCount <= (2 * cellHeight)) {
+    return 0;
+  }
+  return minDecodedPxRowCount - 2 * cellHeight;
 }
 
 //------------------------------------------------------------------------------
 
-struct avifROPartialData
-{
-    avifROData available;
-    size_t fullSize;
+struct avifROPartialData {
+  avifROData available;
+  size_t fullSize;
 };
 
-// Implementation of avifIOReadFunc simulating a stream from an array. See avifIOReadFunc documentation.
-// io->data is expected to point to avifROPartialData.
-avifResult avifIOPartialRead(struct avifIO * io, uint32_t readFlags, uint64_t offset, size_t size, avifROData * out)
-{
-    const avifROPartialData * data = (avifROPartialData *)io->data;
-    if ((readFlags != 0) || !data || (data->fullSize < offset)) {
-        return AVIF_RESULT_IO_ERROR;
-    }
-    if (data->fullSize < (offset + size)) {
-        size = data->fullSize - offset;
-    }
-    if (data->available.size < (offset + size)) {
-        return AVIF_RESULT_WAITING_ON_IO;
-    }
-    out->data = data->available.data + offset;
-    out->size = size;
-    return AVIF_RESULT_OK;
+// Implementation of avifIOReadFunc simulating a stream from an array. See
+// avifIOReadFunc documentation. io->data is expected to point to
+// avifROPartialData.
+avifResult avifIOPartialRead(struct avifIO *io, uint32_t readFlags,
+                             uint64_t offset, size_t size, avifROData *out) {
+  const avifROPartialData *data = (avifROPartialData *)io->data;
+  if ((readFlags != 0) || !data || (data->fullSize < offset)) {
+    return AVIF_RESULT_IO_ERROR;
+  }
+  if (data->fullSize < (offset + size)) {
+    size = data->fullSize - offset;
+  }
+  if (data->available.size < (offset + size)) {
+    return AVIF_RESULT_WAITING_ON_IO;
+  }
+  out->data = data->available.data + offset;
+  out->size = size;
+  return AVIF_RESULT_OK;
 }
 
 //------------------------------------------------------------------------------
 
 // Encodes the image as a grid of at most gridCols*gridRows cells.
-// The cell count is reduced to fit libavif or AVIF format constraints. If impossible, the encoded output is returned empty.
-// The final cellWidth and cellHeight are output.
-void encodeAsGrid(const avifImage & image, uint32_t gridCols, uint32_t gridRows, avifRWData * output, uint32_t * cellWidth, uint32_t * cellHeight)
-{
-    // Chroma subsampling requires even dimensions. See ISO 23000-22 - 7.3.11.4.2
-    const bool needEvenWidths = ((image.yuvFormat == AVIF_PIXEL_FORMAT_YUV420) || (image.yuvFormat == AVIF_PIXEL_FORMAT_YUV422));
-    const bool needEvenHeights = (image.yuvFormat == AVIF_PIXEL_FORMAT_YUV420);
+// The cell count is reduced to fit libavif or AVIF format constraints. If
+// impossible, the encoded output is returned empty. The final cellWidth and
+// cellHeight are output.
+void encodeAsGrid(const avifImage &image, uint32_t gridCols, uint32_t gridRows,
+                  avifRWData *output, uint32_t *cellWidth,
+                  uint32_t *cellHeight) {
+  // Chroma subsampling requires even dimensions. See ISO 23000-22 - 7.3.11.4.2
+  const bool needEvenWidths = ((image.yuvFormat == AVIF_PIXEL_FORMAT_YUV420) ||
+                               (image.yuvFormat == AVIF_PIXEL_FORMAT_YUV422));
+  const bool needEvenHeights = (image.yuvFormat == AVIF_PIXEL_FORMAT_YUV420);
 
-    ASSERT_GT(gridCols * gridRows, 0u);
+  ASSERT_GT(gridCols * gridRows, 0u);
+  *cellWidth = image.width / gridCols;
+  *cellHeight = image.height / gridRows;
+
+  // avifEncoderAddImageGrid() only accepts grids that evenly split the image
+  // into cells at least 64 pixels wide and tall.
+  while ((gridCols > 1) &&
+         (((*cellWidth * gridCols) != image.width) || (*cellWidth < 64) ||
+          (needEvenWidths && ((*cellWidth & 1) != 0)))) {
+    --gridCols;
     *cellWidth = image.width / gridCols;
+  }
+  while ((gridRows > 1) &&
+         (((*cellHeight * gridRows) != image.height) || (*cellHeight < 64) ||
+          (needEvenHeights && ((*cellHeight & 1) != 0)))) {
+    --gridRows;
     *cellHeight = image.height / gridRows;
+  }
 
-    // avifEncoderAddImageGrid() only accepts grids that evenly split the image into cells at least 64 pixels wide and tall.
-    while ((gridCols > 1) &&
-           (((*cellWidth * gridCols) != image.width) || (*cellWidth < 64) || (needEvenWidths && ((*cellWidth & 1) != 0)))) {
-        --gridCols;
-        *cellWidth = image.width / gridCols;
+  std::vector<testutil::avifImagePtr> cellImages;
+  cellImages.reserve(gridCols * gridRows);
+  for (uint32_t row = 0, iCell = 0; row < gridRows; ++row) {
+    for (uint32_t col = 0; col < gridCols; ++col, ++iCell) {
+      avifCropRect cell;
+      cell.x = col * *cellWidth;
+      cell.y = row * *cellHeight;
+      cell.width = ((cell.x + *cellWidth) <= image.width)
+                       ? *cellWidth
+                       : (image.width - cell.x);
+      cell.height = ((cell.y + *cellHeight) <= image.height)
+                        ? *cellHeight
+                        : (image.height - cell.y);
+      cellImages.emplace_back(avifImageCreateEmpty(), avifImageDestroy);
+      ASSERT_NE(cellImages.back(), nullptr);
+      ASSERT_EQ(avifImageSetViewRect(cellImages.back().get(), &image, &cell),
+                AVIF_RESULT_OK);
     }
-    while ((gridRows > 1) &&
-           (((*cellHeight * gridRows) != image.height) || (*cellHeight < 64) || (needEvenHeights && ((*cellHeight & 1) != 0)))) {
-        --gridRows;
-        *cellHeight = image.height / gridRows;
-    }
+  }
 
-    std::vector<testutil::avifImagePtr> cellImages;
-    cellImages.reserve(gridCols * gridRows);
-    for (uint32_t row = 0, iCell = 0; row < gridRows; ++row) {
-        for (uint32_t col = 0; col < gridCols; ++col, ++iCell) {
-            avifCropRect cell;
-            cell.x = col * *cellWidth;
-            cell.y = row * *cellHeight;
-            cell.width = ((cell.x + *cellWidth) <= image.width) ? *cellWidth : (image.width - cell.x);
-            cell.height = ((cell.y + *cellHeight) <= image.height) ? *cellHeight : (image.height - cell.y);
-            cellImages.emplace_back(avifImageCreateEmpty(), avifImageDestroy);
-            ASSERT_NE(cellImages.back(), nullptr);
-            ASSERT_EQ(avifImageSetViewRect(cellImages.back().get(), &image, &cell), AVIF_RESULT_OK);
-        }
-    }
-
-    testutil::avifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
-    ASSERT_NE(encoder, nullptr);
-    encoder->speed = AVIF_SPEED_FASTEST;
-    std::vector<avifImage *> cellImagePtrs(cellImages.size()); // Just here to match libavif API.
-    for (size_t i = 0; i < cellImages.size(); ++i) {
-        cellImagePtrs[i] = cellImages[i].get();
-    }
-    ASSERT_EQ(avifEncoderAddImageGrid(encoder.get(), gridCols, gridRows, cellImagePtrs.data(), AVIF_ADD_IMAGE_FLAG_SINGLE), AVIF_RESULT_OK);
-    ASSERT_EQ(avifEncoderFinish(encoder.get(), output), AVIF_RESULT_OK);
+  testutil::avifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  encoder->speed = AVIF_SPEED_FASTEST;
+  // Just here to match libavif API.
+  std::vector<avifImage *> cellImagePtrs(cellImages.size());
+  for (size_t i = 0; i < cellImages.size(); ++i) {
+    cellImagePtrs[i] = cellImages[i].get();
+  }
+  ASSERT_EQ(
+      avifEncoderAddImageGrid(encoder.get(), gridCols, gridRows,
+                              cellImagePtrs.data(), AVIF_ADD_IMAGE_FLAG_SINGLE),
+      AVIF_RESULT_OK);
+  ASSERT_EQ(avifEncoderFinish(encoder.get(), output), AVIF_RESULT_OK);
 }
 
 // Encodes the image to be decoded incrementally.
-void encodeAsIncremental(const avifImage & image, bool flatCells, avifRWData * output, uint32_t * cellWidth, uint32_t * cellHeight)
-{
-    const uint32_t gridCols = image.width / 64; // 64px is the min cell width.
-    const uint32_t gridRows = flatCells ? 1 : (image.height / 64);
-    encodeAsGrid(image, (gridCols > 1) ? gridCols : 1, (gridRows > 1) ? gridRows : 1, output, cellWidth, cellHeight);
+void encodeAsIncremental(const avifImage &image, bool flatCells,
+                         avifRWData *output, uint32_t *cellWidth,
+                         uint32_t *cellHeight) {
+  const uint32_t gridCols = image.width / 64;  // 64px is the min cell width.
+  const uint32_t gridRows = flatCells ? 1 : (image.height / 64);
+  encodeAsGrid(image, (gridCols > 1) ? gridCols : 1,
+               (gridRows > 1) ? gridRows : 1, output, cellWidth, cellHeight);
 }
 
-} // namespace
+}  // namespace
 
-void encodeRectAsIncremental(const avifImage & image,
-                             uint32_t width,
-                             uint32_t height,
-                             bool createAlphaIfNone,
-                             bool flatCells,
-                             avifRWData * output,
-                             uint32_t * cellWidth,
-                             uint32_t * cellHeight)
-{
-    avifImagePtr subImage(avifImageCreateEmpty(), avifImageDestroy);
-    ASSERT_NE(subImage, nullptr);
-    ASSERT_LE(width, image.width);
-    ASSERT_LE(height, image.height);
-    avifPixelFormatInfo info;
-    avifGetPixelFormatInfo(image.yuvFormat, &info);
-    const avifCropRect rect {
-        /*x=*/((image.width - width) / 2) & ~info.chromaShiftX, /*y=*/((image.height - height) / 2) & ~info.chromaShiftX, width, height
-    };
-    ASSERT_EQ(avifImageSetViewRect(subImage.get(), &image, &rect), AVIF_RESULT_OK);
-    if (createAlphaIfNone && !subImage->alphaPlane) {
-        ASSERT_NE(image.yuvPlanes[AVIF_CHAN_Y], nullptr) << "No luma plane to simulate an alpha plane";
-        subImage->alphaPlane = image.yuvPlanes[AVIF_CHAN_Y];
-        subImage->alphaRowBytes = image.yuvRowBytes[AVIF_CHAN_Y];
-        subImage->alphaPremultiplied = AVIF_FALSE;
-        subImage->imageOwnsAlphaPlane = AVIF_FALSE;
-    }
-    encodeAsIncremental(*subImage, flatCells, output, cellWidth, cellHeight);
-}
-
-//------------------------------------------------------------------------------
-
-void decodeIncrementally(const avifRWData & encodedAvif,
-                         bool isPersistent,
-                         bool giveSizeHint,
-                         bool useNthImageApi,
-                         const avifImage & reference,
-                         uint32_t cellHeight)
-{
-    // AVIF cells are at least 64 pixels tall.
-    if (cellHeight != reference.height) {
-        ASSERT_GE(cellHeight, 64u);
-    }
-
-    // Emulate a byte-by-byte stream.
-    avifROPartialData data = { /*available=*/ { encodedAvif.data, 0 }, /*fullSize=*/encodedAvif.size };
-    avifIO io = { /*destroy=*/nullptr, avifIOPartialRead,
-                  /*write=*/nullptr,   giveSizeHint ? encodedAvif.size : 0,
-                  isPersistent,        &data };
-
-    testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
-    ASSERT_NE(decoder, nullptr);
-    avifDecoderSetIO(decoder.get(), &io);
-    decoder->allowIncremental = AVIF_TRUE;
-    const size_t step = std::max(static_cast<size_t>(1), data.fullSize / 10000);
-
-    // Parsing is not incremental.
-    avifResult parseResult = avifDecoderParse(decoder.get());
-    while (parseResult == AVIF_RESULT_WAITING_ON_IO) {
-        ASSERT_LT(data.available.size, data.fullSize) << "avifDecoderParse() returned WAITING_ON_IO instead of OK";
-        data.available.size = std::min(data.available.size + step, data.fullSize);
-        parseResult = avifDecoderParse(decoder.get());
-    }
-    ASSERT_EQ(parseResult, AVIF_RESULT_OK);
-
-    // Decoding is incremental.
-    uint32_t previouslyDecodedRowCount = 0;
-    avifResult nextImageResult = useNthImageApi ? avifDecoderNthImage(decoder.get(), 0) : avifDecoderNextImage(decoder.get());
-    while (nextImageResult == AVIF_RESULT_WAITING_ON_IO) {
-        ASSERT_LT(data.available.size, data.fullSize)
-            << (useNthImageApi ? "avifDecoderNthImage(0)" : "avifDecoderNextImage()") << " returned WAITING_ON_IO instead of OK";
-        const uint32_t decodedRowCount = avifDecoderDecodedRowCount(decoder.get());
-        ASSERT_GE(decodedRowCount, previouslyDecodedRowCount);
-        const uint32_t minDecodedRowCount =
-            getMinDecodedRowCount(reference.height, cellHeight, reference.alphaPlane != nullptr, data.available.size, data.fullSize);
-        ASSERT_GE(decodedRowCount, minDecodedRowCount);
-        comparePartialYUVA(reference, *decoder->image, decodedRowCount);
-
-        previouslyDecodedRowCount = decodedRowCount;
-        data.available.size = std::min(data.available.size + step, data.fullSize);
-        nextImageResult = useNthImageApi ? avifDecoderNthImage(decoder.get(), 0) : avifDecoderNextImage(decoder.get());
-    }
-    ASSERT_EQ(nextImageResult, AVIF_RESULT_OK);
-    ASSERT_EQ(data.available.size, data.fullSize);
-    ASSERT_EQ(avifDecoderDecodedRowCount(decoder.get()), decoder->image->height);
-
-    comparePartialYUVA(reference, *decoder->image, reference.height);
-}
-
-void decodeNonIncrementallyAndIncrementally(const avifRWData & encodedAvif, bool isPersistent, bool giveSizeHint, bool useNthImageApi, uint32_t cellHeight)
-{
-    avifImagePtr reference(avifImageCreateEmpty(), avifImageDestroy);
-    ASSERT_NE(reference, nullptr);
-    testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
-    ASSERT_NE(decoder, nullptr);
-    ASSERT_EQ(avifDecoderReadMemory(decoder.get(), reference.get(), encodedAvif.data, encodedAvif.size), AVIF_RESULT_OK);
-
-    decodeIncrementally(encodedAvif, isPersistent, giveSizeHint, useNthImageApi, *reference, cellHeight);
+void encodeRectAsIncremental(const avifImage &image, uint32_t width,
+                             uint32_t height, bool createAlphaIfNone,
+                             bool flatCells, avifRWData *output,
+                             uint32_t *cellWidth, uint32_t *cellHeight) {
+  avifImagePtr subImage(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(subImage, nullptr);
+  ASSERT_LE(width, image.width);
+  ASSERT_LE(height, image.height);
+  avifPixelFormatInfo info;
+  avifGetPixelFormatInfo(image.yuvFormat, &info);
+  const avifCropRect rect{
+      /*x=*/((image.width - width) / 2) & ~info.chromaShiftX,
+      /*y=*/((image.height - height) / 2) & ~info.chromaShiftX, width, height};
+  ASSERT_EQ(avifImageSetViewRect(subImage.get(), &image, &rect),
+            AVIF_RESULT_OK);
+  if (createAlphaIfNone && !subImage->alphaPlane) {
+    ASSERT_NE(image.yuvPlanes[AVIF_CHAN_Y], nullptr)
+        << "No luma plane to simulate an alpha plane";
+    subImage->alphaPlane = image.yuvPlanes[AVIF_CHAN_Y];
+    subImage->alphaRowBytes = image.yuvRowBytes[AVIF_CHAN_Y];
+    subImage->alphaPremultiplied = AVIF_FALSE;
+    subImage->imageOwnsAlphaPlane = AVIF_FALSE;
+  }
+  encodeAsIncremental(*subImage, flatCells, output, cellWidth, cellHeight);
 }
 
 //------------------------------------------------------------------------------
 
-} // namespace testutil
-} // namespace libavif
+void decodeIncrementally(const avifRWData &encodedAvif, bool isPersistent,
+                         bool giveSizeHint, bool useNthImageApi,
+                         const avifImage &reference, uint32_t cellHeight) {
+  // AVIF cells are at least 64 pixels tall.
+  if (cellHeight != reference.height) {
+    ASSERT_GE(cellHeight, 64u);
+  }
+
+  // Emulate a byte-by-byte stream.
+  avifROPartialData data = {/*available=*/{encodedAvif.data, 0},
+                            /*fullSize=*/encodedAvif.size};
+  avifIO io = {
+      /*destroy=*/nullptr, avifIOPartialRead,
+      /*write=*/nullptr,   giveSizeHint ? encodedAvif.size : 0,
+      isPersistent,        &data};
+
+  testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  avifDecoderSetIO(decoder.get(), &io);
+  decoder->allowIncremental = AVIF_TRUE;
+  const size_t step = std::max(static_cast<size_t>(1), data.fullSize / 10000);
+
+  // Parsing is not incremental.
+  avifResult parseResult = avifDecoderParse(decoder.get());
+  while (parseResult == AVIF_RESULT_WAITING_ON_IO) {
+    ASSERT_LT(data.available.size, data.fullSize)
+        << "avifDecoderParse() returned WAITING_ON_IO instead of OK";
+    data.available.size = std::min(data.available.size + step, data.fullSize);
+    parseResult = avifDecoderParse(decoder.get());
+  }
+  ASSERT_EQ(parseResult, AVIF_RESULT_OK);
+
+  // Decoding is incremental.
+  uint32_t previouslyDecodedRowCount = 0;
+  avifResult nextImageResult = useNthImageApi
+                                   ? avifDecoderNthImage(decoder.get(), 0)
+                                   : avifDecoderNextImage(decoder.get());
+  while (nextImageResult == AVIF_RESULT_WAITING_ON_IO) {
+    ASSERT_LT(data.available.size, data.fullSize)
+        << (useNthImageApi ? "avifDecoderNthImage(0)"
+                           : "avifDecoderNextImage()")
+        << " returned WAITING_ON_IO instead of OK";
+    const uint32_t decodedRowCount = avifDecoderDecodedRowCount(decoder.get());
+    ASSERT_GE(decodedRowCount, previouslyDecodedRowCount);
+    const uint32_t minDecodedRowCount = getMinDecodedRowCount(
+        reference.height, cellHeight, reference.alphaPlane != nullptr,
+        data.available.size, data.fullSize);
+    ASSERT_GE(decodedRowCount, minDecodedRowCount);
+    comparePartialYUVA(reference, *decoder->image, decodedRowCount);
+
+    previouslyDecodedRowCount = decodedRowCount;
+    data.available.size = std::min(data.available.size + step, data.fullSize);
+    nextImageResult = useNthImageApi ? avifDecoderNthImage(decoder.get(), 0)
+                                     : avifDecoderNextImage(decoder.get());
+  }
+  ASSERT_EQ(nextImageResult, AVIF_RESULT_OK);
+  ASSERT_EQ(data.available.size, data.fullSize);
+  ASSERT_EQ(avifDecoderDecodedRowCount(decoder.get()), decoder->image->height);
+
+  comparePartialYUVA(reference, *decoder->image, reference.height);
+}
+
+void decodeNonIncrementallyAndIncrementally(const avifRWData &encodedAvif,
+                                            bool isPersistent,
+                                            bool giveSizeHint,
+                                            bool useNthImageApi,
+                                            uint32_t cellHeight) {
+  avifImagePtr reference(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(reference, nullptr);
+  testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderReadMemory(decoder.get(), reference.get(),
+                                  encodedAvif.data, encodedAvif.size),
+            AVIF_RESULT_OK);
+
+  decodeIncrementally(encodedAvif, isPersistent, giveSizeHint, useNthImageApi,
+                      *reference, cellHeight);
+}
+
+//------------------------------------------------------------------------------
+
+}  // namespace testutil
+}  // namespace libavif

--- a/tests/gtest/avifincrtest_helpers.h
+++ b/tests/gtest/avifincrtest_helpers.h
@@ -6,41 +6,35 @@
 
 #include "avif/avif.h"
 
-namespace libavif
-{
-namespace testutil
-{
+namespace libavif {
+namespace testutil {
 
 // Encodes a portion of the image to be decoded incrementally.
-void encodeRectAsIncremental(const avifImage & image,
-                             uint32_t width,
-                             uint32_t height,
-                             bool createAlphaIfNone,
-                             bool flatCells,
-                             avifRWData * output,
-                             uint32_t * cellWidth,
-                             uint32_t * cellHeight);
+void encodeRectAsIncremental(const avifImage& image, uint32_t width,
+                             uint32_t height, bool createAlphaIfNone,
+                             bool flatCells, avifRWData* output,
+                             uint32_t* cellWidth, uint32_t* cellHeight);
 
-// Decodes incrementally the encodedAvif and compares the pixels with the given reference.
-// If isPersistent is true, the input encodedAvif is considered as accessible during the whole decoding.
-// If giveSizeHint is true, the whole encodedAvif size is given as a hint to the decoder.
-// useNthImageApi describes whether the NthImage or NextImage decoder API will be used.
-// The cellHeight of all planes of the encodedAvif is given to estimate the incremental granularity.
-void decodeIncrementally(const avifRWData & encodedAvif,
-                         bool isPersistent,
-                         bool giveSizeHint,
-                         bool useNthImageApi,
-                         const avifImage & reference,
-                         uint32_t cellHeight);
+// Decodes incrementally the encodedAvif and compares the pixels with the given
+// reference. If isPersistent is true, the input encodedAvif is considered as
+// accessible during the whole decoding. If giveSizeHint is true, the whole
+// encodedAvif size is given as a hint to the decoder. useNthImageApi describes
+// whether the NthImage or NextImage decoder API will be used. The cellHeight of
+// all planes of the encodedAvif is given to estimate the incremental
+// granularity.
+void decodeIncrementally(const avifRWData& encodedAvif, bool isPersistent,
+                         bool giveSizeHint, bool useNthImageApi,
+                         const avifImage& reference, uint32_t cellHeight);
 
-// Calls decodeIncrementally() with the reference being a regular decoding of encodedAvif.
-void decodeNonIncrementallyAndIncrementally(const avifRWData & encodedAvif,
+// Calls decodeIncrementally() with the reference being a regular decoding of
+// encodedAvif.
+void decodeNonIncrementallyAndIncrementally(const avifRWData& encodedAvif,
                                             bool isPersistent,
                                             bool giveSizeHint,
                                             bool useNthImageApi,
                                             uint32_t cellHeight);
 
-} // namespace testutil
-} // namespace libavif
+}  // namespace testutil
+}  // namespace libavif
 
-#endif // LIBAVIF_TESTS_AVIFINCRTEST_HELPERS_H_
+#endif  // LIBAVIF_TESTS_AVIFINCRTEST_HELPERS_H_

--- a/tests/gtest/avifmetadatatest.cc
+++ b/tests/gtest/avifmetadatatest.cc
@@ -1,101 +1,111 @@
 // Copyright 2022 Google LLC. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include "avif/avif.h"
-
 #include <array>
 #include <tuple>
 
+#include "avif/avif.h"
 #include "aviftest_helpers.h"
 #include "gtest/gtest.h"
 
 using ::testing::Bool;
 using ::testing::Combine;
 
-namespace libavif
-{
-namespace
-{
+namespace libavif {
+namespace {
 
 //------------------------------------------------------------------------------
 
 // ICC color profiles are not checked by libavif so the content does not matter.
 // This is a truncated widespread ICC color profile.
-const std::array<uint8_t, 24> sampleICC = { 0x00, 0x00, 0x02, 0x0c, 0x6c, 0x63, 0x6d, 0x73, 0x02, 0x10, 0x00, 0x00,
-                                            0x6d, 0x6e, 0x74, 0x72, 0x52, 0x47, 0x42, 0x20, 0x58, 0x59, 0x5a, 0x20 };
+const std::array<uint8_t, 24> sampleICC = {
+    0x00, 0x00, 0x02, 0x0c, 0x6c, 0x63, 0x6d, 0x73, 0x02, 0x10, 0x00, 0x00,
+    0x6d, 0x6e, 0x74, 0x72, 0x52, 0x47, 0x42, 0x20, 0x58, 0x59, 0x5a, 0x20};
 
-// Exif bytes are partially checked by libavif. This is a truncated widespread Exif metadata chunk.
-const std::array<uint8_t, 24> sampleExif = { 0xff, 0x1,  0x45, 0x78, 0x69, 0x76, 0x32, 0xff, 0xe1, 0x12, 0x5a, 0x45,
-                                             0x78, 0x69, 0x66, 0x0,  0x0,  0x49, 0x49, 0x2a, 0x0,  0x8,  0x0,  0x0 };
+// Exif bytes are partially checked by libavif. This is a truncated widespread
+// Exif metadata chunk.
+const std::array<uint8_t, 24> sampleExif = {
+    0xff, 0x1,  0x45, 0x78, 0x69, 0x76, 0x32, 0xff, 0xe1, 0x12, 0x5a, 0x45,
+    0x78, 0x69, 0x66, 0x0,  0x0,  0x49, 0x49, 0x2a, 0x0,  0x8,  0x0,  0x0};
 
 // XMP bytes are not checked by libavif so the content does not matter.
 // This is a truncated widespread XMP metadata chunk.
-const std::array<uint8_t, 24> sampleXMP = { 0x3c, 0x3f, 0x78, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x74, 0x20, 0x62, 0x65,
-                                            0x67, 0x69, 0x6e, 0x3d, 0x22, 0xef, 0xbb, 0xbf, 0x22, 0x20, 0x69, 0x64 };
+const std::array<uint8_t, 24> sampleXMP = {
+    0x3c, 0x3f, 0x78, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x74, 0x20, 0x62, 0x65,
+    0x67, 0x69, 0x6e, 0x3d, 0x22, 0xef, 0xbb, 0xbf, 0x22, 0x20, 0x69, 0x64};
 
 //------------------------------------------------------------------------------
 
-class MetadataTest : public testing::TestWithParam<std::tuple</*useICC=*/bool, /*useExif=*/bool, /*useXMP=*/bool>>
-{
-};
+class MetadataTest
+    : public testing::TestWithParam<
+          std::tuple</*useICC=*/bool, /*useExif=*/bool, /*useXMP=*/bool>> {};
 
-// Encodes, decodes then verifies that the output metadata matches the input metadata defined by the parameters.
-TEST_P(MetadataTest, EncodeDecode)
-{
-    const bool useICC = std::get<0>(GetParam());
-    const bool useExif = std::get<1>(GetParam());
-    const bool useXMP = std::get<2>(GetParam());
+// Encodes, decodes then verifies that the output metadata matches the input
+// metadata defined by the parameters.
+TEST_P(MetadataTest, EncodeDecode) {
+  const bool useICC = std::get<0>(GetParam());
+  const bool useExif = std::get<1>(GetParam());
+  const bool useXMP = std::get<2>(GetParam());
 
-    testutil::avifImagePtr image =
-        testutil::createImage(/*width=*/12, /*height=*/34, /*depth=*/10, AVIF_PIXEL_FORMAT_YUV444, AVIF_PLANES_ALL);
-    ASSERT_NE(image, nullptr);
-    testutil::fillImageGradient(image.get()); // The pixels do not matter.
-    if (useICC) {
-        avifImageSetProfileICC(image.get(), sampleICC.data(), sampleICC.size());
-    }
-    if (useExif) {
-        avifImageSetMetadataExif(image.get(), sampleExif.data(), sampleExif.size());
-    }
-    if (useXMP) {
-        avifImageSetMetadataXMP(image.get(), sampleXMP.data(), sampleXMP.size());
-    }
+  testutil::avifImagePtr image =
+      testutil::createImage(/*width=*/12, /*height=*/34, /*depth=*/10,
+                            AVIF_PIXEL_FORMAT_YUV444, AVIF_PLANES_ALL);
+  ASSERT_NE(image, nullptr);
+  testutil::fillImageGradient(image.get());  // The pixels do not matter.
+  if (useICC) {
+    avifImageSetProfileICC(image.get(), sampleICC.data(), sampleICC.size());
+  }
+  if (useExif) {
+    avifImageSetMetadataExif(image.get(), sampleExif.data(), sampleExif.size());
+  }
+  if (useXMP) {
+    avifImageSetMetadataXMP(image.get(), sampleXMP.data(), sampleXMP.size());
+  }
 
-    // Encode.
-    testutil::avifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
-    ASSERT_NE(encoder, nullptr);
-    encoder->speed = AVIF_SPEED_FASTEST;
-    testutil::avifRWDataCleaner encodedAvif;
-    ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encodedAvif), AVIF_RESULT_OK);
+  // Encode.
+  testutil::avifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  encoder->speed = AVIF_SPEED_FASTEST;
+  testutil::avifRWDataCleaner encodedAvif;
+  ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encodedAvif),
+            AVIF_RESULT_OK);
 
-    // Decode.
-    testutil::avifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
-    ASSERT_NE(decoded, nullptr);
-    testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
-    ASSERT_NE(decoder, nullptr);
-    ASSERT_EQ(avifDecoderReadMemory(decoder.get(), decoded.get(), encodedAvif.data, encodedAvif.size), AVIF_RESULT_OK);
+  // Decode.
+  testutil::avifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  testutil::avifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderReadMemory(decoder.get(), decoded.get(),
+                                  encodedAvif.data, encodedAvif.size),
+            AVIF_RESULT_OK);
 
-    // Compare input and output metadata.
-    if (useICC) {
-        ASSERT_EQ(decoded->icc.size, sampleICC.size());
-        EXPECT_TRUE(std::equal(sampleICC.begin(), sampleICC.end(), decoded->icc.data));
-    } else {
-        EXPECT_EQ(decoded->icc.size, 0u);
-    }
-    if (useExif) {
-        ASSERT_EQ(decoded->exif.size, sampleExif.size());
-        EXPECT_TRUE(std::equal(sampleExif.begin(), sampleExif.end(), decoded->exif.data));
-    } else {
-        EXPECT_EQ(decoded->exif.size, 0u);
-    }
-    if (useXMP) {
-        ASSERT_EQ(decoded->xmp.size, sampleXMP.size());
-        EXPECT_TRUE(std::equal(sampleXMP.begin(), sampleXMP.end(), decoded->xmp.data));
-    } else {
-        EXPECT_EQ(decoded->xmp.size, 0u);
-    }
+  // Compare input and output metadata.
+  if (useICC) {
+    ASSERT_EQ(decoded->icc.size, sampleICC.size());
+    EXPECT_TRUE(
+        std::equal(sampleICC.begin(), sampleICC.end(), decoded->icc.data));
+  } else {
+    EXPECT_EQ(decoded->icc.size, 0u);
+  }
+  if (useExif) {
+    ASSERT_EQ(decoded->exif.size, sampleExif.size());
+    EXPECT_TRUE(
+        std::equal(sampleExif.begin(), sampleExif.end(), decoded->exif.data));
+  } else {
+    EXPECT_EQ(decoded->exif.size, 0u);
+  }
+  if (useXMP) {
+    ASSERT_EQ(decoded->xmp.size, sampleXMP.size());
+    EXPECT_TRUE(
+        std::equal(sampleXMP.begin(), sampleXMP.end(), decoded->xmp.data));
+  } else {
+    EXPECT_EQ(decoded->xmp.size, 0u);
+  }
 }
 
-INSTANTIATE_TEST_SUITE_P(All, MetadataTest, Combine(/*useICC=*/Bool(), /*useExif=*/Bool(), /*useXMP=*/Bool()));
+INSTANTIATE_TEST_SUITE_P(All, MetadataTest,
+                         Combine(/*useICC=*/Bool(), /*useExif=*/Bool(),
+                                 /*useXMP=*/Bool()));
 
-} // namespace
-} // namespace libavif
+}  // namespace
+}  // namespace libavif

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -33,12 +33,12 @@ avifImagePtr createImage(int width, int height, int depth,
   return image;
 }
 
-void fillImagePlain(avifImage *image, const uint32_t yuva[4]) {
+void fillImagePlain(avifImage* image, const uint32_t yuva[4]) {
   avifPixelFormatInfo info;
   avifGetPixelFormatInfo(image->yuvFormat, &info);
 
   for (int c : AVIF_CHANS) {
-    uint8_t *row = (c == AVIF_CHAN_A) ? image->alphaPlane : image->yuvPlanes[c];
+    uint8_t* row = (c == AVIF_CHAN_A) ? image->alphaPlane : image->yuvPlanes[c];
     if (!row) {
       continue;
     }
@@ -54,8 +54,8 @@ void fillImagePlain(avifImage *image, const uint32_t yuva[4]) {
             : ((image->height + info.chromaShiftY) >> info.chromaShiftY);
     for (uint32_t y = 0; y < planeHeight; ++y) {
       if (avifImageUsesU16(image)) {
-        std::fill(reinterpret_cast<uint16_t *>(row),
-                  reinterpret_cast<uint16_t *>(row) + planeWidth,
+        std::fill(reinterpret_cast<uint16_t*>(row),
+                  reinterpret_cast<uint16_t*>(row) + planeWidth,
                   static_cast<uint16_t>(yuva[c]));
       } else {
         std::fill(row, row + planeWidth, static_cast<uint8_t>(yuva[c]));
@@ -65,12 +65,12 @@ void fillImagePlain(avifImage *image, const uint32_t yuva[4]) {
   }
 }
 
-void fillImageGradient(avifImage *image) {
+void fillImageGradient(avifImage* image) {
   avifPixelFormatInfo info;
   avifGetPixelFormatInfo(image->yuvFormat, &info);
 
   for (int c : AVIF_CHANS) {
-    uint8_t *row = (c == AVIF_CHAN_A) ? image->alphaPlane : image->yuvPlanes[c];
+    uint8_t* row = (c == AVIF_CHAN_A) ? image->alphaPlane : image->yuvPlanes[c];
     if (!row) {
       continue;
     }
@@ -89,7 +89,7 @@ void fillImageGradient(avifImage *image) {
         const uint32_t value = (x + y) * ((1u << image->depth) - 1u) /
                                std::max(1u, planeWidth + planeHeight - 2);
         if (avifImageUsesU16(image)) {
-          reinterpret_cast<uint16_t *>(row)[x] = static_cast<uint16_t>(value);
+          reinterpret_cast<uint16_t*>(row)[x] = static_cast<uint16_t>(value);
         } else {
           row[x] = static_cast<uint8_t>(value);
         }
@@ -102,7 +102,7 @@ void fillImageGradient(avifImage *image) {
 //------------------------------------------------------------------------------
 
 // Returns true if image1 and image2 are identical.
-bool areImagesEqual(const avifImage &image1, const avifImage &image2) {
+bool areImagesEqual(const avifImage& image1, const avifImage& image2) {
   if (image1.width != image2.width || image1.height != image2.height ||
       image1.depth != image2.depth || image1.yuvFormat != image2.yuvFormat ||
       image1.yuvRange != image2.yuvRange) {
@@ -114,9 +114,9 @@ bool areImagesEqual(const avifImage &image1, const avifImage &image2) {
   avifGetPixelFormatInfo(image1.yuvFormat, &info);
 
   for (int c : AVIF_CHANS) {
-    uint8_t *row1 =
+    uint8_t* row1 =
         (c == AVIF_CHAN_A) ? image1.alphaPlane : image1.yuvPlanes[c];
-    uint8_t *row2 =
+    uint8_t* row2 =
         (c == AVIF_CHAN_A) ? image2.alphaPlane : image2.yuvPlanes[c];
     if (!row1 != !row2) {
       return false;
@@ -138,9 +138,9 @@ bool areImagesEqual(const avifImage &image1, const avifImage &image2) {
             : ((image1.height + info.chromaShiftY) >> info.chromaShiftY);
     for (uint32_t y = 0; y < planeHeight; ++y) {
       if (avifImageUsesU16(&image1)) {
-        if (!std::equal(reinterpret_cast<uint16_t *>(row1),
-                        reinterpret_cast<uint16_t *>(row1) + planeWidth,
-                        reinterpret_cast<uint16_t *>(row2))) {
+        if (!std::equal(reinterpret_cast<uint16_t*>(row1),
+                        reinterpret_cast<uint16_t*>(row1) + planeWidth,
+                        reinterpret_cast<uint16_t*>(row2))) {
           return false;
         }
       } else {

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -2,142 +2,160 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "aviftest_helpers.h"
-#include "avif/avif.h"
 
 #include <algorithm>
 #include <cassert>
 
-namespace libavif
-{
-namespace testutil
-{
-namespace
-{
+#include "avif/avif.h"
+
+namespace libavif {
+namespace testutil {
+namespace {
 
 constexpr int AVIF_CHAN_A = AVIF_CHAN_V + 1;
-constexpr int AVIF_CHANS[] = { AVIF_CHAN_Y, AVIF_CHAN_U, AVIF_CHAN_V, AVIF_CHAN_A };
+constexpr int AVIF_CHANS[] = {AVIF_CHAN_Y, AVIF_CHAN_U, AVIF_CHAN_V,
+                              AVIF_CHAN_A};
 
-} // namespace
+}  // namespace
 
 //------------------------------------------------------------------------------
 
-avifImagePtr createImage(int width, int height, int depth, avifPixelFormat yuvFormat, avifPlanesFlags planes, avifRange yuvRange)
-{
-    avifImagePtr image(avifImageCreate(width, height, depth, yuvFormat), avifImageDestroy);
-    if (!image) {
-        return { nullptr, nullptr };
-    }
-    image->yuvRange = yuvRange;
-    avifImageAllocatePlanes(image.get(), planes);
-    return image;
+avifImagePtr createImage(int width, int height, int depth,
+                         avifPixelFormat yuvFormat, avifPlanesFlags planes,
+                         avifRange yuvRange) {
+  avifImagePtr image(avifImageCreate(width, height, depth, yuvFormat),
+                     avifImageDestroy);
+  if (!image) {
+    return {nullptr, nullptr};
+  }
+  image->yuvRange = yuvRange;
+  avifImageAllocatePlanes(image.get(), planes);
+  return image;
 }
 
-void fillImagePlain(avifImage * image, const uint32_t yuva[4])
-{
-    avifPixelFormatInfo info;
-    avifGetPixelFormatInfo(image->yuvFormat, &info);
+void fillImagePlain(avifImage *image, const uint32_t yuva[4]) {
+  avifPixelFormatInfo info;
+  avifGetPixelFormatInfo(image->yuvFormat, &info);
 
-    for (int c : AVIF_CHANS) {
-        uint8_t * row = (c == AVIF_CHAN_A) ? image->alphaPlane : image->yuvPlanes[c];
-        if (!row) {
-            continue;
-        }
-        const uint32_t rowBytes = (c == AVIF_CHAN_A) ? image->alphaRowBytes : image->yuvRowBytes[c];
-        const uint32_t planeWidth =
-            (c == AVIF_CHAN_Y || c == AVIF_CHAN_A) ? image->width : ((image->width + info.chromaShiftX) >> info.chromaShiftX);
-        const uint32_t planeHeight =
-            (c == AVIF_CHAN_Y || c == AVIF_CHAN_A) ? image->height : ((image->height + info.chromaShiftY) >> info.chromaShiftY);
-        for (uint32_t y = 0; y < planeHeight; ++y) {
-            if (avifImageUsesU16(image)) {
-                std::fill(reinterpret_cast<uint16_t *>(row),
-                          reinterpret_cast<uint16_t *>(row) + planeWidth,
-                          static_cast<uint16_t>(yuva[c]));
-            } else {
-                std::fill(row, row + planeWidth, static_cast<uint8_t>(yuva[c]));
-            }
-            row += rowBytes;
-        }
+  for (int c : AVIF_CHANS) {
+    uint8_t *row = (c == AVIF_CHAN_A) ? image->alphaPlane : image->yuvPlanes[c];
+    if (!row) {
+      continue;
     }
+    const uint32_t rowBytes =
+        (c == AVIF_CHAN_A) ? image->alphaRowBytes : image->yuvRowBytes[c];
+    const uint32_t planeWidth =
+        (c == AVIF_CHAN_Y || c == AVIF_CHAN_A)
+            ? image->width
+            : ((image->width + info.chromaShiftX) >> info.chromaShiftX);
+    const uint32_t planeHeight =
+        (c == AVIF_CHAN_Y || c == AVIF_CHAN_A)
+            ? image->height
+            : ((image->height + info.chromaShiftY) >> info.chromaShiftY);
+    for (uint32_t y = 0; y < planeHeight; ++y) {
+      if (avifImageUsesU16(image)) {
+        std::fill(reinterpret_cast<uint16_t *>(row),
+                  reinterpret_cast<uint16_t *>(row) + planeWidth,
+                  static_cast<uint16_t>(yuva[c]));
+      } else {
+        std::fill(row, row + planeWidth, static_cast<uint8_t>(yuva[c]));
+      }
+      row += rowBytes;
+    }
+  }
 }
 
-void fillImageGradient(avifImage * image)
-{
-    avifPixelFormatInfo info;
-    avifGetPixelFormatInfo(image->yuvFormat, &info);
+void fillImageGradient(avifImage *image) {
+  avifPixelFormatInfo info;
+  avifGetPixelFormatInfo(image->yuvFormat, &info);
 
-    for (int c : AVIF_CHANS) {
-        uint8_t * row = (c == AVIF_CHAN_A) ? image->alphaPlane : image->yuvPlanes[c];
-        if (!row) {
-            continue;
-        }
-        const uint32_t rowBytes = (c == AVIF_CHAN_A) ? image->alphaRowBytes : image->yuvRowBytes[c];
-        const uint32_t planeWidth =
-            (c == AVIF_CHAN_Y || c == AVIF_CHAN_A) ? image->width : ((image->width + info.chromaShiftX) >> info.chromaShiftX);
-        const uint32_t planeHeight =
-            (c == AVIF_CHAN_Y || c == AVIF_CHAN_A) ? image->height : ((image->height + info.chromaShiftY) >> info.chromaShiftY);
-        for (uint32_t y = 0; y < planeHeight; ++y) {
-            for (uint32_t x = 0; x < planeWidth; ++x) {
-                const uint32_t value = (x + y) * ((1u << image->depth) - 1u) / std::max(1u, planeWidth + planeHeight - 2);
-                if (avifImageUsesU16(image)) {
-                    reinterpret_cast<uint16_t *>(row)[x] = static_cast<uint16_t>(value);
-                } else {
-                    row[x] = static_cast<uint8_t>(value);
-                }
-            }
-            row += rowBytes;
-        }
+  for (int c : AVIF_CHANS) {
+    uint8_t *row = (c == AVIF_CHAN_A) ? image->alphaPlane : image->yuvPlanes[c];
+    if (!row) {
+      continue;
     }
+    const uint32_t rowBytes =
+        (c == AVIF_CHAN_A) ? image->alphaRowBytes : image->yuvRowBytes[c];
+    const uint32_t planeWidth =
+        (c == AVIF_CHAN_Y || c == AVIF_CHAN_A)
+            ? image->width
+            : ((image->width + info.chromaShiftX) >> info.chromaShiftX);
+    const uint32_t planeHeight =
+        (c == AVIF_CHAN_Y || c == AVIF_CHAN_A)
+            ? image->height
+            : ((image->height + info.chromaShiftY) >> info.chromaShiftY);
+    for (uint32_t y = 0; y < planeHeight; ++y) {
+      for (uint32_t x = 0; x < planeWidth; ++x) {
+        const uint32_t value = (x + y) * ((1u << image->depth) - 1u) /
+                               std::max(1u, planeWidth + planeHeight - 2);
+        if (avifImageUsesU16(image)) {
+          reinterpret_cast<uint16_t *>(row)[x] = static_cast<uint16_t>(value);
+        } else {
+          row[x] = static_cast<uint8_t>(value);
+        }
+      }
+      row += rowBytes;
+    }
+  }
 }
 
 //------------------------------------------------------------------------------
 
 // Returns true if image1 and image2 are identical.
-bool areImagesEqual(const avifImage & image1, const avifImage & image2)
-{
-    if (image1.width != image2.width || image1.height != image2.height || image1.depth != image2.depth ||
-        image1.yuvFormat != image2.yuvFormat || image1.yuvRange != image2.yuvRange) {
-        return false;
-    }
-    assert(image1.width * image1.height > 0);
+bool areImagesEqual(const avifImage &image1, const avifImage &image2) {
+  if (image1.width != image2.width || image1.height != image2.height ||
+      image1.depth != image2.depth || image1.yuvFormat != image2.yuvFormat ||
+      image1.yuvRange != image2.yuvRange) {
+    return false;
+  }
+  assert(image1.width * image1.height > 0);
 
-    avifPixelFormatInfo info;
-    avifGetPixelFormatInfo(image1.yuvFormat, &info);
+  avifPixelFormatInfo info;
+  avifGetPixelFormatInfo(image1.yuvFormat, &info);
 
-    for (int c : AVIF_CHANS) {
-        uint8_t * row1 = (c == AVIF_CHAN_A) ? image1.alphaPlane : image1.yuvPlanes[c];
-        uint8_t * row2 = (c == AVIF_CHAN_A) ? image2.alphaPlane : image2.yuvPlanes[c];
-        if (!row1 != !row2) {
-            return false;
-        }
-        if (!row1) {
-            continue;
-        }
-        const uint32_t rowBytes1 = (c == AVIF_CHAN_A) ? image1.alphaRowBytes : image1.yuvRowBytes[c];
-        const uint32_t rowBytes2 = (c == AVIF_CHAN_A) ? image2.alphaRowBytes : image2.yuvRowBytes[c];
-        const uint32_t planeWidth =
-            (c == AVIF_CHAN_Y || c == AVIF_CHAN_A) ? image1.width : ((image1.width + info.chromaShiftX) >> info.chromaShiftX);
-        const uint32_t planeHeight =
-            (c == AVIF_CHAN_Y || c == AVIF_CHAN_A) ? image1.height : ((image1.height + info.chromaShiftY) >> info.chromaShiftY);
-        for (uint32_t y = 0; y < planeHeight; ++y) {
-            if (avifImageUsesU16(&image1)) {
-                if (!std::equal(reinterpret_cast<uint16_t *>(row1),
-                                reinterpret_cast<uint16_t *>(row1) + planeWidth,
-                                reinterpret_cast<uint16_t *>(row2))) {
-                    return false;
-                }
-            } else {
-                if (!std::equal(row1, row1 + planeWidth, row2)) {
-                    return false;
-                }
-            }
-            row1 += rowBytes1;
-            row2 += rowBytes2;
-        }
+  for (int c : AVIF_CHANS) {
+    uint8_t *row1 =
+        (c == AVIF_CHAN_A) ? image1.alphaPlane : image1.yuvPlanes[c];
+    uint8_t *row2 =
+        (c == AVIF_CHAN_A) ? image2.alphaPlane : image2.yuvPlanes[c];
+    if (!row1 != !row2) {
+      return false;
     }
-    return true;
+    if (!row1) {
+      continue;
+    }
+    const uint32_t rowBytes1 =
+        (c == AVIF_CHAN_A) ? image1.alphaRowBytes : image1.yuvRowBytes[c];
+    const uint32_t rowBytes2 =
+        (c == AVIF_CHAN_A) ? image2.alphaRowBytes : image2.yuvRowBytes[c];
+    const uint32_t planeWidth =
+        (c == AVIF_CHAN_Y || c == AVIF_CHAN_A)
+            ? image1.width
+            : ((image1.width + info.chromaShiftX) >> info.chromaShiftX);
+    const uint32_t planeHeight =
+        (c == AVIF_CHAN_Y || c == AVIF_CHAN_A)
+            ? image1.height
+            : ((image1.height + info.chromaShiftY) >> info.chromaShiftY);
+    for (uint32_t y = 0; y < planeHeight; ++y) {
+      if (avifImageUsesU16(&image1)) {
+        if (!std::equal(reinterpret_cast<uint16_t *>(row1),
+                        reinterpret_cast<uint16_t *>(row1) + planeWidth,
+                        reinterpret_cast<uint16_t *>(row2))) {
+          return false;
+        }
+      } else {
+        if (!std::equal(row1, row1 + planeWidth, row2)) {
+          return false;
+        }
+      }
+      row1 += rowBytes1;
+      row2 += rowBytes2;
+    }
+  }
+  return true;
 }
 
 //------------------------------------------------------------------------------
 
-} // namespace testutil
-} // namespace libavif
+}  // namespace testutil
+}  // namespace libavif

--- a/tests/gtest/aviftest_helpers.h
+++ b/tests/gtest/aviftest_helpers.h
@@ -4,37 +4,38 @@
 #ifndef LIBAVIF_TESTS_AVIFTEST_HELPERS_H_
 #define LIBAVIF_TESTS_AVIFTEST_HELPERS_H_
 
-#include "avif/avif.h"
-
 #include <memory>
 
-namespace libavif
-{
-namespace testutil
-{
+#include "avif/avif.h"
+
+namespace libavif {
+namespace testutil {
 
 using avifImagePtr = std::unique_ptr<avifImage, decltype(&avifImageDestroy)>;
-using avifEncoderPtr = std::unique_ptr<avifEncoder, decltype(&avifEncoderDestroy)>;
-using avifDecoderPtr = std::unique_ptr<avifDecoder, decltype(&avifDecoderDestroy)>;
+using avifEncoderPtr =
+    std::unique_ptr<avifEncoder, decltype(&avifEncoderDestroy)>;
+using avifDecoderPtr =
+    std::unique_ptr<avifDecoder, decltype(&avifDecoderDestroy)>;
 
-class avifRWDataCleaner : public avifRWData
-{
-public:
-    avifRWDataCleaner() : avifRWData({}) {}
-    ~avifRWDataCleaner() { avifRWDataFree(this); }
+class avifRWDataCleaner : public avifRWData {
+ public:
+  avifRWDataCleaner() : avifRWData({}) {}
+  ~avifRWDataCleaner() { avifRWDataFree(this); }
 };
 
 // Creates an image. Returns null in case of memory failure.
-avifImagePtr createImage(int width, int height, int depth, avifPixelFormat yuvFormat, avifPlanesFlags planes, avifRange yuvRange = AVIF_RANGE_FULL);
+avifImagePtr createImage(int width, int height, int depth,
+                         avifPixelFormat yuvFormat, avifPlanesFlags planes,
+                         avifRange yuvRange = AVIF_RANGE_FULL);
 
 // Set all pixels of each plane of an image.
-void fillImagePlain(avifImage * image, const uint32_t yuva[4]);
-void fillImageGradient(avifImage * image);
+void fillImagePlain(avifImage* image, const uint32_t yuva[4]);
+void fillImageGradient(avifImage* image);
 
 // Returns true if both images have the same features and pixel values.
-bool areImagesEqual(const avifImage & image1, const avifImage & image2);
+bool areImagesEqual(const avifImage& image1, const avifImage& image2);
 
-} // namespace testutil
-} // namespace libavif
+}  // namespace testutil
+}  // namespace libavif
 
-#endif // LIBAVIF_TESTS_AVIFTEST_HELPERS_H_
+#endif  // LIBAVIF_TESTS_AVIFTEST_HELPERS_H_

--- a/tests/gtest/avify4mtest.cc
+++ b/tests/gtest/avify4mtest.cc
@@ -1,70 +1,73 @@
 // Copyright 2022 Google LLC. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include "avif/avif.h"
-
-#include "y4m.h"
-
 #include <sstream>
 #include <tuple>
 
+#include "avif/avif.h"
 #include "aviftest_helpers.h"
 #include "gtest/gtest.h"
+#include "y4m.h"
 
 using testing::Combine;
 using testing::Values;
 
-namespace libavif
-{
-namespace
-{
+namespace libavif {
+namespace {
 
-class Y4mTest
-    : public testing::TestWithParam<std::tuple</*width=*/int, /*height=*/int, /*bitDepth=*/int, /*yuvFormat=*/avifPixelFormat, /*yuvRange=*/avifRange, /*createAlpha=*/bool>>
-{
+class Y4mTest : public testing::TestWithParam<
+                    std::tuple</*width=*/int, /*height=*/int, /*bitDepth=*/int,
+                               /*yuvFormat=*/avifPixelFormat,
+                               /*yuvRange=*/avifRange, /*createAlpha=*/bool>> {
 };
 
-TEST_P(Y4mTest, EncodeDecode)
-{
-    const int width = std::get<0>(GetParam());
-    const int height = std::get<1>(GetParam());
-    const int bitDepth = std::get<2>(GetParam());
-    const avifPixelFormat yuvFormat = std::get<3>(GetParam());
-    const avifRange yuvRange = std::get<4>(GetParam());
-    const bool createAlpha = std::get<5>(GetParam());
-    std::ostringstream filePath;
-    filePath << testing::TempDir() << "avify4mtest_" << width << "_" << height << "_" << bitDepth << "_" << yuvFormat << "_"
-             << yuvRange << "_" << createAlpha;
+TEST_P(Y4mTest, EncodeDecode) {
+  const int width = std::get<0>(GetParam());
+  const int height = std::get<1>(GetParam());
+  const int bitDepth = std::get<2>(GetParam());
+  const avifPixelFormat yuvFormat = std::get<3>(GetParam());
+  const avifRange yuvRange = std::get<4>(GetParam());
+  const bool createAlpha = std::get<5>(GetParam());
+  std::ostringstream filePath;
+  filePath << testing::TempDir() << "avify4mtest_" << width << "_" << height
+           << "_" << bitDepth << "_" << yuvFormat << "_" << yuvRange << "_"
+           << createAlpha;
 
-    testutil::avifImagePtr image =
-        testutil::createImage(width, height, bitDepth, yuvFormat, createAlpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV, yuvRange);
-    ASSERT_NE(image, nullptr);
-    const uint32_t yuva[] = { (yuvRange == AVIF_RANGE_LIMITED) ? (235u << (bitDepth - 8)) : ((1u << bitDepth) - 1),
-                              (yuvRange == AVIF_RANGE_LIMITED) ? (240u << (bitDepth - 8)) : ((1u << bitDepth) - 1),
-                              (yuvRange == AVIF_RANGE_LIMITED) ? (240u << (bitDepth - 8)) : ((1u << bitDepth) - 1),
-                              (1u << bitDepth) - 1 };
-    testutil::fillImagePlain(image.get(), yuva);
-    ASSERT_TRUE(y4mWrite(filePath.str().c_str(), image.get()));
+  testutil::avifImagePtr image = testutil::createImage(
+      width, height, bitDepth, yuvFormat,
+      createAlpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV, yuvRange);
+  ASSERT_NE(image, nullptr);
+  const uint32_t yuva[] = {
+      (yuvRange == AVIF_RANGE_LIMITED) ? (235u << (bitDepth - 8))
+                                       : ((1u << bitDepth) - 1),
+      (yuvRange == AVIF_RANGE_LIMITED) ? (240u << (bitDepth - 8))
+                                       : ((1u << bitDepth) - 1),
+      (yuvRange == AVIF_RANGE_LIMITED) ? (240u << (bitDepth - 8))
+                                       : ((1u << bitDepth) - 1),
+      (1u << bitDepth) - 1};
+  testutil::fillImagePlain(image.get(), yuva);
+  ASSERT_TRUE(y4mWrite(filePath.str().c_str(), image.get()));
 
-    testutil::avifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
-    ASSERT_NE(decoded, nullptr);
-    ASSERT_TRUE(y4mRead(filePath.str().c_str(), decoded.get(), /*sourceTiming=*/nullptr, /*iter=*/nullptr));
+  testutil::avifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  ASSERT_TRUE(y4mRead(filePath.str().c_str(), decoded.get(),
+                      /*sourceTiming=*/nullptr, /*iter=*/nullptr));
 
-    EXPECT_TRUE(testutil::areImagesEqual(*image, *decoded));
+  EXPECT_TRUE(testutil::areImagesEqual(*image, *decoded));
 }
 
-INSTANTIATE_TEST_SUITE_P(OpaqueCombinations,
-                         Y4mTest,
-                         Combine(/*width=*/Values(1, 2, 3),
-                                 /*height=*/Values(1, 2, 3),
-                                 /*depths=*/Values(8, 10, 12),
-                                 Values(AVIF_PIXEL_FORMAT_YUV444, AVIF_PIXEL_FORMAT_YUV422, AVIF_PIXEL_FORMAT_YUV420, AVIF_PIXEL_FORMAT_YUV400),
-                                 Values(AVIF_RANGE_LIMITED, AVIF_RANGE_FULL),
-                                 /*createAlpha=*/Values(false)));
+INSTANTIATE_TEST_SUITE_P(
+    OpaqueCombinations, Y4mTest,
+    Combine(/*width=*/Values(1, 2, 3),
+            /*height=*/Values(1, 2, 3),
+            /*depths=*/Values(8, 10, 12),
+            Values(AVIF_PIXEL_FORMAT_YUV444, AVIF_PIXEL_FORMAT_YUV422,
+                   AVIF_PIXEL_FORMAT_YUV420, AVIF_PIXEL_FORMAT_YUV400),
+            Values(AVIF_RANGE_LIMITED, AVIF_RANGE_FULL),
+            /*createAlpha=*/Values(false)));
 
 // Writing alpha is currently only supported in 8bpc YUV444.
-INSTANTIATE_TEST_SUITE_P(AlphaCombinations,
-                         Y4mTest,
+INSTANTIATE_TEST_SUITE_P(AlphaCombinations, Y4mTest,
                          Combine(/*width=*/Values(1, 2, 3),
                                  /*height=*/Values(1, 2, 3),
                                  /*depths=*/Values(8),
@@ -72,5 +75,5 @@ INSTANTIATE_TEST_SUITE_P(AlphaCombinations,
                                  Values(AVIF_RANGE_LIMITED, AVIF_RANGE_FULL),
                                  /*createAlpha=*/Values(true)));
 
-} // namespace
-} // namespace libavif
+}  // namespace
+}  // namespace libavif


### PR DESCRIPTION
Add tests/gtest/.clang-format for that purpose.
Fix .github/workflows/clang-format-check.yml