### PR TITLE
Add avifImageYUVToRGBLibYUV12bpc()

### DIFF
--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -240,6 +240,10 @@ static avifResult avifImageYUVToRGBLibYUV10bpc(const avifImage * image,
                                                avifRGBImage * rgb,
                                                const struct YuvConstants * matrixYUV,
                                                const struct YuvConstants * matrixYVU);
+static avifResult avifImageYUVToRGBLibYUV12bpc(const avifImage * image,
+                                               avifRGBImage * rgb,
+                                               const struct YuvConstants * matrixYUV,
+                                               const struct YuvConstants * matrixYVU);
 
 avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
 {
@@ -391,6 +395,10 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
         return avifImageYUVToRGBLibYUV10bpc(image, rgb, matrixYUV, matrixYVU);
     }
 
+    if ((image->depth == 12) && (rgb->depth == 8)) {
+        return avifImageYUVToRGBLibYUV12bpc(image, rgb, matrixYUV, matrixYVU);
+    }
+
     // This function didn't do anything; use the built-in YUV conversion
     return AVIF_RESULT_NOT_IMPLEMENTED;
 }
@@ -411,6 +419,9 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
 #endif
 #if LIBYUV_VERSION < 1756
 #define I400ToARGBMatrix NULL
+#endif
+#if LIBYUV_VERSION < 1781
+#define I012ToARGBMatrix NULL
 #endif
 
 // Lookup table for isYVU. If the entry in this table is AVIF_TRUE, then it
