### PR TITLE
Layered encoding support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ avifEncoder struct.
   minQuantizer, maxQuantizer, minQuantizerAlpha, and maxQuantizerAlpha
   initialized to the default values.
 * Add the public API function avifImageIsOpaque() in avif.h.
+* Add experimental API for progressive AVIF encoding.
 
 ### Changed
 * Exif and XMP metadata is exported to PNG and JPEG files by default,

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -99,6 +99,9 @@ typedef int avifBool;
 // to handle this case however they want.
 #define AVIF_REPETITION_COUNT_UNKNOWN -2
 
+// The number of spatial layers in AV1, with spatial_id = 0..3.
+#define AVIF_MAX_AV1_LAYER_COUNT 4
+
 typedef enum avifPlanesFlag
 {
     AVIF_PLANES_YUV = (1 << 0),
@@ -343,6 +346,15 @@ typedef struct avifDiagnostics
 } avifDiagnostics;
 
 AVIF_API void avifDiagnosticsClearError(avifDiagnostics * diag);
+
+// ---------------------------------------------------------------------------
+// Fraction utility
+
+typedef struct avifFraction
+{
+    int32_t n;
+    int32_t d;
+} avifFraction;
 
 // ---------------------------------------------------------------------------
 // Optional transformation structs
@@ -1067,6 +1079,12 @@ AVIF_API avifResult avifDecoderNthImageMaxExtent(const avifDecoder * decoder, ui
 struct avifEncoderData;
 struct avifCodecSpecificOptions;
 
+typedef struct avifScalingMode
+{
+    avifFraction horizontal;
+    avifFraction vertical;
+} avifScalingMode;
+
 // Notes:
 // * If avifEncoderWrite() returns AVIF_RESULT_OK, output must be freed with avifRWDataFree()
 // * If (maxThreads < 2), multithreading is disabled
@@ -1087,6 +1105,8 @@ struct avifCodecSpecificOptions;
 //   image in less bytes. AVIF_SPEED_DEFAULT means "Leave the AV1 codec to its default speed settings"./
 //   If avifEncoder uses rav1e, the speed value is directly passed through (0-10). If libaom is used,
 //   a combination of settings are tweaked to simulate this speed range.
+// * Extra layer count: [0 - (AVIF_MAX_AV1_LAYER_COUNT-1)]. Non-zero value indicates a layered
+//   (progressive) image.
 // * Some encoder settings can be changed after encoding starts. Changes will take effect in the next
 //   call to avifEncoderAddImage().
 typedef struct avifEncoder
@@ -1103,6 +1123,7 @@ typedef struct avifEncoder
                           // AVIF_REPETITION_COUNT_INFINITE for infinite repetitions.  Only applicable for image sequences.
                           // Essentially, if repetitionCount is a non-negative integer `n`, then the image sequence should be
                           // played back `n + 1` times. Defaults to AVIF_REPETITION_COUNT_INFINITE.
+    uint32_t extraLayerCount;
 
     // changeable encoder settings
     int quality;
@@ -1114,6 +1135,7 @@ typedef struct avifEncoder
     int tileRowsLog2;
     int tileColsLog2;
     avifBool autoTiling;
+    avifScalingMode scalingMode;
 
     // stats from the most recent write
     avifIOStats ioStats;
@@ -1137,26 +1159,36 @@ typedef enum avifAddImageFlag
     // Force this frame to be a keyframe (sync frame).
     AVIF_ADD_IMAGE_FLAG_FORCE_KEYFRAME = (1 << 0),
 
-    // Use this flag when encoding a single image. Signals "still_picture" to AV1 encoders, which
-    // tweaks various compression rules. This is enabled automatically when using the
-    // avifEncoderWrite() single-image encode path.
+    // Use this flag when encoding a single frame, single layer image.
+    // Signals "still_picture" to AV1 encoders, which tweaks various compression rules.
+    // This is enabled automatically when using the avifEncoderWrite() single-image encode path.
     AVIF_ADD_IMAGE_FLAG_SINGLE = (1 << 1)
 } avifAddImageFlag;
 typedef uint32_t avifAddImageFlags;
 
