### PR TITLE
Shorten AppVeyor build to fix build timeout

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,6 @@ skip_commits:
     - '*.md'
 
 install:
- # Install Rust
- - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
- - rustup-init -yv --default-toolchain stable --default-host x86_64-pc-windows-msvc
- - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
- - rustc -vV
- - cargo -vV
  # Get submodules
  - git submodule update --init --recursive
  # Prepare VS env
@@ -28,7 +22,6 @@ install:
  - cd ext
  - aom.cmd
  - dav1d.cmd
- - rav1e.cmd
  - svt.cmd
  - libjpeg.cmd
  - zlibpng.cmd
@@ -37,7 +30,7 @@ install:
  - mkdir build
  - cd build
  - cmake --version
- - cmake .. -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=ON -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON -DBUILD_SHARED_LIBS=OFF -DAVIF_LOCAL_JPEG=1 -DAVIF_LOCAL_ZLIBPNG=1 -DAVIF_BUILD_APPS=ON
+ - cmake .. -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON -DBUILD_SHARED_LIBS=OFF -DAVIF_LOCAL_JPEG=ON -DAVIF_LOCAL_ZLIBPNG=ON -DAVIF_BUILD_APPS=ON
 
 build:
   project: build/libavif.sln


### PR DESCRIPTION
The AppVeyor build has been failing with this error message:
  Build execution time has reached the maximum allowed time for your
  plan (60 minutes).

Do not build rav1e.