### PR TITLE
Correctly update encoder settings, clear csOptions after avifEncoderAddImage()

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1058,8 +1058,8 @@ struct avifCodecSpecificOptions;
 //   image in less bytes. AVIF_SPEED_DEFAULT means "Leave the AV1 codec to its default speed settings"./
 //   If avifEncoder uses rav1e, the speed value is directly passed through (0-10). If libaom is used,
 //   a combination of settings are tweaked to simulate this speed range.
-// * AV1 encoder settings and codec specific options set by avifEncoderSetCodecSpecificOption()
-//   will be applied / updated to AV1 encoder before each call to avifEncoderAddImage().
+// * Some encoder settings can be changed. Changes will take effect from next call to
+//   avifEncoderAddImage().
 typedef struct avifEncoder
 {
     // Defaults to AVIF_CODEC_CHOICE_AUTO: Preference determined by order in availableCodecs table (avif.c)
@@ -1068,15 +1068,15 @@ typedef struct avifEncoder
     // settings (see Notes above)
     int keyframeInterval; // How many frames between automatic forced keyframes; 0 to disable (default).
     uint64_t timescale;   // timescale of the media (Hz)
-    // AV1 encoder settings.
     int maxThreads;
+    int speed;
+    // changeable encoder settings.
     int minQuantizer;
     int maxQuantizer;
     int minQuantizerAlpha;
     int maxQuantizerAlpha;
     int tileRowsLog2;
     int tileColsLog2;
-    int speed;
 
     // stats from the most recent write
     avifIOStats ioStats;
@@ -1129,9 +1129,9 @@ AVIF_API avifResult avifEncoderAddImageGrid(avifEncoder * encoder,
 AVIF_API avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output);
 
 // Codec-specific, optional "advanced" tuning settings, in the form of string key/value pairs,
-// to be sent to codec at the next avifEncoderAddImage() call.
-// See the codec documentation to know if a setting is permanent or applied only to the next frame.
-// key must be non-NULL, but passing a NULL value will delete that pending key, if it exists.
+// to be consumed by the codec at the next avifEncoderAddImage() call.
+// See the codec documentation to know if a setting is persistent or applied only to the next frame.
+// key must be non-NULL, but passing a NULL value will delete the pending key, if it exists.
 // Setting an incorrect or unknown option for the current codec will cause errors of type
 // AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION from avifEncoderWrite() or avifEncoderAddImage().
 AVIF_API void avifEncoderSetCodecSpecificOption(avifEncoder * encoder, const char * key, const char * value);

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1129,7 +1129,7 @@ AVIF_API avifResult avifEncoderAddImageGrid(avifEncoder * encoder,
 AVIF_API avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output);
 
 // Codec-specific, optional "advanced" tuning settings, in the form of string key/value pairs,
-// to be sent to codec once at the next avifEncoderAddImage() call.
+// to be sent to codec at the next avifEncoderAddImage() call.
 // See the codec documentation to know if a setting is permanent or applied only to the next frame.
 // key must be non-NULL, but passing a NULL value will delete that pending key, if it exists.
 // Setting an incorrect or unknown option for the current codec will cause errors of type

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1128,9 +1128,10 @@ AVIF_API avifResult avifEncoderAddImageGrid(avifEncoder * encoder,
                                             avifAddImageFlags addImageFlags);
 AVIF_API avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output);
 
-// Codec-specific, optional "advanced" tuning settings, in the form of string key/value pairs.
-// key must be non-NULL, but passing a NULL value will delete that key, if it exists.
-// Settings will be sent to codec once at the next avifEncoderAddImage() call.
+// Codec-specific, optional "advanced" tuning settings, in the form of string key/value pairs,
+// to be sent to codec once at the next avifEncoderAddImage() call.
+// See the codec documentation to know if a setting is permanent or applied only to the next frame.
+// key must be non-NULL, but passing a NULL value will delete that pending key, if it exists.
 // Setting an incorrect or unknown option for the current codec will cause errors of type
 // AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION from avifEncoderWrite() or avifEncoderAddImage().
 AVIF_API void avifEncoderSetCodecSpecificOption(avifEncoder * encoder, const char * key, const char * value);

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1130,6 +1130,7 @@ AVIF_API avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output
 
 // Codec-specific, optional "advanced" tuning settings, in the form of string key/value pairs.
 // key must be non-NULL, but passing a NULL value will delete that key, if it exists.
