### PR TITLE
Build the tests in the windows-latest os image

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -8,8 +8,7 @@
 #   * Runs ext/*.cmd as Windows batch files rather than using bash. This is
 #     important for ext/svt.cmd, to prevent it from running ext/svt.sh.
 #   * Builds with local zlib and libpng (-DAVIF_LOCAL_ZLIBPNG=ON).
-#   * Doesn't build GoogleTest and the tests, because MSVC's /Wall option
-#     reports too many warnings in the C++ test code.
+#   * Doesn't run ctest, because the test 'test_cmd' is a shell script.
 
 name: CI
 on: [push, pull_request]
@@ -75,6 +74,10 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./zlibpng.cmd
+    - name: Build GoogleTest
+      #if: steps.cache-ext.outputs.cache-hit != 'true'
+      working-directory: ./ext
+      run: ./googletest.cmd
 
     - name: Prepare libavif (cmake)
       run: >
@@ -90,6 +93,7 @@ jobs:
         -DAVIF_LOCAL_LIBYUV=ON -DAVIF_LOCAL_JPEG=ON
         -DAVIF_LOCAL_ZLIBPNG=ON
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
+        -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@
 
 cmake_minimum_required(VERSION 3.13)
 
+# New in CMake version 3.15. MSVC warning flags are not in CMAKE_<LANG>_FLAGS by default.
+if(POLICY CMP0092)
+    cmake_policy(SET CMP0092 NEW)
+endif()
+
 # Specify search path for CMake modules to be loaded by include() and find_package()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
@@ -132,16 +137,9 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
 elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
     message(STATUS "libavif: Enabling warnings for MSVC")
     add_definitions(
-        /Wall # All warnings
-        /wd4255 # Disable: no function prototype given
+        /W4
         /wd4324 # Disable: structure was padded due to alignment specifier
-        /wd4668 # Disable: is not defined as a preprocessor macro, replacing with '0'
-        /wd4710 # Disable: function not inlined
-        /wd4711 # Disable: function selected for inline expansion
-        /wd4738 # Disable: storing 32-bit float result in memory, possible loss of performance
-        /wd4820 # Disable: bytes padding added after data member
         /wd4996 # Disable: potentially unsafe stdlib methods
-        /wd5045 # Disable: Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
         # This tells MSVC to read source code as UTF-8 and assume console can only use ASCII (minimal safe).
         # libavif uses ANSI API to print to console, which is not portable between systems using different
         # languages and results in mojibake unless we only use codes shared by every code page: ASCII.


### PR DESCRIPTION
In CMakeLists.txt, compile with MSVC warning /W4 instead of /Wall.
Remove the /wd (disable warning) options that are no longer needed.