### PR TITLE
googletest.cmd: Pass -Dgtest_force_shared_crt=ON

### DIFF
--- a/ext/googletest.cmd
+++ b/ext/googletest.cmd
@@ -11,6 +11,9 @@ git clone -b release-1.11.0 --depth 1 https://github.com/google/googletest.git
 cd googletest
 mkdir build
 cd build
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_GMOCK=OFF ..
+: # The gtest_force_shared_crt option makes gtest link the Microsoft C runtime library (CRT) dynamically
+: # on Windows:
+: # https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_GMOCK=OFF -Dgtest_force_shared_crt=ON ..
 cmake --build .
 cd ../..


### PR DESCRIPTION
Pass the -Dgtest_force_shared_crt=ON option to cmake so that GoogleTest
is compiled with the DLL version of the MSVC runtime library (MSVCRT) on
Windows. By default GoogleTest uses the static library version of the
MSVCRT on Windows. All the other libraries (libavif, libaom, dav1d,
etc.) use the the MSVCRT DLL by default, so we will get errors about
using both the MSVCRT DLL and static library when linking
GoogleTest-based tests if GoogleTest is compiled with the MSVCRT static
library.