-// Multi-function alternative to avifEncoderWrite() for image sequences.
+// Multi-function alternative to avifEncoderWrite() for advanced features.
 //
 // Usage / function call order is:
 // * avifEncoderCreate()
-// * Set encoder->timescale (Hz) correctly
-// * avifEncoderAddImage() ... [repeatedly; at least once]
-//   OR
-// * avifEncoderAddImageGrid() [exactly once, AVIF_ADD_IMAGE_FLAG_SINGLE is assumed]
+// - Still image:
+//   * avifEncoderAddImage() [exactly once]
+// - Still image grid:
+//   * avifEncoderAddImageGrid() [exactly once, AVIF_ADD_IMAGE_FLAG_SINGLE is assumed]
+// - Image sequence:
+//   * Set encoder->timescale (Hz) correctly
+//   * avifEncoderAddImage() ... [repeatedly; at least once]
+// - Still layered image:
+//   * Set encoder->extraLayerCount correctly
+//   * avifEncoderAddImage() ... [exactly encoder->extraLayerCount+1 times]
+// - Still layered grid:
+//   * Set encoder->extraLayerCount correctly
+//   * avifEncoderAddImageGrid() ... [exactly encoder->extraLayerCount+1 times]
 // * avifEncoderFinish()
 // * avifEncoderDestroy()
 //
 
-// durationInTimescales is ignored if AVIF_ADD_IMAGE_FLAG_SINGLE is set in addImageFlags.
+// durationInTimescales is ignored if AVIF_ADD_IMAGE_FLAG_SINGLE is set in addImageFlags,
+// or if we are encoding a layered image.
 AVIF_API avifResult avifEncoderAddImage(avifEncoder * encoder, const avifImage * image, uint64_t durationInTimescales, avifAddImageFlags addImageFlags);
 AVIF_API avifResult avifEncoderAddImageGrid(avifEncoder * encoder,
                                             uint32_t gridCols,

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1117,13 +1117,13 @@ typedef struct avifEncoder
     // settings (see Notes above)
     int maxThreads;
     int speed;
-    int keyframeInterval; // How many frames between automatic forced keyframes; 0 to disable (default).
-    uint64_t timescale;   // timescale of the media (Hz)
-    int repetitionCount;  // Number of times the image sequence should be repeated. This can also be set to
-                          // AVIF_REPETITION_COUNT_INFINITE for infinite repetitions.  Only applicable for image sequences.
-                          // Essentially, if repetitionCount is a non-negative integer `n`, then the image sequence should be
-                          // played back `n + 1` times. Defaults to AVIF_REPETITION_COUNT_INFINITE.
-    uint32_t extraLayerCount;
+    int keyframeInterval;     // How many frames between automatic forced keyframes; 0 to disable (default).
+    uint64_t timescale;       // timescale of the media (Hz)
+    int repetitionCount;      // Number of times the image sequence should be repeated. This can also be set to
+                              // AVIF_REPETITION_COUNT_INFINITE for infinite repetitions.  Only applicable for image sequences.
+                              // Essentially, if repetitionCount is a non-negative integer `n`, then the image sequence should be
+                              // played back `n + 1` times. Defaults to AVIF_REPETITION_COUNT_INFINITE.
+    uint32_t extraLayerCount; // EXPERIMENTAL: Non-zero value encodes layered image.
 
     // changeable encoder settings
     int quality;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -72,6 +72,11 @@ void avifArrayPush(void * arrayStruct, void * element);
 void avifArrayPop(void * arrayStruct);
 void avifArrayDestroy(void * arrayStruct);
 
+void avifFractionSimplify(avifFraction * f);
+avifBool avifFractionCD(avifFraction * a, avifFraction * b);
+avifBool avifFractionAdd(avifFraction a, avifFraction b, avifFraction * result);
+avifBool avifFractionSub(avifFraction a, avifFraction b, avifFraction * result);
+
 void avifImageSetDefaults(avifImage * image);
 // Copies all fields that do not need to be freed/allocated from srcImage to dstImage.
 void avifImageCopyNoAlloc(avifImage * dstImage, const avifImage * srcImage);
@@ -288,6 +293,7 @@ typedef enum avifEncoderChange
     AVIF_ENCODER_CHANGE_TILE_COLS_LOG2 = (1u << 5),
     AVIF_ENCODER_CHANGE_QUANTIZER = (1u << 6),
     AVIF_ENCODER_CHANGE_QUANTIZER_ALPHA = (1u << 7),
+    AVIF_ENCODER_CHANGE_SCALING_MODE = (1u << 8),
 
     AVIF_ENCODER_CHANGE_CODEC_SPECIFIC = (1u << 31)
 } avifEncoderChange;

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -73,6 +73,11 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
 
