### PR TITLE
Make avifImageAllocatePlanes() return avifResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-There are incompatible ABI changes in this release. Members were removed from
-avifImage struct. avifImageCopy() and avifImageAllocatePlanes() signatures
-changed. It is necessary to recompile your code. It is also recommended to check
-the return values of avifImageCopy() and avifImageAllocatePlanes().
+There are incompatible ABI changes in this release. The alphaRange member was
+removed from avifImage struct. avifImageCopy() and avifImageAllocatePlanes()
+signatures changed. It is necessary to recompile your code. Also check the
+return values of avifImageCopy() and avifImageAllocatePlanes().
 
 ### Changed
 * Update aom.cmd: v3.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-There is an incompatible ABI change in this release. Members were removed from
-avifImage struct and avifImage*() signatures changed. It is necessary to
-recompile your code.
+There are incompatible ABI changes in this release. Members were removed from
+avifImage struct. avifImageCopy() and avifImageAllocatePlanes() signatures
+changed. It is necessary to recompile your code. It is also recommended to check
+the return values of avifImageCopy() and avifImageAllocatePlanes().
 
 ### Changed
 * Update aom.cmd: v3.4.0
 * Update svt.cmd/svt.sh: v1.1.0
 * avifImageCopy() and avifImageAllocatePlanes() now return avifResult instead of
-  void to warn about invalid parameters or memory allocation failures
+  void to report invalid parameters or memory allocation failures
 
 ### Removed
 * alphaRange field was removed from the avifImage struct. It it presumed that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 There is an incompatible ABI change in this release. Members were removed from
-avifImage struct. It is necessary to recompile your code.
+avifImage struct and avifImage*() signatures changed. It is necessary to
+recompile your code.
 
 ### Changed
 * Update aom.cmd: v3.4.0
 * Update svt.cmd/svt.sh: v1.1.0
+* avifImageCopy() and avifImageAllocatePlanes() now return avifResult instead of
+  void to warn about invalid parameters or memory allocation failures
 
 ### Removed
 * alphaRange field was removed from the avifImage struct. It it presumed that

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -352,7 +352,11 @@ static avifBool avifImageSplitGrid(const avifImage * gridSplitImage, uint32_t gr
             avifImage * cellImage = avifImageCreateEmpty();
             gridCells[gridIndex] = cellImage;
 
-            avifImageCopy(cellImage, gridSplitImage, 0);
+            const avifResult copyResult = avifImageCopy(cellImage, gridSplitImage, 0);
+            if (copyResult != AVIF_RESULT_OK) {
+                fprintf(stderr, "ERROR: Image copy failed (%s)\n", avifResultToString(copyResult));
+                return AVIF_FALSE;
+            }
             cellImage->width = cellWidth;
             cellImage->height = cellHeight;
 

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -354,7 +354,7 @@ static avifBool avifImageSplitGrid(const avifImage * gridSplitImage, uint32_t gr
 
             const avifResult copyResult = avifImageCopy(cellImage, gridSplitImage, 0);
             if (copyResult != AVIF_RESULT_OK) {
-                fprintf(stderr, "ERROR: Image copy failed (%s)\n", avifResultToString(copyResult));
+                fprintf(stderr, "ERROR: Image copy failed: %s\n", avifResultToString(copyResult));
                 return AVIF_FALSE;
             }
             cellImage->width = cellWidth;

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -40,7 +40,7 @@ static void my_error_exit(j_common_ptr cinfo)
 
 // An internal function used by avifJPEGReadCopy(), this is the shared libjpeg decompression code
 // for all paths avifJPEGReadCopy() takes.
-static void avifJPEGCopyPixels(avifImage * avif, struct jpeg_decompress_struct * cinfo)
+static avifBool avifJPEGCopyPixels(avifImage * avif, struct jpeg_decompress_struct * cinfo)
 {
     cinfo->raw_data_out = TRUE;
     jpeg_start_decompress(cinfo);
@@ -68,7 +68,9 @@ static void avifJPEGCopyPixels(avifImage * avif, struct jpeg_decompress_struct *
         readLines = AVIF_MAX(readLines, linesPerCall[i]);
     }
 
-    avifImageAllocatePlanes(avif, AVIF_PLANES_YUV);
+    if (avifImageAllocatePlanes(avif, AVIF_PLANES_YUV) != AVIF_RESULT_OK) {
+        return AVIF_FALSE;
+    }
 
     // destination avif channel for each jpeg channel
     avifChannelIndex targetChannel[3] = { AVIF_CHAN_Y, AVIF_CHAN_Y, AVIF_CHAN_Y };
@@ -102,6 +104,7 @@ static void avifJPEGCopyPixels(avifImage * avif, struct jpeg_decompress_struct *
             alreadyRead[i] += linesPerCall[i];
         }
     }
+    return AVIF_TRUE;
 }
 
 static avifBool avifJPEGHasCompatibleMatrixCoefficients(avifMatrixCoefficients matrixCoefficients)
@@ -148,9 +151,7 @@ static avifBool avifJPEGReadCopy(avifImage * avif, struct jpeg_decompress_struct
                 }
                 if (avif->yuvFormat == jpegFormat) {
                     cinfo->out_color_space = JCS_YCbCr;
-                    avifJPEGCopyPixels(avif, cinfo);
-
-                    return AVIF_TRUE;
+                    return avifJPEGCopyPixels(avif, cinfo);
                 }
             }
 
