### PR TITLE
Use libpng,libjpeg in /usr/local/ in macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,6 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash libyuv.cmd
-    - name: Build libjpeg
-      if: steps.cache-ext.outputs.cache-hit != 'true'
-      working-directory: ./ext
-      run: bash libjpeg.cmd
     - name: Build libsharpyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
@@ -84,14 +80,13 @@ jobs:
         -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=ON
         -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON
         -DAVIF_CODEC_LIBGAV1=ON -DAVIF_LOCAL_LIBGAV1=ON
-        -DAVIF_LOCAL_LIBYUV=ON -DAVIF_LOCAL_JPEG=ON
+        -DAVIF_LOCAL_LIBYUV=ON
         -DAVIF_LOCAL_LIBSHARPYUV=ON
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja
-    - name: Run AVIF Tests (on Linux)
-      if: runner.os == 'Linux'
+    - name: Run AVIF Tests
       working-directory: ./build
-      run: ctest -j $(nproc)
+      run: ctest -j 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,11 @@ set(AVIF_SRCS
     src/write.c
 )
 
+# Only applicable to macOS. In GitHub CI's macos-latest os image, this prevents using the libpng
+# and libjpeg headers from /Library/Frameworks/Mono.framework/Headers instead of
+# /usr/local/include.
+set(CMAKE_FIND_FRAMEWORK LAST)
+
 set(AVIF_PLATFORM_DEFINITIONS)
 set(AVIF_PLATFORM_INCLUDES)
 set(AVIF_PLATFORM_LIBRARIES)
@@ -480,7 +485,14 @@ if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND AVIF_ENABLE_GTEST))
                          apps/shared/y4m.c
     )
     target_link_libraries(avif_apps avif ${AVIF_PLATFORM_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
-    target_include_directories(avif_apps PRIVATE ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR} INTERFACE apps/shared)
+    # In GitHub CI's macos-latest os image, /usr/local/include has not only the headers of libpng
+    # libjpeg but also the headers of an older version of libavif. Put the avif include directory
+    # before ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR} to prevent picking up old libavif headers
+    # from /usr/local/include.
+    target_include_directories(
+        avif_apps PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR}
+        INTERFACE apps/shared
+    )
 endif()
 
 if(AVIF_BUILD_APPS)


### PR DESCRIPTION
Without these changes, the avifdec command in tests/test_cmd.sh fails
with the following error in GitHub CI's macos-latest os image:

  libpng warning: Application built with libpng-1.4.12 but running with 1.6.37
  Cannot init libpng (png): /tmp/kodim03.png

The reason is that we compile apps/shared/avifpng.c with the old libpng
1.4.12 headers in /Library/Frameworks/Mono.framework/Headers, and then
run with /usr/local/lib/libpng.dylib, which is the latest libpng 1.6.37.

These changes allow us to run the AVIF tests on macOS in
.github/workflows/ci.yml. Pass 2 instead of $(nproc) to the -j option of
the ctest command because the nproc command is not available on macOS.