### PR TITLE
Ext: Update to SVT-AV1 v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ return values of avifImageCopy() and avifImageAllocatePlanes().
 
 ### Changed
 * Update aom.cmd: v3.4.0
-* Update svt.cmd/svt.sh: v1.2.0
+* Update svt.cmd/svt.sh: v1.2.1
 * Update libgav1.cmd: v0.18.0
 * Update libyuv.cmd: 9b17af9b (version 1838)
 * avifImageCopy() and avifImageAllocatePlanes() now return avifResult instead of

--- a/ext/svt.cmd
+++ b/ext/svt.cmd
@@ -11,12 +11,12 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #    "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-git clone -b v1.2.0 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v1.2.1 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 
 cd SVT-AV1
 cd Build/windows
 
-call build.bat release static
+call build.bat release static no-dec no-apps
 cd ../..
 mkdir include\svt-av1
 copy Source\API\*.h include\svt-av1

--- a/ext/svt.sh
+++ b/ext/svt.sh
@@ -2,12 +2,12 @@
 # then enable CMake's AVIF_CODEC_SVT and AVIF_LOCAL_SVT options.
 # cmake and ninja must be in your PATH.
 
-git clone -b v1.2.0 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v1.2.1 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 
 cd SVT-AV1
 cd Build/linux
 
-./build.sh release static no-dec
+./build.sh release static no-dec no-apps
 cd ../..
 mkdir -p include/svt-av1
 cp Source/API/*.h include/svt-av1

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -69,7 +69,7 @@ cargo cinstall --prefix=/usr --release
 
 # SVT-AV1
 cd
-git clone -b v1.2.0 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v1.2.1 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 cd SVT-AV1
 cd Build
 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release ..


### PR DESCRIPTION
Do not build the SVT-AV1 decoder and apps. src/codec_svt.c only supports
using SVT-AV1 as an AV1 encoder, and it only needs the SVT-AV1 library.