### PR TITLE
Update libgav1 to v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ return values of avifImageCopy() and avifImageAllocatePlanes().
 ### Changed
 * Update aom.cmd: v3.4.0
 * Update svt.cmd/svt.sh: v1.1.0
+* Update libgav1.cmd: v0.18.0
 * Update libyuv.cmd: d53f1be (version 1837)
 * avifImageCopy() and avifImageAllocatePlanes() now return avifResult instead of
   void to report invalid parameters or memory allocation failures.

--- a/ext/libgav1.cmd
+++ b/ext/libgav1.cmd
@@ -9,13 +9,12 @@
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
 # When updating the libgav1 version, make the same change to libgav1_android.sh.
-git clone -b v0.17.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
+git clone -b v0.18.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
 
 cd libgav1
-git clone -b lts_2021_03_24 --depth 1 https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
 mkdir build
 cd build
 
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLIBGAV1_THREADPOOL_USE_STD_MUTEX=1 ..
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLIBGAV1_THREADPOOL_USE_STD_MUTEX=1 -DLIBGAV1_ENABLE_EXAMPLES=0 -DLIBGAV1_ENABLE_TESTS=0 ..
 ninja
 cd ../..

--- a/ext/libgav1_android.sh
+++ b/ext/libgav1_android.sh
@@ -14,10 +14,9 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 # When updating the libgav1 version, make the same change to libgav1.cmd.
-git clone -b v0.17.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
+git clone -b v0.18.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
 
 cd libgav1
-git clone -b lts_2021_03_24 --depth 1 https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
 mkdir build
 cd build
 
@@ -31,6 +30,8 @@ for abi in ${ABI_LIST}; do
     -DCMAKE_BUILD_TYPE=Release \
     -DLIBGAV1_ANDROID_NDK_PATH=${1} \
     -DLIBGAV1_THREADPOOL_USE_STD_MUTEX=1 \
+    -DLIBGAV1_ENABLE_EXAMPLES=0 \
+    -DLIBGAV1_ENABLE_TESTS=0 \
     -DANDROID_ABI=${abi}
   ninja
   cd ..

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -54,12 +54,11 @@ ninja install
 
 # libgav1
 cd
-git clone -b v0.17.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
+git clone -b v0.18.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
 cd libgav1
-git clone -b lts_2021_03_24 --depth 1 https://github.com/abseil/abseil-cpp.git third_party/abseil-cpp
 mkdir build
 cd build
-cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DLIBGAV1_THREADPOOL_USE_STD_MUTEX=1 ..
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DLIBGAV1_THREADPOOL_USE_STD_MUTEX=1 -DLIBGAV1_ENABLE_EXAMPLES=0 -DLIBGAV1_ENABLE_TESTS=0 ..
 ninja install
 
 # rav1e


### PR DESCRIPTION
Shorten the build by building only the library and not building examples
and tests. So the Abseil source tree is not needed.