### PR TITLE
Use the latest versions of GitHub Actions

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -22,15 +22,17 @@ jobs:
         os: [windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Visual Studio shell
       if: runner.os == 'Windows'
       uses: egor-tensin/vs-shell@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
 
     - name: Cache external dependencies
       id: cache-ext
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ext
         key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}
@@ -40,9 +42,7 @@ jobs:
       with:
         version: 2.15.05
     - uses: seanmiddleditch/gha-setup-ninja@v3
-      if: steps.cache-ext.outputs.cache-hit != 'true'
     - run: pip install meson
-      if: steps.cache-ext.outputs.cache-hit != 'true'
     - name: Build aom
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,17 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set GCC & G++ 10 compiler (on Linux)
       if: runner.os == 'Linux'
       run: echo "CC=gcc-10" >> $GITHUB_ENV && echo "CXX=g++-10" >> $GITHUB_ENV
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
 
     - name: Cache external dependencies
       id: cache-ext
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ext
         key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}
@@ -31,9 +33,7 @@ jobs:
       with:
         version: 2.15.05
     - uses: seanmiddleditch/gha-setup-ninja@v3
-      #if: steps.cache-ext.outputs.cache-hit != 'true'
     - run: pip install meson
-      if: steps.cache-ext.outputs.cache-hit != 'true'
     - name: Build aom
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext


### PR DESCRIPTION
Use the latest versions of actions/checkout, actions/setup-python, and
actions/cache.

Do not check for cache hit in the seanmiddleditch/gha-setup-ninja@v3
and "pip install meson" steps, because their results are not in the
"ext" directory. Only the "ext" directory is cached.