### PR TITLE
Run AVIF tests on Windows in GitHub CI

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -2,13 +2,13 @@
 #
 #   * The os matrix consists of windows-latest only.
 #   * Installs Visual Studio in the os image.
-#   * Doesn't install cmake 3.13.x, because only recent versions of cmake with
-#     the following bug fix detect Visual Studio compilers correctly:
+#   * Doesn't install cmake 3.17.x, because only cmake 3.18 or later, with the
+#     following bug fix, detects Visual Studio compilers correctly:
 #     https://gitlab.kitware.com/cmake/cmake/-/issues/20585
 #   * Runs ext/*.cmd as Windows batch files rather than using bash. This is
 #     important for ext/svt.cmd, to prevent it from running ext/svt.sh.
+#   * Builds with local libjpeg (-DAVIF_LOCAL_JPEG=ON).
 #   * Builds with local zlib and libpng (-DAVIF_LOCAL_ZLIBPNG=ON).
-#   * Doesn't run ctest, because the test 'test_cmd' is a shell script.
 
 name: CI
 on: [push, pull_request]
@@ -102,3 +102,6 @@ jobs:
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja
+    - name: Run AVIF Tests
+      working-directory: ./build
+      run: ctest -j 2

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,6 +119,6 @@ if(AVIF_BUILD_APPS)
     target_link_libraries(are_images_equal aviftest_helpers avif_apps)
     add_test(
         NAME test_cmd
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd.sh ${CMAKE_BINARY_DIR}
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd.sh ${CMAKE_BINARY_DIR}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()


### PR DESCRIPTION
Invoke test_cmd.sh using bash. This works on Windows if bash is installed.

Pass 2 to the -j option of the ctest command. The nproc command is not
available on Windows, but there is a NUMBER_OF_PROCESSORS environment
variable. We can consider replacing 2 with %NUMBER_OF_PROCESSORS%.