### PR TITLE
Fix Clang and GCC -Wswitch-enum warnings

### DIFF
--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -90,6 +90,7 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
                     codec->internal->yShift = 1;
                     break;
                 case AVIF_PIXEL_FORMAT_NONE:
+                case AVIF_PIXEL_FORMAT_COUNT:
                 default:
                     return AVIF_RESULT_UNKNOWN_ERROR;
             }

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -74,6 +74,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
                 break;
             case AVIF_PIXEL_FORMAT_YUV400:
             case AVIF_PIXEL_FORMAT_NONE:
+            case AVIF_PIXEL_FORMAT_COUNT:
             default:
                 return AVIF_RESULT_UNKNOWN_ERROR;
         }

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -40,9 +40,12 @@ RgbChannelOffsets GetRgbChannelOffsets(avifRGBFormat format) {
       return {/*r=*/2, /*g=*/1, /*b=*/0, /*a=*/0};
     case AVIF_RGB_FORMAT_BGRA:
       return {/*r=*/2, /*g=*/1, /*b=*/0, /*a=*/3};
-    default:
-      assert(format == AVIF_RGB_FORMAT_ABGR);
+    case AVIF_RGB_FORMAT_ABGR:
       return {/*r=*/3, /*g=*/2, /*b=*/1, /*a=*/0};
+    case AVIF_RGB_FORMAT_RGB_565:
+    case AVIF_RGB_FORMAT_COUNT:
+    default:
+      return {/*r=*/0, /*g=*/0, /*b=*/0, /*a=*/0};
   }
 }
 


### PR DESCRIPTION
-Wswitch-enum warns about unhandled enum values in switch statements
even when the switch statements have a default case.

MSVC also warns about this when /Wall is specified. Since we compile
with MSVC's /Wall option on Windows, this pull request is a prerequisite
for https://github.com/AOMediaCodec/libavif/pull/1011.