### PR TITLE
Pass $(getconf _NPROCESSORS_ONLN) to ctest -j

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -104,4 +104,4 @@ jobs:
       run: ninja
     - name: Run AVIF Tests
       working-directory: ./build
-      run: ctest -j 2
+      run: ctest -j $Env:NUMBER_OF_PROCESSORS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,4 +89,4 @@ jobs:
       run: ninja
     - name: Run AVIF Tests
       working-directory: ./build
-      run: ctest -j 2
+      run: ctest -j $(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
Use getconf _NPROCESSORS_ONLN as the portable replacement of nproc on
Linux and macOS.

On Windows use %NUMBER_OF_PROCESSORS%.