+// Settings will be sent to codec once at the next avifEncoderAddImage() call.
 // Setting an incorrect or unknown option for the current codec will cause errors of type
 // AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION from avifEncoderWrite() or avifEncoderAddImage().
 AVIF_API void avifEncoderSetCodecSpecificOption(avifEncoder * encoder, const char * key, const char * value);

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1058,8 +1058,8 @@ struct avifCodecSpecificOptions;
 //   image in less bytes. AVIF_SPEED_DEFAULT means "Leave the AV1 codec to its default speed settings"./
 //   If avifEncoder uses rav1e, the speed value is directly passed through (0-10). If libaom is used,
 //   a combination of settings are tweaked to simulate this speed range.
-// * Some encoder settings can be changed. Changes will take effect from next call to
-//   avifEncoderAddImage().
+// * Some encoder settings can be changed after encoding starts. Changes will take effect in the next
+//   call to avifEncoderAddImage().
 typedef struct avifEncoder
 {
     // Defaults to AVIF_CODEC_CHOICE_AUTO: Preference determined by order in availableCodecs table (avif.c)

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -244,6 +244,7 @@ typedef struct avifCodecSpecificOption
 } avifCodecSpecificOption;
 AVIF_ARRAY_DECLARE(avifCodecSpecificOptions, avifCodecSpecificOption, entries);
 avifCodecSpecificOptions * avifCodecSpecificOptionsCreate(void);
+void avifCodecSpecificOptionsClear(avifCodecSpecificOptions * csOptions);
 void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions);
 void avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const char * key, const char * value); // if(value==NULL), key is deleted
 

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -254,6 +254,18 @@ void avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const cha
 struct avifCodec;
 struct avifCodecInternal;
 
+typedef enum avifEncoderConfig
+{
+    AVIF_ENCODER_CONFIG_MIN_QUANTIZER = (1 << 0),
+    AVIF_ENCODER_CONFIG_MAX_QUANTIZER = (1 << 1),
+    AVIF_ENCODER_CONFIG_MIN_QUANTIZER_ALPHA = (1 << 2),
+    AVIF_ENCODER_CONFIG_MAX_QUANTIZER_ALPHA = (1 << 3),
+    AVIF_ENCODER_CONFIG_TILE_ROWS_LOG_2 = (1 << 4),
+    AVIF_ENCODER_CONFIG_TILE_COLS_LOG_2 = (1 << 5),
+
+    AVIF_ENCODER_CONFIG_CODEC_SPECIFIC = (1 << 31)
+} avifEncoderConfig;
+
 typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec,
                                               struct avifDecoder * decoder,
                                               const avifDecodeSample * sample,
@@ -268,7 +280,7 @@ typedef avifResult (*avifCodecEncodeImageFunc)(struct avifCodec * codec,
                                                avifEncoder * encoder,
                                                const avifImage * image,
                                                avifBool alpha,
-                                               avifBool updateConfig,
+                                               avifEncoderConfig updateConfig,
                                                avifAddImageFlags addImageFlags,
                                                avifCodecEncodeOutput * output);
 typedef avifBool (*avifCodecEncodeFinishFunc)(struct avifCodec * codec, avifCodecEncodeOutput * output);

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -254,17 +254,18 @@ void avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const cha
 struct avifCodec;
 struct avifCodecInternal;
 
