### PR TITLE
Shorten AppVeyor build to fix build timeout

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ install:
  - cd ext
  - aom.cmd
  - dav1d.cmd
- - svt.cmd
  - libjpeg.cmd
  - zlibpng.cmd
  - cd ..
@@ -30,7 +29,7 @@ install:
  - mkdir build
  - cd build
  - cmake --version
- - cmake .. -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON -DBUILD_SHARED_LIBS=OFF -DAVIF_LOCAL_JPEG=ON -DAVIF_LOCAL_ZLIBPNG=ON -DAVIF_BUILD_APPS=ON
+ - cmake .. -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON -DBUILD_SHARED_LIBS=OFF -DAVIF_LOCAL_JPEG=ON -DAVIF_LOCAL_ZLIBPNG=ON -DAVIF_BUILD_APPS=ON
 
 build:
   project: build/libavif.sln


### PR DESCRIPTION
The AppVeyor build has been failing with this error message:
Build execution time has reached the maximum allowed time for your plan
(60 minutes).

Do not build SVT-AV1.

This is a follow-up to
https://github.com/AOMediaCodec/libavif/pull/1000.