### PR TITLE
android_jni: Set cmake version to 3.18.1

### DIFF
--- a/android_jni/avifandroidjni/build.gradle
+++ b/android_jni/avifandroidjni/build.gradle
@@ -24,6 +24,9 @@ android {
     }
     externalNativeBuild {
         cmake {
+            // Lowest version of cmake that is available on the Android SDK that
+            // is greater than or equal to 3.13 is 3.18.1.
+            version '3.18.1'
             path 'src/main/jni/CMakeLists.txt'
         }
     }


### PR DESCRIPTION
While the CMakeLists.txt lists the minimum cmake version required
as 3.13, the Android SDK contains snapshots of cmake only at
certain versions.

As of now, it contains 3.10.1 and 3.18.1. So if we don't specify
the cmake version in build.gradle, it uses 3.10.1 by default and
it fails to build because it does not match the minimum required
version of 3.13.

So by setting it to 3.18.1, we can ensure that the build runs
successfully using the cmake snapshot that is bundled with the
Android SDK.