-typedef enum avifEncoderConfig
+typedef enum avifEncoderChange
 {
-    AVIF_ENCODER_CONFIG_MIN_QUANTIZER = (1 << 0),
-    AVIF_ENCODER_CONFIG_MAX_QUANTIZER = (1 << 1),
-    AVIF_ENCODER_CONFIG_MIN_QUANTIZER_ALPHA = (1 << 2),
-    AVIF_ENCODER_CONFIG_MAX_QUANTIZER_ALPHA = (1 << 3),
-    AVIF_ENCODER_CONFIG_TILE_ROWS_LOG_2 = (1 << 4),
-    AVIF_ENCODER_CONFIG_TILE_COLS_LOG_2 = (1 << 5),
+    AVIF_ENCODER_CHANGE_MIN_QUANTIZER = (1 << 0),
+    AVIF_ENCODER_CHANGE_MAX_QUANTIZER = (1 << 1),
+    AVIF_ENCODER_CHANGE_MIN_QUANTIZER_ALPHA = (1 << 2),
+    AVIF_ENCODER_CHANGE_MAX_QUANTIZER_ALPHA = (1 << 3),
+    AVIF_ENCODER_CHANGE_TILE_ROWS_LOG2 = (1 << 4),
+    AVIF_ENCODER_CHANGE_TILE_COLS_LOG2 = (1 << 5),
 
-    AVIF_ENCODER_CONFIG_CODEC_SPECIFIC = (1 << 31)
-} avifEncoderConfig;
+    AVIF_ENCODER_CHANGE_CODEC_SPECIFIC = (1 << 31)
+} avifEncoderChange;
+typedef uint32_t avifEncoderChanges;
 
 typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec,
                                               struct avifDecoder * decoder,
@@ -280,7 +281,7 @@ typedef avifResult (*avifCodecEncodeImageFunc)(struct avifCodec * codec,
                                                avifEncoder * encoder,
                                                const avifImage * image,
                                                avifBool alpha,
-                                               avifEncoderConfig updateConfig,
+                                               avifEncoderChanges encoderChanges,
                                                avifAddImageFlags addImageFlags,
                                                avifCodecEncodeOutput * output);
 typedef avifBool (*avifCodecEncodeFinishFunc)(struct avifCodec * codec, avifCodecEncodeOutput * output);

--- a/src/avif.c
+++ b/src/avif.c
@@ -880,10 +880,6 @@ error:
 
 void avifCodecSpecificOptionsClear(avifCodecSpecificOptions * csOptions)
 {
-    if (!csOptions) {
-        return;
-    }
-
     for (uint32_t i = 0; i < csOptions->count; ++i) {
         avifCodecSpecificOption * entry = &csOptions->entries[i];
         avifFree(entry->key);
@@ -895,6 +891,10 @@ void avifCodecSpecificOptionsClear(avifCodecSpecificOptions * csOptions)
 
 void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions)
 {
+    if (!csOptions) {
+        return;
+    }
+
     avifCodecSpecificOptionsClear(csOptions);
     avifArrayDestroy(csOptions);
     avifFree(csOptions);

--- a/src/avif.c
+++ b/src/avif.c
@@ -878,7 +878,7 @@ error:
     return NULL;
 }
 
-void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions)
+void avifCodecSpecificOptionsClear(avifCodecSpecificOptions * csOptions)
 {
     if (!csOptions) {
         return;
@@ -889,6 +889,13 @@ void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions)
         avifFree(entry->key);
         avifFree(entry->value);
     }
+
+    csOptions->count = 0;
+}
+
+void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions)
+{
+    avifCodecSpecificOptionsClear(csOptions);
     avifArrayDestroy(csOptions);
     avifFree(csOptions);
 }
@@ -916,10 +923,12 @@ void avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const cha
         }
     }
 