@@ -158,9 +159,7 @@ static avifBool avifJPEGReadCopy(avifImage * avif, struct jpeg_decompress_struct
             if ((avif->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) && (cinfo->comp_info[0].h_samp_factor == cinfo->max_h_samp_factor &&
                                                                   cinfo->comp_info[0].v_samp_factor == cinfo->max_v_samp_factor)) {
                 cinfo->out_color_space = JCS_YCbCr;
-                avifJPEGCopyPixels(avif, cinfo);
-
-                return AVIF_TRUE;
+                return avifJPEGCopyPixels(avif, cinfo);
             }
         }
     } else if (cinfo->jpeg_color_space == JCS_GRAYSCALE) {
@@ -173,16 +172,16 @@ static avifBool avifJPEGReadCopy(avifImage * avif, struct jpeg_decompress_struct
                 if ((avif->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) || (avif->yuvFormat == AVIF_PIXEL_FORMAT_NONE)) {
                     avif->yuvFormat = AVIF_PIXEL_FORMAT_YUV400;
                     cinfo->out_color_space = JCS_GRAYSCALE;
-                    avifJPEGCopyPixels(avif, cinfo);
-
-                    return AVIF_TRUE;
+                    return avifJPEGCopyPixels(avif, cinfo);
                 }
 
                 // Grayscale->YUV: copy Y, fill UV with monochrome value.
                 if ((avif->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) || (avif->yuvFormat == AVIF_PIXEL_FORMAT_YUV422) ||
                     (avif->yuvFormat == AVIF_PIXEL_FORMAT_YUV420)) {
                     cinfo->out_color_space = JCS_GRAYSCALE;
-                    avifJPEGCopyPixels(avif, cinfo);
+                    if (!avifJPEGCopyPixels(avif, cinfo)) {
+                        return AVIF_FALSE;
+                    }
 
                     avifPixelFormatInfo info;
                     avifGetPixelFormatInfo(avif->yuvFormat, &info);
@@ -199,7 +198,9 @@ static avifBool avifJPEGReadCopy(avifImage * avif, struct jpeg_decompress_struct
                 ((avif->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) || (avif->yuvFormat == AVIF_PIXEL_FORMAT_NONE))) {
                 avif->yuvFormat = AVIF_PIXEL_FORMAT_YUV444;
                 cinfo->out_color_space = JCS_GRAYSCALE;
-                avifJPEGCopyPixels(avif, cinfo);
+                if (!avifJPEGCopyPixels(avif, cinfo)) {
+                    return AVIF_FALSE;
+                }
 
                 memcpy(avif->yuvPlanes[AVIF_CHAN_U], avif->yuvPlanes[AVIF_CHAN_Y], (size_t)avif->yuvRowBytes[AVIF_CHAN_U] * avif->height);
                 memcpy(avif->yuvPlanes[AVIF_CHAN_V], avif->yuvPlanes[AVIF_CHAN_Y], (size_t)avif->yuvRowBytes[AVIF_CHAN_V] * avif->height);
@@ -216,9 +217,7 @@ static avifBool avifJPEGReadCopy(avifImage * avif, struct jpeg_decompress_struct
              cinfo->comp_info[2].h_samp_factor == 1 && cinfo->comp_info[2].v_samp_factor == 1)) {
             avif->yuvFormat = AVIF_PIXEL_FORMAT_YUV444;
             cinfo->out_color_space = JCS_RGB;
-            avifJPEGCopyPixels(avif, cinfo);
-
-            return AVIF_TRUE;
+            return avifJPEGCopyPixels(avif, cinfo);
         }
     }
 

--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -348,19 +348,16 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
         *sourceTiming = frame.sourceTiming;
     }
 
-    avifImageFreePlanes(avif, AVIF_PLANES_YUV | AVIF_PLANES_A);
+    avifImageFreePlanes(avif, AVIF_PLANES_ALL);
     avif->width = frame.width;
     avif->height = frame.height;
     avif->depth = frame.depth;
     avif->yuvFormat = frame.format;
     avif->yuvRange = frame.range;
     avif->yuvChromaSamplePosition = frame.chromaSamplePosition;
-    avifResult allocationResult = avifImageAllocatePlanes(avif, AVIF_PLANES_YUV);
-    if ((allocationResult == AVIF_RESULT_OK) && frame.hasAlpha) {
-        allocationResult = avifImageAllocatePlanes(avif, AVIF_PLANES_A);
-    }
+    avifResult allocationResult = avifImageAllocatePlanes(avif, frame.hasAlpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV);
     if (allocationResult != AVIF_RESULT_OK) {
-        fprintf(stderr, "Allocation failed: %s\n", avifResultToString(allocationResult));
+        fprintf(stderr, "Failed to allocate the planes: %s\n", avifResultToString(allocationResult));
         goto cleanup;
     }
 

--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -355,9 +355,13 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
     avif->yuvFormat = frame.format;
     avif->yuvRange = frame.range;
     avif->yuvChromaSamplePosition = frame.chromaSamplePosition;
-    avifImageAllocatePlanes(avif, AVIF_PLANES_YUV);
-    if (frame.hasAlpha) {
-        avifImageAllocatePlanes(avif, AVIF_PLANES_A);
+    avifResult allocationResult = avifImageAllocatePlanes(avif, AVIF_PLANES_YUV);
+    if ((allocationResult == AVIF_RESULT_OK) && frame.hasAlpha) {
+        allocationResult = avifImageAllocatePlanes(avif, AVIF_PLANES_A);
+    }
+    if (allocationResult != AVIF_RESULT_OK) {
+        fprintf(stderr, "Allocation failed: %s\n", avifResultToString(allocationResult));
+        goto cleanup;
     }
 
     avifPixelFormatInfo formatInfo;

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -41,9 +41,9 @@ int main(int argc, char * argv[])
         // If you have YUV(A) data you want to encode, use this path
         printf("Encoding raw YUVA data\n");
 
-        const avifResult allocateResult = avifImageAllocatePlanes(image, AVIF_PLANES_YUV | AVIF_PLANES_A);
+        const avifResult allocateResult = avifImageAllocatePlanes(image, AVIF_PLANES_ALL);
         if (allocateResult != AVIF_RESULT_OK) {
-            fprintf(stderr, "Failed to allocate the image: %s\n", avifResultToString(allocateResult));
+            fprintf(stderr, "Failed to allocate the planes: %s\n", avifResultToString(allocateResult));
             goto cleanup;
         }
 

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -41,7 +41,11 @@ int main(int argc, char * argv[])
         // If you have YUV(A) data you want to encode, use this path
         printf("Encoding raw YUVA data\n");
 
-        avifImageAllocatePlanes(image, AVIF_PLANES_YUV | AVIF_PLANES_A);
+        const avifResult allocateResult = avifImageAllocatePlanes(image, AVIF_PLANES_YUV | AVIF_PLANES_A);
+        if (allocateResult != AVIF_RESULT_OK) {
+            fprintf(stderr, "Failed to allocate the image: %s\n", avifResultToString(allocateResult));
+            goto cleanup;
+        }
 
         // Fill your YUV(A) data here
         memset(image->yuvPlanes[AVIF_CHAN_Y], 255, image->yuvRowBytes[AVIF_CHAN_Y] * image->height);

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -466,7 +466,7 @@ typedef struct avifImage
 
 AVIF_API avifImage * avifImageCreate(int width, int height, int depth, avifPixelFormat yuvFormat);
 AVIF_API avifImage * avifImageCreateEmpty(void); // helper for making an image to decode into
-AVIF_API void avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes); // deep copy
+AVIF_API avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes); // deep copy
 AVIF_API avifResult avifImageSetViewRect(avifImage * dstImage, const avifImage * srcImage, const avifCropRect * rect); // shallow copy, no metadata
 AVIF_API void avifImageDestroy(avifImage * image);
 
