### PR TITLE
Fix some MSVC warnings

### DIFF
--- a/tests/gtest/are_images_equal.cc
+++ b/tests/gtest/are_images_equal.cc
@@ -3,6 +3,7 @@
 // Compares two files and returns whether they are the same once decoded.
 
 #include <iostream>
+#include <string>
 
 #include "aviftest_helpers.h"
 #include "avifutil.h"

--- a/tests/gtest/avifincrtest_helpers.cc
+++ b/tests/gtest/avifincrtest_helpers.cc
@@ -40,7 +40,7 @@ void ComparePartialYuva(const avifImage& image1, const avifImage& image2,
   const uint32_t pixel_byte_count =
       (image1.depth > 8) ? sizeof(uint16_t) : sizeof(uint8_t);
 
-  for (uint32_t plane = 0; plane < (info.monochrome ? 1 : AVIF_PLANE_COUNT_YUV);
+  for (int plane = 0; plane < (info.monochrome ? 1 : AVIF_PLANE_COUNT_YUV);
        ++plane) {
     const uint32_t width = (plane == AVIF_CHAN_Y) ? image1.width : uv_width;
     const uint32_t width_byte_count = width * pixel_byte_count;

--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -229,7 +229,8 @@ TEST_P(RGBToYUVTest, ConvertWholeRange) {
       static_cast<double>(diff_sum) / static_cast<double>(num_diffs);
   const double average_abs_diff =
       static_cast<double>(abs_diff_sum) / static_cast<double>(num_diffs);
-  const double psnr = GetPsnr(sq_diff_sum, num_diffs, rgb_max);
+  const double psnr = GetPsnr(static_cast<double>(sq_diff_sum),
+                              static_cast<double>(num_diffs), rgb_max);
   EXPECT_LE(std::abs(average_diff), max_abs_average_diff);
   EXPECT_GE(psnr, min_psnr);
 
@@ -307,7 +308,9 @@ TEST_P(RGBToYUVTest, ConvertWholeBuffer) {
   // max_abs_average_diff is not tested here because it is not meaningful for
   // only 3*3 conversions as it takes the maximum difference per conversion.
   // PSNR is averaged on all pixels so it can be tested here.
-  EXPECT_GE(GetPsnr(sq_diff_sum, num_diffs, rgb_max), min_psnr);
+  EXPECT_GE(GetPsnr(static_cast<double>(sq_diff_sum),
+                    static_cast<double>(num_diffs), rgb_max),
+            min_psnr);
 }
 
 constexpr avifRGBFormat kAllRgbFormats[] = {


### PR DESCRIPTION
are_images_equal.cc: Include <string> because this file uses
std::stoi().

avifincrtest_helpers.cc: The '<' comparison in the following for loop
has a signed/unsigned mismatch:
  for (uint32_t plane = 0; plane < (info.monochrome ? 1 : AVIF_PLANE_COUNT_YUV);

Fix the warning by declaring 'plane' as 'int'.

avifrgbtoyuvtest.cc: The first two parameters of GetPsnr() are of the
'double' type but we are passing 'int64_t' arguments, and MSVC warns
about possible loss of data in the conversion from 'int64_t' to
'double'. Cast the 'int64_t' arguments to 'double'.