-    // Add a new key
-    avifCodecSpecificOption * entry = (avifCodecSpecificOption *)avifArrayPushPtr(csOptions);
-    entry->key = avifStrdup(key);
-    entry->value = avifStrdup(value);
+    if (value) {
+        // Add a new key
+        avifCodecSpecificOption * entry = (avifCodecSpecificOption *)avifArrayPushPtr(csOptions);
+        entry->key = avifStrdup(key);
+        entry->value = avifStrdup(value);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -527,11 +527,17 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
                                       avifEncoder * encoder,
                                       const avifImage * image,
                                       avifBool alpha,
-                                      avifBool updateConfig,
+                                      avifEncoderConfig updatedConfig,
                                       avifAddImageFlags addImageFlags,
                                       avifCodecEncodeOutput * output)
 {
-    if (!codec->internal->encoderInitialized || updateConfig) {
+    struct aom_codec_enc_cfg * cfg = &codec->internal->cfg;
+    aom_codec_iface_t * encoderInterface = NULL;
+    unsigned int aomUsage = AOM_USAGE_GOOD_QUALITY;
+    int aomCpuUsed = -1;
+    avifBool lossless = AVIF_FALSE;
+
+    if (!codec->internal->encoderInitialized) {
         // Map encoder speed to AOM usage + CpuUsed:
         // Speed  0: GoodQuality CpuUsed 0
         // Speed  1: GoodQuality CpuUsed 1
@@ -544,7 +550,6 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
         // Speed  8: RealTime    CpuUsed 8
         // Speed  9: RealTime    CpuUsed 9
         // Speed 10: RealTime    CpuUsed 9
-        unsigned int aomUsage = AOM_USAGE_GOOD_QUALITY;
         // Use the new AOM_USAGE_ALL_INTRA (added in https://crbug.com/aomedia/2959) for still
         // image encoding if it is available.
 #if defined(AOM_USAGE_ALL_INTRA)
@@ -552,7 +557,6 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             aomUsage = AOM_USAGE_ALL_INTRA;
         }
 #endif
-        int aomCpuUsed = -1;
         if (encoder->speed != AVIF_SPEED_DEFAULT) {
             aomCpuUsed = AVIF_CLAMP(encoder->speed, 0, 9);
             if (aomCpuUsed >= 7) {
@@ -589,50 +593,19 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             }
         }
 
-        struct aom_codec_enc_cfg * cfg = &codec->internal->cfg;
-
-        aom_codec_iface_t * encoderInterface = NULL;
-        if (!codec->internal->encoderInitialized) {
-            codec->internal->aomFormat = avifImageCalcAOMFmt(image, alpha);
-            if (codec->internal->aomFormat == AOM_IMG_FMT_NONE) {
-                return AVIF_RESULT_UNKNOWN_ERROR;
-            }
-
-            avifGetPixelFormatInfo(image->yuvFormat, &codec->internal->formatInfo);
-
-            encoderInterface = aom_codec_av1_cx();
-            aom_codec_err_t err = aom_codec_enc_config_default(encoderInterface, cfg, aomUsage);
-            if (err != AOM_CODEC_OK) {
-                avifDiagnosticsPrintf(codec->diag, "aom_codec_enc_config_default() failed: %s", aom_codec_err_to_string(err));
-                return AVIF_RESULT_UNKNOWN_ERROR;
-            }
-        } else {
-            // aomUsage was taken into account by aom_codec_enc_config_default() but it can only be manually updated afterwards.
-            cfg->g_usage = aomUsage;
+        codec->internal->aomFormat = avifImageCalcAOMFmt(image, alpha);
+        if (codec->internal->aomFormat == AOM_IMG_FMT_NONE) {
+            return AVIF_RESULT_UNKNOWN_ERROR;
         }
 
-        if (!codec->internal->endUsageSet) {
-            // Set our own default cfg->rc_end_usage value, which may differ from libaom's default.
-            switch (aomUsage) {
-                case AOM_USAGE_GOOD_QUALITY:
-                    // libaom's default is AOM_VBR. Change the default to AOM_Q since we don't need to
-                    // hit a certain target bit rate. It's easier to control the worst quality in Q
-                    // mode.
-                    cfg->rc_end_usage = AOM_Q;
-                    break;
-                case AOM_USAGE_REALTIME:
-                    // For real-time mode we need to use CBR rate control mode. AOM_Q doesn't fit the
-                    // rate control requirements for real-time mode. CBR does.
-                    cfg->rc_end_usage = AOM_CBR;
-                    break;
-#if defined(AOM_USAGE_ALL_INTRA)
-                case AOM_USAGE_ALL_INTRA:
-                    cfg->rc_end_usage = AOM_Q;
-                    break;
-#endif
-            }
-        }
+        avifGetPixelFormatInfo(image->yuvFormat, &codec->internal->formatInfo);
 
+        encoderInterface = aom_codec_av1_cx();
+        aom_codec_err_t err = aom_codec_enc_config_default(encoderInterface, cfg, aomUsage);
+        if (err != AOM_CODEC_OK) {
+            avifDiagnosticsPrintf(codec->diag, "aom_codec_enc_config_default() failed: %s", aom_codec_err_to_string(err));
+            return AVIF_RESULT_UNKNOWN_ERROR;
+        }
         // Profile 0.  8-bit and 10-bit 4:2:0 and 4:0:0 only.
         // Profile 1.  8-bit and 10-bit 4:4:4
         // Profile 2.  8-bit and 10-bit 4:2:2
@@ -671,8 +644,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
         cfg->g_profile = seqProfile;
         cfg->g_bit_depth = image->depth;
         cfg->g_input_bit_depth = image->depth;
-        cfg->g_w = image->width;
-        cfg->g_h = image->height;
+
         if (addImageFlags & AVIF_ADD_IMAGE_FLAG_SINGLE) {
             // Set the maximum number of frames to encode to 1. This instructs
             // libaom to set still_picture and reduced_still_picture_header to
@@ -695,16 +667,6 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             cfg->g_threads = encoder->maxThreads;
         }
 
-        int minQuantizer = AVIF_CLAMP(encoder->minQuantizer, 0, 63);
-        int maxQuantizer = AVIF_CLAMP(encoder->maxQuantizer, 0, 63);
-        if (alpha) {
-            minQuantizer = AVIF_CLAMP(encoder->minQuantizerAlpha, 0, 63);
-            maxQuantizer = AVIF_CLAMP(encoder->maxQuantizerAlpha, 0, 63);
-        }
-        avifBool lossless = ((minQuantizer == AVIF_QUANTIZER_LOSSLESS) && (maxQuantizer == AVIF_QUANTIZER_LOSSLESS));
-        cfg->rc_min_quantizer = minQuantizer;
-        cfg->rc_max_quantizer = maxQuantizer;
-
         codec->internal->monochromeEnabled = AVIF_FALSE;
         if (aomVersion > aomVersion_2_0_0) {
             // There exists a bug in libaom's chroma_check() function where it will attempt to
@@ -720,60 +682,95 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
                 cfg->monochrome = 1;
             }
         }
+    }
+
+    avifBool dimensionChanged = AVIF_FALSE;
+    if ((cfg->g_w != image->width) || (cfg->g_h != image->height)) {
+        cfg->g_w = image->width;
+        cfg->g_h = image->height;
+        if (codec->internal->encoderInitialized) {
+            // We are not ready for dimension change for now.
+            return AVIF_RESULT_NOT_IMPLEMENTED;
+        }
+    }
+
+    if (!codec->internal->encoderInitialized || updatedConfig) {
+        int minQuantizer = AVIF_CLAMP(encoder->minQuantizer, 0, 63);
+        int maxQuantizer = AVIF_CLAMP(encoder->maxQuantizer, 0, 63);
+        if (alpha) {
+            minQuantizer = AVIF_CLAMP(encoder->minQuantizerAlpha, 0, 63);
+            maxQuantizer = AVIF_CLAMP(encoder->maxQuantizerAlpha, 0, 63);
+        }
+        lossless = ((minQuantizer == AVIF_QUANTIZER_LOSSLESS) && (maxQuantizer == AVIF_QUANTIZER_LOSSLESS));
+        cfg->rc_min_quantizer = minQuantizer;
+        cfg->rc_max_quantizer = maxQuantizer;
 
         if (!avifProcessAOMOptionsPreInit(codec, alpha, cfg)) {
             return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
         }
+    }
 
-        avifBool initPhase = AVIF_FALSE;
-        if (!codec->internal->encoderInitialized) {
-            aom_codec_flags_t encoderFlags = 0;
-            if (image->depth > 8) {
-                encoderFlags |= AOM_CODEC_USE_HIGHBITDEPTH;
-            }
-
-            if (aom_codec_enc_init(&codec->internal->encoder, encoderInterface, cfg, encoderFlags) != AOM_CODEC_OK) {
-                avifDiagnosticsPrintf(codec->diag,
-                                      "aom_codec_enc_init() failed: %s: %s",
-                                      aom_codec_error(&codec->internal->encoder),
-                                      aom_codec_error_detail(&codec->internal->encoder));
-                return AVIF_RESULT_UNKNOWN_ERROR;
-            }
-            codec->internal->encoderInitialized = AVIF_TRUE;
-            initPhase = AVIF_TRUE;
-        } else {
-            if (aom_codec_enc_config_set(&codec->internal->encoder, cfg) != AOM_CODEC_OK) {
-                avifDiagnosticsPrintf(codec->diag,
-                                      "aom_codec_enc_config_set() failed: %s: %s",
-                                      aom_codec_error(&codec->internal->encoder),
-                                      aom_codec_error_detail(&codec->internal->encoder));
-                return AVIF_RESULT_UNKNOWN_ERROR;
+    if (!codec->internal->encoderInitialized) {
+        if (!codec->internal->endUsageSet) {
+            // Set our own default cfg->rc_end_usage value, which may differ from libaom's default.
+            switch (aomUsage) {
+                case AOM_USAGE_GOOD_QUALITY:
+                    // libaom's default is AOM_VBR. Change the default to AOM_Q since we don't need to
+                    // hit a certain target bit rate. It's easier to control the worst quality in Q
+                    // mode.
+                    cfg->rc_end_usage = AOM_Q;
+                    break;
+                case AOM_USAGE_REALTIME:
+                    // For real-time mode we need to use CBR rate control mode. AOM_Q doesn't fit the
+                    // rate control requirements for real-time mode. CBR does.
+                    cfg->rc_end_usage = AOM_CBR;
+                    break;
+#if defined(AOM_USAGE_ALL_INTRA)
+                case AOM_USAGE_ALL_INTRA:
+                    cfg->rc_end_usage = AOM_Q;
+                    break;
+#endif
             }
         }
 
-        if (!initPhase || lossless) {
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_LOSSLESS, lossless);
+        aom_codec_flags_t encoderFlags = 0;
+        if (image->depth > 8) {
+            encoderFlags |= AOM_CODEC_USE_HIGHBITDEPTH;
         }
-        int rowMT = encoder->maxThreads > 1;
-        if (!initPhase || rowMT) {
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_ROW_MT, rowMT);
+
+        if (aom_codec_enc_init(&codec->internal->encoder, encoderInterface, cfg, encoderFlags) != AOM_CODEC_OK) {
+            avifDiagnosticsPrintf(codec->diag,
+                                  "aom_codec_enc_init() failed: %s: %s",
+                                  aom_codec_error(&codec->internal->encoder),
+                                  aom_codec_error_detail(&codec->internal->encoder));
+            return AVIF_RESULT_UNKNOWN_ERROR;
         }
-        int tileRowsLog2 = AVIF_CLAMP(encoder->tileRowsLog2, 0, 6);
-        if (!initPhase || (tileRowsLog2 > 0)) {
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, tileRowsLog2);
-        }
-        int tileColsLog2 = AVIF_CLAMP(encoder->tileColsLog2, 0, 6);
-        if (!initPhase || (tileColsLog2 > 0)) {
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, tileColsLog2);
+
+        if (encoder->maxThreads > 1) {
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_ROW_MT, 1);
         }
         if (aomCpuUsed != -1) {
             if (aom_codec_control(&codec->internal->encoder, AOME_SET_CPUUSED, aomCpuUsed) != AOM_CODEC_OK) {
                 return AVIF_RESULT_UNKNOWN_ERROR;
             }
         }
+    } else if ((updatedConfig &~ AVIF_ENCODER_CONFIG_CODEC_SPECIFIC) || dimensionChanged) {
+        // Codec specific options does not change cfg, so no need to update it.
+        aom_codec_err_t err = aom_codec_enc_config_set(&codec->internal->encoder, cfg);
+        if (err != AOM_CODEC_OK) {
+            avifDiagnosticsPrintf(codec->diag,
+                                  "aom_codec_enc_config_set() failed: %s: %s",
+                                  aom_codec_error(&codec->internal->encoder),
+                                  aom_codec_error_detail(&codec->internal->encoder));
+            return AVIF_RESULT_UNKNOWN_ERROR;
+        }
+    }
+
+    if (!codec->internal->encoderInitialized || (updatedConfig & AVIF_ENCODER_CONFIG_CODEC_SPECIFIC)) {
         if (!avifProcessAOMOptionsPostInit(codec, alpha)) {
             return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
         }
+
 #if defined(AOM_USAGE_ALL_INTRA)
         if (aomUsage == AOM_USAGE_ALL_INTRA && !codec->internal->endUsageSet && !codec->internal->cqLevelSet) {
             // The default rc_end_usage in all intra mode is AOM_Q, which requires cq-level to
@@ -786,14 +783,39 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             aom_codec_control(&codec->internal->encoder, AOME_SET_CQ_LEVEL, cqLevel);
         }
 #endif
+    }
+
+    if (!codec->internal->encoderInitialized) {
+        if (lossless) {
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_LOSSLESS, lossless);
+        }
+        int tileRowsLog2 = AVIF_CLAMP(encoder->tileRowsLog2, 0, 6);
+        if (tileRowsLog2 > 0) {
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, tileRowsLog2);
+        }
+        int tileColsLog2 = AVIF_CLAMP(encoder->tileColsLog2, 0, 6);
+        if (tileColsLog2 > 0) {
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, tileColsLog2);
+        }
+
         if (!codec->internal->tuningSet) {
             if (aom_codec_control(&codec->internal->encoder, AOME_SET_TUNING, AOM_TUNE_SSIM) != AOM_CODEC_OK) {
                 return AVIF_RESULT_UNKNOWN_ERROR;
             }
         }
