### PR TITLE
Skip YUV<->RGB conversion tests for large images

### DIFF
--- a/tests/oss-fuzz/avif_decode_fuzzer.cc
+++ b/tests/oss-fuzz/avif_decode_fuzzer.cc
@@ -32,7 +32,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
     if (result == AVIF_RESULT_OK) {
         for (int loop = 0; loop < 2; ++loop) {
             while (avifDecoderNextImage(decoder) == AVIF_RESULT_OK) {
-                if ((loop != 0) || (decoder->imageIndex != 0)) {
+                if (((decoder->image->width * decoder->image->height) > (47 * 1024 * 1024)) || (loop != 0) ||
+                    (decoder->imageIndex != 0)) {
                     // Skip the YUV<->RGB conversion tests, which are time-consuming for large
                     // images. It suffices to run these tests only for loop == 0 and only for the
                     // first image of an image sequence.


### PR DESCRIPTION
The built-in implementation of avifImageYUVToRGB() and
avifImageRGBToYUV() is slow for large images. For an image of
width=15107, height=3328, depth=10, the avifImageYUVToRGB() and
avifImageRGBToYUV() calls take about 5 seconds each on a Linux
workstation. Since avif_decode_fuzzer is run 100 times with a 90 seconds
timeout, we need to skip the YUV<->RGB conversion tests for large
images.

It is not clear what the image size threshold should be, so we begin
with the largest threshold (as an integer multiple of 1024 * 1024) that
excludes this particular test image.

Bug: b/241457214