### PR TITLE
Remove AVIF_API from include/avif/internal.h

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -175,12 +175,7 @@ avifBool avifImageScale(avifImage * image, uint32_t dstWidth, uint32_t dstHeight
 
 // Returns false if the tiles in a grid image violate any standards.
 // The image contains imageW*imageH pixels. The tiles are of tileW*tileH pixels each.
-AVIF_API avifBool avifAreGridDimensionsValid(avifPixelFormat yuvFormat,
-                                             uint32_t imageW,
-                                             uint32_t imageH,
-                                             uint32_t tileW,
-                                             uint32_t tileH,
-                                             avifDiagnostics * diag);
+avifBool avifAreGridDimensionsValid(avifPixelFormat yuvFormat, uint32_t imageW, uint32_t imageH, uint32_t tileW, uint32_t tileH, avifDiagnostics * diag);
 
 // ---------------------------------------------------------------------------
 // avifCodecDecodeInput


### PR DESCRIPTION
This is most likely a copy-and-paste error, because this declaration may
have been in include/avif/avif.h originally.