@@ -641,6 +652,111 @@ avifResult avifImageYUVToRGBLibYUV10bpc(const avifImage * image,
         { NULL, I410ToARGBMatrix, I210ToARGBMatrix, I010ToARGBMatrix, NULL }, // BGRA
         { NULL, NULL, NULL, NULL, NULL },                                     // ABGR
         { NULL, NULL, NULL, NULL, NULL },                                     // RGB_565
+    };
+    YUVToRGBMatrix yuvToRgbMatrix = lutYuvToRgbMatrix[rgb->format][image->yuvFormat];
+    if (yuvToRgbMatrix != NULL) {
+        if (yuvToRgbMatrix((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                           image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                           (const uint16_t *)image->yuvPlanes[uPlaneIndex],
+                           image->yuvRowBytes[uPlaneIndex] / 2,
+                           (const uint16_t *)image->yuvPlanes[vPlaneIndex],
+                           image->yuvRowBytes[vPlaneIndex] / 2,
+                           rgb->pixels,
+                           rgb->rowBytes,
+                           matrix,
+                           image->width,
+                           image->height) != 0) {
+            return AVIF_RESULT_REFORMAT_FAILED;
+        }
+        return AVIF_RESULT_OK;
+    }
+
+    return AVIF_RESULT_NOT_IMPLEMENTED;
+}
+
+avifResult avifImageYUVToRGBLibYUV12bpc(const avifImage * image,
+                                        avifRGBImage * rgb,
+                                        const struct YuvConstants * matrixYUV,
+                                        const struct YuvConstants * matrixYVU)
+{
+    // See if the current settings can be accomplished with libyuv, and use it (if possible).
+
+    assert((image->depth == 12) && (rgb->depth == 8));
+
+    // libavif uses byte-order when describing pixel formats, such that the R in RGBA is the lowest address,
+    // similar to PNG. libyuv orders in word-order, so libavif's RGBA would be referred to in libyuv as ABGR.
+    // In addition, swapping U and V in any of these calls, along with using the Yvu matrix instead of Yuv matrix,
+    // swaps B and R in these orderings as well. This table summarizes the lookup tables that follow:
+    //
+    // libavif format        libyuv Func     UV matrix (and UV argument ordering)
+    // --------------------  -------------   ------------------------------------
+    // AVIF_RGB_FORMAT_RGB   n/a             n/a
+    // AVIF_RGB_FORMAT_RGBA  *ToARGBMatrix   matrixYVU
+    // AVIF_RGB_FORMAT_ARGB  n/a             n/a
+    // AVIF_RGB_FORMAT_BGR   n/a             n/a
+    // AVIF_RGB_FORMAT_BGRA  *ToARGBMatrix   matrixYUV
+    // AVIF_RGB_FORMAT_ABGR  n/a             n/a
+    // AVIF_RGB_FORMAT_565   n/a             n/a
+
+    avifBool isYVU = lutIsYVU[rgb->format];
+    const struct YuvConstants * matrix = isYVU ? matrixYVU : matrixYUV;
+    int uPlaneIndex = isYVU ? AVIF_CHAN_V : AVIF_CHAN_U;
+    int vPlaneIndex = isYVU ? AVIF_CHAN_U : AVIF_CHAN_V;
+
+    // Lookup table for YUV To RGB Matrix (with filter).
+    typedef int (*YUVToRGBMatrixFilter)(const uint16_t *,
+                                        int,
+                                        const uint16_t *,
+                                        int,
+                                        const uint16_t *,
+                                        int,
+                                        uint8_t *,
+                                        int,
+                                        const struct YuvConstants *,
+                                        int,
+                                        int,
+                                        enum FilterMode);
+    YUVToRGBMatrixFilter lutYuvToRgbMatrixFilter[AVIF_RGB_FORMAT_COUNT][AVIF_PIXEL_FORMAT_COUNT] = {
+        { NULL, NULL, NULL, NULL, NULL }, // RGB
+        { NULL, NULL, NULL, NULL, NULL }, // RGBA
+        { NULL, NULL, NULL, NULL, NULL }, // ARGB
+        { NULL, NULL, NULL, NULL, NULL }, // BGR
+        { NULL, NULL, NULL, NULL, NULL }, // BGRA
+        { NULL, NULL, NULL, NULL, NULL }, // ABGR
+        { NULL, NULL, NULL, NULL, NULL }, // RGB_565
+    };
+    YUVToRGBMatrixFilter yuvToRgbMatrixFilter = lutYuvToRgbMatrixFilter[rgb->format][image->yuvFormat];
+    if (yuvToRgbMatrixFilter != NULL) {
+        // 'None' (Nearest neighbor) filter is faster than bilinear.
+        enum FilterMode filter = (rgb->chromaUpsampling == AVIF_CHROMA_UPSAMPLING_FASTEST) ? kFilterNone : kFilterBilinear;
+        if (yuvToRgbMatrixFilter((const uint16_t *)image->yuvPlanes[AVIF_CHAN_Y],
+                                 image->yuvRowBytes[AVIF_CHAN_Y] / 2,
+                                 (const uint16_t *)image->yuvPlanes[uPlaneIndex],
+                                 image->yuvRowBytes[uPlaneIndex] / 2,
+                                 (const uint16_t *)image->yuvPlanes[vPlaneIndex],
+                                 image->yuvRowBytes[vPlaneIndex] / 2,
+                                 rgb->pixels,
+                                 rgb->rowBytes,
+                                 matrix,
+                                 image->width,
+                                 image->height,
+                                 filter) != 0) {
+            return AVIF_RESULT_REFORMAT_FAILED;
+        }
+        return AVIF_RESULT_OK;
+    }
+
+    // Lookup table for YUV To RGB Matrix (without filter).
+    typedef int (
+        *YUVToRGBMatrix)(const uint16_t *, int, const uint16_t *, int, const uint16_t *, int, uint8_t *, int, const struct YuvConstants *, int, int);
+    YUVToRGBMatrix lutYuvToRgbMatrix[AVIF_RGB_FORMAT_COUNT][AVIF_PIXEL_FORMAT_COUNT] = {
+        { NULL, NULL, NULL, NULL, NULL },             // RGB
+        { NULL, NULL, NULL, I012ToARGBMatrix, NULL }, // RGBA
+        { NULL, NULL, NULL, NULL, NULL },             // ARGB
+        { NULL, NULL, NULL, NULL, NULL },             // BGR
+        { NULL, NULL, NULL, I012ToARGBMatrix, NULL }, // BGRA
+        { NULL, NULL, NULL, NULL, NULL },             // ABGR
+        { NULL, NULL, NULL, NULL, NULL },             // RGB_565
     };
     YUVToRGBMatrix yuvToRgbMatrix = lutYuvToRgbMatrix[rgb->format][image->yuvFormat];
     if (yuvToRgbMatrix != NULL) {


### PR DESCRIPTION
It was created as a copy of avifImageYUVToRGBLibYUV10bpc(). It currently
uses I012ToARGBMatrix() only.

I012ToARGBMatrix() was added in
https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2727775. That
commit is between version 1780 and version 1781. See
https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2707003 and
https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2746780.