+    // rav1e does not support encoding layered image.
+    if (encoder->extraLayerCount > 0) {
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
+
     avifResult result = AVIF_RESULT_UNKNOWN_ERROR;
 
     RaConfig * rav1eConfig = NULL;

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -65,6 +65,11 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
         }
     }
 
+    // SVT-AV1 does not support encoding layered image.
+    if (encoder->extraLayerCount > 0) {
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
+
     avifResult result = AVIF_RESULT_UNKNOWN_ERROR;
     EbColorFormat color_format = EB_YUV420;
     EbBufferHeaderType * input_buffer = NULL;

--- a/src/read.c
+++ b/src/read.c
@@ -37,8 +37,6 @@ static const size_t xmpContentTypeSize = sizeof(xmpContentType);
 // can't be more than 4 unique tuples right now.
 #define MAX_IPMA_VERSION_AND_FLAGS_SEEN 4
 
-#define MAX_AV1_LAYER_COUNT 4
-
 // ---------------------------------------------------------------------------
 // Box data structures
 
@@ -577,7 +575,7 @@ static avifBool avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput * d
         sample->itemID = item->id;
         sample->offset = 0;
         sample->size = sampleSize;
-        assert(lselProp->u.lsel.layerID < MAX_AV1_LAYER_COUNT);
+        assert(lselProp->u.lsel.layerID < AVIF_MAX_AV1_LAYER_COUNT);
         sample->spatialID = (uint8_t)lselProp->u.lsel.layerID;
         sample->sync = AVIF_TRUE;
     } else if (allowProgressive && item->progressive) {
@@ -1899,7 +1897,7 @@ static avifBool avifParseLayerSelectorProperty(avifProperty * prop, const uint8_
 
     avifLayerSelectorProperty * lsel = &prop->u.lsel;
     AVIF_CHECK(avifROStreamReadU16(&s, &lsel->layerID));
-    if ((lsel->layerID != 0xFFFF) && (lsel->layerID >= MAX_AV1_LAYER_COUNT)) {
+    if ((lsel->layerID != 0xFFFF) && (lsel->layerID >= AVIF_MAX_AV1_LAYER_COUNT)) {
         avifDiagnosticsPrintf(diag, "Box[lsel] contains an unsupported layer [%u]", lsel->layerID);
         return AVIF_FALSE;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,6 +118,11 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifpng16bittest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifpng16bittest COMMAND avifpng16bittest ${CMAKE_CURRENT_SOURCE_DIR}/data/)
 
+    add_executable(avifprogressivetest gtest/avifprogressivetest.cc)
+    target_link_libraries(avifprogressivetest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
+    target_include_directories(avifprogressivetest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifprogressivetest COMMAND avifprogressivetest)
+
     add_executable(avifreadimagetest gtest/avifreadimagetest.cc)
     target_link_libraries(avifreadimagetest aviftest_helpers ${GTEST_LIBRARIES})
     target_include_directories(avifreadimagetest PRIVATE ${GTEST_INCLUDE_DIRS})

--- a/tests/gtest/avifprogressivetest.cc
+++ b/tests/gtest/avifprogressivetest.cc
@@ -1,0 +1,163 @@
+// Copyright 2022 Yuan Tong. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+class ProgressiveTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    if (avifCodecName(AVIF_CODEC_CHOICE_AOM, AVIF_CODEC_FLAG_CAN_ENCODE) ==
+        nullptr) {
+      GTEST_SKIP() << "ProgressiveTest requires the AOM encoder.";
+    }
+
+    ASSERT_NE(encoder_, nullptr);
+    encoder_->codecChoice = AVIF_CODEC_CHOICE_AOM;
+    // The fastest speed that uses AOM_USAGE_GOOD_QUALITY.
+    encoder_->speed = 6;
+
+    ASSERT_NE(decoder_, nullptr);
+    decoder_->allowProgressive = true;
+
+    ASSERT_NE(image_, nullptr);
+    testutil::FillImageGradient(image_.get());
+  }
+
+  void TestDecode(uint32_t expect_width, uint32_t expect_height) {
+    ASSERT_EQ(avifDecoderSetIOMemory(decoder_.get(), encoded_avif_.data,
+                                     encoded_avif_.size),
+              AVIF_RESULT_OK);
+    ASSERT_EQ(avifDecoderParse(decoder_.get()), AVIF_RESULT_OK);
+    ASSERT_EQ(decoder_->progressiveState, AVIF_PROGRESSIVE_STATE_ACTIVE);
+    ASSERT_EQ(static_cast<uint32_t>(decoder_->imageCount),
+              encoder_->extraLayerCount + 1);
+
+    for (uint32_t layer = 0; layer < encoder_->extraLayerCount + 1; ++layer) {
+      ASSERT_EQ(avifDecoderNextImage(decoder_.get()), AVIF_RESULT_OK);
+      // libavif scales frame automatically.
+      ASSERT_EQ(decoder_->image->width, expect_width);
+      ASSERT_EQ(decoder_->image->height, expect_height);
+      // TODO(wtc): Check avifDecoderNthImageMaxExtent().
+    }
+
+    // TODO(wtc): Check decoder_->image and image_ are similar, and better
+    // quality layer is more similar.
+  }
+
+  static constexpr uint32_t kImageSize = 256;
+
+  testutil::AvifEncoderPtr encoder_{avifEncoderCreate(), avifEncoderDestroy};
+  testutil::AvifDecoderPtr decoder_{avifDecoderCreate(), avifDecoderDestroy};
+
+  testutil::AvifImagePtr image_ =
+      testutil::CreateImage(kImageSize, kImageSize, 8, AVIF_PIXEL_FORMAT_YUV444,
+                            AVIF_PLANES_YUV, AVIF_RANGE_FULL);
+
+  testutil::AvifRwData encoded_avif_;
+};
+
+TEST_F(ProgressiveTest, QualityChange) {
+  encoder_->extraLayerCount = 1;
+  encoder_->minQuantizer = 50;
+  encoder_->maxQuantizer = 50;
+
+  ASSERT_EQ(avifEncoderAddImage(encoder_.get(), image_.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_OK);
+
+  encoder_->minQuantizer = 0;
+  encoder_->maxQuantizer = 0;
+  ASSERT_EQ(avifEncoderAddImage(encoder_.get(), image_.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_OK);
+
+  ASSERT_EQ(avifEncoderFinish(encoder_.get(), &encoded_avif_), AVIF_RESULT_OK);
+
+  TestDecode(kImageSize, kImageSize);
+}
+
+TEST_F(ProgressiveTest, DimensionChange) {
+  encoder_->extraLayerCount = 1;
+  encoder_->minQuantizer = 0;
+  encoder_->maxQuantizer = 0;
+  encoder_->scalingMode = {{1, 2}, {1, 2}};
+
+  ASSERT_EQ(avifEncoderAddImage(encoder_.get(), image_.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_OK);
+
+  encoder_->scalingMode = {{1, 1}, {1, 1}};
+  ASSERT_EQ(avifEncoderAddImage(encoder_.get(), image_.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_OK);
+
+  ASSERT_EQ(avifEncoderFinish(encoder_.get(), &encoded_avif_), AVIF_RESULT_OK);
+
+  TestDecode(kImageSize, kImageSize);
+}
+
+TEST_F(ProgressiveTest, LayeredGrid) {
+  encoder_->extraLayerCount = 1;
+  encoder_->minQuantizer = 50;
+  encoder_->maxQuantizer = 50;
+
+  avifImage* image_grid[2] = {image_.get(), image_.get()};
+  ASSERT_EQ(avifEncoderAddImageGrid(encoder_.get(), 2, 1, image_grid,
+                                    AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_OK);
+
+  encoder_->minQuantizer = 0;
+  encoder_->maxQuantizer = 0;
+  ASSERT_EQ(avifEncoderAddImageGrid(encoder_.get(), 2, 1, image_grid,
+                                    AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_OK);
+
+  ASSERT_EQ(avifEncoderFinish(encoder_.get(), &encoded_avif_), AVIF_RESULT_OK);
+
+  TestDecode(2 * kImageSize, kImageSize);
+}
+
+TEST_F(ProgressiveTest, SameLayers) {
+  encoder_->extraLayerCount = 3;
+  for (uint32_t layer = 0; layer < encoder_->extraLayerCount + 1; ++layer) {
+    ASSERT_EQ(avifEncoderAddImage(encoder_.get(), image_.get(), 1,
+                                  AVIF_ADD_IMAGE_FLAG_NONE),
+              AVIF_RESULT_OK);
+  }
+  ASSERT_EQ(avifEncoderFinish(encoder_.get(), &encoded_avif_), AVIF_RESULT_OK);
+
+  TestDecode(kImageSize, kImageSize);
+}
+
+TEST_F(ProgressiveTest, TooManyLayers) {
+  encoder_->extraLayerCount = 1;
+
+  ASSERT_EQ(avifEncoderAddImage(encoder_.get(), image_.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_OK);
+  ASSERT_EQ(avifEncoderAddImage(encoder_.get(), image_.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_OK);
+  ASSERT_EQ(avifEncoderAddImage(encoder_.get(), image_.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_INVALID_ARGUMENT);
+}
+
+TEST_F(ProgressiveTest, TooFewLayers) {
+  encoder_->extraLayerCount = 1;
+
+  ASSERT_EQ(avifEncoderAddImage(encoder_.get(), image_.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_NONE),
+            AVIF_RESULT_OK);
+
+  ASSERT_EQ(avifEncoderFinish(encoder_.get(), &encoded_avif_),
+            AVIF_RESULT_INVALID_ARGUMENT);
+}
+
+}  // namespace
+}  // namespace libavif

--- a/tests/gtest/avifprogressivetest.cc
+++ b/tests/gtest/avifprogressivetest.cc
@@ -82,6 +82,10 @@ TEST_F(ProgressiveTest, QualityChange) {
 }
 
 TEST_F(ProgressiveTest, DimensionChange) {
+  if (avifLibYUVVersion() == 0) {
+    GTEST_SKIP() << "libyuv not available, skip test.";
+  }
+
   encoder_->extraLayerCount = 1;
   encoder_->minQuantizer = 0;
   encoder_->maxQuantizer = 0;


### PR DESCRIPTION
This is the third part of #761.

Layered image can be encoded by calling `avifEncoderAddImage()` multiple times, one layer per call.

@y-guyon:
- Rational to keep `avifScalingMode`: In very early version of #761 `avifScalingMode` is simply an alias of libaom's `AOM_SCALING_MODE`, and I later changed it to a struct representing a fraction. As @joedrago [said](https://github.com/AOMediaCodec/libavif/pull/761#issuecomment-924100022) directly using what libaom offers is not so good as libavif also supports other codecs, and available `AOM_SCALING_MODE`-s are also rather some arbitrary selected values instead of the only values supported by AV1. We may define some commonly used `avifScalingMode` as static constants for convenience, anyway.
- `AVIF_ADD_IMAGE_FLAG_LAYER`: I found that I don't need this flag. We know whether we are dealing layer image by checking `encoder->extraLayerCount`.
- Encoding of layered grid do works, and libavif decoder also decodes it correctly, but if you are concerned about corner cases, we can disable it for now.

@wantehchang:
This PR currently rely on libaom to scale the layers internally, so it's restricted to the modes defined by `AOM_SCALING_MODE`.  Also there's still a bug in libaom's internal scaler that it doesn't scale YUV420 images with 4n+2 dimensions correctly. But other than that it looks good. Also once #1069 is done, directly encoding layers of different dimensions should also work.