@@ -476,8 +476,8 @@ AVIF_API void avifImageSetProfileICC(avifImage * image, const uint8_t * icc, siz
 AVIF_API void avifImageSetMetadataExif(avifImage * image, const uint8_t * exif, size_t exifSize);
 AVIF_API void avifImageSetMetadataXMP(avifImage * image, const uint8_t * xmp, size_t xmpSize);
 
-AVIF_API void avifImageAllocatePlanes(avifImage * image, avifPlanesFlags planes); // Ignores any pre-existing planes
-AVIF_API void avifImageFreePlanes(avifImage * image, avifPlanesFlags planes);     // Ignores already-freed planes
+AVIF_API avifResult avifImageAllocatePlanes(avifImage * image, avifPlanesFlags planes); // Ignores any pre-existing planes
+AVIF_API void avifImageFreePlanes(avifImage * image, avifPlanesFlags planes);           // Ignores already-freed planes
 AVIF_API void avifImageStealPlanes(avifImage * dstImage, avifImage * srcImage, avifPlanesFlags planes);
 
 // ---------------------------------------------------------------------------

--- a/src/avif.c
+++ b/src/avif.c
@@ -293,8 +293,8 @@ avifResult avifImageAllocatePlanes(avifImage * image, avifPlanesFlags planes)
         avifGetPixelFormatInfo(image->yuvFormat, &info);
 
         // Intermediary computation as 64 bits in case width or height is exactly UINT32_MAX.
-        const uint32_t shiftedW = (uint32_t)((image->width + (uint64_t)info.chromaShiftX) >> info.chromaShiftX);
-        const uint32_t shiftedH = (uint32_t)((image->height + (uint64_t)info.chromaShiftY) >> info.chromaShiftY);
+        const uint32_t shiftedW = (uint32_t)(((uint64_t)image->width + info.chromaShiftX) >> info.chromaShiftX);
+        const uint32_t shiftedH = (uint32_t)(((uint64_t)image->height + info.chromaShiftY) >> info.chromaShiftY);
 
         // These are less than or equal to fullRowBytes/fullSize. No need to check overflows.
         const size_t uvRowBytes = channelSize * shiftedW;

--- a/src/avif.c
+++ b/src/avif.c
@@ -293,10 +293,10 @@ avifResult avifImageAllocatePlanes(avifImage * image, avifPlanesFlags planes)
         avifGetPixelFormatInfo(image->yuvFormat, &info);
 
         // Intermediary computation as 64 bits in case width or height is exactly UINT32_MAX.
-        const size_t shiftedW = (image->width + (uint64_t)info.chromaShiftX) >> info.chromaShiftX;
-        const size_t shiftedH = (image->height + (uint64_t)info.chromaShiftY) >> info.chromaShiftY;
+        const uint32_t shiftedW = (uint32_t)((image->width + (uint64_t)info.chromaShiftX) >> info.chromaShiftX);
+        const uint32_t shiftedH = (uint32_t)((image->height + (uint64_t)info.chromaShiftY) >> info.chromaShiftY);
 
-        // These are equal to fullRowBytes/fullSize or lower. No need to check overflows.
+        // These are less than or equal to fullRowBytes/fullSize. No need to check overflows.
         const size_t uvRowBytes = channelSize * shiftedW;
         const size_t uvSize = uvRowBytes * shiftedH;
 

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -194,14 +194,17 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
     }
 
     avifAlphaMultiplyMode alphaMode = AVIF_ALPHA_MULTIPLY_MODE_NO_OP;
