### PR TITLE
testutil::ReadImage()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,15 +479,18 @@ if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND AVIF_ENABLE_GTEST))
     find_package(JPEG REQUIRED)
 
     add_library(
-        avif_apps STATIC apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c
+        avif_apps OBJECT apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c
                          apps/shared/y4m.c
     )
-    target_link_libraries(avif_apps avif ${AVIF_PLATFORM_LIBRARIES} PNG::PNG ZLIB::ZLIB JPEG::JPEG)
+    target_link_libraries(avif_apps avif ${AVIF_PLATFORM_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
     # In GitHub CI's macos-latest os image, /usr/local/include has not only the headers of libpng
     # libjpeg but also the headers of an older version of libavif. Put the avif include directory
     # before ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR} to prevent picking up old libavif headers
     # from /usr/local/include.
-    target_include_directories(avif_apps PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> INTERFACE apps/shared)
+    target_include_directories(
+        avif_apps PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR}
+        INTERFACE apps/shared
+    )
 endif()
 
 if(AVIF_BUILD_APPS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,18 +479,15 @@ if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND AVIF_ENABLE_GTEST))
     find_package(JPEG REQUIRED)
 
     add_library(
-        avif_apps OBJECT apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c
+        avif_apps STATIC apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c
                          apps/shared/y4m.c
     )
