### PR TITLE
Write cmake command as YAML Folded Block Scalar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,18 +65,19 @@ jobs:
       run: bash googletest.cmd
 
     - name: Prepare libavif (cmake)
-      run: |
+      run: >
         mkdir build && cd build
-        cmake .. -G Ninja \
-          -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
-          -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON \
-          -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON \
-          -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=ON \
-          -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON \
-          -DAVIF_CODEC_LIBGAV1=ON -DAVIF_LOCAL_LIBGAV1=ON \
-          -DAVIF_LOCAL_LIBYUV=ON \
-          -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON \
-          -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON
+
+        cmake .. -G Ninja
+        -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
+        -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON
+        -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON
+        -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=ON
+        -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON
+        -DAVIF_CODEC_LIBGAV1=ON -DAVIF_LOCAL_LIBGAV1=ON
+        -DAVIF_LOCAL_LIBYUV=ON
+        -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
+        -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja


### PR DESCRIPTION
Write the multi-line cmake command as a YAML Folded Block Scalar. See
https://yaml-multiline.info/.

This change is needed because the default shell on Windows (PowerShell)
does not support line continuation with a backslash (\) character.