-    avifImageAllocatePlanes(image, AVIF_PLANES_YUV);
-    if (avifRGBFormatHasAlpha(rgb->format) && !rgb->ignoreAlpha) {
-        avifImageAllocatePlanes(image, AVIF_PLANES_A);
+    avifResult allocationResult = avifImageAllocatePlanes(image, AVIF_PLANES_YUV);
+    if ((allocationResult == AVIF_RESULT_OK) && avifRGBFormatHasAlpha(rgb->format) && !rgb->ignoreAlpha) {
+        allocationResult = avifImageAllocatePlanes(image, AVIF_PLANES_A);
         if (!rgb->alphaPremultiplied && image->alphaPremultiplied) {
             alphaMode = AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY;
         } else if (rgb->alphaPremultiplied && !image->alphaPremultiplied) {
             alphaMode = AVIF_ALPHA_MULTIPLY_MODE_UNMULTIPLY;
         }
+    }
+    if (allocationResult != AVIF_RESULT_OK) {
+        return allocationResult;
     }
 
     const float kr = state.kr;

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -193,18 +193,19 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
 
+    const avifBool hasAlpha = avifRGBFormatHasAlpha(rgb->format) && !rgb->ignoreAlpha;
+    avifResult allocationResult = avifImageAllocatePlanes(image, hasAlpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV);
+    if (allocationResult != AVIF_RESULT_OK) {
+        return allocationResult;
+    }
+
     avifAlphaMultiplyMode alphaMode = AVIF_ALPHA_MULTIPLY_MODE_NO_OP;
-    avifResult allocationResult = avifImageAllocatePlanes(image, AVIF_PLANES_YUV);
-    if ((allocationResult == AVIF_RESULT_OK) && avifRGBFormatHasAlpha(rgb->format) && !rgb->ignoreAlpha) {
-        allocationResult = avifImageAllocatePlanes(image, AVIF_PLANES_A);
+    if (hasAlpha) {
         if (!rgb->alphaPremultiplied && image->alphaPremultiplied) {
             alphaMode = AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY;
         } else if (rgb->alphaPremultiplied && !image->alphaPremultiplied) {
             alphaMode = AVIF_ALPHA_MULTIPLY_MODE_UNMULTIPLY;
         }
-    }
-    if (allocationResult != AVIF_RESULT_OK) {
-        return allocationResult;
     }
 
     const float kr = state.kr;

--- a/src/scale.c
+++ b/src/scale.c
@@ -89,7 +89,11 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
     }
 
     if (srcYUVPlanes[0]) {
-        avifImageAllocatePlanes(image, AVIF_PLANES_YUV);
+        const avifResult allocationResult = avifImageAllocatePlanes(image, AVIF_PLANES_YUV);
+        if (allocationResult != AVIF_RESULT_OK) {
+            avifDiagnosticsPrintf(diag, "Image allocation failed: %s", avifResultToString(allocationResult));
+            return AVIF_FALSE;
+        }
 
         avifPixelFormatInfo formatInfo;
         avifGetPixelFormatInfo(image->yuvFormat, &formatInfo);
@@ -132,7 +136,11 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
     }
 
     if (srcAlphaPlane) {
-        avifImageAllocatePlanes(image, AVIF_PLANES_A);
+        const avifResult allocationResult = avifImageAllocatePlanes(image, AVIF_PLANES_A);
+        if (allocationResult != AVIF_RESULT_OK) {
+            avifDiagnosticsPrintf(diag, "Image allocation failed: %s", avifResultToString(allocationResult));
+            return AVIF_FALSE;
+        }
 
         if (image->depth > 8) {
             uint16_t * const srcPlane = (uint16_t *)srcAlphaPlane;

--- a/src/scale.c
+++ b/src/scale.c
@@ -91,7 +91,7 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
     if (srcYUVPlanes[0]) {
         const avifResult allocationResult = avifImageAllocatePlanes(image, AVIF_PLANES_YUV);
         if (allocationResult != AVIF_RESULT_OK) {
-            avifDiagnosticsPrintf(diag, "Image allocation failed: %s", avifResultToString(allocationResult));
+            avifDiagnosticsPrintf(diag, "Allocation of YUV planes failed: %s", avifResultToString(allocationResult));
             return AVIF_FALSE;
         }
 
@@ -138,7 +138,7 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
     if (srcAlphaPlane) {
         const avifResult allocationResult = avifImageAllocatePlanes(image, AVIF_PLANES_A);
         if (allocationResult != AVIF_RESULT_OK) {
-            avifDiagnosticsPrintf(diag, "Image allocation failed: %s", avifResultToString(allocationResult));
+            avifDiagnosticsPrintf(diag, "Allocation of alpha plane failed: %s", avifResultToString(allocationResult));
             return AVIF_FALSE;
         }
 

--- a/src/write.c
+++ b/src/write.c
@@ -683,7 +683,10 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
 
     if (encoder->data->items.count == 0) {
         // Make a copy of the first image's metadata (sans pixels) for future writing/validation
-        avifImageCopy(encoder->data->imageMetadata, firstCell, 0);
+        const avifResult copyResult = avifImageCopy(encoder->data->imageMetadata, firstCell, 0);
+        if (copyResult != AVIF_RESULT_OK) {
+            return copyResult;
+        }
 
         // Prepare all AV1 items
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,11 @@ if(AVIF_ENABLE_GTEST)
         find_package(GTest REQUIRED)
     endif()
 
+    add_executable(avifallocationtest gtest/avifallocationtest.cc)
+    target_link_libraries(avifallocationtest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
+    target_include_directories(avifallocationtest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifallocationtest COMMAND avifallocationtest)
+
     add_executable(avifgridapitest gtest/avifgridapitest.cc)
     target_link_libraries(avifgridapitest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avifgridapitest PRIVATE ${GTEST_INCLUDE_DIRS})

--- a/tests/gtest/avifallocationtest.cc
+++ b/tests/gtest/avifallocationtest.cc
@@ -1,0 +1,167 @@
+// Copyright 2022 Google LLC. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <array>
+#include <limits>
+#include <tuple>
+
+#include "avif/avif.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+using ::testing::Combine;
+using ::testing::Values;
+using ::testing::ValuesIn;
+
+namespace libavif {
+namespace {
+
+void TestAllocation(uint32_t width, uint32_t height, uint32_t depth,
+                    avifResult expected_result) {
+  // The format of the image and which planes are allocated should not matter.
+  // Test all combinations.
+  for (avifPixelFormat format :
+       {AVIF_PIXEL_FORMAT_NONE, AVIF_PIXEL_FORMAT_YUV444,
+        AVIF_PIXEL_FORMAT_YUV422, AVIF_PIXEL_FORMAT_YUV420,
+        AVIF_PIXEL_FORMAT_YUV400}) {
+    for (avifPlanesFlag planes :
+         {AVIF_PLANES_YUV, AVIF_PLANES_A, AVIF_PLANES_ALL}) {
+      testutil::AvifImagePtr image(avifImageCreateEmpty(), avifImageDestroy);
+      ASSERT_NE(image, nullptr);
+      image->width = width;
+      image->height = height;
+      image->depth = depth;
+      image->yuvFormat = format;
+      EXPECT_EQ(avifImageAllocatePlanes(image.get(), planes), expected_result);
+
+      // Make sure the actual plane pointers are consistent with the settings.
+      if (expected_result == AVIF_RESULT_OK &&
+          format != AVIF_PIXEL_FORMAT_NONE &&
+          (planes == AVIF_PLANES_YUV || planes == AVIF_PLANES_ALL)) {
+        EXPECT_NE(image->yuvPlanes[AVIF_CHAN_Y], nullptr);
+      } else {
+        EXPECT_EQ(image->yuvPlanes[AVIF_CHAN_Y], nullptr);
+      }
+      if (expected_result == AVIF_RESULT_OK &&
+          format != AVIF_PIXEL_FORMAT_NONE &&
+          format != AVIF_PIXEL_FORMAT_YUV400 && (planes & AVIF_PLANES_YUV)) {
+        EXPECT_NE(image->yuvPlanes[AVIF_CHAN_U], nullptr);
+        EXPECT_NE(image->yuvPlanes[AVIF_CHAN_V], nullptr);
+      } else {
+        EXPECT_EQ(image->yuvPlanes[AVIF_CHAN_U], nullptr);
+        EXPECT_EQ(image->yuvPlanes[AVIF_CHAN_V], nullptr);
+      }
+      if (expected_result == AVIF_RESULT_OK && (planes & AVIF_PLANES_A)) {
+        EXPECT_NE(image->alphaPlane, nullptr);
+      } else {
+        EXPECT_EQ(image->alphaPlane, nullptr);
+      }
+    }
+  }
+}
+
+TEST(AllocationTest, MinimumValid) { TestAllocation(1, 1, 8, AVIF_RESULT_OK); }
+
+TEST(AllocationTest, MaximumValid) {
+  TestAllocation(AVIF_DEFAULT_IMAGE_SIZE_LIMIT, 1, 12, AVIF_RESULT_OK);
+  TestAllocation(1, AVIF_DEFAULT_IMAGE_SIZE_LIMIT, 12, AVIF_RESULT_OK);
+}
+
+TEST(AllocationTest, MinimumInvalid) {
+  TestAllocation(0, 1, 8, AVIF_RESULT_INVALID_ARGUMENT);
+  TestAllocation(1, 0, 8, AVIF_RESULT_INVALID_ARGUMENT);
+  TestAllocation(1, 1, 0, AVIF_RESULT_UNSUPPORTED_DEPTH);
+  TestAllocation(AVIF_DEFAULT_IMAGE_SIZE_LIMIT + 1, 1, 8,
+                 AVIF_RESULT_INVALID_ARGUMENT);
+  TestAllocation(1, AVIF_DEFAULT_IMAGE_SIZE_LIMIT + 1, 8,
+                 AVIF_RESULT_INVALID_ARGUMENT);
+}
+
+TEST(AllocationTest, MaximumInvalid) {
+  TestAllocation(std::numeric_limits<typeof(avifImage::width)>::max(), 1, 8,
+                 AVIF_RESULT_INVALID_ARGUMENT);
+  TestAllocation(1, std::numeric_limits<typeof(avifImage::height)>::max(), 8,
+                 AVIF_RESULT_INVALID_ARGUMENT);
+  TestAllocation(std::numeric_limits<typeof(avifImage::width)>::max(),
+                 std::numeric_limits<typeof(avifImage::height)>::max(), 12,
+                 AVIF_RESULT_INVALID_ARGUMENT);
+  TestAllocation(1, 1, std::numeric_limits<typeof(avifImage::depth)>::max(),
+                 AVIF_RESULT_UNSUPPORTED_DEPTH);
+}
+
+void TestEncoding(uint32_t width, uint32_t height, uint32_t depth,
+                  avifResult expected_result) {
+  testutil::AvifImagePtr image(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(image, nullptr);
+  image->width = width;
+  image->height = height;
+  image->depth = depth;
+  image->yuvFormat = AVIF_PIXEL_FORMAT_YUV444;
+
+  // This is the maximum number of bytes that can safely be allocated in
+  // this test.
+  static constexpr uint64_t kMaxAlloc = std::numeric_limits<int32_t>::max();
+  size_t num_allocated_bytes;
+  if ((uint64_t)image->width * image->height >
+      kMaxAlloc / (avifImageUsesU16(image.get()) ? 2 : 1)) {
+    num_allocated_bytes = kMaxAlloc;
+  } else {
+    num_allocated_bytes =
+        image->width * image->height * (avifImageUsesU16(image.get()) ? 2 : 1);
+  }
+
+  // Initialize pixels as 16b values to make sure values are valid for 10
+  // and 12-bit depths. The array will be cast to uint8_t for 8-bit depth.
+  std::vector<uint16_t> pixels(num_allocated_bytes / sizeof(uint16_t), 400);
+  uint8_t* bytes = reinterpret_cast<uint8_t*>(pixels.data());
+  // Avoid avifImageAllocatePlanes() to exercise the checks at encoding.
+  image->imageOwnsYUVPlanes = AVIF_FALSE;
+  image->imageOwnsAlphaPlane = AVIF_FALSE;
+  image->yuvRowBytes[AVIF_CHAN_Y] = image->width;
+  image->yuvPlanes[AVIF_CHAN_Y] = bytes;
+  image->yuvRowBytes[AVIF_CHAN_U] = image->width;
+  image->yuvPlanes[AVIF_CHAN_U] = bytes;
+  image->yuvRowBytes[AVIF_CHAN_V] = image->width;
+  image->yuvPlanes[AVIF_CHAN_V] = bytes;
+  image->alphaRowBytes = image->width;
+  image->alphaPlane = bytes;
+
+  // Try to encode.
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  encoder->speed = AVIF_SPEED_FASTEST;
+  testutil::AvifRwData encoded_avif;
+  ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encoded_avif),
+            expected_result);
+}
+
+TEST(EncodingTest, MinimumValid) { TestAllocation(1, 1, 8, AVIF_RESULT_OK); }
+
+TEST(EncodingTest, MaximumValid) {
+  TestEncoding(65535, 1, 12, AVIF_RESULT_OK);
+  TestEncoding(1, 65535, 12, AVIF_RESULT_OK);
+  // TestEncoding(16384, 8096, 12, AVIF_RESULT_OK);  // Too slow.
+}
+
+TEST(EncodingTest, MinimumInvalid) {
+  TestEncoding(0, 1, 8, AVIF_RESULT_NO_CONTENT);
+  TestEncoding(1, 0, 8, AVIF_RESULT_NO_CONTENT);
+  TestEncoding(1, 1, 0, AVIF_RESULT_UNSUPPORTED_DEPTH);
+  TestEncoding(65536, 1, 12, AVIF_RESULT_ENCODE_COLOR_FAILED);
+  TestEncoding(1, 65536, 12, AVIF_RESULT_ENCODE_COLOR_FAILED);
+}
+
+TEST(EncodingTest, MaximumInvalid) {
+  TestEncoding(std::numeric_limits<typeof(avifImage::width)>::max(), 1, 8,
+               AVIF_RESULT_ENCODE_COLOR_FAILED);
+  TestEncoding(1, std::numeric_limits<typeof(avifImage::height)>::max(), 8,
+               AVIF_RESULT_ENCODE_COLOR_FAILED);
+  TestEncoding(std::numeric_limits<typeof(avifImage::width)>::max(),
+               std::numeric_limits<typeof(avifImage::height)>::max(), 12,
+               AVIF_RESULT_ENCODE_COLOR_FAILED);
+  TestEncoding(1, 1, std::numeric_limits<typeof(avifImage::depth)>::max(),
+               AVIF_RESULT_UNSUPPORTED_DEPTH);
+}
+
+}  // namespace
+}  // namespace libavif

--- a/tests/gtest/avifallocationtest.cc
+++ b/tests/gtest/avifallocationtest.cc
@@ -98,9 +98,11 @@ void TestEncoding(uint32_t width, uint32_t height, uint32_t depth,
   image->depth = depth;
   image->yuvFormat = AVIF_PIXEL_FORMAT_YUV444;
 
-  // This is the maximum number of bytes that can safely be allocated in
-  // this test.
-  static constexpr uint64_t kMaxAlloc = std::numeric_limits<int32_t>::max();
+  // This is a fairly high number of bytes that can safely be allocated in this
+  // test. The goal is to have something to give to libavif but libavif should
+  // return an error before attempting to read all of it, so it does not matter
+  // if there are fewer bytes than the provided image dimensions.
+  static constexpr uint64_t kMaxAlloc = 2147483647;
   size_t num_allocated_bytes;
   if ((uint64_t)image->width * image->height >
       kMaxAlloc / (avifImageUsesU16(image.get()) ? 2 : 1)) {

--- a/tests/gtest/avifgridapitest.cc
+++ b/tests/gtest/avifgridapitest.cc
@@ -41,6 +41,9 @@ TEST_P(GridApiTest, EncodeDecode) {
     cell_images.emplace_back(testutil::CreateImage(
         horizontal.size, vertical.size, bit_depth, yuv_format,
         create_alpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV));
+    if (cell_images.back() == nullptr && !expected_success) {
+      return;  // Bad dimensions may be already caught.
+    }
     ASSERT_NE(cell_images.back(), nullptr);
     testutil::FillImageGradient(cell_images.back().get());
   }

--- a/tests/gtest/avifgridapitest.cc
+++ b/tests/gtest/avifgridapitest.cc
@@ -42,7 +42,7 @@ TEST_P(GridApiTest, EncodeDecode) {
         horizontal.size, vertical.size, bit_depth, yuv_format,
         create_alpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV));
     if (cell_images.back() == nullptr && !expected_success) {
-      return;  // Bad dimensions may be already caught.
+      return;  // Bad dimensions may have been already caught.
     }
     ASSERT_NE(cell_images.back(), nullptr);
     testutil::FillImageGradient(cell_images.back().get());

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -57,7 +57,9 @@ AvifImagePtr CreateImage(int width, int height, int depth,
     return {nullptr, nullptr};
   }
   image->yuvRange = yuv_range;
-  avifImageAllocatePlanes(image.get(), planes);
+  if (avifImageAllocatePlanes(image.get(), planes) != AVIF_RESULT_OK) {
+    return {nullptr, nullptr};
+  }
   return image;
 }
 


### PR DESCRIPTION
To catch memory allocation failures and invalid parameters, it is
safer to return a status from avifImageAllocatePlanes() and from
avifImageCopy().

Fixes https://github.com/AOMediaCodec/libavif/issues/992.