### PR TITLE
Use clang-cl to build libyuv on Windows on CI

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -66,6 +66,9 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./libyuv.cmd
+      env:
+        CC: clang-cl
+        CXX: clang-cl
     - name: Build libjpeg
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -66,9 +66,6 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./libyuv.cmd
-      env:
-        CC: clang-cl
-        CXX: clang-cl
     - name: Build libjpeg
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,9 @@ install:
  - dav1d.cmd
  - libjpeg.cmd
  - zlibpng.cmd
+ - set CC=clang-cl && set CXX=clang-cl
  - libyuv.cmd
+ - set "CC=" && set "CXX="
  - cd ..
  # Configure with CMake
  - mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
  - dav1d.cmd
  - libjpeg.cmd
  - zlibpng.cmd
- - set CC=clang-cl && set CXX=clang-cl
+ - set "CC=clang-cl" && set "CXX=clang-cl"
  - libyuv.cmd
  - set "CC=" && set "CXX="
  - cd ..

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -6,6 +6,8 @@
 
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
+: # Clang-cl is recommended to build libyuv on Windows. Run this if you have clang-cl installed:
+: #     set CC=clang-cl && set CXX=clang-cl
 
 git clone --single-branch https://chromium.googlesource.com/libyuv/libyuv
 

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -6,9 +6,10 @@
 
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
-: # It is recommended to build libyuv with clang-cl on Windows, because most libyuv's assembly code is written in GCC
-: # inline assembly syntax which MSVC doesn't support. Run this if you have clang-cl installed:
-: #     set CC=clang-cl && set CXX=clang-cl
+: # We recommend building libyuv with clang-cl on Windows, because most of libyuv's assembly code is
+: # written in GCC inline assembly syntax, which MSVC doesn't support. Run this if you have clang-cl
+: # installed:
+: #     set "CC=clang-cl" && set "CXX=clang-cl"
 
 git clone --single-branch https://chromium.googlesource.com/libyuv/libyuv
 

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -6,7 +6,8 @@
 
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
-: # Clang-cl is recommended to build libyuv on Windows. Run this if you have clang-cl installed:
+: # It is recommended to build libyuv with clang-cl on Windows, because most libyuv's assembly code is written in GCC
+: # inline assembly syntax which MSVC doesn't support. Run this if you have clang-cl installed:
 : #     set CC=clang-cl && set CXX=clang-cl
 
 git clone --single-branch https://chromium.googlesource.com/libyuv/libyuv


### PR DESCRIPTION
libyuv has far more optimized routines written for GCC/Clang than MSVC. Use clang-cl to build libyuv so that these can be used on Windows.