### PR TITLE
Document the --dimension-limit option of avifdec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ avifImageCopy() and avifImageAllocatePlanes().
 * Add avifChromaDownsampling enum
 * Add chromaDownsampling field to avifRGBImage struct
 * Add imageDimensionLimit field to avifDecoder struct
+* avifdec: Add --dimension-limit, which specifies the image dimension limit
+  (width or height) that should be tolerated
 
 ## [0.10.1] - 2022-04-11
 

--- a/doc/avifdec.1.md
+++ b/doc/avifdec.1.md
@@ -112,6 +112,11 @@ Output format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Specifies the image size limit (in total pixels) that should be tolerated.
     Default is 268,435,456 pixels (16,384 by 16,384 pixels for a square image).
 
+**\--dimension-limit** _C_
+:   Specifies the image dimension limit (width or height) that should be
+    tolerated.
+    Default is 32,768. Set it to 0 to ignore the limit.
+
 # EXAMPLES
 
 Decompress an AVIF file to a PNG file:


### PR DESCRIPTION
This should have been part of
https://github.com/AOMediaCodec/libavif/pull/1040.