### PR TITLE
Use libyuv for default PNG RGB-to-YUV in avifenc

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -16,7 +16,7 @@ extern "C" {
 #define AVIF_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 // Returns the equivalent of ceil(a/b) but for positive integers.
-#define AVIF_CEIL(a, b) (((a) + (b)-1) / (b))
+#define AVIF_DIV_CEIL(a, b) (((a) + (b)-1) / (b))
 
 // Used by stream related things.
 #define CHECK(A)               \

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -15,7 +15,7 @@ extern "C" {
 #define AVIF_MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define AVIF_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
-// Returns the equivalent of ceil(a/b) but for positive integers.
+// Returns the equivalent of ceil(a/b) for positive integers a and b.
 #define AVIF_DIV_CEIL(a, b) (((a) + (b)-1) / (b))
 
 // Used by stream related things.

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -15,9 +15,6 @@ extern "C" {
 #define AVIF_MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define AVIF_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
-// Returns the equivalent of ceil(a/b) for positive integers a and b.
-#define AVIF_DIV_CEIL(a, b) (((a) + (b)-1) / (b))
-
 // Used by stream related things.
 #define CHECK(A)               \
     do {                       \

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -15,6 +15,9 @@ extern "C" {
 #define AVIF_MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define AVIF_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
+// Returns the equivalent of ceil(a/b) but for positive integers.
+#define AVIF_CEIL(a, b) (((a) + (b)-1) / (b))
+
 // Used by stream related things.
 #define CHECK(A)               \
     do {                       \

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -111,15 +111,15 @@ static int avifABGRToJ420(const uint8_t * src_abgr,
 
     for (int y = 0; y < height; y += num_allocated_rows) {
         const int num_rows = AVIF_MIN(num_allocated_rows, height - y);
-        if (ARGBToABGR(src_abgr, src_stride_abgr, src_argb, src_stride_argb, width, num_rows) ||
+        if (ABGRToARGB(src_abgr, src_stride_abgr, src_argb, src_stride_argb, width, num_rows) ||
             ARGBToJ420(src_argb, src_stride_argb, dst_y, dst_stride_y, dst_u, dst_stride_u, dst_v, dst_stride_v, width, num_rows)) {
             avifFree(src_argb);
             return -1;
         }
         src_abgr += (size_t)num_rows * src_stride_abgr;
         dst_y += (size_t)num_rows * dst_stride_y;
-        dst_u += (size_t)num_rows * dst_stride_u / 2; // 4:2:0
-        dst_v += (size_t)num_rows * dst_stride_v / 2; // (either num_rows is even or this is the last loop turn)
+        dst_u += (size_t)num_rows / 2 * dst_stride_u; // 4:2:0
+        dst_v += (size_t)num_rows / 2 * dst_stride_v; // (either num_rows is even or this is the last iteration)
     }
     avifFree(src_argb);
     return 0;

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -94,7 +94,7 @@ static int avifABGRToJ420(const uint8_t * src_abgr,
     const int src_stride_argb = width * 4;
     const uint64_t soft_allocation_limit = 16384; // Arbitrarily chosen trade-off between CPU and memory footprints.
     int num_allocated_rows;
-    if ((uint64_t)src_stride_argb * height <= soft_allocation_limit) {
+    if (height == 1 || (uint64_t)src_stride_argb * height <= soft_allocation_limit) {
         // Process the whole buffer in one go.
         num_allocated_rows = height;
     } else {

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -102,9 +102,9 @@ static int avifABGRToJ420(const uint8_t * src_abgr,
         // by libyuv, so make sure all steps but the last one process an even number of rows.
         // Try to process as many row pairs as possible in a single step without allocating more than
         // soft_allocation_limit, unless two rows need more than that.
-        num_allocated_rows = AVIF_MAX(1, (int)(soft_allocation_limit / (uint64_t)src_stride_argb * 2)) * 2;
+        num_allocated_rows = AVIF_MAX(1, soft_allocation_limit / ((uint64_t)src_stride_argb * 2)) * 2;
     }
-    src_argb = avifAlloc(num_allocated_rows * src_stride_argb);
+    src_argb = avifAlloc((uint64_t)num_allocated_rows * src_stride_argb);
     if (!src_argb) {
         return -1;
     }

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -102,11 +102,11 @@ static int avifABGRToJ420(const uint8_t * src_abgr,
         // by libyuv, so make sure all steps but the last one process an even number of rows.
         // Try to process as many row pairs as possible in a single step without allocating more than
         // soft_allocation_limit, unless two rows need more than that.
-        num_allocated_rows = (int)AVIF_CEIL(soft_allocation_limit, (uint64_t)src_stride_argb * 2) * 2;
+        num_allocated_rows = (int)AVIF_DIV_CEIL(soft_allocation_limit, (uint64_t)src_stride_argb * 2) * 2;
     }
     src_argb = avifAlloc(num_allocated_rows * src_stride_argb);
     if (!src_argb) {
-        return 1;
+        return -1;
     }
 
     for (int y = 0; y < height; y += num_allocated_rows) {
@@ -114,12 +114,12 @@ static int avifABGRToJ420(const uint8_t * src_abgr,
         if (ARGBToABGR(src_abgr, src_stride_abgr, src_argb, src_stride_argb, width, num_rows) ||
             ARGBToJ420(src_argb, src_stride_argb, dst_y, dst_stride_y, dst_u, dst_stride_u, dst_v, dst_stride_v, width, num_rows)) {
             avifFree(src_argb);
-            return 1;
+            return -1;
         }
-        src_abgr += (uint64_t)num_rows * src_stride_abgr;
-        dst_y += (uint64_t)num_rows * dst_stride_y;
-        dst_u += (uint64_t)num_rows * dst_stride_u / 2; // 4:2:0
-        dst_v += (uint64_t)num_rows * dst_stride_v / 2; // (either num_rows is even or this is the last loop turn)
+        src_abgr += (size_t)num_rows * src_stride_abgr;
+        dst_y += (size_t)num_rows * dst_stride_y;
+        dst_u += (size_t)num_rows * dst_stride_u / 2; // 4:2:0
+        dst_v += (size_t)num_rows * dst_stride_v / 2; // (either num_rows is even or this is the last loop turn)
     }
     avifFree(src_argb);
     return 0;

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -94,7 +94,7 @@ static int avifABGRToJ420(const uint8_t * src_abgr,
     const int src_stride_argb = width * 4;
     const uint64_t soft_allocation_limit = 16384; // Arbitrarily chosen trade-off between CPU and memory footprints.
     int num_allocated_rows;
-    if (height == 1 || (uint64_t)src_stride_argb * height <= soft_allocation_limit) {
+    if ((height == 1) || ((uint64_t)src_stride_argb * height <= soft_allocation_limit)) {
         // Process the whole buffer in one go.
         num_allocated_rows = height;
     } else {

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -102,7 +102,7 @@ static int avifABGRToJ420(const uint8_t * src_abgr,
         // by libyuv, so make sure all steps but the last one process an even number of rows.
         // Try to process as many row pairs as possible in a single step without allocating more than
         // soft_allocation_limit, unless two rows need more than that.
-        num_allocated_rows = (int)AVIF_DIV_CEIL(soft_allocation_limit, (uint64_t)src_stride_argb * 2) * 2;
+        num_allocated_rows = AVIF_MAX(1, (int)(soft_allocation_limit / (uint64_t)src_stride_argb * 2)) * 2;
     }
     src_argb = avifAlloc(num_allocated_rows * src_stride_argb);
     if (!src_argb) {

--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -19,24 +19,26 @@ namespace {
 
 //------------------------------------------------------------------------------
 
+constexpr uint32_t kModifierSize = 4 * 4;
+
 // Modifies the pixel values of a channel in image by modifier[] (row-ordered).
 template <typename PixelType>
 void ModifyImageChannel(avifRGBImage* image, uint32_t channel_offset,
-                        const int32_t modifier[]) {
+                        const int32_t modifier[kModifierSize]) {
   const uint32_t channel_count = avifRGBFormatChannelCount(image->format);
   assert(channel_offset < channel_count);
   for (uint32_t y = 0, i = 0; y < image->height; ++y) {
     PixelType* pixel =
         reinterpret_cast<PixelType*>(image->pixels + image->rowBytes * y);
     for (uint32_t x = 0; x < image->width; ++x, ++i) {
-      pixel[channel_offset] += modifier[i];
+      pixel[channel_offset] += modifier[i % kModifierSize];
       pixel += channel_count;
     }
   }
 }
 
 void ModifyImageChannel(avifRGBImage* image, uint32_t channel_offset,
-                        const int32_t modifier[]) {
+                        const int32_t modifier[kModifierSize]) {
   (image->depth <= 8)
       ? ModifyImageChannel<uint8_t>(image, channel_offset, modifier)
       : ModifyImageChannel<uint16_t>(image, channel_offset, modifier);
@@ -45,7 +47,7 @@ void ModifyImageChannel(avifRGBImage* image, uint32_t channel_offset,
 // Fills the image channel with the given value, and modifies the individual
 // pixel values of that channel with the modifier, if not null.
 void SetImageChannel(avifRGBImage* image, uint32_t channel_offset,
-                     uint32_t value, const int32_t modifier[]) {
+                     uint32_t value, const int32_t modifier[kModifierSize]) {
   testutil::FillImageChannel(image, channel_offset, value);
   if (modifier) {
     ModifyImageChannel(image, channel_offset, modifier);
@@ -96,6 +98,28 @@ double GetPsnr(double sq_diff_sum, double num_diffs, double max_abs_diff) {
 
 //------------------------------------------------------------------------------
 
+// To exercise the chroma subsampling loss, the input samples must differ in
+// each of the RGB channels. Chroma subsampling expects the input RGB channels
+// to be correlated to minimize the quality loss.
+constexpr int32_t kRedNoise[kModifierSize] = {
+    7,  14, 11, 5,   // Random permutation of 16 values.
+    4,  6,  8,  15,  //
+    2,  9,  13, 3,   //
+    12, 1,  10, 0};
+constexpr int32_t kGreenNoise[kModifierSize] = {
+    3,  2,  12, 15,  // Random permutation of 16 values
+    14, 10, 7,  13,  // that is somewhat close to kRedNoise.
+    5,  1,  9,  0,   //
+    8,  4,  11, 6};
+constexpr int32_t kBlueNoise[kModifierSize] = {
+    0,  8,  14, 9,   // Random permutation of 16 values
+    13, 12, 2,  7,   // that is somewhat close to kGreenNoise.
+    3,  1,  11, 10,  //
+    6,  15, 5,  4};
+constexpr int32_t* kPlainColor = nullptr;
+
+//------------------------------------------------------------------------------
+
 class RGBToYUVTest
     : public testing::TestWithParam<
           std::tuple</*rgb_depth=*/int, /*yuv_depth=*/int, avifRGBFormat,
@@ -106,7 +130,7 @@ class RGBToYUVTest
 // Converts from RGB to YUV and back to RGB for all RGB combinations, separated
 // by a color step for reasonable timing. If add_noise is true, also applies
 // some noise to the input samples to exercise chroma subsampling.
-TEST_P(RGBToYUVTest, Convert) {
+TEST_P(RGBToYUVTest, ConvertWholeRange) {
   const int rgb_depth = std::get<0>(GetParam());
   const int yuv_depth = std::get<1>(GetParam());
   const avifRGBFormat rgb_format = std::get<2>(GetParam());
@@ -146,26 +170,6 @@ TEST_P(RGBToYUVTest, Convert) {
     testutil::FillImageChannel(&src_rgb, offsets.a, rgb_max);
   }
 
-  // To exercise the chroma subsampling loss, the input samples must differ in
-  // each of the RGB channels. Chroma subsampling expects the input RGB channels
-  // to be correlated to minimize the quality loss.
-  static constexpr int32_t kRedNoise[] = {
-      7,  14, 11, 5,   // Random permutation of 16 values.
-      4,  6,  8,  15,  //
-      2,  9,  13, 3,   //
-      12, 1,  10, 0};
-  static constexpr int32_t kGreenNoise[] = {
-      3,  2,  12, 15,  // Random permutation of 16 values
-      14, 10, 7,  13,  // that is somewhat close to kRedNoise.
-      5,  1,  9,  0,   //
-      8,  4,  11, 6};
-  static constexpr int32_t kBlueNoise[] = {
-      0,  8,  14, 9,   // Random permutation of 16 values
-      13, 12, 2,  7,   // that is somewhat close to kGreenNoise.
-      3,  1,  11, 10,  //
-      6,  15, 5,  4};
-  static constexpr int32_t* kPlainColor = nullptr;
-
   // Estimate the loss from converting RGB values to YUV and back.
   int64_t diff_sum = 0, abs_diff_sum = 0, sq_diff_sum = 0, max_abs_diff = 0;
   int64_t num_diffs = 0;
@@ -202,6 +206,11 @@ TEST_P(RGBToYUVTest, Convert) {
           SetImageChannel(&src_rgb, offsets.b, b,
                           add_noise ? kBlueNoise : kPlainColor);
 
+          // Change these to BEST_QUALITY to force built-in over libyuv
+          // conversion.
+          src_rgb.chromaDownsampling = AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC;
+          dst_rgb.chromaUpsampling = AVIF_CHROMA_UPSAMPLING_AUTOMATIC;
+
           ASSERT_EQ(avifImageRGBToYUV(yuv.get(), &src_rgb), AVIF_RESULT_OK);
           ASSERT_EQ(avifImageYUVToRGB(yuv.get(), &dst_rgb), AVIF_RESULT_OK);
           GetDiffSumAndSqDiffSum(src_rgb, dst_rgb, &diff_sum, &abs_diff_sum,
@@ -235,6 +244,69 @@ TEST_P(RGBToYUVTest, Convert) {
             << ", " << (add_noise ? "noisy" : "plain") << ", avg "
             << average_diff << ", abs avg " << average_abs_diff << ", max "
             << max_abs_diff << ", PSNR " << psnr << "dB" << std::endl;
+}
+
+// Converts from RGB to YUV and back to RGB for multiple buffer dimensions to
+// exercise stride computation and subsampling edge cases.
+TEST_P(RGBToYUVTest, ConvertWholeBuffer) {
+  const int rgb_depth = std::get<0>(GetParam());
+  const int yuv_depth = std::get<1>(GetParam());
+  const avifRGBFormat rgb_format = std::get<2>(GetParam());
+  const avifPixelFormat yuv_format = std::get<3>(GetParam());
+  const avifRange yuv_range = std::get<4>(GetParam());
+  const avifMatrixCoefficients matrix_coefficients = std::get<5>(GetParam());
+  // Whether to add noise to the input RGB samples.
+  const bool add_noise = std::get<6>(GetParam());
+  // Threshold to pass.
+  const double min_psnr = std::get<9>(GetParam());
+  // Deduced constants.
+  const bool is_monochrome =
+      (yuv_format == AVIF_PIXEL_FORMAT_YUV400);  // If so, only test grey input.
+  const uint32_t rgb_max = (1 << rgb_depth) - 1;
+
+  // Estimate the loss from converting RGB values to YUV and back.
+  int64_t diff_sum = 0, abs_diff_sum = 0, sq_diff_sum = 0, max_abs_diff = 0;
+  int64_t num_diffs = 0;
+  for (int width : {1, 2, 127}) {
+    for (int height : {1, 2, 251}) {
+      std::unique_ptr<avifImage, decltype(&avifImageDestroy)> yuv(
+          avifImageCreate(width, height, yuv_depth, yuv_format),
+          avifImageDestroy);
+      yuv->matrixCoefficients = matrix_coefficients;
+      yuv->yuvRange = yuv_range;
+      testutil::AvifRgbImage src_rgb(yuv.get(), rgb_depth, rgb_format);
+      testutil::AvifRgbImage dst_rgb(yuv.get(), rgb_depth, rgb_format);
+      // Change these to BEST_QUALITY to force built-in over libyuv conversion.
+      src_rgb.chromaDownsampling = AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC;
+      dst_rgb.chromaUpsampling = AVIF_CHROMA_UPSAMPLING_AUTOMATIC;
+      const testutil::RgbChannelOffsets offsets =
+          testutil::GetRgbChannelOffsets(rgb_format);
+
+      // Fill the input buffer with whatever content.
+      SetImageChannel(&src_rgb, offsets.r, /*value=*/0,
+                      add_noise ? kRedNoise : kPlainColor);
+      SetImageChannel(
+          &src_rgb, offsets.g, /*value=*/0,
+          add_noise ? is_monochrome ? kRedNoise : kGreenNoise : kPlainColor);
+      SetImageChannel(
+          &src_rgb, offsets.b, /*value=*/0,
+          add_noise ? is_monochrome ? kRedNoise : kBlueNoise : kPlainColor);
+      // Alpha values are not tested here. Keep it opaque.
+      if (avifRGBFormatHasAlpha(src_rgb.format)) {
+        testutil::FillImageChannel(&src_rgb, offsets.a, rgb_max);
+      }
+
+      ASSERT_EQ(avifImageRGBToYUV(yuv.get(), &src_rgb), AVIF_RESULT_OK);
+      ASSERT_EQ(avifImageYUVToRGB(yuv.get(), &dst_rgb), AVIF_RESULT_OK);
+      GetDiffSumAndSqDiffSum(src_rgb, dst_rgb, &diff_sum, &abs_diff_sum,
+                             &sq_diff_sum, &max_abs_diff);
+      num_diffs += src_rgb.width * src_rgb.height * 3;
+    }
+  }
+  // max_abs_average_diff is not tested here because it is not meaningful for
+  // only 3*3 conversions as it takes the maximum difference per conversion.
+  // PSNR is averaged on all pixels so it can be tested here.
+  EXPECT_GE(GetPsnr(sq_diff_sum, num_diffs, rgb_max), min_psnr);
 }
 
 constexpr avifRGBFormat kAllRgbFormats[] = {


### PR DESCRIPTION
Speed up at the expense of a small conversion loss.

According to avifrgbtoyuvtest, for 8-bit RGBA to 8-bit full range BT.601:
```
C float conversion: avg 0.0728848, abs avg 2.75841, max 12, PSNR 37.1393dB
libyuv conversion:  avg 0.0442412, abs avg 2.81094, max 13, PSNR 37.0215dB
```
According to a profiling of a local encoding of 30 ~2k images with the following flags:
```
--speed 9 --jobs 1 -y 420 --min 0 --max 63 --tilecolslog2 2 --tilerowslog2 2
-a end-usage=q -a cq-level=28 -a tune=ssim -a deltaq-mode=3 -a sharpness=3 --range full
```
```
avifenc 7.74s (including 1.46s of avifImageRGBToYUV() )
avifenc 6.47s (including 0.22s of avifImageRGBToYUV() )
```
representing an 85% speedup of avifImageRGBToYUV() and a 16% speedup of avifenc with these settings.