### PR TITLE
googletest.cmd: cd back to original dir when done

### DIFF
--- a/ext/googletest.cmd
+++ b/ext/googletest.cmd
@@ -13,3 +13,4 @@ mkdir build
 cd build
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_GMOCK=OFF ..
 cmake --build .
+cd ../..


### PR DESCRIPTION
Change back to the original directory when done. All the other ext/*.cmd
files do this.