-
-        // Sync our copy with updated config in AOM encoder.
-        *cfg = *codec->internal->encoder.config.enc;
+        codec->internal->encoderInitialized = AVIF_TRUE;
+    } else if (updatedConfig) {
+        if (((!alpha) && ((updatedConfig & AVIF_ENCODER_CONFIG_MIN_QUANTIZER) || (updatedConfig & AVIF_ENCODER_CONFIG_MAX_QUANTIZER))) ||
+            (alpha && ((updatedConfig & AVIF_ENCODER_CONFIG_MIN_QUANTIZER_ALPHA) ||
+                       (updatedConfig & AVIF_ENCODER_CONFIG_MAX_QUANTIZER_ALPHA)))) {
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_LOSSLESS, lossless);
+        }
+        if (updatedConfig & AVIF_ENCODER_CONFIG_TILE_ROWS_LOG_2) {
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, AVIF_CLAMP(encoder->tileRowsLog2, 0, 6));
+        }
+        if (updatedConfig & AVIF_ENCODER_CONFIG_TILE_COLS_LOG_2) {
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, AVIF_CLAMP(encoder->tileColsLog2, 0, 6));
+        }
     }
 
     aom_image_t aomImage;

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -518,7 +518,6 @@ static avifBool avifProcessAOMOptionsPostInit(avifCodec * codec, avifBool alpha)
         }
 #endif // defined(HAVE_AOM_CODEC_SET_OPTION)
     }
