### PR TITLE
test_cmd.sh: Don't redirect stderr to /dev/null

### DIFF
--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -41,8 +41,8 @@ PNG_FILE=/tmp/kodim03.png
 # Prepare some extra data.
 set +x
 echo "Generating a color PNG"
-"${AVIFENC}" -s 10 "${TESTDATA_DIR}"/kodim03_yuv420_8bpc.y4m -o "${TMP_ENCODED_FILE}" &> /dev/null
-"${AVIFDEC}" "${TMP_ENCODED_FILE}" "${PNG_FILE}"  &> /dev/null
+"${AVIFENC}" -s 10 "${TESTDATA_DIR}"/kodim03_yuv420_8bpc.y4m -o "${TMP_ENCODED_FILE}" > /dev/null
+"${AVIFDEC}" "${TMP_ENCODED_FILE}" "${PNG_FILE}" > /dev/null
 set -x
 
 # Basic calls.


### PR DESCRIPTION
In the "Generating a color PNG" step, don't redirect stderr to
/dev/null. This allows us to see the error messages if the avifenc or
avifdec command fails.