### PR TITLE
Add int32_t casts to fix MSVC warnings

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -481,8 +481,8 @@ static void clapFractionSimplify(clapFraction * f)
 {
     int64_t gcd = calcGCD(f->n, f->d);
     if (gcd > 1) {
-        f->n /= gcd;
-        f->d /= gcd;
+        f->n = (int32_t)(f->n / gcd);
+        f->d = (int32_t)(f->d / gcd);
     }
 }
 


### PR DESCRIPTION
Fix the following MSVC warnings:
libavif\src\avif.c(484): warning C4242: '/=': conversion from 'int64_t' to 'int32_t', possible loss of data
libavif\src\avif.c(485): warning C4242: '/=': conversion from 'int64_t' to 'int32_t', possible loss of data

The warnings were introduced in
https://github.com/AOMediaCodec/libavif/pull/973.