### PR TITLE
Fix Clang -Wshorten-64-to-32 warnings

### DIFF
--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -365,12 +365,11 @@ static gboolean avif_image_saver(FILE          *f,
                 }
 
                 if (quality < 0 || quality > 100) {
-
                     g_set_error(error,
                                 GDK_PIXBUF_ERROR,
                                 GDK_PIXBUF_ERROR_BAD_OPTION,
-                                "AVIF quality must be a value between 0 and 100; value \"%d\" is not allowed.",
-                                (int)quality);
+                                "AVIF quality must be a value between 0 and 100; value \"%ld\" is not allowed.",
+                                quality);
 
                     return FALSE;
                 }
@@ -423,7 +422,7 @@ static gboolean avif_image_saver(FILE          *f,
         }
     }
 
-    max_quantizer = AVIF_QUANTIZER_WORST_QUALITY * ( 100 - CLAMP(quality, 0, 100)) / 100;
+    max_quantizer = AVIF_QUANTIZER_WORST_QUALITY * (100 - (int)quality) / 100;
     min_quantizer = 0;
     alpha_quantizer = 0;
 

--- a/src/read.c
+++ b/src/read.c
@@ -3101,7 +3101,11 @@ static avifResult avifDecoderPrepareSample(avifDecoder * decoder, avifDecodeSamp
 
             avifDecoderItem * item = avifMetaFindItem(decoder->data->meta, sample->itemID);
             avifROData itemContents;
-            avifResult readResult = avifDecoderItemRead(item, decoder->io, &itemContents, sample->offset, bytesToRead, &decoder->diag);
+            if (sample->offset > SIZE_MAX) {
+                return AVIF_RESULT_BMFF_PARSE_FAILED;
+            }
+            size_t offset = (size_t)sample->offset;
+            avifResult readResult = avifDecoderItemRead(item, decoder->io, &itemContents, offset, bytesToRead, &decoder->diag);
             if (readResult != AVIF_RESULT_OK) {
                 return readResult;
             }


### PR DESCRIPTION
Finish the job of https://github.com/AOMediaCodec/libavif/pull/1037.