### PR TITLE
Initialize base class avifRWData with {nullptr, 0}

### DIFF
--- a/tests/gtest/aviftest_helpers.h
+++ b/tests/gtest/aviftest_helpers.h
@@ -22,7 +22,7 @@ using AvifDecoderPtr =
 
 class AvifRwData : public avifRWData {
  public:
-  AvifRwData() : avifRWData({}) {}
+  AvifRwData() : avifRWData{nullptr, 0} {}
   ~AvifRwData() { avifRWDataFree(this); }
 };
 


### PR DESCRIPTION
The initializer avifRWData{nullptr, 0} seems more obvious than
avifRWData(), avifRWData{}, or avifRWData({}).