-    codec->csOptions->count = 0;
     return AVIF_TRUE;
 }
 
@@ -608,6 +607,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
                 return AVIF_RESULT_UNKNOWN_ERROR;
             }
         } else {
+            // Update AOM usage according to updated speed setting.
             cfg->g_usage = aomUsage;
         }
 
@@ -780,6 +780,9 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
                 return AVIF_RESULT_UNKNOWN_ERROR;
             }
         }
+
+        // Sync our copy with updated config in AOM encoder.
+        *cfg = *codec->internal->encoder.config.enc;
     }
 
     aom_image_t aomImage;

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -12,6 +12,8 @@ struct avifCodecInternal
     RaContext * rav1eContext;
     RaChromaSampling chromaSampling;
     int yShift;
+    uint32_t encodeWidth;
+    uint32_t encodeHeight;
 };
 
 static void rav1eCodecDestroyInternal(avifCodec * codec)
@@ -51,11 +53,20 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
                                         avifEncoder * encoder,
                                         const avifImage * image,
                                         avifBool alpha,
-                                        avifBool updateConfig,
+                                        avifEncoderConfig updatedConfig,
                                         uint32_t addImageFlags,
                                         avifCodecEncodeOutput * output)
 {
-    if (updateConfig) {
+    // rav1e does not support changing config.
+    if (updatedConfig) {
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
+
+    // rav1e does not support changing encoding dimension.
+    if (!codec->internal->rav1eContext) {
+        codec->internal->encodeWidth = image->width;
+        codec->internal->encodeHeight = image->height;
+    } else if ((codec->internal->encodeWidth != image->width) || (codec->internal->encodeHeight != image->height)) {
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
 

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -53,7 +53,7 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
                                         avifEncoder * encoder,
                                         const avifImage * image,
                                         avifBool alpha,
-                                        avifEncoderConfig updatedConfig,
+                                        avifEncoderChanges updatedConfig,
                                         uint32_t addImageFlags,
                                         avifCodecEncodeOutput * output)
 {

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -46,7 +46,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
                                       avifEncoder * encoder,
                                       const avifImage * image,
                                       avifBool alpha,
-                                      avifEncoderConfig updatedConfig,
+                                      avifEncoderChanges updatedConfig,
                                       uint32_t addImageFlags,
                                       avifCodecEncodeOutput * output)
 {

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -46,12 +46,20 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
                                       avifEncoder * encoder,
                                       const avifImage * image,
                                       avifBool alpha,
-                                      avifBool updateConfig,
+                                      avifEncoderConfig updatedConfig,
                                       uint32_t addImageFlags,
                                       avifCodecEncodeOutput * output)
 {
-    if (updateConfig) {
+    // svt does not support changing config.
+    if (updatedConfig) {
         return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
+
+    // svt does not support changing encoding dimension.
+    if (codec->internal->svt_encoder != NULL) {
+        if ((codec->internal->svt_config.source_width != image->width) || (codec->internal->svt_config.source_height != image->height)) {
+            return AVIF_RESULT_NOT_IMPLEMENTED;
+        }
     }
 
     avifResult result = AVIF_RESULT_UNKNOWN_ERROR;

--- a/src/write.c
+++ b/src/write.c
@@ -893,6 +893,7 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         }
     }
 
+    avifCodecSpecificOptionsClear(encoder->csOptions);
     avifEncoderFrame * frame = (avifEncoderFrame *)avifArrayPushPtr(&encoder->data->frames);
     frame->durationInTimescales = durationInTimescales;
     return AVIF_RESULT_OK;


### PR DESCRIPTION
This is a follow up of #1033.

The init logic was skipping some calls if the option is the default value. Now it no longer skip calls so that encoder settings can be reverted to default.

Switch to discard csOptions after being applied to encoder.