### PR TITLE
avifEncoder: Add the autoTiling option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,15 @@ avifImageCopy() and avifImageAllocatePlanes().
 * Add avifChromaDownsampling enum
 * Add chromaDownsampling field to avifRGBImage struct
 * Add imageDimensionLimit field to avifDecoder struct
+* Add autoTiling field to avifEncoder struct
 * avifdec: Add --dimension-limit, which specifies the image dimension limit
   (width or height) that should be tolerated
 * avifenc: Add --sharpyuv, which enables "sharp" RGB to YUV420 conversion, which
   reduces artifacts caused by 420 chroma downsampling. Needs libsharpyuv (part
   of the libwebp repository) at compile time.
 * avifenc: Add --ignore-exif and --ignore-xmp flags.
+* avifenc: Add --autotiling, which sets --tilerowslog2 and --tilecolslog2
+  automatically
 
 ## [0.10.1] - 2022-04-11
 

--- a/doc/avifenc.1.md
+++ b/doc/avifenc.1.md
@@ -122,6 +122,9 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
     Possible values are in the range **0**-**6**.
     Default is 0.
 
+**\--autotiling**
+:   Set **\--tilerowslog2** and **\--tilecolslog2** automatically.
+
 **-g**, **\--grid** *M***x***N*
 :   Encode a single-image grid AVIF with _M_ cols and _N_ rows.
     Either supply MxN images of the same width, height and depth, or a single

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1020,6 +1020,8 @@ struct avifCodecSpecificOptions;
 // * Quality range: [AVIF_QUANTIZER_BEST_QUALITY - AVIF_QUANTIZER_WORST_QUALITY]
 // * To enable tiling, set tileRowsLog2 > 0 and/or tileColsLog2 > 0.
 //   Tiling values range [0-6], where the value indicates a request for 2^n tiles in that dimension.
+//   If autoTiling is set to AVIF_TRUE, libavif ignores tileRowsLog2 and tileColsLog2 and
+//   automatically chooses suitable tiling values.
 // * Speed range: [AVIF_SPEED_SLOWEST - AVIF_SPEED_FASTEST]. Slower should make for a better quality
 //   image in less bytes. AVIF_SPEED_DEFAULT means "Leave the AV1 codec to its default speed settings"./
 //   If avifEncoder uses rav1e, the speed value is directly passed through (0-10). If libaom is used,
@@ -1043,6 +1045,7 @@ typedef struct avifEncoder
     int maxQuantizerAlpha;
     int tileRowsLog2;
     int tileColsLog2;
+    avifBool autoTiling;
 
     // stats from the most recent write
     avifIOStats ioStats;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -295,6 +295,12 @@ typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec,
 // encoder->tileRowsLog2, encoder->tileColsLog2, and encoder->autoTiling. The caller of
 // avifCodecEncodeImageFunc is responsible for automatic tiling if encoder->autoTiling is set to
 // AVIF_TRUE. The actual tiling values are passed to avifCodecEncodeImageFunc as parameters.
+//
+// Note: The caller of avifCodecEncodeImageFunc always passes encoder->data->tileRowsLog2 and
+// encoder->data->tileColsLog2 as the tileRowsLog2 and tileColsLog2 arguments. Because
+// encoder->data is of a struct type defined in src/write.c, avifCodecEncodeImageFunc cannot
+// dereference encoder->data and has to receive encoder->data->tileRowsLog2 and
+// encoder->data->tileColsLog2 via function parameters.
 typedef avifResult (*avifCodecEncodeImageFunc)(struct avifCodec * codec,
                                                avifEncoder * encoder,
                                                const avifImage * image,

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -527,6 +527,8 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
                                       avifEncoder * encoder,
                                       const avifImage * image,
                                       avifBool alpha,
+                                      int tileRowsLog2,
+                                      int tileColsLog2,
                                       avifEncoderChanges encoderChanges,
                                       avifAddImageFlags addImageFlags,
                                       avifCodecEncodeOutput * output)
