### PR TITLE
Fix MSVC cast warning in avifABGRToJ420()

### DIFF
--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -95,11 +95,11 @@ static int avifABGRToJ420(const uint8_t * src_abgr,
     const int src_stride_argb = width * 4;
     const int soft_allocation_limit = 16384; // Arbitrarily chosen trade-off between CPU and memory footprints.
     int num_allocated_rows;
-    if ((height == 1) || ((uint64_t)src_stride_argb * height <= (uint64_t)soft_allocation_limit)) {
+    if ((height == 1) || ((int64_t)src_stride_argb * height <= soft_allocation_limit)) {
         // Process the whole buffer in one go.
         num_allocated_rows = height;
     } else {
-        if ((uint64_t)src_stride_argb * 2 > INT_MAX) {
+        if ((int64_t)src_stride_argb * 2 > INT_MAX) {
             return -1;
         }
         // The last row of an odd number of RGB rows to be converted to subsampled YUV is treated differently

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -93,9 +93,9 @@ static int avifABGRToJ420(const uint8_t * src_abgr,
     // A temporary buffer is needed to swap the R and B channels before calling ARGBToJ420().
     uint8_t * src_argb;
     const int src_stride_argb = width * 4;
-    const uint64_t soft_allocation_limit = 16384; // Arbitrarily chosen trade-off between CPU and memory footprints.
+    const int soft_allocation_limit = 16384; // Arbitrarily chosen trade-off between CPU and memory footprints.
     int num_allocated_rows;
-    if ((height == 1) || ((uint64_t)src_stride_argb * height <= soft_allocation_limit)) {
+    if ((height == 1) || ((uint64_t)src_stride_argb * height <= (uint64_t)soft_allocation_limit)) {
         // Process the whole buffer in one go.
         num_allocated_rows = height;
     } else {


### PR DESCRIPTION
src\reformat_libyuv.c(109,89): warning C4242: '=': conversion from
'const uint64_t' to 'int', possible loss of data