-    target_link_libraries(avif_apps avif ${AVIF_PLATFORM_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
+    target_link_libraries(avif_apps avif ${AVIF_PLATFORM_LIBRARIES} PNG::PNG ZLIB::ZLIB JPEG::JPEG)
     # In GitHub CI's macos-latest os image, /usr/local/include has not only the headers of libpng
     # libjpeg but also the headers of an older version of libavif. Put the avif include directory
     # before ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR} to prevent picking up old libavif headers
     # from /usr/local/include.
-    target_include_directories(
-        avif_apps PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR}
-        INTERFACE apps/shared
-    )
+    target_include_directories(avif_apps PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES> INTERFACE apps/shared)
 endif()
 
 if(AVIF_BUILD_APPS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,7 +479,7 @@ if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND AVIF_ENABLE_GTEST))
     find_package(JPEG REQUIRED)
 
     add_library(
-        avif_apps OBJECT apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c
+        avif_apps STATIC apps/shared/avifjpeg.c apps/shared/iccjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c
                          apps/shared/y4m.c
     )
     target_link_libraries(avif_apps avif ${AVIF_PLATFORM_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,14 +42,12 @@ endforeach()
 ################################################################################
 # GoogleTest
 
-if(AVIF_ENABLE_GTEST OR AVIF_BUILD_APPS)
+if(AVIF_ENABLE_GTEST)
     enable_language(CXX)
     set(CMAKE_CXX_STANDARD 11)
     add_library(aviftest_helpers OBJECT gtest/aviftest_helpers.cc)
-    target_link_libraries(aviftest_helpers avif ${AVIF_PLATFORM_LIBRARIES})
-endif()
+    target_link_libraries(aviftest_helpers avif_apps)
 
-if(AVIF_ENABLE_GTEST)
     if(AVIF_LOCAL_GTEST)
         set(GTEST_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/ext/googletest/googletest/include)
         set(GTEST_LIBRARIES
@@ -93,12 +91,12 @@ if(AVIF_ENABLE_GTEST)
 
     add_executable(avifincrtest gtest/avifincrtest.cc)
     target_link_libraries(avifincrtest aviftest_helpers avifincrtest_helpers)
-    add_test(NAME avifincrtest COMMAND avifincrtest ${CMAKE_CURRENT_SOURCE_DIR}/data)
+    add_test(NAME avifincrtest COMMAND avifincrtest ${CMAKE_CURRENT_SOURCE_DIR}/data/)
 
     add_executable(avifmetadatatest gtest/avifmetadatatest.cc)
-    target_link_libraries(avifmetadatatest aviftest_helpers avif_apps ${GTEST_LIBRARIES})
+    target_link_libraries(avifmetadatatest aviftest_helpers ${GTEST_LIBRARIES})
     target_include_directories(avifmetadatatest PRIVATE ${GTEST_INCLUDE_DIRS})
-    add_test(NAME avifmetadatatest COMMAND avifmetadatatest ${CMAKE_CURRENT_SOURCE_DIR}/data)
+    add_test(NAME avifmetadatatest COMMAND avifmetadatatest ${CMAKE_CURRENT_SOURCE_DIR}/data/)
 
     add_executable(avifrgbtoyuvtest gtest/avifrgbtoyuvtest.cc)
     target_link_libraries(avifrgbtoyuvtest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
@@ -115,7 +113,7 @@ if(AVIF_ENABLE_GTEST)
     endif()
 
     add_executable(avify4mtest gtest/avify4mtest.cc)
-    target_link_libraries(avify4mtest aviftest_helpers avif_apps ${GTEST_BOTH_LIBRARIES})
+    target_link_libraries(avify4mtest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avify4mtest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avify4mtest COMMAND avify4mtest)
 else()
@@ -129,7 +127,7 @@ if(AVIF_BUILD_APPS)
     # When building apps, test the avifenc/avifdec.
     # 'are_images_equal' is used to make sure inputs/outputs are unchanged.
     add_executable(are_images_equal gtest/are_images_equal.cc)
-    target_link_libraries(are_images_equal aviftest_helpers avif_apps)
+    target_link_libraries(are_images_equal aviftest_helpers)
     add_test(NAME test_cmd COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd.sh ${CMAKE_BINARY_DIR}
                                    ${CMAKE_CURRENT_SOURCE_DIR}/data
     )

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -6,8 +6,10 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <string>
 
 #include "avif/avif.h"
+#include "avifutil.h"
 
 namespace libavif {
 namespace testutil {
@@ -227,6 +229,26 @@ bool AreImagesEqual(const avifImage& image1, const avifImage& image2,
          AreByteSequencesEqual(image1.xmp, image2.xmp);
 }
 
+//------------------------------------------------------------------------------
+
+AvifImagePtr ReadImage(const char* folder_path, const char* file_name,
+                       avifPixelFormat requested_format, int requested_depth,
+                       avifRGBToYUVFlags flags, avifBool ignore_icc,
+                       avifBool ignore_exif, avifBool ignore_xmp) {
+  testutil::AvifImagePtr image(avifImageCreateEmpty(), avifImageDestroy);
+  if (!image ||
+      avifReadImage((std::string(folder_path) + file_name).c_str(),
+                    requested_format, requested_depth, flags, ignore_icc,
+                    ignore_exif, ignore_xmp, image.get(), /*outDepth=*/nullptr,
+                    /*sourceTiming=*/nullptr,
+                    /*frameIter=*/nullptr) == AVIF_APP_FILE_FORMAT_UNKNOWN) {
+    return {nullptr, avifImageDestroy};
+  }
+  return image;
+}
+
+//------------------------------------------------------------------------------
+
 static avifResult avifIOLimitedReaderRead(avifIO* io, uint32_t readFlags,
                                           uint64_t offset, size_t size,
                                           avifROData* out) {
@@ -264,5 +286,6 @@ avifIO* AvifIOCreateLimitedReader(avifIO* underlyingIO, uint64_t clamp) {
 }
 
 //------------------------------------------------------------------------------
+
 }  // namespace testutil
 }  // namespace libavif

--- a/tests/gtest/aviftest_helpers.h
+++ b/tests/gtest/aviftest_helpers.h
@@ -68,6 +68,18 @@ bool AreImagesEqual(const avifImage& image1, const avifImage& image2,
                     bool ignore_alpha = false);
 
 //------------------------------------------------------------------------------
+// Shorter versions of avifutil.h functions
+
+// Reads the image named file_name located in directory at folder_path.
+// Returns nullptr in case of error.
+AvifImagePtr ReadImage(
+    const char* folder_path, const char* file_name,
+    avifPixelFormat requested_format = AVIF_PIXEL_FORMAT_NONE,
+    int requested_depth = 0, avifRGBToYUVFlags flags = AVIF_RGB_TO_YUV_DEFAULT,
+    avifBool ignore_icc = false, avifBool ignore_exif = false,
+    avifBool ignore_xmp = false);
+
+//------------------------------------------------------------------------------
 // avifIO overlay
 
 struct AvifIOLimitedReader {


### PR DESCRIPTION
Use AvifImagePtr in avifmetadatatest.cc to fix C API  memory leaks.

The aviftest_helpers target must be linked to avif_apps. Use a STATIC avif_apps library instead of an OBJECT library to avoid issues related to the lack of property transitivity in OBJECT libs.
See https://cmake.org/cmake/help/latest/command/target_link_libraries.html#linking-object-libraries