@@ -737,12 +739,12 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
         if (encoder->maxThreads > 1) {
             aom_codec_control(&codec->internal->encoder, AV1E_SET_ROW_MT, 1);
         }
-        if (encoder->tileRowsLog2 != 0) {
-            int tileRowsLog2 = AVIF_CLAMP(encoder->tileRowsLog2, 0, 6);
+        if (tileRowsLog2 != 0) {
+            tileRowsLog2 = AVIF_CLAMP(tileRowsLog2, 0, 6);
             aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, tileRowsLog2);
         }
-        if (encoder->tileColsLog2 != 0) {
-            int tileColsLog2 = AVIF_CLAMP(encoder->tileColsLog2, 0, 6);
+        if (tileColsLog2 != 0) {
+            tileColsLog2 = AVIF_CLAMP(tileColsLog2, 0, 6);
             aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, tileColsLog2);
         }
         if (aomCpuUsed != -1) {
@@ -793,10 +795,10 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             }
         }
         if (encoderChanges & AVIF_ENCODER_CHANGE_TILE_ROWS_LOG2) {
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, AVIF_CLAMP(encoder->tileRowsLog2, 0, 6));
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, AVIF_CLAMP(tileRowsLog2, 0, 6));
         }
         if (encoderChanges & AVIF_ENCODER_CHANGE_TILE_COLS_LOG2) {
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, AVIF_CLAMP(encoder->tileColsLog2, 0, 6));
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, AVIF_CLAMP(tileColsLog2, 0, 6));
         }
         if (encoderChanges & AVIF_ENCODER_CHANGE_CODEC_SPECIFIC) {
             if (!avifProcessAOMOptionsPostInit(codec, alpha)) {

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -740,11 +740,9 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             aom_codec_control(&codec->internal->encoder, AV1E_SET_ROW_MT, 1);
         }
         if (tileRowsLog2 != 0) {
-            tileRowsLog2 = AVIF_CLAMP(tileRowsLog2, 0, 6);
             aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, tileRowsLog2);
         }
         if (tileColsLog2 != 0) {
-            tileColsLog2 = AVIF_CLAMP(tileColsLog2, 0, 6);
             aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, tileColsLog2);
         }
         if (aomCpuUsed != -1) {
@@ -795,10 +793,10 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             }
         }
         if (encoderChanges & AVIF_ENCODER_CHANGE_TILE_ROWS_LOG2) {
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, AVIF_CLAMP(tileRowsLog2, 0, 6));
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, tileRowsLog2);
         }
         if (encoderChanges & AVIF_ENCODER_CHANGE_TILE_COLS_LOG2) {
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, AVIF_CLAMP(tileColsLog2, 0, 6));
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_COLUMNS, tileColsLog2);
         }
         if (encoderChanges & AVIF_ENCODER_CHANGE_CODEC_SPECIFIC) {
             if (!avifProcessAOMOptionsPostInit(codec, alpha)) {

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -153,13 +153,11 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
             goto cleanup;
         }
         if (tileRowsLog2 != 0) {
-            tileRowsLog2 = AVIF_CLAMP(tileRowsLog2, 0, 6);
             if (rav1e_config_parse_int(rav1eConfig, "tile_rows", 1 << tileRowsLog2) == -1) {
                 goto cleanup;
             }
         }
         if (tileColsLog2 != 0) {
-            tileColsLog2 = AVIF_CLAMP(tileColsLog2, 0, 6);
             if (rav1e_config_parse_int(rav1eConfig, "tile_cols", 1 << tileColsLog2) == -1) {
                 goto cleanup;
             }

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -53,6 +53,8 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
                                         avifEncoder * encoder,
                                         const avifImage * image,
                                         avifBool alpha,
+                                        int tileRowsLog2,
+                                        int tileColsLog2,
                                         avifEncoderChanges encoderChanges,
                                         uint32_t addImageFlags,
                                         avifCodecEncodeOutput * output)
@@ -150,14 +152,14 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
         if (rav1e_config_parse_int(rav1eConfig, "quantizer", maxQuantizer) == -1) {
             goto cleanup;
         }
-        if (encoder->tileRowsLog2 != 0) {
-            int tileRowsLog2 = AVIF_CLAMP(encoder->tileRowsLog2, 0, 6);
+        if (tileRowsLog2 != 0) {
+            tileRowsLog2 = AVIF_CLAMP(tileRowsLog2, 0, 6);
             if (rav1e_config_parse_int(rav1eConfig, "tile_rows", 1 << tileRowsLog2) == -1) {
                 goto cleanup;
             }
         }
-        if (encoder->tileColsLog2 != 0) {
-            int tileColsLog2 = AVIF_CLAMP(encoder->tileColsLog2, 0, 6);
+        if (tileColsLog2 != 0) {
+            tileColsLog2 = AVIF_CLAMP(tileColsLog2, 0, 6);
             if (rav1e_config_parse_int(rav1eConfig, "tile_cols", 1 << tileColsLog2) == -1) {
                 goto cleanup;
             }

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -46,6 +46,8 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
                                       avifEncoder * encoder,
                                       const avifImage * image,
                                       avifBool alpha,
+                                      int tileRowsLog2,
+                                      int tileColsLog2,
                                       avifEncoderChanges encoderChanges,
                                       uint32_t addImageFlags,
                                       avifCodecEncodeOutput * output)
@@ -134,11 +136,11 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
             svt_config->qp = AVIF_CLAMP(encoder->maxQuantizer, 0, 63);
         }
 
-        if (encoder->tileRowsLog2 != 0) {
-            svt_config->tile_rows = AVIF_CLAMP(encoder->tileRowsLog2, 0, 6);
+        if (tileRowsLog2 != 0) {
+            svt_config->tile_rows = AVIF_CLAMP(tileRowsLog2, 0, 6);
         }
-        if (encoder->tileColsLog2 != 0) {
-            svt_config->tile_columns = AVIF_CLAMP(encoder->tileColsLog2, 0, 6);
+        if (tileColsLog2 != 0) {
+            svt_config->tile_columns = AVIF_CLAMP(tileColsLog2, 0, 6);
         }
         if (encoder->speed != AVIF_SPEED_DEFAULT) {
             int speed = AVIF_CLAMP(encoder->speed, 0, 8);

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -137,10 +137,10 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
         }
 
         if (tileRowsLog2 != 0) {
-            svt_config->tile_rows = AVIF_CLAMP(tileRowsLog2, 0, 6);
+            svt_config->tile_rows = tileRowsLog2;
         }
         if (tileColsLog2 != 0) {
-            svt_config->tile_columns = AVIF_CLAMP(tileColsLog2, 0, 6);
+            svt_config->tile_columns = tileColsLog2;
         }
         if (encoder->speed != AVIF_SPEED_DEFAULT) {
             int speed = AVIF_CLAMP(encoder->speed, 0, 8);

--- a/src/write.c
+++ b/src/write.c
@@ -40,6 +40,84 @@ static avifBool avifImageIsOpaque(const avifImage * image);
 static void writeConfigBox(avifRWStream * s, avifCodecConfigurationBox * cfg);
 
 // ---------------------------------------------------------------------------
+// avifSetTileConfiguration
+
+static int countLeadingZeros(uint32_t n)
+{
+    int count = 32;
+    while (n != 0) {
+        --count;
+        n >>= 1;
+    }
+    return count;
+}
+
+static int floorLog2(uint32_t n)
+{
+    assert(n > 0);
+    return 31 ^ countLeadingZeros(n);
+}
+
+// Splits tilesLog2 into *tileDim1Log2 and *tileDim2Log2, considering the ratio of dim1 to dim2.
+//
+// Precondition:
+//     dim1 >= dim2
+// Postcondition:
+//     tilesLog2 == *tileDim1Log2 + *tileDim2Log2
+//     *tileDim1Log2 >= *tileDim2Log2
+static void splitTilesLog2(uint32_t dim1, uint32_t dim2, int tilesLog2, int * tileDim1Log2, int * tileDim2Log2)
+{
+    assert(dim1 >= dim2);
+    uint32_t ratio = dim1 / dim2;
+    int diffLog2 = floorLog2(ratio);
+    int subtract = tilesLog2 - diffLog2;
+    if (subtract < 0) {
+        subtract = 0;
+    }
+    *tileDim2Log2 = subtract / 2;
+    *tileDim1Log2 = tilesLog2 - *tileDim2Log2;
+    assert(*tileDim1Log2 >= *tileDim2Log2);
+}
+
+// Set the tile configuration: the number of tiles and the tile size.
+//
+// Tiles improve encoding and decoding speeds when multiple threads are available. However, for
+// image coding, the total tile boundary length affects the compression efficiency because intra
+// prediction can't go across tile boundaries. So the more tiles there are in an image, the worse
+// the compression ratio is. For a given number of tiles, making the tile size close to a square
+// tends to reduce the total tile boundary length inside the image. Use more tiles along the longer
+// dimension of the image to make the tile size closer to a square.
+void avifSetTileConfiguration(int threads, uint32_t width, uint32_t height, int * tileRowsLog2, int * tileColsLog2)
+{
+    *tileRowsLog2 = 0;
+    *tileColsLog2 = 0;
+    if (threads > 1) {
+        // Avoid small tiles because they are particularly bad for image coding.
+        //
+        // Use no more tiles than the number of threads. Aim for one tile per thread. Using more
+        // than one thread inside one tile could be less efficient. Using more tiles than the
+        // number of threads would result in a compression penalty without much benefit.
+        const uint32_t kMinTileArea = 512 * 512;
+        const uint32_t kMaxTiles = 32;
+        uint32_t imageArea = width * height;
+        uint32_t tiles = (imageArea + kMinTileArea - 1) / kMinTileArea;
+        if (tiles > kMaxTiles) {
+            tiles = kMaxTiles;
+        }
+        if (tiles > (uint32_t)threads) {
+            tiles = threads;
+        }
+        int tilesLog2 = floorLog2(tiles);
+        // If the image's width is greater than the height, use more tile columns than tile rows.
+        if (width >= height) {
+            splitTilesLog2(width, height, tilesLog2, tileColsLog2, tileRowsLog2);
+        } else {
+            splitTilesLog2(height, width, tilesLog2, tileRowsLog2, tileColsLog2);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // avifCodecEncodeOutput
 
 avifCodecEncodeOutput * avifCodecEncodeOutputCreate(void)
@@ -122,7 +200,13 @@ typedef struct avifEncoderData
 {
     avifEncoderItemArray items;
     avifEncoderFrameArray frames;
+    // tileRowsLog2 and tileColsLog2 are the actual tiling values after automatic tiling is handled
+    int tileRowsLog2;
+    int tileColsLog2;
     avifEncoder lastEncoder;
+    // lastTileRowsLog2 and lastTileColsLog2 are the actual tiling values used last time
+    int lastTileRowsLog2;
+    int lastTileColsLog2;
     avifImage * imageMetadata;
     uint16_t lastItemID;
     uint16_t primaryItemID;
@@ -303,6 +387,7 @@ avifEncoder * avifEncoderCreate(void)
     encoder->maxQuantizerAlpha = AVIF_QUANTIZER_LOSSLESS;
     encoder->tileRowsLog2 = 0;
     encoder->tileColsLog2 = 0;
+    encoder->autoTiling = AVIF_FALSE;
     encoder->data = avifEncoderDataCreate();
     encoder->csOptions = avifCodecSpecificOptionsCreate();
     return encoder;
@@ -336,8 +421,8 @@ static void avifEncoderBackupSettings(avifEncoder * encoder)
     lastEncoder->maxQuantizer = encoder->maxQuantizer;
     lastEncoder->minQuantizerAlpha = encoder->minQuantizerAlpha;
     lastEncoder->maxQuantizerAlpha = encoder->maxQuantizerAlpha;
-    lastEncoder->tileRowsLog2 = encoder->tileRowsLog2;
-    lastEncoder->tileColsLog2 = encoder->tileColsLog2;
+    encoder->data->lastTileRowsLog2 = encoder->data->tileRowsLog2;
+    encoder->data->lastTileColsLog2 = encoder->data->tileColsLog2;
 }
 
 // This function detects changes made on avifEncoder. It returns true on success (i.e., if every
@@ -371,10 +456,10 @@ static avifBool avifEncoderDetectChanges(const avifEncoder * encoder, avifEncode
     if (lastEncoder->maxQuantizerAlpha != encoder->maxQuantizerAlpha) {
         *encoderChanges |= AVIF_ENCODER_CHANGE_MAX_QUANTIZER_ALPHA;
     }
-    if (lastEncoder->tileRowsLog2 != encoder->tileRowsLog2) {
+    if (encoder->data->lastTileRowsLog2 != encoder->data->tileRowsLog2) {
         *encoderChanges |= AVIF_ENCODER_CHANGE_TILE_ROWS_LOG2;
     }
-    if (lastEncoder->tileColsLog2 != encoder->tileColsLog2) {
+    if (encoder->data->lastTileColsLog2 != encoder->data->tileColsLog2) {
         *encoderChanges |= AVIF_ENCODER_CHANGE_TILE_COLS_LOG2;
     }
     if (encoder->csOptions->count > 0) {
@@ -671,12 +756,6 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         return AVIF_RESULT_NO_CODEC_AVAILABLE;
     }
 
-    avifEncoderChanges encoderChanges;
-    if (!avifEncoderDetectChanges(encoder, &encoderChanges)) {
-        return AVIF_RESULT_CANNOT_CHANGE_SETTING;
-    }
-    avifEncoderBackupSettings(encoder);
-
     // -----------------------------------------------------------------------
     // Validate images
 
@@ -745,6 +824,27 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             return AVIF_RESULT_INVALID_ARGUMENT;
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Handle automatic tiling
+
+    encoder->data->tileRowsLog2 = encoder->tileRowsLog2;
+    encoder->data->tileColsLog2 = encoder->tileColsLog2;
+    if (encoder->autoTiling) {
+        // Use as many tiles as allowed by the minimum tile area requirement and impose a maximum
+        // of 8 tiles.
+        const int threads = 8;
+        avifSetTileConfiguration(threads, firstCell->width, firstCell->height, &encoder->data->tileRowsLog2, &encoder->data->tileColsLog2);
+    }
+
+    // -----------------------------------------------------------------------
+    // All encoder settings are known now. Detect changes.
+
+    avifEncoderChanges encoderChanges;
+    if (!avifEncoderDetectChanges(encoder, &encoderChanges)) {
+        return AVIF_RESULT_CANNOT_CHANGE_SETTING;
+    }
+    avifEncoderBackupSettings(encoder);
 
     // -----------------------------------------------------------------------
 
@@ -901,8 +1001,15 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         avifEncoderItem * item = &encoder->data->items.item[itemIndex];
         if (item->codec) {
             const avifImage * cellImage = cellImages[item->cellIndex];
-            avifResult encodeResult =
-                item->codec->encodeImage(item->codec, encoder, cellImage, item->alpha, encoderChanges, addImageFlags, item->encodeOutput);
+            avifResult encodeResult = item->codec->encodeImage(item->codec,
+                                                               encoder,
+                                                               cellImage,
+                                                               item->alpha,
+                                                               encoder->data->tileRowsLog2,
+                                                               encoder->data->tileColsLog2,
+                                                               encoderChanges,
+                                                               addImageFlags,
+                                                               item->encodeOutput);
             if (encodeResult == AVIF_RESULT_UNKNOWN_ERROR) {
                 encodeResult = item->alpha ? AVIF_RESULT_ENCODE_ALPHA_FAILED : AVIF_RESULT_ENCODE_COLOR_FAILED;
             }

--- a/src/write.c
+++ b/src/write.c
@@ -828,8 +828,8 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
     // -----------------------------------------------------------------------
     // Handle automatic tiling
 
-    encoder->data->tileRowsLog2 = encoder->tileRowsLog2;
-    encoder->data->tileColsLog2 = encoder->tileColsLog2;
+    encoder->data->tileRowsLog2 = AVIF_CLAMP(encoder->tileRowsLog2, 0, 6);
+    encoder->data->tileColsLog2 = AVIF_CLAMP(encoder->tileColsLog2, 0, 6);
     if (encoder->autoTiling) {
         // Use as many tiles as allowed by the minimum tile area requirement and impose a maximum
         // of 8 tiles.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,15 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifrgbtoyuvtest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifrgbtoyuvtest COMMAND avifrgbtoyuvtest)
 
+    if(NOT BUILD_SHARED_LIBS)
+        # Test the internal function avifSetTileConfiguration(), which is not exported from the
+        # shared library.
+        add_executable(aviftilingtest gtest/aviftilingtest.cc)
+        target_link_libraries(aviftilingtest avif ${GTEST_BOTH_LIBRARIES})
+        target_include_directories(aviftilingtest PRIVATE ${GTEST_INCLUDE_DIRS})
+        add_test(NAME aviftilingtest COMMAND aviftilingtest)
+    endif()
+
     add_executable(avify4mtest gtest/avify4mtest.cc)
     target_link_libraries(avify4mtest aviftest_helpers avif_apps ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avify4mtest PRIVATE ${GTEST_INCLUDE_DIRS})

--- a/tests/gtest/aviftilingtest.cc
+++ b/tests/gtest/aviftilingtest.cc
@@ -1,0 +1,112 @@
+// Copyright 2022 Google LLC. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+#include "avif/internal.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(TilingTest, SetTileConfiguration) {
+  constexpr int kThreads = 8;
+  int tile_rows_log2;
+  int tile_cols_log2;
+  // 144p
+  avifSetTileConfiguration(kThreads, 256, 144, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 0);
+  EXPECT_EQ(tile_cols_log2, 0);
+  avifSetTileConfiguration(kThreads, 144, 256, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 0);
+  EXPECT_EQ(tile_cols_log2, 0);
+  // 240p
+  avifSetTileConfiguration(kThreads, 426, 240, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 0);
+  EXPECT_EQ(tile_cols_log2, 0);
+  avifSetTileConfiguration(kThreads, 240, 426, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 0);
+  EXPECT_EQ(tile_cols_log2, 0);
+  // 360p
+  avifSetTileConfiguration(kThreads, 640, 360, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 0);
+  EXPECT_EQ(tile_cols_log2, 0);
+  avifSetTileConfiguration(kThreads, 360, 640, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 0);
+  EXPECT_EQ(tile_cols_log2, 0);
+  // 480p
+  avifSetTileConfiguration(kThreads, 854, 480, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 0);
+  EXPECT_EQ(tile_cols_log2, 1);
+  avifSetTileConfiguration(kThreads, 480, 854, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 1);
+  EXPECT_EQ(tile_cols_log2, 0);
+  // 720p
+  avifSetTileConfiguration(kThreads, 1280, 720, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 1);
+  EXPECT_EQ(tile_cols_log2, 1);
+  avifSetTileConfiguration(kThreads, 720, 1280, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 1);
+  EXPECT_EQ(tile_cols_log2, 1);
+  // 1080p
+  avifSetTileConfiguration(kThreads, 1920, 1080, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 1);
+  EXPECT_EQ(tile_cols_log2, 2);
+  avifSetTileConfiguration(kThreads, 1080, 1920, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 2);
+  EXPECT_EQ(tile_cols_log2, 1);
+  // 2K
+  avifSetTileConfiguration(kThreads, 2560, 1440, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 1);
+  EXPECT_EQ(tile_cols_log2, 2);
+  avifSetTileConfiguration(kThreads, 1440, 2560, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 2);
+  EXPECT_EQ(tile_cols_log2, 1);
+  // 4K
+  avifSetTileConfiguration(32, 3840, 2160, &tile_rows_log2, &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 2);
+  EXPECT_EQ(tile_cols_log2, 3);
+  avifSetTileConfiguration(32, 2160, 3840, &tile_rows_log2, &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 3);
+  EXPECT_EQ(tile_cols_log2, 2);
+  // 8K
+  avifSetTileConfiguration(32, 7680, 4320, &tile_rows_log2, &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 2);
+  EXPECT_EQ(tile_cols_log2, 3);
+  avifSetTileConfiguration(32, 4320, 7680, &tile_rows_log2, &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 3);
+  EXPECT_EQ(tile_cols_log2, 2);
+
+  // Kodak image set: 768x512
+  avifSetTileConfiguration(kThreads, 768, 512, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 0);
+  EXPECT_EQ(tile_cols_log2, 1);
+  avifSetTileConfiguration(kThreads, 512, 768, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 1);
+  EXPECT_EQ(tile_cols_log2, 0);
+
+  avifSetTileConfiguration(kThreads, 16384, 64, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 0);
+  EXPECT_EQ(tile_cols_log2, 2);
+  avifSetTileConfiguration(kThreads, 64, 16384, &tile_rows_log2,
+                           &tile_cols_log2);
+  EXPECT_EQ(tile_rows_log2, 2);
+  EXPECT_EQ(tile_cols_log2, 0);
+}
+
+}  // namespace

--- a/tests/gtest/aviftilingtest.cc
+++ b/tests/gtest/aviftilingtest.cc
@@ -1,112 +1,68 @@
 // Copyright 2022 Google LLC. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include <ostream>
+
 #include "avif/avif.h"
 #include "avif/internal.h"
 #include "gtest/gtest.h"
 
 namespace {
 
+struct SetTileConfigurationTestParams {
+  int threads;
+  uint32_t width;
+  uint32_t height;
+  int expected_tile_rows_log2;
+  int expected_tile_cols_log2;
+};
+
+std::ostream& operator<<(std::ostream& os,
+                         const SetTileConfigurationTestParams& test) {
+  return os << "SetTileConfigurationTestParams { threads:" << test.threads
+            << " width:" << test.width << " height:" << test.height << " }";
+}
+
 TEST(TilingTest, SetTileConfiguration) {
   constexpr int kThreads = 8;
   int tile_rows_log2;
   int tile_cols_log2;
-  // 144p
-  avifSetTileConfiguration(kThreads, 256, 144, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 0);
-  EXPECT_EQ(tile_cols_log2, 0);
-  avifSetTileConfiguration(kThreads, 144, 256, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 0);
-  EXPECT_EQ(tile_cols_log2, 0);
-  // 240p
-  avifSetTileConfiguration(kThreads, 426, 240, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 0);
-  EXPECT_EQ(tile_cols_log2, 0);
-  avifSetTileConfiguration(kThreads, 240, 426, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 0);
-  EXPECT_EQ(tile_cols_log2, 0);
-  // 360p
-  avifSetTileConfiguration(kThreads, 640, 360, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 0);
-  EXPECT_EQ(tile_cols_log2, 0);
-  avifSetTileConfiguration(kThreads, 360, 640, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 0);
-  EXPECT_EQ(tile_cols_log2, 0);
-  // 480p
-  avifSetTileConfiguration(kThreads, 854, 480, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 0);
-  EXPECT_EQ(tile_cols_log2, 1);
-  avifSetTileConfiguration(kThreads, 480, 854, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 1);
-  EXPECT_EQ(tile_cols_log2, 0);
-  // 720p
-  avifSetTileConfiguration(kThreads, 1280, 720, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 1);
-  EXPECT_EQ(tile_cols_log2, 1);
-  avifSetTileConfiguration(kThreads, 720, 1280, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 1);
-  EXPECT_EQ(tile_cols_log2, 1);
-  // 1080p
-  avifSetTileConfiguration(kThreads, 1920, 1080, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 1);
-  EXPECT_EQ(tile_cols_log2, 2);
-  avifSetTileConfiguration(kThreads, 1080, 1920, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 2);
-  EXPECT_EQ(tile_cols_log2, 1);
-  // 2K
-  avifSetTileConfiguration(kThreads, 2560, 1440, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 1);
-  EXPECT_EQ(tile_cols_log2, 2);
-  avifSetTileConfiguration(kThreads, 1440, 2560, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 2);
-  EXPECT_EQ(tile_cols_log2, 1);
-  // 4K
-  avifSetTileConfiguration(32, 3840, 2160, &tile_rows_log2, &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 2);
-  EXPECT_EQ(tile_cols_log2, 3);
-  avifSetTileConfiguration(32, 2160, 3840, &tile_rows_log2, &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 3);
-  EXPECT_EQ(tile_cols_log2, 2);
-  // 8K
-  avifSetTileConfiguration(32, 7680, 4320, &tile_rows_log2, &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 2);
-  EXPECT_EQ(tile_cols_log2, 3);
-  avifSetTileConfiguration(32, 4320, 7680, &tile_rows_log2, &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 3);
-  EXPECT_EQ(tile_cols_log2, 2);
 
-  // Kodak image set: 768x512
-  avifSetTileConfiguration(kThreads, 768, 512, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 0);
-  EXPECT_EQ(tile_cols_log2, 1);
-  avifSetTileConfiguration(kThreads, 512, 768, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 1);
-  EXPECT_EQ(tile_cols_log2, 0);
+  constexpr SetTileConfigurationTestParams kTests[]{
+      // 144p
+      {kThreads, 256, 144, 0, 0},
+      // 240p
+      {kThreads, 426, 240, 0, 0},
+      // 360p
+      {kThreads, 640, 360, 0, 0},
+      // 480p
+      {kThreads, 854, 480, 0, 1},
+      // 720p
+      {kThreads, 1280, 720, 1, 1},
+      // 1080p
+      {kThreads, 1920, 1080, 1, 2},
+      // 2K
+      {kThreads, 2560, 1440, 1, 2},
+      // 4K
+      {32, 3840, 2160, 2, 3},
+      // 8K
+      {32, 7680, 4320, 2, 3},
+      // Kodak image set: 768x512
+      {kThreads, 768, 512, 0, 1},
+      {kThreads, 16384, 64, 0, 2},
+  };
 
-  avifSetTileConfiguration(kThreads, 16384, 64, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 0);
-  EXPECT_EQ(tile_cols_log2, 2);
-  avifSetTileConfiguration(kThreads, 64, 16384, &tile_rows_log2,
-                           &tile_cols_log2);
-  EXPECT_EQ(tile_rows_log2, 2);
-  EXPECT_EQ(tile_cols_log2, 0);
+  for (const auto& test : kTests) {
+    avifSetTileConfiguration(test.threads, test.width, test.height,
+                             &tile_rows_log2, &tile_cols_log2);
+    EXPECT_EQ(tile_rows_log2, test.expected_tile_rows_log2) << test;
+    EXPECT_EQ(tile_cols_log2, test.expected_tile_cols_log2) << test;
+    // Swap width and height.
+    avifSetTileConfiguration(test.threads, test.height, test.width,
+                             &tile_rows_log2, &tile_cols_log2);
+    EXPECT_EQ(tile_rows_log2, test.expected_tile_cols_log2) << test;
+    EXPECT_EQ(tile_cols_log2, test.expected_tile_rows_log2) << test;
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
The autoTiling option, if set to AVIF_TRUE, causes avifEncoder to ignore
the tileRowsLog2 and tileColsLog2 options and automatically choose
suitable tiling values.

Also add the --autotiling option to avifenc, which sets --tilerowslog2
and --tilecolslog2 automatically.

The current implementation uses as many tiles as allowed by the minimum
tile area requirement and imposes a maximum of 8 tiles.