### PR TITLE
Add support RGB565 format

### DIFF
--- a/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
+++ b/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
@@ -127,8 +127,9 @@ FUNC(jboolean, decode, jobject encoded, int length, jobject bitmap) {
         decoder.decoder->image->height);
     return false;
   }
-  // Ensure that the bitmap format is either RGBA_8888 or RGBA_F16.
+  // Ensure that the bitmap format is RGBA_8888, RGB_565 or RGBA_F16.
   if (bitmap_info.format != ANDROID_BITMAP_FORMAT_RGBA_8888 &&
+      bitmap_info.format != ANDROID_BITMAP_FORMAT_RGB_565 &&
       bitmap_info.format != ANDROID_BITMAP_FORMAT_RGBA_F16) {
     LOGE("Bitmap format (%d) is not supported.", bitmap_info.format);
     return false;
@@ -144,6 +145,9 @@ FUNC(jboolean, decode, jobject encoded, int length, jobject bitmap) {
   if (bitmap_info.format == ANDROID_BITMAP_FORMAT_RGBA_F16) {
     rgb_image.depth = 16;
     rgb_image.isFloat = AVIF_TRUE;
+  } else if (bitmap_info.format == ANDROID_BITMAP_FORMAT_RGB_565) {
+    rgb_image.format = AVIF_RGB_FORMAT_RGB_565;
+    rgb_image.depth = 8;
   } else {
     rgb_image.depth = 8;
   }

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -551,7 +551,17 @@ typedef enum avifRGBFormat
     AVIF_RGB_FORMAT_ARGB,
     AVIF_RGB_FORMAT_BGR,
     AVIF_RGB_FORMAT_BGRA,
-    AVIF_RGB_FORMAT_ABGR
+    AVIF_RGB_FORMAT_ABGR,
+    // RGB_565 format uses five bits for the red and blue components and six
+    // bits for the green component. Each RGB pixel is 16 bits (2 bytes), which
+    // is packed as follows:
+    //   uint16_t: [r4 r3 r2 r1 r0 g5 g4 g3 g2 g1 g0 b4 b3 b2 b1 b0]
+    //   r4 and r0 are the MSB and LSB of the red component respectively.
+    //   g5 and g0 are the MSB and LSB of the green component respectively.
+    //   b4 and b0 are the MSB and LSB of the blue component respectively.
+    // This format is only supported for YUV -> RGB conversion and when
+    // avifRGBImage.depth is set to 8.
+    AVIF_RGB_FORMAT_RGB_565
 } avifRGBFormat;
 AVIF_API uint32_t avifRGBFormatChannelCount(avifRGBFormat format);
 AVIF_API avifBool avifRGBFormatHasAlpha(avifRGBFormat format);

--- a/src/avif.c
+++ b/src/avif.c
@@ -420,7 +420,7 @@ void avifCodecDestroy(avifCodec * codec)
 
 avifBool avifRGBFormatHasAlpha(avifRGBFormat format)
 {
-    return (format != AVIF_RGB_FORMAT_RGB) && (format != AVIF_RGB_FORMAT_BGR);
+    return (format != AVIF_RGB_FORMAT_RGB) && (format != AVIF_RGB_FORMAT_BGR) && (format != AVIF_RGB_FORMAT_RGB_565);
 }
 
 uint32_t avifRGBFormatChannelCount(avifRGBFormat format)
@@ -430,6 +430,9 @@ uint32_t avifRGBFormatChannelCount(avifRGBFormat format)
 
 uint32_t avifRGBImagePixelSize(const avifRGBImage * rgb)
 {
+    if (rgb->format == AVIF_RGB_FORMAT_RGB_565) {
+        return 2;
+    }
     return avifRGBFormatChannelCount(rgb->format) * ((rgb->depth > 8) ? 2 : 1);
 }
 

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -359,14 +359,15 @@ avifResult avifImageYUVToRGBLibYUV8bpc(const avifImage * image,
     // In addition, swapping U and V in any of these calls, along with using the Yvu matrix instead of Yuv matrix,
     // swaps B and R in these orderings as well. This table summarizes this block's intent:
     //
-    // libavif format        libyuv Func     UV matrix (and UV argument ordering)
-    // --------------------  -------------   ------------------------------------
-    // AVIF_RGB_FORMAT_RGB   *ToRGB24Matrix  matrixYVU
-    // AVIF_RGB_FORMAT_BGR   *ToRGB24Matrix  matrixYUV
-    // AVIF_RGB_FORMAT_BGRA  *ToARGBMatrix   matrixYUV
-    // AVIF_RGB_FORMAT_RGBA  *ToARGBMatrix   matrixYVU
-    // AVIF_RGB_FORMAT_ABGR  *ToRGBAMatrix   matrixYUV
-    // AVIF_RGB_FORMAT_ARGB  *ToRGBAMatrix   matrixYVU
+    // libavif format            libyuv Func      UV matrix (and UV argument ordering)
+    // --------------------      -------------    ------------------------------------
+    // AVIF_RGB_FORMAT_RGB       *ToRGB24Matrix   matrixYVU
+    // AVIF_RGB_FORMAT_BGR       *ToRGB24Matrix   matrixYUV
+    // AVIF_RGB_FORMAT_RGB_565   *ToRGB565Matrix  matrixYUV
+    // AVIF_RGB_FORMAT_BGRA      *ToARGBMatrix    matrixYUV
+    // AVIF_RGB_FORMAT_RGBA      *ToARGBMatrix    matrixYVU
+    // AVIF_RGB_FORMAT_ABGR      *ToRGBAMatrix    matrixYUV
+    // AVIF_RGB_FORMAT_ARGB      *ToRGBAMatrix    matrixYVU
 
     if (rgb->format == AVIF_RGB_FORMAT_RGB) {
         // AVIF_RGB_FORMAT_RGB   *ToRGB24Matrix  matrixYVU
@@ -402,6 +403,25 @@ avifResult avifImageYUVToRGBLibYUV8bpc(const avifImage * image,
                                   matrixYUV,
                                   image->width,
                                   image->height) != 0) {
+                return AVIF_RESULT_REFORMAT_FAILED;
+            }
+            return AVIF_RESULT_OK;
+        }
+    } else if (rgb->format == AVIF_RGB_FORMAT_RGB_565) {
+        // AVIF_RGB_FORMAT_BGR   *ToRGB565Matrix  matrixYUV
+
+        if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
+            if (I420ToRGB565Matrix(image->yuvPlanes[AVIF_CHAN_Y],
+                                   image->yuvRowBytes[AVIF_CHAN_Y],
+                                   image->yuvPlanes[AVIF_CHAN_U],
+                                   image->yuvRowBytes[AVIF_CHAN_U],
+                                   image->yuvPlanes[AVIF_CHAN_V],
+                                   image->yuvRowBytes[AVIF_CHAN_V],
+                                   rgb->pixels,
+                                   rgb->rowBytes,
+                                   matrixYUV,
+                                   image->width,
+                                   image->height) != 0) {
                 return AVIF_RESULT_REFORMAT_FAILED;
             }
             return AVIF_RESULT_OK;

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -39,6 +39,8 @@ static const char * rgbFormatToString(avifRGBFormat format)
             return "BGRA";
         case AVIF_RGB_FORMAT_ABGR:
             return "ABGR";
+        case AVIF_RGB_FORMAT_RGB_565:
+            return "RGB_565";
     }
     return "Unknown";
 }


### PR DESCRIPTION
RGB565 [1] is a pixel format used by Android. It stores each pixel
in 2 bytes (with 5, 6 and 5 bits respectively for R, G and B
channels).

This is used in some older android devices which have low RAM to
minimize the size of bitmaps on those devices.

[1] https://developer.android.com/reference/android/graphics/Bitmap.Config#RGB_565