### PR TITLE
Disable some strict mode flags in the JNI wrapper

### DIFF
--- a/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
+++ b/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2022 Google LLC. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.13)
 
 project(avif_android_jni)
 

--- a/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
+++ b/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
@@ -52,6 +52,15 @@ bool CreateDecoderAndParse(AvifDecoderWrapper* const decoder,
   }
   decoder->decoder->ignoreXMP = AVIF_TRUE;
   decoder->decoder->ignoreExif = AVIF_TRUE;
+
+  // Turn off 'clap' (clean aperture) property validation. The JNI wrapper
+  // ignores the 'clap' property.
+  decoder->decoder->strictFlags &= ~AVIF_STRICT_CLAP_VALID;
+  // Allow 'pixi' (pixel information) property to be missing. Older versions of
+  // libheif did not add the 'pixi' item property to AV1 image items (See
+  // crbug.com/1198455).
+  decoder->decoder->strictFlags &= ~AVIF_STRICT_PIXI_REQUIRED;
+
   avifResult res = avifDecoderSetIOMemory(decoder->decoder, buffer, length);
   if (res != AVIF_RESULT_OK) {
     LOGE("Failed to set AVIF IO to a memory reader.");


### PR DESCRIPTION
It is ok for the JNI wrapper to be more permissive.

Also update the cmake version required in build.gradle. Some
sdk installations use 3.10 by default which is not enough to build
libavif.