### PR TITLE
Fix rgbPixelBytes computation in avifPrepareReformatState

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -69,7 +69,7 @@ static avifBool avifPrepareReformatState(const avifImage * image, const avifRGBI
     state->yuvChannelBytes = (image->depth > 8) ? 2 : 1;
     state->rgbChannelBytes = (rgb->depth > 8) ? 2 : 1;
     state->rgbChannelCount = avifRGBFormatChannelCount(rgb->format);
-    state->rgbPixelBytes = state->rgbChannelBytes * state->rgbChannelCount;
+    state->rgbPixelBytes = avifRGBImagePixelSize(rgb);
 
     switch (rgb->format) {
         case AVIF_RGB_FORMAT_RGB:


### PR DESCRIPTION
Use avifRGBImagePixelSize() instead of repeating the logic for
pixel size computation. avifRGBImagePixelSize() accounts for
RGB_565 format correctly while the current computation does not.