### PR TITLE
Refactor avifImageRGBToYUVLibYUV8bpc() and avif.h

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -529,8 +529,7 @@ AVIF_API void avifImageStealPlanes(avifImage * dstImage, avifImage * srcImage, a
 // routines will fail if the width and height don't match the associated avifImage.
 
 // If libavif is built with a version of libyuv offering a fast conversion between RGB and YUV for
-// the given settings (avifMatrixCoefficients, avifColorPrimaries, avifPixelFormat, avifRGBFormat,
-// avifRange, bit depth), libavif will use it. See reformat_libyuv.c for the details.
+// the given inputs, libavif will use it. See reformat_libyuv.c for the details.
 
 // Note to libavif maintainers: The lookup tables in avifImageYUVToRGBLibYUV
 // rely on the ordering of this enum values for their correctness. So changing

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -528,38 +528,9 @@ AVIF_API void avifImageStealPlanes(avifImage * dstImage, avifImage * srcImage, a
 // conversion, if necessary. Pixels in an avifRGBImage buffer are always full range, and conversion
 // routines will fail if the width and height don't match the associated avifImage.
 
-// If libavif is built with libyuv fast paths enabled, libavif will use libyuv for conversion from
-// RGB to YUV if the following requirements are met:
-//
-// * YUV depth: 8
-// * RGB depth: 8
-// * rgb.chromaDownsampling: AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC, AVIF_CHROMA_DOWNSAMPLING_FASTEST
-// * CICP is one of the following combinations (CP/TC/MC):
-//   *  x/x/[5|6]
-// * One of the following combinations (avifRGBFormat to avifPixelFormat/Range):
-//   * RGBA     to  [      |      |YUV420|      ]/[Limited|Full]
-//   * ARGB     to  [      |      |YUV420|      ]/[Limited|    ]
-//   * BGR      to  [      |      |YUV420|      ]/[Limited|Full]
-//   * BGRA     to  [YUV444|YUV422|YUV420|YUV400]/[Limited|    ] or
-//                  [      |YUV422|YUV420|YUV400]/[       |Full]
-//   * ABGR     to  [      |      |YUV420|      ]/[Limited|    ]
-
-// If libavif is built with libyuv fast paths enabled, libavif will use libyuv for conversion from
-// YUV to RGB if the following requirements are met:
-//
-// * RGB depth: 8
-// * rgb.chromaUpsampling: AVIF_CHROMA_UPSAMPLING_AUTOMATIC, AVIF_CHROMA_UPSAMPLING_FASTEST
-// * CICP is one of the following combinations (CP/TC/MC/Range):
-//   *      x     /x/[1|2|5|6|9]/[Limited|Full]
-//   * [1|2|5|6|9]/x/    12     /[Limited|Full]
-// * One of the following combinations (avifRGBFormat from avifPixelFormat/depth):
-//   * RGB      from  [      |      |YUV420|      ]/8-bit
-//   * RGBA     from  [YUV444|YUV422|YUV420|YUV400]/8-bit or [YUV444|YUV422|YUV420]/10-bit or [YUV420]/12-bit
-//   * ARGB     from  [      |YUV422|YUV420|      ]/8-bit
-//   * BGR      from  [      |      |YUV420|      ]/8-bit
-//   * BGRA     from  [YUV444|YUV422|YUV420|YUV400]/8-bit or [YUV444|YUV422|YUV420]/10-bit or [YUV420]/12-bit
-//   * ABGR     from  [      |YUV422|YUV420|      ]/8-bit
-//   * RGB_565  from  [      |YUV422|YUV420|      ]/8-bit
+// If libavif is built with a version of libyuv offering a fast conversion between RGB and YUV for
+// the given settings (avifMatrixCoefficients, avifColorPrimaries, avifPixelFormat, avifRGBFormat,
+// avifRange, bit depth), libavif will use it. See reformat_libyuv.c for the details.
 
 // Note to libavif maintainers: The lookup tables in avifImageYUVToRGBLibYUV
 // rely on the ordering of this enum values for their correctness. So changing

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -529,31 +529,37 @@ AVIF_API void avifImageStealPlanes(avifImage * dstImage, avifImage * srcImage, a
 // routines will fail if the width and height don't match the associated avifImage.
 
 // If libavif is built with libyuv fast paths enabled, libavif will use libyuv for conversion from
-// YUV to RGB if the following requirements are met:
-//
-// * YUV depth: 8 or 10
-// * RGB depth: 8
-// * rgb.chromaUpsampling: AVIF_CHROMA_UPSAMPLING_AUTOMATIC, AVIF_CHROMA_UPSAMPLING_FASTEST
-// * rgb.format: AVIF_RGB_FORMAT_RGBA, AVIF_RGB_FORMAT_BGRA (420/422 support for
-//               AVIF_RGB_FORMAT_ABGR, AVIF_RGB_FORMAT_ARGB, AVIF_RGB_FORMAT_RGB_565)
-// * CICP is one of the following combinations (CP/TC/MC/Range):
-//   * x/x/[2|5|6]/Full
-//   * [5|6]/x/12/Full
-//   * x/x/[1|2|5|6|9]/Limited
-//   * [1|2|5|6|9]/x/12/Limited
-
-// If libavif is built with libyuv fast paths enabled, libavif will use libyuv for conversion from
 // RGB to YUV if the following requirements are met:
 //
 // * YUV depth: 8
 // * RGB depth: 8
 // * rgb.chromaDownsampling: AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC, AVIF_CHROMA_DOWNSAMPLING_FASTEST
-// * One of the following combinations (avifRGBFormat to avifPixelFormat/MC/Range):
-//   *  BGRA            to  YUV400        /  x  /[Full|Limited]
-//   *  BGRA            to [YUV420|YUV422]/[5|6]/[Full|Limited]
-//   *  BGRA            to  YUV444        /[5|6]/ Limited
-//   *  BGR             to  YUV420        /[5|6]/[Full|Limited]
-//   * [RGBA|ARGB|ABGR] to  YUV420        /[5|6]/ Limited
+// * CICP is one of the following combinations (CP/TC/MC):
+//   *  x/x/[5|6]
+// * One of the following combinations (avifRGBFormat to avifPixelFormat/Range):
+//   * RGBA     to  [      |      |YUV420|      ]/[Limited|Full]
+//   * ARGB     to  [      |      |YUV420|      ]/[Limited|    ]
+//   * BGR      to  [      |      |YUV420|      ]/[Limited|Full]
+//   * BGRA     to  [YUV444|YUV422|YUV420|YUV400]/[Limited|    ] or
+//                  [      |YUV422|YUV420|YUV400]/[       |Full]
+//   * ABGR     to  [      |      |YUV420|      ]/[Limited|    ]
+
+// If libavif is built with libyuv fast paths enabled, libavif will use libyuv for conversion from
+// YUV to RGB if the following requirements are met:
+//
+// * RGB depth: 8
+// * rgb.chromaUpsampling: AVIF_CHROMA_UPSAMPLING_AUTOMATIC, AVIF_CHROMA_UPSAMPLING_FASTEST
+// * CICP is one of the following combinations (CP/TC/MC/Range):
+//   *      x     /x/[1|2|5|6|9]/[Limited|Full]
+//   * [1|2|5|6|9]/x/    12     /[Limited|Full]
+// * One of the following combinations (avifRGBFormat from avifPixelFormat/depth):
+//   * RGB      from  [      |      |YUV420|      ]/8-bit
+//   * RGBA     from  [YUV444|YUV422|YUV420|YUV400]/8-bit or [YUV444|YUV422|YUV420]/10-bit or [YUV420]/12-bit
+//   * ARGB     from  [      |YUV422|YUV420|      ]/8-bit
+//   * BGR      from  [      |      |YUV420|      ]/8-bit
+//   * BGRA     from  [YUV444|YUV422|YUV420|YUV400]/8-bit or [YUV444|YUV422|YUV420]/10-bit or [YUV420]/12-bit
+//   * ABGR     from  [      |YUV422|YUV420|      ]/8-bit
+//   * RGB_565  from  [      |YUV422|YUV420|      ]/8-bit
 
 // Note to libavif maintainers: The lookup tables in avifImageYUVToRGBLibYUV
 // rely on the ordering of this enum values for their correctness. So changing

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -32,6 +32,9 @@ static avifBool avifPrepareReformatState(const avifImage * image, const avifRGBI
         rgb->format < AVIF_RGB_FORMAT_RGB || rgb->format >= AVIF_RGB_FORMAT_COUNT) {
         return AVIF_FALSE;
     }
+    if (image->yuvRange != AVIF_RANGE_LIMITED && image->yuvRange != AVIF_RANGE_FULL) {
+        return AVIF_FALSE;
+    }
 
     // These matrix coefficients values are currently unsupported. Revise this list as more support is added.
     //

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -142,7 +142,7 @@ avifResult avifImageRGBToYUVLibYUV8bpc(avifImage * image, const avifRGBImage * r
             (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420)) {
             // Lookup table for RGB To YUV Matrix (average filter).
             typedef int (*RGBtoYUV)(const uint8_t *, int, uint8_t *, int, uint8_t *, int, uint8_t *, int, int, int);
-            // Third dimension is for avifRange: 0 is AVIF_RANGE_LIMITED, 1 is AVIF_RANGE_FULL.
+            // Third dimension is for avifRange.
             RGBtoYUV lutRgbToYuv[AVIF_RGB_FORMAT_COUNT][AVIF_PIXEL_FORMAT_COUNT][2] = {
                 { { NULL, NULL }, { NULL, NULL }, { NULL, NULL }, { NULL, NULL }, { NULL, NULL } },                 // RGB
                 { { NULL, NULL }, { NULL, NULL }, { NULL, NULL }, { ABGRToI420, avifABGRToJ420 }, { NULL, NULL } }, // RGBA
@@ -168,10 +168,10 @@ avifResult avifImageRGBToYUVLibYUV8bpc(avifImage * image, const avifRGBImage * r
                 }
                 return AVIF_RESULT_OK;
             }
-        } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
+        } else { // image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400
             // Lookup table for RGB To Y (monochrome).
             typedef int (*RGBtoY)(const uint8_t *, int, uint8_t *, int, int, int);
-            // Second dimension is for avifRange: 0 is AVIF_RANGE_LIMITED, 1 is AVIF_RANGE_FULL.
+            // Second dimension is for avifRange.
             RGBtoY lutRgbToY[AVIF_RGB_FORMAT_COUNT][2] = {
                 { NULL, NULL },             // RGB
                 { NULL, NULL },             // RGBA

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -498,7 +498,7 @@ avifResult avifImageYUVToRGBLibYUV8bpc(const avifImage * image,
             }
             return AVIF_RESULT_OK;
         }
-    } else if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) {
+    } else { // image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400
         // Lookup table for YUV400 to RGB Matrix.
         typedef int (*YUV400ToRGBMatrix)(const uint8_t *, int, uint8_t *, int, const struct YuvConstants *, int, int);
         YUV400ToRGBMatrix lutYuv400ToRgbMatrix[AVIF_RGB_FORMAT_COUNT] = {

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -221,61 +221,7 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
     // Find the correct libyuv YuvConstants, based on range and CP/MC
     const struct YuvConstants * matrixYUV = NULL;
     const struct YuvConstants * matrixYVU = NULL;
-    if (image->yuvRange == AVIF_RANGE_LIMITED) {
-        switch (image->matrixCoefficients) {
-            case AVIF_MATRIX_COEFFICIENTS_BT709:
-                matrixYUV = &kYuvH709Constants;
-                matrixYVU = &kYvuH709Constants;
-                break;
-            case AVIF_MATRIX_COEFFICIENTS_BT470BG:
-            case AVIF_MATRIX_COEFFICIENTS_BT601:
-            case AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED:
-                matrixYUV = &kYuvI601Constants;
-                matrixYVU = &kYvuI601Constants;
-                break;
-            case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
-                matrixYUV = &kYuv2020Constants;
-                matrixYVU = &kYvu2020Constants;
-                break;
-            case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
-                switch (image->colorPrimaries) {
-                    case AVIF_COLOR_PRIMARIES_BT709:
-                    case AVIF_COLOR_PRIMARIES_UNSPECIFIED:
-                        matrixYUV = &kYuvH709Constants;
-                        matrixYVU = &kYvuH709Constants;
-                        break;
-                    case AVIF_COLOR_PRIMARIES_BT470BG:
-                    case AVIF_COLOR_PRIMARIES_BT601:
-                        matrixYUV = &kYuvI601Constants;
-                        matrixYVU = &kYvuI601Constants;
-                        break;
-                    case AVIF_COLOR_PRIMARIES_BT2020:
-                        matrixYUV = &kYuv2020Constants;
-                        matrixYVU = &kYvu2020Constants;
-                        break;
-
-                    case AVIF_COLOR_PRIMARIES_UNKNOWN:
-                    case AVIF_COLOR_PRIMARIES_BT470M:
-                    case AVIF_COLOR_PRIMARIES_SMPTE240:
-                    case AVIF_COLOR_PRIMARIES_GENERIC_FILM:
-                    case AVIF_COLOR_PRIMARIES_XYZ:
-                    case AVIF_COLOR_PRIMARIES_SMPTE431:
-                    case AVIF_COLOR_PRIMARIES_SMPTE432:
-                    case AVIF_COLOR_PRIMARIES_EBU3213:
-                        break;
-                }
-                break;
-            case AVIF_MATRIX_COEFFICIENTS_IDENTITY:
-            case AVIF_MATRIX_COEFFICIENTS_FCC:
-            case AVIF_MATRIX_COEFFICIENTS_SMPTE240:
-            case AVIF_MATRIX_COEFFICIENTS_YCGCO:
-            case AVIF_MATRIX_COEFFICIENTS_BT2020_CL:
-            case AVIF_MATRIX_COEFFICIENTS_SMPTE2085:
-            case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL:
-            case AVIF_MATRIX_COEFFICIENTS_ICTCP:
-                break;
-        }
-    } else { // image->yuvRange == AVIF_RANGE_FULL
+    if (image->yuvRange == AVIF_RANGE_FULL) {
         switch (image->matrixCoefficients) {
             // BT.709 full range YuvConstants were added in libyuv version 1772.
             // See https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2646472.
@@ -332,6 +278,60 @@ avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb)
                 }
                 break;
 
+            case AVIF_MATRIX_COEFFICIENTS_IDENTITY:
+            case AVIF_MATRIX_COEFFICIENTS_FCC:
+            case AVIF_MATRIX_COEFFICIENTS_SMPTE240:
+            case AVIF_MATRIX_COEFFICIENTS_YCGCO:
+            case AVIF_MATRIX_COEFFICIENTS_BT2020_CL:
+            case AVIF_MATRIX_COEFFICIENTS_SMPTE2085:
+            case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL:
+            case AVIF_MATRIX_COEFFICIENTS_ICTCP:
+                break;
+        }
+    } else { // image->yuvRange == AVIF_RANGE_LIMITED
+        switch (image->matrixCoefficients) {
+            case AVIF_MATRIX_COEFFICIENTS_BT709:
+                matrixYUV = &kYuvH709Constants;
+                matrixYVU = &kYvuH709Constants;
+                break;
+            case AVIF_MATRIX_COEFFICIENTS_BT470BG:
+            case AVIF_MATRIX_COEFFICIENTS_BT601:
+            case AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED:
+                matrixYUV = &kYuvI601Constants;
+                matrixYVU = &kYvuI601Constants;
+                break;
+            case AVIF_MATRIX_COEFFICIENTS_BT2020_NCL:
+                matrixYUV = &kYuv2020Constants;
+                matrixYVU = &kYvu2020Constants;
+                break;
+            case AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
+                switch (image->colorPrimaries) {
+                    case AVIF_COLOR_PRIMARIES_BT709:
+                    case AVIF_COLOR_PRIMARIES_UNSPECIFIED:
+                        matrixYUV = &kYuvH709Constants;
+                        matrixYVU = &kYvuH709Constants;
+                        break;
+                    case AVIF_COLOR_PRIMARIES_BT470BG:
+                    case AVIF_COLOR_PRIMARIES_BT601:
+                        matrixYUV = &kYuvI601Constants;
+                        matrixYVU = &kYvuI601Constants;
+                        break;
+                    case AVIF_COLOR_PRIMARIES_BT2020:
+                        matrixYUV = &kYuv2020Constants;
+                        matrixYVU = &kYvu2020Constants;
+                        break;
+
+                    case AVIF_COLOR_PRIMARIES_UNKNOWN:
+                    case AVIF_COLOR_PRIMARIES_BT470M:
+                    case AVIF_COLOR_PRIMARIES_SMPTE240:
+                    case AVIF_COLOR_PRIMARIES_GENERIC_FILM:
+                    case AVIF_COLOR_PRIMARIES_XYZ:
+                    case AVIF_COLOR_PRIMARIES_SMPTE431:
+                    case AVIF_COLOR_PRIMARIES_SMPTE432:
+                    case AVIF_COLOR_PRIMARIES_EBU3213:
+                        break;
+                }
+                break;
             case AVIF_MATRIX_COEFFICIENTS_IDENTITY:
             case AVIF_MATRIX_COEFFICIENTS_FCC:
             case AVIF_MATRIX_COEFFICIENTS_SMPTE240:


### PR DESCRIPTION
Describe RGB-to-YUV before YUV-to-RGB in avif.h
Order description and code by avifRGBFormat, avifPixelFormat, and
avifRange for both RGB-to-YUV and YUV-to-RGB.

Fix libyuv RGB-to-YUV 4:0:0 being used for any avifMatrixCoefficients
and not only for BT.601.

Note: Previous description in avif.h was inaccurate for 10-bit YUV-to-RGB and missing for 12-bit
(10-bit has fewer paths than 8-bit and 12-bit got added in https://github.com/AOMediaCodec/libavif/pull/1059).