### PR TITLE
Use I420ToRGB24Matrix() in reformat_libyuv.c

### DIFF
--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -239,14 +239,52 @@ avifResult avifImageYUVToRGBLibYUV8bpc(const avifImage * image,
     //
     // libavif format        libyuv Func     UV matrix (and UV argument ordering)
     // --------------------  -------------   ------------------------------------
-    // AVIF_RGB_FORMAT_RGB   n/a             n/a
-    // AVIF_RGB_FORMAT_BGR   n/a             n/a
+    // AVIF_RGB_FORMAT_RGB   *ToRGB24Matrix  matrixYVU
+    // AVIF_RGB_FORMAT_BGR   *ToRGB24Matrix  matrixYUV
     // AVIF_RGB_FORMAT_BGRA  *ToARGBMatrix   matrixYUV
     // AVIF_RGB_FORMAT_RGBA  *ToARGBMatrix   matrixYVU
     // AVIF_RGB_FORMAT_ABGR  *ToRGBAMatrix   matrixYUV
     // AVIF_RGB_FORMAT_ARGB  *ToRGBAMatrix   matrixYVU
 
-    if (rgb->format == AVIF_RGB_FORMAT_BGRA) {
+    if (rgb->format == AVIF_RGB_FORMAT_RGB) {
+        // AVIF_RGB_FORMAT_RGB   *ToRGB24Matrix  matrixYVU
+
+        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
+            if (I420ToRGB24Matrix(image->yuvPlanes[AVIF_CHAN_Y],
+                                  image->yuvRowBytes[AVIF_CHAN_Y],
+                                  image->yuvPlanes[AVIF_CHAN_V],
+                                  image->yuvRowBytes[AVIF_CHAN_V],
+                                  image->yuvPlanes[AVIF_CHAN_U],
+                                  image->yuvRowBytes[AVIF_CHAN_U],
+                                  rgb->pixels,
+                                  rgb->rowBytes,
+                                  matrixYVU,
+                                  image->width,
+                                  image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+        }
+    } else if (rgb->format == AVIF_RGB_FORMAT_BGR) {
+        // AVIF_RGB_FORMAT_BGR   *ToRGB24Matrix  matrixYUV
+
+        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
+            if (I420ToRGB24Matrix(image->yuvPlanes[AVIF_CHAN_Y],
+                                  image->yuvRowBytes[AVIF_CHAN_Y],
+                                  image->yuvPlanes[AVIF_CHAN_U],
+                                  image->yuvRowBytes[AVIF_CHAN_U],
+                                  image->yuvPlanes[AVIF_CHAN_V],
+                                  image->yuvRowBytes[AVIF_CHAN_V],
+                                  rgb->pixels,
+                                  rgb->rowBytes,
+                                  matrixYUV,
+                                  image->width,
+                                  image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+        }
+    } else if (rgb->format == AVIF_RGB_FORMAT_BGRA) {
         // AVIF_RGB_FORMAT_BGRA  *ToARGBMatrix   matrixYUV
 
         if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {


### PR DESCRIPTION
As suggested in https://crbug.com/libyuv/936.

Summary using `tests/gtest/avifrgbtoyuvtest` results (8-bit BT.601 4:2:0),
libyuv compared to built-in conversion:
- YUV to RGB/BGR on noisy samples:
    Overall average drift increased by 0.03
    Quality loss is decreased by 1.7%
    Max sample value difference is increased by 1.5 in average, up to 2
    PSNR rises by 0.18dB
- YUV to RGB/BGR on single color:
    Overall average drift increased by 0.03
    Quality loss is increased by 20%
    Max sample value difference is increased by 1
    PSNR drops by 1.1dB on average, 1.6dB max