### PR TITLE
android_jni: Set threads to number of available CPU cores

### DIFF
--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.12
         with:
-          # We use the same version as the one in build.gradle.
-          cmake-version: "3.18.1"
+          # This is the minimum cmake version needed to build libgav1.
+          cmake-version: "3.7.x"
       - name: Build libgav1 with the Android NDK
         working-directory: ext
         run: bash libgav1_android.sh ${{ steps.setup-ndk.outputs.ndk-path }}
@@ -32,6 +32,10 @@ jobs:
           java-version: 11
       - name: Download and Setup the Android SDK
         uses: android-actions/setup-android@v2
+      - name: Install CMake in the Android SDK
+        # This is the same version of cmake that is found in build.gradle. This
+        # will be used to build libavif and the JNI bindings.
+        run: sdkmanager "cmake;3.18.1"
       - name: Build the libavif JNI Wrapper
         working-directory: android_jni
         run: ./gradlew --no-daemon assembleRelease

--- a/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
+++ b/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
@@ -26,4 +26,9 @@ add_subdirectory(../../../../.. build)
 
 add_library("avif_android" SHARED "libavif_jni.cc")
 
-target_link_libraries(avif_android jnigraphics avif log)
+# Import the cpu-features module to compute the number of threads used for
+# decoding.
+include(AndroidNdkModules)
+android_ndk_import_module_cpufeatures()
+
+target_link_libraries(avif_android jnigraphics avif log cpufeatures)


### PR DESCRIPTION
This will speed up the decoding process.

Also update the Android JNI CI to install the cmake from the SDK for building android specific code.