### PR TITLE
Add CI for Android JNI Bindings

### DIFF
--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -1,0 +1,39 @@
+name: CI-Android-JNI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      - name: Download and Setup the Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
+      - name: Setup ninja
+        uses: seanmiddleditch/gha-setup-ninja@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.12
+        with:
+          # We use the same version as the one in build.gradle.
+          cmake-version: "3.18.1"
+      - name: Build libgav1 with the Android NDK
+        working-directory: ext
+        run: bash libgav1_android.sh ${{ steps.setup-ndk.outputs.ndk-path }}
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: 11
+      - name: Download and Setup the Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Build the libavif JNI Wrapper
+        working-directory: android_jni
+        run: ./gradlew --no-daemon assembleRelease
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}


### PR DESCRIPTION
This will build the JNI bindings with each PR/push to ensure that
we don't break the Android JNI build.

It is quite fast (< 3 minutes) when run locally.

We could potentially add some tests as well and run them in an
emulator on the CI. But that is work for the future.