### PR TITLE
Rename CHECK and CHEKERR to AVIF_CHECK

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -16,17 +16,17 @@ extern "C" {
 #define AVIF_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 // Used by stream related things.
-#define CHECK(A)               \
+#define AVIF_CHECK(A)          \
     do {                       \
         if (!(A))              \
             return AVIF_FALSE; \
     } while (0)
 
 // Used instead of CHECK if needing to return a specific error on failure, instead of AVIF_FALSE
-#define CHECKERR(A, ERR) \
-    do {                 \
-        if (!(A))        \
-            return ERR;  \
+#define AVIF_CHECKERR(A, ERR) \
+    do {                      \
+        if (!(A))             \
+            return ERR;       \
     } while (0)
 
 // ---------------------------------------------------------------------------

--- a/src/read.c
+++ b/src/read.c
@@ -1480,7 +1480,8 @@ static avifResult avifDecoderFindMetadata(avifDecoder * decoder, avifMeta * meta
             // Advance past Annex A.2.1's header
             BEGIN_STREAM(exifBoxStream, exifContents.data, exifContents.size, &decoder->diag, "Exif header");
             uint32_t exifTiffHeaderOffset;
-            CHECKERR(avifROStreamReadU32(&exifBoxStream, &exifTiffHeaderOffset), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) exif_tiff_header_offset;
+            AVIF_CHECKERR(avifROStreamReadU32(&exifBoxStream, &exifTiffHeaderOffset),
+                          AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) exif_tiff_header_offset;
 
             avifImageSetMetadataExif(image, avifROStreamCurrent(&exifBoxStream), avifROStreamRemainingBytes(&exifBoxStream));
         } else if (!decoder->ignoreXMP && !memcmp(item->type, "mime", 4) &&
@@ -1512,17 +1513,17 @@ static avifBool avifParseHandlerBox(const uint8_t * raw, size_t rawLen, avifDiag
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[hdlr]");
 
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     uint32_t predefined;
-    CHECK(avifROStreamReadU32(&s, &predefined)); // unsigned int(32) pre_defined = 0;
+    AVIF_CHECK(avifROStreamReadU32(&s, &predefined)); // unsigned int(32) pre_defined = 0;
     if (predefined != 0) {
         avifDiagnosticsPrintf(diag, "Box[hdlr] contains a pre_defined value that is nonzero");
         return AVIF_FALSE;
     }
 
     uint8_t handlerType[4];
-    CHECK(avifROStreamRead(&s, handlerType, 4)); // unsigned int(32) handler_type;
+    AVIF_CHECK(avifROStreamRead(&s, handlerType, 4)); // unsigned int(32) handler_type;
     if (memcmp(handlerType, "pict", 4) != 0) {
         avifDiagnosticsPrintf(diag, "Box[hdlr] handler_type is not 'pict'");
         return AVIF_FALSE;
@@ -1530,11 +1531,11 @@ static avifBool avifParseHandlerBox(const uint8_t * raw, size_t rawLen, avifDiag
 
     for (int i = 0; i < 3; ++i) {
         uint32_t reserved;
-        CHECK(avifROStreamReadU32(&s, &reserved)); // const unsigned int(32)[3] reserved = 0;
+        AVIF_CHECK(avifROStreamReadU32(&s, &reserved)); // const unsigned int(32)[3] reserved = 0;
     }
 
     // Verify that a valid string is here, but don't bother to store it
-    CHECK(avifROStreamReadString(&s, NULL, 0)); // string name;
+    AVIF_CHECK(avifROStreamReadString(&s, NULL, 0)); // string name;
     return AVIF_TRUE;
 }
 
@@ -1543,19 +1544,19 @@ static avifBool avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw, s
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[iloc]");
 
     uint8_t version;
-    CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
+    AVIF_CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
     if (version > 2) {
         avifDiagnosticsPrintf(diag, "Box[iloc] has an unsupported version [%u]", version);
         return AVIF_FALSE;
     }
 
     uint8_t offsetSizeAndLengthSize;
-    CHECK(avifROStreamRead(&s, &offsetSizeAndLengthSize, 1));
+    AVIF_CHECK(avifROStreamRead(&s, &offsetSizeAndLengthSize, 1));
     uint8_t offsetSize = (offsetSizeAndLengthSize >> 4) & 0xf; // unsigned int(4) offset_size;
     uint8_t lengthSize = (offsetSizeAndLengthSize >> 0) & 0xf; // unsigned int(4) length_size;
 
     uint8_t baseOffsetSizeAndIndexSize;
-    CHECK(avifROStreamRead(&s, &baseOffsetSizeAndIndexSize, 1));
+    AVIF_CHECK(avifROStreamRead(&s, &baseOffsetSizeAndIndexSize, 1));
     uint8_t baseOffsetSize = (baseOffsetSizeAndIndexSize >> 4) & 0xf; // unsigned int(4) base_offset_size;
     uint8_t indexSize = 0;
     if ((version == 1) || (version == 2)) {
@@ -1570,18 +1571,18 @@ static avifBool avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw, s
     uint16_t tmp16;
     uint32_t itemCount;
     if (version < 2) {
-        CHECK(avifROStreamReadU16(&s, &tmp16)); // unsigned int(16) item_count;
+        AVIF_CHECK(avifROStreamReadU16(&s, &tmp16)); // unsigned int(16) item_count;
         itemCount = tmp16;
     } else {
-        CHECK(avifROStreamReadU32(&s, &itemCount)); // unsigned int(32) item_count;
+        AVIF_CHECK(avifROStreamReadU32(&s, &itemCount)); // unsigned int(32) item_count;
     }
     for (uint32_t i = 0; i < itemCount; ++i) {
         uint32_t itemID;
         if (version < 2) {
-            CHECK(avifROStreamReadU16(&s, &tmp16)); // unsigned int(16) item_ID;
+            AVIF_CHECK(avifROStreamReadU16(&s, &tmp16)); // unsigned int(16) item_ID;
             itemID = tmp16;
         } else {
-            CHECK(avifROStreamReadU32(&s, &itemID)); // unsigned int(32) item_ID;
+            AVIF_CHECK(avifROStreamReadU32(&s, &itemID)); // unsigned int(32) item_ID;
         }
 
         avifDecoderItem * item = avifMetaFindItem(meta, itemID);
@@ -1598,8 +1599,8 @@ static avifBool avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw, s
         if ((version == 1) || (version == 2)) {
             uint8_t ignored;
             uint8_t constructionMethod;
-            CHECK(avifROStreamRead(&s, &ignored, 1));            // unsigned int(12) reserved = 0;
-            CHECK(avifROStreamRead(&s, &constructionMethod, 1)); // unsigned int(4) construction_method;
+            AVIF_CHECK(avifROStreamRead(&s, &ignored, 1));            // unsigned int(12) reserved = 0;
+            AVIF_CHECK(avifROStreamRead(&s, &constructionMethod, 1)); // unsigned int(4) construction_method;
             constructionMethod = constructionMethod & 0xf;
             if ((constructionMethod != 0 /* file */) && (constructionMethod != 1 /* idat */)) {
                 // construction method item(2) unsupported
@@ -1611,12 +1612,12 @@ static avifBool avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw, s
             }
         }
 
-        uint16_t dataReferenceIndex;                                 // unsigned int(16) data_ref rence_index;
-        CHECK(avifROStreamReadU16(&s, &dataReferenceIndex));         //
-        uint64_t baseOffset;                                         // unsigned int(base_offset_size*8) base_offset;
-        CHECK(avifROStreamReadUX8(&s, &baseOffset, baseOffsetSize)); //
-        uint16_t extentCount;                                        // unsigned int(16) extent_count;
-        CHECK(avifROStreamReadU16(&s, &extentCount));                //
+        uint16_t dataReferenceIndex;                                      // unsigned int(16) data_ref rence_index;
+        AVIF_CHECK(avifROStreamReadU16(&s, &dataReferenceIndex));         //
+        uint64_t baseOffset;                                              // unsigned int(base_offset_size*8) base_offset;
+        AVIF_CHECK(avifROStreamReadUX8(&s, &baseOffset, baseOffsetSize)); //
+        uint16_t extentCount;                                             // unsigned int(16) extent_count;
+        AVIF_CHECK(avifROStreamReadU16(&s, &extentCount));                //
         for (int extentIter = 0; extentIter < extentCount; ++extentIter) {
             // If extent_index is ever supported, this spec must be implemented here:
             // ::  if (((version == 1) || (version == 2)) && (index_size > 0)) {
@@ -1624,9 +1625,9 @@ static avifBool avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw, s
             // ::  }
 
             uint64_t extentOffset; // unsigned int(offset_size*8) extent_offset;
-            CHECK(avifROStreamReadUX8(&s, &extentOffset, offsetSize));
+            AVIF_CHECK(avifROStreamReadUX8(&s, &extentOffset, offsetSize));
             uint64_t extentLength; // unsigned int(offset_size*8) extent_length;
-            CHECK(avifROStreamReadUX8(&s, &extentLength, lengthSize));
+            AVIF_CHECK(avifROStreamReadUX8(&s, &extentLength, lengthSize));
 
             avifExtent * extent = (avifExtent *)avifArrayPushPtr(&item->extents);
             if (extentOffset > UINT64_MAX - baseOffset) {
@@ -1668,23 +1669,23 @@ static avifBool avifParseImageGridBox(avifImageGrid * grid,
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[grid]");
 
     uint8_t version, flags;
-    CHECK(avifROStreamRead(&s, &version, 1)); // unsigned int(8) version = 0;
+    AVIF_CHECK(avifROStreamRead(&s, &version, 1)); // unsigned int(8) version = 0;
     if (version != 0) {
         avifDiagnosticsPrintf(diag, "Box[grid] has unsupported version [%u]", version);
         return AVIF_FALSE;
     }
     uint8_t rowsMinusOne, columnsMinusOne;
-    CHECK(avifROStreamRead(&s, &flags, 1));           // unsigned int(8) flags;
-    CHECK(avifROStreamRead(&s, &rowsMinusOne, 1));    // unsigned int(8) rows_minus_one;
-    CHECK(avifROStreamRead(&s, &columnsMinusOne, 1)); // unsigned int(8) columns_minus_one;
+    AVIF_CHECK(avifROStreamRead(&s, &flags, 1));           // unsigned int(8) flags;
+    AVIF_CHECK(avifROStreamRead(&s, &rowsMinusOne, 1));    // unsigned int(8) rows_minus_one;
+    AVIF_CHECK(avifROStreamRead(&s, &columnsMinusOne, 1)); // unsigned int(8) columns_minus_one;
     grid->rows = (uint32_t)rowsMinusOne + 1;
     grid->columns = (uint32_t)columnsMinusOne + 1;
 
     uint32_t fieldLength = ((flags & 1) + 1) * 16;
     if (fieldLength == 16) {
         uint16_t outputWidth16, outputHeight16;
-        CHECK(avifROStreamReadU16(&s, &outputWidth16));  // unsigned int(FieldLength) output_width;
-        CHECK(avifROStreamReadU16(&s, &outputHeight16)); // unsigned int(FieldLength) output_height;
+        AVIF_CHECK(avifROStreamReadU16(&s, &outputWidth16));  // unsigned int(FieldLength) output_width;
+        AVIF_CHECK(avifROStreamReadU16(&s, &outputHeight16)); // unsigned int(FieldLength) output_height;
         grid->outputWidth = outputWidth16;
         grid->outputHeight = outputHeight16;
     } else {
@@ -1693,8 +1694,8 @@ static avifBool avifParseImageGridBox(avifImageGrid * grid,
             avifDiagnosticsPrintf(diag, "Grid box contains illegal field length: [%u]", fieldLength);
             return AVIF_FALSE;
         }
-        CHECK(avifROStreamReadU32(&s, &grid->outputWidth));  // unsigned int(FieldLength) output_width;
-        CHECK(avifROStreamReadU32(&s, &grid->outputHeight)); // unsigned int(FieldLength) output_height;
+        AVIF_CHECK(avifROStreamReadU32(&s, &grid->outputWidth));  // unsigned int(FieldLength) output_width;
+        AVIF_CHECK(avifROStreamReadU32(&s, &grid->outputHeight)); // unsigned int(FieldLength) output_height;
     }
     if ((grid->outputWidth == 0) || (grid->outputHeight == 0)) {
         avifDiagnosticsPrintf(diag, "Grid box contains illegal dimensions: [%u x %u]", grid->outputWidth, grid->outputHeight);
@@ -1710,20 +1711,20 @@ static avifBool avifParseImageGridBox(avifImageGrid * grid,
 static avifBool avifParseImageSpatialExtentsProperty(avifProperty * prop, const uint8_t * raw, size_t rawLen, avifDiagnostics * diag)
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[ispe]");
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     avifImageSpatialExtents * ispe = &prop->u.ispe;
-    CHECK(avifROStreamReadU32(&s, &ispe->width));
-    CHECK(avifROStreamReadU32(&s, &ispe->height));
+    AVIF_CHECK(avifROStreamReadU32(&s, &ispe->width));
+    AVIF_CHECK(avifROStreamReadU32(&s, &ispe->height));
     return AVIF_TRUE;
 }
 
 static avifBool avifParseAuxiliaryTypeProperty(avifProperty * prop, const uint8_t * raw, size_t rawLen, avifDiagnostics * diag)
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[auxC]");
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
-    CHECK(avifROStreamReadString(&s, prop->u.auxC.auxType, AUXTYPE_SIZE));
+    AVIF_CHECK(avifROStreamReadString(&s, prop->u.auxC.auxType, AUXTYPE_SIZE));
     return AVIF_TRUE;
 }
 
@@ -1736,19 +1737,19 @@ static avifBool avifParseColourInformationBox(avifProperty * prop, const uint8_t
     colr->hasNCLX = AVIF_FALSE;
 
     uint8_t colorType[4]; // unsigned int(32) colour_type;
-    CHECK(avifROStreamRead(&s, colorType, 4));
+    AVIF_CHECK(avifROStreamRead(&s, colorType, 4));
     if (!memcmp(colorType, "rICC", 4) || !memcmp(colorType, "prof", 4)) {
         colr->hasICC = AVIF_TRUE;
         colr->icc = avifROStreamCurrent(&s);
         colr->iccSize = avifROStreamRemainingBytes(&s);
     } else if (!memcmp(colorType, "nclx", 4)) {
-        CHECK(avifROStreamReadU16(&s, &colr->colorPrimaries));          // unsigned int(16) colour_primaries;
-        CHECK(avifROStreamReadU16(&s, &colr->transferCharacteristics)); // unsigned int(16) transfer_characteristics;
-        CHECK(avifROStreamReadU16(&s, &colr->matrixCoefficients));      // unsigned int(16) matrix_coefficients;
+        AVIF_CHECK(avifROStreamReadU16(&s, &colr->colorPrimaries));          // unsigned int(16) colour_primaries;
+        AVIF_CHECK(avifROStreamReadU16(&s, &colr->transferCharacteristics)); // unsigned int(16) transfer_characteristics;
+        AVIF_CHECK(avifROStreamReadU16(&s, &colr->matrixCoefficients));      // unsigned int(16) matrix_coefficients;
         // unsigned int(1) full_range_flag;
         // unsigned int(7) reserved = 0;
         uint8_t tmp8;
-        CHECK(avifROStreamRead(&s, &tmp8, 1));
+        AVIF_CHECK(avifROStreamRead(&s, &tmp8, 1));
         colr->range = (tmp8 & 0x80) ? AVIF_RANGE_FULL : AVIF_RANGE_LIMITED;
         colr->hasNCLX = AVIF_TRUE;
     }
@@ -1760,11 +1761,11 @@ static avifBool avifParseAV1CodecConfigurationBox(const uint8_t * raw, size_t ra
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[av1C]");
 
     uint8_t markerAndVersion = 0;
-    CHECK(avifROStreamRead(&s, &markerAndVersion, 1));
+    AVIF_CHECK(avifROStreamRead(&s, &markerAndVersion, 1));
     uint8_t seqProfileAndIndex = 0;
-    CHECK(avifROStreamRead(&s, &seqProfileAndIndex, 1));
+    AVIF_CHECK(avifROStreamRead(&s, &seqProfileAndIndex, 1));
     uint8_t rawFlags = 0;
-    CHECK(avifROStreamRead(&s, &rawFlags, 1));
+    AVIF_CHECK(avifROStreamRead(&s, &rawFlags, 1));
 
     if (markerAndVersion != 0x81) {
         // Marker and version must both == 1
@@ -1794,8 +1795,8 @@ static avifBool avifParsePixelAspectRatioBoxProperty(avifProperty * prop, const 
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[pasp]");
 
     avifPixelAspectRatioBox * pasp = &prop->u.pasp;
-    CHECK(avifROStreamReadU32(&s, &pasp->hSpacing)); // unsigned int(32) hSpacing;
-    CHECK(avifROStreamReadU32(&s, &pasp->vSpacing)); // unsigned int(32) vSpacing;
+    AVIF_CHECK(avifROStreamReadU32(&s, &pasp->hSpacing)); // unsigned int(32) hSpacing;
+    AVIF_CHECK(avifROStreamReadU32(&s, &pasp->vSpacing)); // unsigned int(32) vSpacing;
     return AVIF_TRUE;
 }
 
@@ -1804,14 +1805,14 @@ static avifBool avifParseCleanApertureBoxProperty(avifProperty * prop, const uin
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[clap]");
 
     avifCleanApertureBox * clap = &prop->u.clap;
-    CHECK(avifROStreamReadU32(&s, &clap->widthN));    // unsigned int(32) cleanApertureWidthN;
-    CHECK(avifROStreamReadU32(&s, &clap->widthD));    // unsigned int(32) cleanApertureWidthD;
-    CHECK(avifROStreamReadU32(&s, &clap->heightN));   // unsigned int(32) cleanApertureHeightN;
-    CHECK(avifROStreamReadU32(&s, &clap->heightD));   // unsigned int(32) cleanApertureHeightD;
-    CHECK(avifROStreamReadU32(&s, &clap->horizOffN)); // unsigned int(32) horizOffN;
-    CHECK(avifROStreamReadU32(&s, &clap->horizOffD)); // unsigned int(32) horizOffD;
-    CHECK(avifROStreamReadU32(&s, &clap->vertOffN));  // unsigned int(32) vertOffN;
-    CHECK(avifROStreamReadU32(&s, &clap->vertOffD));  // unsigned int(32) vertOffD;
+    AVIF_CHECK(avifROStreamReadU32(&s, &clap->widthN));    // unsigned int(32) cleanApertureWidthN;
+    AVIF_CHECK(avifROStreamReadU32(&s, &clap->widthD));    // unsigned int(32) cleanApertureWidthD;
+    AVIF_CHECK(avifROStreamReadU32(&s, &clap->heightN));   // unsigned int(32) cleanApertureHeightN;
+    AVIF_CHECK(avifROStreamReadU32(&s, &clap->heightD));   // unsigned int(32) cleanApertureHeightD;
+    AVIF_CHECK(avifROStreamReadU32(&s, &clap->horizOffN)); // unsigned int(32) horizOffN;
+    AVIF_CHECK(avifROStreamReadU32(&s, &clap->horizOffD)); // unsigned int(32) horizOffD;
+    AVIF_CHECK(avifROStreamReadU32(&s, &clap->vertOffN));  // unsigned int(32) vertOffN;
+    AVIF_CHECK(avifROStreamReadU32(&s, &clap->vertOffD));  // unsigned int(32) vertOffD;
     return AVIF_TRUE;
 }
 
@@ -1820,7 +1821,7 @@ static avifBool avifParseImageRotationProperty(avifProperty * prop, const uint8_
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[irot]");
 
     avifImageRotation * irot = &prop->u.irot;
-    CHECK(avifROStreamRead(&s, &irot->angle, 1)); // unsigned int (6) reserved = 0; unsigned int (2) angle;
+    AVIF_CHECK(avifROStreamRead(&s, &irot->angle, 1)); // unsigned int (6) reserved = 0; unsigned int (2) angle;
     if ((irot->angle & 0xfc) != 0) {
         // reserved bits must be 0
         avifDiagnosticsPrintf(diag, "Box[irot] contains nonzero reserved bits [%u]", irot->angle);
@@ -1834,7 +1835,7 @@ static avifBool avifParseImageMirrorProperty(avifProperty * prop, const uint8_t 
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[imir]");
 
     avifImageMirror * imir = &prop->u.imir;
-    CHECK(avifROStreamRead(&s, &imir->mode, 1)); // unsigned int (7) reserved = 0; unsigned int (1) mode;
+    AVIF_CHECK(avifROStreamRead(&s, &imir->mode, 1)); // unsigned int (7) reserved = 0; unsigned int (1) mode;
     if ((imir->mode & 0xfe) != 0) {
         // reserved bits must be 0
         avifDiagnosticsPrintf(diag, "Box[imir] contains nonzero reserved bits [%u]", imir->mode);
@@ -1846,16 +1847,16 @@ static avifBool avifParseImageMirrorProperty(avifProperty * prop, const uint8_t 
 static avifBool avifParsePixelInformationProperty(avifProperty * prop, const uint8_t * raw, size_t rawLen, avifDiagnostics * diag)
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[pixi]");
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     avifPixelInformationProperty * pixi = &prop->u.pixi;
-    CHECK(avifROStreamRead(&s, &pixi->planeCount, 1)); // unsigned int (8) num_channels;
+    AVIF_CHECK(avifROStreamRead(&s, &pixi->planeCount, 1)); // unsigned int (8) num_channels;
     if (pixi->planeCount > MAX_PIXI_PLANE_DEPTHS) {
         avifDiagnosticsPrintf(diag, "Box[pixi] contains unsupported plane count [%u]", pixi->planeCount);
         return AVIF_FALSE;
     }
     for (uint8_t i = 0; i < pixi->planeCount; ++i) {
-        CHECK(avifROStreamRead(&s, &pixi->planeDepths[i], 1)); // unsigned int (8) bits_per_channel;
+        AVIF_CHECK(avifROStreamRead(&s, &pixi->planeDepths[i], 1)); // unsigned int (8) bits_per_channel;
     }
     return AVIF_TRUE;
 }
@@ -1865,7 +1866,7 @@ static avifBool avifParseOperatingPointSelectorProperty(avifProperty * prop, con
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[a1op]");
 
     avifOperatingPointSelectorProperty * a1op = &prop->u.a1op;
-    CHECK(avifROStreamRead(&s, &a1op->opIndex, 1));
+    AVIF_CHECK(avifROStreamRead(&s, &a1op->opIndex, 1));
     if (a1op->opIndex > 31) { // 31 is AV1's max operating point value
         avifDiagnosticsPrintf(diag, "Box[a1op] contains an unsupported operating point [%u]", a1op->opIndex);
         return AVIF_FALSE;
@@ -1878,7 +1879,7 @@ static avifBool avifParseLayerSelectorProperty(avifProperty * prop, const uint8_
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[lsel]");
 
     avifLayerSelectorProperty * lsel = &prop->u.lsel;
-    CHECK(avifROStreamReadU16(&s, &lsel->layerID));
+    AVIF_CHECK(avifROStreamReadU16(&s, &lsel->layerID));
     if ((lsel->layerID != 0xFFFF) && (lsel->layerID >= MAX_AV1_LAYER_COUNT)) {
         avifDiagnosticsPrintf(diag, "Box[lsel] contains an unsupported layer [%u]", lsel->layerID);
         return AVIF_FALSE;
@@ -1893,7 +1894,7 @@ static avifBool avifParseAV1LayeredImageIndexingProperty(avifProperty * prop, co
     avifAV1LayeredImageIndexingProperty * a1lx = &prop->u.a1lx;
 
     uint8_t largeSize = 0;
-    CHECK(avifROStreamRead(&s, &largeSize, 1));
+    AVIF_CHECK(avifROStreamRead(&s, &largeSize, 1));
     if (largeSize & 0xFE) {
         avifDiagnosticsPrintf(diag, "Box[a1lx] has bits set in the reserved section [%u]", largeSize);
         return AVIF_FALSE;
@@ -1901,10 +1902,10 @@ static avifBool avifParseAV1LayeredImageIndexingProperty(avifProperty * prop, co
 
     for (int i = 0; i < 3; ++i) {
         if (largeSize) {
-            CHECK(avifROStreamReadU32(&s, &a1lx->layerSize[i]));
+            AVIF_CHECK(avifROStreamReadU32(&s, &a1lx->layerSize[i]));
         } else {
             uint16_t layerSize16;
-            CHECK(avifROStreamReadU16(&s, &layerSize16));
+            AVIF_CHECK(avifROStreamReadU16(&s, &layerSize16));
             a1lx->layerSize[i] = (uint32_t)layerSize16;
         }
     }
@@ -1919,38 +1920,38 @@ static avifBool avifParseItemPropertyContainerBox(avifPropertyArray * properties
 
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader header;
-        CHECK(avifROStreamReadBoxHeader(&s, &header));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
         int propertyIndex = avifArrayPushIndex(properties);
         avifProperty * prop = &properties->prop[propertyIndex];
         memcpy(prop->type, header.type, 4);
         if (!memcmp(header.type, "ispe", 4)) {
-            CHECK(avifParseImageSpatialExtentsProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseImageSpatialExtentsProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "auxC", 4)) {
-            CHECK(avifParseAuxiliaryTypeProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseAuxiliaryTypeProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "colr", 4)) {
-            CHECK(avifParseColourInformationBox(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseColourInformationBox(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "av1C", 4)) {
-            CHECK(avifParseAV1CodecConfigurationBoxProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseAV1CodecConfigurationBoxProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "pasp", 4)) {
-            CHECK(avifParsePixelAspectRatioBoxProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParsePixelAspectRatioBoxProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "clap", 4)) {
-            CHECK(avifParseCleanApertureBoxProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseCleanApertureBoxProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "irot", 4)) {
-            CHECK(avifParseImageRotationProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseImageRotationProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "imir", 4)) {
-            CHECK(avifParseImageMirrorProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseImageMirrorProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "pixi", 4)) {
-            CHECK(avifParsePixelInformationProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParsePixelInformationProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "a1op", 4)) {
-            CHECK(avifParseOperatingPointSelectorProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseOperatingPointSelectorProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "lsel", 4)) {
-            CHECK(avifParseLayerSelectorProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseLayerSelectorProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "a1lx", 4)) {
-            CHECK(avifParseAV1LayeredImageIndexingProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseAV1LayeredImageIndexingProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         }
 
-        CHECK(avifROStreamSkip(&s, header.size));
+        AVIF_CHECK(avifROStreamSkip(&s, header.size));
     }
     return AVIF_TRUE;
 }
@@ -1964,12 +1965,12 @@ static avifBool avifParseItemPropertyAssociation(avifMeta * meta, const uint8_t 
 
     uint8_t version;
     uint32_t flags;
-    CHECK(avifROStreamReadVersionAndFlags(&s, &version, &flags));
+    AVIF_CHECK(avifROStreamReadVersionAndFlags(&s, &version, &flags));
     avifBool propertyIndexIsU16 = ((flags & 0x1) != 0);
     *outVersionAndFlags = ((uint32_t)version << 24) | flags;
 
     uint32_t entryCount;
-    CHECK(avifROStreamReadU32(&s, &entryCount));
+    AVIF_CHECK(avifROStreamReadU32(&s, &entryCount));
     unsigned int prevItemID = 0;
     for (uint32_t entryIndex = 0; entryIndex < entryCount; ++entryIndex) {
         // ISO/IEC 23008-12, First edition, 2017-12, Section 9.3.1:
@@ -1978,10 +1979,10 @@ static avifBool avifParseItemPropertyAssociation(avifMeta * meta, const uint8_t 
         unsigned int itemID;
         if (version < 1) {
             uint16_t tmp;
-            CHECK(avifROStreamReadU16(&s, &tmp));
+            AVIF_CHECK(avifROStreamReadU16(&s, &tmp));
             itemID = tmp;
         } else {
-            CHECK(avifROStreamReadU32(&s, &itemID));
+            AVIF_CHECK(avifROStreamReadU32(&s, &itemID));
         }
         if (itemID <= prevItemID) {
             avifDiagnosticsPrintf(diag, "Box[ipma] item IDs are not ordered by increasing ID");
@@ -2001,17 +2002,17 @@ static avifBool avifParseItemPropertyAssociation(avifMeta * meta, const uint8_t 
         item->ipmaSeen = AVIF_TRUE;
 
         uint8_t associationCount;
-        CHECK(avifROStreamRead(&s, &associationCount, 1));
+        AVIF_CHECK(avifROStreamRead(&s, &associationCount, 1));
         for (uint8_t associationIndex = 0; associationIndex < associationCount; ++associationIndex) {
             avifBool essential = AVIF_FALSE;
             uint16_t propertyIndex = 0;
             if (propertyIndexIsU16) {
-                CHECK(avifROStreamReadU16(&s, &propertyIndex));
+                AVIF_CHECK(avifROStreamReadU16(&s, &propertyIndex));
                 essential = ((propertyIndex & 0x8000) != 0);
                 propertyIndex &= 0x7fff;
             } else {
                 uint8_t tmp;
-                CHECK(avifROStreamRead(&s, &tmp, 1));
+                AVIF_CHECK(avifROStreamRead(&s, &tmp, 1));
                 essential = ((tmp & 0x80) != 0);
                 propertyIndex = tmp & 0x7f;
             }
@@ -2116,14 +2117,14 @@ static avifBool avifParsePrimaryItemBox(avifMeta * meta, const uint8_t * raw, si
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[pitm]");
 
     uint8_t version;
-    CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
+    AVIF_CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
 
     if (version == 0) {
         uint16_t tmp16;
-        CHECK(avifROStreamReadU16(&s, &tmp16)); // unsigned int(16) item_ID;
+        AVIF_CHECK(avifROStreamReadU16(&s, &tmp16)); // unsigned int(16) item_ID;
         meta->primaryItemID = tmp16;
     } else {
-        CHECK(avifROStreamReadU32(&s, &meta->primaryItemID)); // unsigned int(32) item_ID;
+        AVIF_CHECK(avifROStreamReadU32(&s, &meta->primaryItemID)); // unsigned int(32) item_ID;
     }
     return AVIF_TRUE;
 }
@@ -2149,15 +2150,15 @@ static avifBool avifParseItemPropertiesBox(avifMeta * meta, const uint8_t * raw,
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[iprp]");
 
     avifBoxHeader ipcoHeader;
-    CHECK(avifROStreamReadBoxHeader(&s, &ipcoHeader));
+    AVIF_CHECK(avifROStreamReadBoxHeader(&s, &ipcoHeader));
     if (memcmp(ipcoHeader.type, "ipco", 4)) {
         avifDiagnosticsPrintf(diag, "Failed to find Box[ipco] as the first box in Box[iprp]");
         return AVIF_FALSE;
     }
 
     // Read all item properties inside of ItemPropertyContainerBox
-    CHECK(avifParseItemPropertyContainerBox(&meta->properties, avifROStreamCurrent(&s), ipcoHeader.size, diag));
-    CHECK(avifROStreamSkip(&s, ipcoHeader.size));
+    AVIF_CHECK(avifParseItemPropertyContainerBox(&meta->properties, avifROStreamCurrent(&s), ipcoHeader.size, diag));
+    AVIF_CHECK(avifROStreamSkip(&s, ipcoHeader.size));
 
     uint32_t versionAndFlagsSeen[MAX_IPMA_VERSION_AND_FLAGS_SEEN];
     uint32_t versionAndFlagsSeenCount = 0;
@@ -2165,11 +2166,11 @@ static avifBool avifParseItemPropertiesBox(avifMeta * meta, const uint8_t * raw,
     // Now read all ItemPropertyAssociation until the end of the box, and make associations
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader ipmaHeader;
-        CHECK(avifROStreamReadBoxHeader(&s, &ipmaHeader));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &ipmaHeader));
 
         if (!memcmp(ipmaHeader.type, "ipma", 4)) {
             uint32_t versionAndFlags;
-            CHECK(avifParseItemPropertyAssociation(meta, avifROStreamCurrent(&s), ipmaHeader.size, diag, &versionAndFlags));
+            AVIF_CHECK(avifParseItemPropertyAssociation(meta, avifROStreamCurrent(&s), ipmaHeader.size, diag, &versionAndFlags));
             for (uint32_t i = 0; i < versionAndFlagsSeenCount; ++i) {
                 if (versionAndFlagsSeen[i] == versionAndFlags) {
                     // HEIF (ISO 23008-12:2017) 9.3.1 - There shall be at most one
@@ -2191,7 +2192,7 @@ static avifBool avifParseItemPropertiesBox(avifMeta * meta, const uint8_t * raw,
             return AVIF_FALSE;
         }
 
-        CHECK(avifROStreamSkip(&s, ipmaHeader.size));
+        AVIF_CHECK(avifROStreamSkip(&s, ipmaHeader.size));
     }
     return AVIF_TRUE;
 }
@@ -2202,7 +2203,7 @@ static avifBool avifParseItemInfoEntry(avifMeta * meta, const uint8_t * raw, siz
 
     uint8_t version;
     uint32_t flags;
-    CHECK(avifROStreamReadVersionAndFlags(&s, &version, &flags));
+    AVIF_CHECK(avifROStreamReadVersionAndFlags(&s, &version, &flags));
     // Version 2+ is required for item_type
     if (version != 2 && version != 3) {
         avifDiagnosticsPrintf(s.diag, "%s: Expecting box version 2 or 3, got version %u", s.diagContext, version);
@@ -2223,21 +2224,21 @@ static avifBool avifParseItemInfoEntry(avifMeta * meta, const uint8_t * raw, siz
     uint32_t itemID;
     if (version == 2) {
         uint16_t tmp;
-        CHECK(avifROStreamReadU16(&s, &tmp)); // unsigned int(16) item_ID;
+        AVIF_CHECK(avifROStreamReadU16(&s, &tmp)); // unsigned int(16) item_ID;
         itemID = tmp;
     } else {
         assert(version == 3);
-        CHECK(avifROStreamReadU32(&s, &itemID)); // unsigned int(32) item_ID;
+        AVIF_CHECK(avifROStreamReadU32(&s, &itemID)); // unsigned int(32) item_ID;
     }
-    uint16_t itemProtectionIndex;                         // unsigned int(16) item_protection_index;
-    CHECK(avifROStreamReadU16(&s, &itemProtectionIndex)); //
-    uint8_t itemType[4];                                  // unsigned int(32) item_type;
-    CHECK(avifROStreamRead(&s, itemType, 4));             //
+    uint16_t itemProtectionIndex;                              // unsigned int(16) item_protection_index;
+    AVIF_CHECK(avifROStreamReadU16(&s, &itemProtectionIndex)); //
+    uint8_t itemType[4];                                       // unsigned int(32) item_type;
+    AVIF_CHECK(avifROStreamRead(&s, itemType, 4));             //
 
     avifContentType contentType;
     if (!memcmp(itemType, "mime", 4)) {
-        CHECK(avifROStreamReadString(&s, NULL, 0));                                   // string item_name; (skipped)
-        CHECK(avifROStreamReadString(&s, contentType.contentType, CONTENTTYPE_SIZE)); // string content_type;
+        AVIF_CHECK(avifROStreamReadString(&s, NULL, 0));                                   // string item_name; (skipped)
+        AVIF_CHECK(avifROStreamReadString(&s, contentType.contentType, CONTENTTYPE_SIZE)); // string content_type;
     } else {
         memset(&contentType, 0, sizeof(contentType));
     }
@@ -2258,14 +2259,14 @@ static avifBool avifParseItemInfoBox(avifMeta * meta, const uint8_t * raw, size_
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[iinf]");
 
     uint8_t version;
-    CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
+    AVIF_CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
     uint32_t entryCount;
     if (version == 0) {
         uint16_t tmp;
-        CHECK(avifROStreamReadU16(&s, &tmp)); // unsigned int(16) entry_count;
+        AVIF_CHECK(avifROStreamReadU16(&s, &tmp)); // unsigned int(16) entry_count;
         entryCount = tmp;
     } else if (version == 1) {
-        CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
+        AVIF_CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
     } else {
         avifDiagnosticsPrintf(diag, "Box[iinf] has an unsupported version %u", version);
         return AVIF_FALSE;
@@ -2273,17 +2274,17 @@ static avifBool avifParseItemInfoBox(avifMeta * meta, const uint8_t * raw, size_
 
     for (uint32_t entryIndex = 0; entryIndex < entryCount; ++entryIndex) {
         avifBoxHeader infeHeader;
-        CHECK(avifROStreamReadBoxHeader(&s, &infeHeader));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &infeHeader));
 
         if (!memcmp(infeHeader.type, "infe", 4)) {
-            CHECK(avifParseItemInfoEntry(meta, avifROStreamCurrent(&s), infeHeader.size, diag));
+            AVIF_CHECK(avifParseItemInfoEntry(meta, avifROStreamCurrent(&s), infeHeader.size, diag));
         } else {
             // These must all be type infe
             avifDiagnosticsPrintf(diag, "Box[iinf] contains a box that isn't type 'infe'");
             return AVIF_FALSE;
         }
 
-        CHECK(avifROStreamSkip(&s, infeHeader.size));
+        AVIF_CHECK(avifROStreamSkip(&s, infeHeader.size));
     }
 
     return AVIF_TRUE;
@@ -2294,35 +2295,35 @@ static avifBool avifParseItemReferenceBox(avifMeta * meta, const uint8_t * raw, 
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[iref]");
 
     uint8_t version;
-    CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
+    AVIF_CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
 
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader irefHeader;
-        CHECK(avifROStreamReadBoxHeader(&s, &irefHeader));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &irefHeader));
 
         uint32_t fromID = 0;
         if (version == 0) {
             uint16_t tmp;
-            CHECK(avifROStreamReadU16(&s, &tmp)); // unsigned int(16) from_item_ID;
+            AVIF_CHECK(avifROStreamReadU16(&s, &tmp)); // unsigned int(16) from_item_ID;
             fromID = tmp;
         } else if (version == 1) {
-            CHECK(avifROStreamReadU32(&s, &fromID)); // unsigned int(32) from_item_ID;
+            AVIF_CHECK(avifROStreamReadU32(&s, &fromID)); // unsigned int(32) from_item_ID;
         } else {
             // unsupported iref version, skip it
             break;
         }
 
         uint16_t referenceCount = 0;
-        CHECK(avifROStreamReadU16(&s, &referenceCount)); // unsigned int(16) reference_count;
+        AVIF_CHECK(avifROStreamReadU16(&s, &referenceCount)); // unsigned int(16) reference_count;
 
         for (uint16_t refIndex = 0; refIndex < referenceCount; ++refIndex) {
             uint32_t toID = 0;
             if (version == 0) {
                 uint16_t tmp;
-                CHECK(avifROStreamReadU16(&s, &tmp)); // unsigned int(16) to_item_ID;
+                AVIF_CHECK(avifROStreamReadU16(&s, &tmp)); // unsigned int(16) to_item_ID;
                 toID = tmp;
             } else if (version == 1) {
-                CHECK(avifROStreamReadU32(&s, &toID)); // unsigned int(32) to_item_ID;
+                AVIF_CHECK(avifROStreamReadU32(&s, &toID)); // unsigned int(32) to_item_ID;
             } else {
                 // unsupported iref version, skip it
                 break;
@@ -2365,7 +2366,7 @@ static avifBool avifParseMetaBox(avifMeta * meta, const uint8_t * raw, size_t ra
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[meta]");
 
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     ++meta->idatID; // for tracking idat
 
@@ -2373,12 +2374,12 @@ static avifBool avifParseMetaBox(avifMeta * meta, const uint8_t * raw, size_t ra
     uint32_t uniqueBoxFlags = 0;
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader header;
-        CHECK(avifROStreamReadBoxHeader(&s, &header));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
         if (firstBox) {
             if (!memcmp(header.type, "hdlr", 4)) {
-                CHECK(uniqueBoxSeen(&uniqueBoxFlags, 0, "meta", "hdlr", diag));
-                CHECK(avifParseHandlerBox(avifROStreamCurrent(&s), header.size, diag));
+                AVIF_CHECK(uniqueBoxSeen(&uniqueBoxFlags, 0, "meta", "hdlr", diag));
+                AVIF_CHECK(avifParseHandlerBox(avifROStreamCurrent(&s), header.size, diag));
                 firstBox = AVIF_FALSE;
             } else {
                 // hdlr must be the first box!
@@ -2386,26 +2387,26 @@ static avifBool avifParseMetaBox(avifMeta * meta, const uint8_t * raw, size_t ra
                 return AVIF_FALSE;
             }
         } else if (!memcmp(header.type, "iloc", 4)) {
-            CHECK(uniqueBoxSeen(&uniqueBoxFlags, 1, "meta", "iloc", diag));
-            CHECK(avifParseItemLocationBox(meta, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(uniqueBoxSeen(&uniqueBoxFlags, 1, "meta", "iloc", diag));
+            AVIF_CHECK(avifParseItemLocationBox(meta, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "pitm", 4)) {
-            CHECK(uniqueBoxSeen(&uniqueBoxFlags, 2, "meta", "pitm", diag));
-            CHECK(avifParsePrimaryItemBox(meta, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(uniqueBoxSeen(&uniqueBoxFlags, 2, "meta", "pitm", diag));
+            AVIF_CHECK(avifParsePrimaryItemBox(meta, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "idat", 4)) {
-            CHECK(uniqueBoxSeen(&uniqueBoxFlags, 3, "meta", "idat", diag));
-            CHECK(avifParseItemDataBox(meta, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(uniqueBoxSeen(&uniqueBoxFlags, 3, "meta", "idat", diag));
+            AVIF_CHECK(avifParseItemDataBox(meta, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "iprp", 4)) {
-            CHECK(uniqueBoxSeen(&uniqueBoxFlags, 4, "meta", "iprp", diag));
-            CHECK(avifParseItemPropertiesBox(meta, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(uniqueBoxSeen(&uniqueBoxFlags, 4, "meta", "iprp", diag));
+            AVIF_CHECK(avifParseItemPropertiesBox(meta, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "iinf", 4)) {
-            CHECK(uniqueBoxSeen(&uniqueBoxFlags, 5, "meta", "iinf", diag));
-            CHECK(avifParseItemInfoBox(meta, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(uniqueBoxSeen(&uniqueBoxFlags, 5, "meta", "iinf", diag));
+            AVIF_CHECK(avifParseItemInfoBox(meta, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "iref", 4)) {
-            CHECK(uniqueBoxSeen(&uniqueBoxFlags, 6, "meta", "iref", diag));
-            CHECK(avifParseItemReferenceBox(meta, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(uniqueBoxSeen(&uniqueBoxFlags, 6, "meta", "iref", diag));
+            AVIF_CHECK(avifParseItemReferenceBox(meta, avifROStreamCurrent(&s), header.size, diag));
         }
 
-        CHECK(avifROStreamSkip(&s, header.size));
+        AVIF_CHECK(avifROStreamSkip(&s, header.size));
     }
     if (firstBox) {
         // The meta box must not be empty (it must contain at least a hdlr box)
@@ -2425,22 +2426,22 @@ static avifBool avifParseTrackHeaderBox(avifTrack * track,
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[tkhd]");
 
     uint8_t version;
-    CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
+    AVIF_CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
 
     uint32_t ignored32, trackID;
     uint64_t ignored64;
     if (version == 1) {
-        CHECK(avifROStreamReadU64(&s, &ignored64)); // unsigned int(64) creation_time;
-        CHECK(avifROStreamReadU64(&s, &ignored64)); // unsigned int(64) modification_time;
-        CHECK(avifROStreamReadU32(&s, &trackID));   // unsigned int(32) track_ID;
-        CHECK(avifROStreamReadU32(&s, &ignored32)); // const unsigned int(32) reserved = 0;
-        CHECK(avifROStreamReadU64(&s, &ignored64)); // unsigned int(64) duration;
+        AVIF_CHECK(avifROStreamReadU64(&s, &ignored64)); // unsigned int(64) creation_time;
+        AVIF_CHECK(avifROStreamReadU64(&s, &ignored64)); // unsigned int(64) modification_time;
+        AVIF_CHECK(avifROStreamReadU32(&s, &trackID));   // unsigned int(32) track_ID;
+        AVIF_CHECK(avifROStreamReadU32(&s, &ignored32)); // const unsigned int(32) reserved = 0;
+        AVIF_CHECK(avifROStreamReadU64(&s, &ignored64)); // unsigned int(64) duration;
     } else if (version == 0) {
-        CHECK(avifROStreamReadU32(&s, &ignored32)); // unsigned int(32) creation_time;
-        CHECK(avifROStreamReadU32(&s, &ignored32)); // unsigned int(32) modification_time;
-        CHECK(avifROStreamReadU32(&s, &trackID));   // unsigned int(32) track_ID;
-        CHECK(avifROStreamReadU32(&s, &ignored32)); // const unsigned int(32) reserved = 0;
-        CHECK(avifROStreamReadU32(&s, &ignored32)); // unsigned int(32) duration;
+        AVIF_CHECK(avifROStreamReadU32(&s, &ignored32)); // unsigned int(32) creation_time;
+        AVIF_CHECK(avifROStreamReadU32(&s, &ignored32)); // unsigned int(32) modification_time;
+        AVIF_CHECK(avifROStreamReadU32(&s, &trackID));   // unsigned int(32) track_ID;
+        AVIF_CHECK(avifROStreamReadU32(&s, &ignored32)); // const unsigned int(32) reserved = 0;
+        AVIF_CHECK(avifROStreamReadU32(&s, &ignored32)); // unsigned int(32) duration;
     } else {
         // Unsupported version
         avifDiagnosticsPrintf(diag, "Box[tkhd] has an unsupported version [%u]", version);
@@ -2455,11 +2456,11 @@ static avifBool avifParseTrackHeaderBox(avifTrack * track,
     // template int(16) volume = {if track_is_audio 0x0100 else 0};
     // const unsigned int(16) reserved = 0;
     // template int(32)[9] matrix= { 0x00010000,0,0,0,0x00010000,0,0,0,0x40000000 }; // unity matrix
-    CHECK(avifROStreamSkip(&s, 52));
+    AVIF_CHECK(avifROStreamSkip(&s, 52));
 
     uint32_t width, height;
-    CHECK(avifROStreamReadU32(&s, &width));  // unsigned int(32) width;
-    CHECK(avifROStreamReadU32(&s, &height)); // unsigned int(32) height;
+    AVIF_CHECK(avifROStreamReadU32(&s, &width));  // unsigned int(32) width;
+    AVIF_CHECK(avifROStreamReadU32(&s, &height)); // unsigned int(32) height;
     track->width = width >> 16;
     track->height = height >> 16;
 
@@ -2483,21 +2484,21 @@ static avifBool avifParseMediaHeaderBox(avifTrack * track, const uint8_t * raw, 
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[mdhd]");
 
     uint8_t version;
-    CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
+    AVIF_CHECK(avifROStreamReadVersionAndFlags(&s, &version, NULL));
 
     uint32_t ignored32, mediaTimescale, mediaDuration32;
     uint64_t ignored64, mediaDuration64;
     if (version == 1) {
-        CHECK(avifROStreamReadU64(&s, &ignored64));       // unsigned int(64) creation_time;
-        CHECK(avifROStreamReadU64(&s, &ignored64));       // unsigned int(64) modification_time;
-        CHECK(avifROStreamReadU32(&s, &mediaTimescale));  // unsigned int(32) timescale;
-        CHECK(avifROStreamReadU64(&s, &mediaDuration64)); // unsigned int(64) duration;
+        AVIF_CHECK(avifROStreamReadU64(&s, &ignored64));       // unsigned int(64) creation_time;
+        AVIF_CHECK(avifROStreamReadU64(&s, &ignored64));       // unsigned int(64) modification_time;
+        AVIF_CHECK(avifROStreamReadU32(&s, &mediaTimescale));  // unsigned int(32) timescale;
+        AVIF_CHECK(avifROStreamReadU64(&s, &mediaDuration64)); // unsigned int(64) duration;
         track->mediaDuration = mediaDuration64;
     } else if (version == 0) {
-        CHECK(avifROStreamReadU32(&s, &ignored32));       // unsigned int(32) creation_time;
-        CHECK(avifROStreamReadU32(&s, &ignored32));       // unsigned int(32) modification_time;
-        CHECK(avifROStreamReadU32(&s, &mediaTimescale));  // unsigned int(32) timescale;
-        CHECK(avifROStreamReadU32(&s, &mediaDuration32)); // unsigned int(32) duration;
+        AVIF_CHECK(avifROStreamReadU32(&s, &ignored32));       // unsigned int(32) creation_time;
+        AVIF_CHECK(avifROStreamReadU32(&s, &ignored32));       // unsigned int(32) modification_time;
+        AVIF_CHECK(avifROStreamReadU32(&s, &mediaTimescale));  // unsigned int(32) timescale;
+        AVIF_CHECK(avifROStreamReadU32(&s, &mediaDuration32)); // unsigned int(32) duration;
         track->mediaDuration = (uint64_t)mediaDuration32;
     } else {
         // Unsupported version
@@ -2513,17 +2514,17 @@ static avifBool avifParseChunkOffsetBox(avifSampleTable * sampleTable, avifBool 
 {
     BEGIN_STREAM(s, raw, rawLen, diag, largeOffsets ? "Box[co64]" : "Box[stco]");
 
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     uint32_t entryCount;
-    CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
+    AVIF_CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
     for (uint32_t i = 0; i < entryCount; ++i) {
         uint64_t offset;
         if (largeOffsets) {
-            CHECK(avifROStreamReadU64(&s, &offset)); // unsigned int(32) chunk_offset;
+            AVIF_CHECK(avifROStreamReadU64(&s, &offset)); // unsigned int(32) chunk_offset;
         } else {
             uint32_t offset32;
-            CHECK(avifROStreamReadU32(&s, &offset32)); // unsigned int(32) chunk_offset;
+            AVIF_CHECK(avifROStreamReadU32(&s, &offset32)); // unsigned int(32) chunk_offset;
             offset = (uint64_t)offset32;
         }
 
@@ -2537,16 +2538,16 @@ static avifBool avifParseSampleToChunkBox(avifSampleTable * sampleTable, const u
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[stsc]");
 
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     uint32_t entryCount;
-    CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
+    AVIF_CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
     uint32_t prevFirstChunk = 0;
     for (uint32_t i = 0; i < entryCount; ++i) {
         avifSampleTableSampleToChunk * sampleToChunk = (avifSampleTableSampleToChunk *)avifArrayPushPtr(&sampleTable->sampleToChunks);
-        CHECK(avifROStreamReadU32(&s, &sampleToChunk->firstChunk));             // unsigned int(32) first_chunk;
-        CHECK(avifROStreamReadU32(&s, &sampleToChunk->samplesPerChunk));        // unsigned int(32) samples_per_chunk;
-        CHECK(avifROStreamReadU32(&s, &sampleToChunk->sampleDescriptionIndex)); // unsigned int(32) sample_description_index;
+        AVIF_CHECK(avifROStreamReadU32(&s, &sampleToChunk->firstChunk));             // unsigned int(32) first_chunk;
+        AVIF_CHECK(avifROStreamReadU32(&s, &sampleToChunk->samplesPerChunk));        // unsigned int(32) samples_per_chunk;
+        AVIF_CHECK(avifROStreamReadU32(&s, &sampleToChunk->sampleDescriptionIndex)); // unsigned int(32) sample_description_index;
         // The first_chunk fields should start with 1 and be strictly increasing.
         if (i == 0) {
             if (sampleToChunk->firstChunk != 1) {
@@ -2568,18 +2569,18 @@ static avifBool avifParseSampleSizeBox(avifSampleTable * sampleTable, const uint
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[stsz]");
 
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     uint32_t allSamplesSize, sampleCount;
-    CHECK(avifROStreamReadU32(&s, &allSamplesSize)); // unsigned int(32) sample_size;
-    CHECK(avifROStreamReadU32(&s, &sampleCount));    // unsigned int(32) sample_count;
+    AVIF_CHECK(avifROStreamReadU32(&s, &allSamplesSize)); // unsigned int(32) sample_size;
+    AVIF_CHECK(avifROStreamReadU32(&s, &sampleCount));    // unsigned int(32) sample_count;
 
     if (allSamplesSize > 0) {
         sampleTable->allSamplesSize = allSamplesSize;
     } else {
         for (uint32_t i = 0; i < sampleCount; ++i) {
             avifSampleTableSampleSize * sampleSize = (avifSampleTableSampleSize *)avifArrayPushPtr(&sampleTable->sampleSizes);
-            CHECK(avifROStreamReadU32(&s, &sampleSize->size)); // unsigned int(32) entry_size;
+            AVIF_CHECK(avifROStreamReadU32(&s, &sampleSize->size)); // unsigned int(32) entry_size;
         }
     }
     return AVIF_TRUE;
@@ -2589,14 +2590,14 @@ static avifBool avifParseSyncSampleBox(avifSampleTable * sampleTable, const uint
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[stss]");
 
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     uint32_t entryCount;
-    CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
+    AVIF_CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
 
     for (uint32_t i = 0; i < entryCount; ++i) {
         uint32_t sampleNumber = 0;
-        CHECK(avifROStreamReadU32(&s, &sampleNumber)); // unsigned int(32) sample_number;
+        AVIF_CHECK(avifROStreamReadU32(&s, &sampleNumber)); // unsigned int(32) sample_number;
         avifSyncSample * syncSample = (avifSyncSample *)avifArrayPushPtr(&sampleTable->syncSamples);
         syncSample->sampleNumber = sampleNumber;
     }
@@ -2607,15 +2608,15 @@ static avifBool avifParseTimeToSampleBox(avifSampleTable * sampleTable, const ui
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[stts]");
 
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     uint32_t entryCount;
-    CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
+    AVIF_CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
 
     for (uint32_t i = 0; i < entryCount; ++i) {
         avifSampleTableTimeToSample * timeToSample = (avifSampleTableTimeToSample *)avifArrayPushPtr(&sampleTable->timeToSamples);
-        CHECK(avifROStreamReadU32(&s, &timeToSample->sampleCount)); // unsigned int(32) sample_count;
-        CHECK(avifROStreamReadU32(&s, &timeToSample->sampleDelta)); // unsigned int(32) sample_delta;
+        AVIF_CHECK(avifROStreamReadU32(&s, &timeToSample->sampleCount)); // unsigned int(32) sample_count;
+        AVIF_CHECK(avifROStreamReadU32(&s, &timeToSample->sampleDelta)); // unsigned int(32) sample_delta;
     }
     return AVIF_TRUE;
 }
@@ -2624,14 +2625,14 @@ static avifBool avifParseSampleDescriptionBox(avifSampleTable * sampleTable, con
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[stsd]");
 
-    CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
+    AVIF_CHECK(avifROStreamReadAndEnforceVersion(&s, 0));
 
     uint32_t entryCount;
-    CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
+    AVIF_CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
 
     for (uint32_t i = 0; i < entryCount; ++i) {
         avifBoxHeader sampleEntryHeader;
-        CHECK(avifROStreamReadBoxHeader(&s, &sampleEntryHeader));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &sampleEntryHeader));
 
         avifSampleDescription * description = (avifSampleDescription *)avifArrayPushPtr(&sampleTable->sampleDescriptions);
         if (!avifArrayCreate(&description->properties, sizeof(avifProperty), 16)) {
@@ -2641,13 +2642,13 @@ static avifBool avifParseSampleDescriptionBox(avifSampleTable * sampleTable, con
         memcpy(description->format, sampleEntryHeader.type, sizeof(description->format));
         size_t remainingBytes = avifROStreamRemainingBytes(&s);
         if (!memcmp(description->format, "av01", 4) && (remainingBytes > VISUALSAMPLEENTRY_SIZE)) {
-            CHECK(avifParseItemPropertyContainerBox(&description->properties,
-                                                    avifROStreamCurrent(&s) + VISUALSAMPLEENTRY_SIZE,
-                                                    remainingBytes - VISUALSAMPLEENTRY_SIZE,
-                                                    diag));
+            AVIF_CHECK(avifParseItemPropertyContainerBox(&description->properties,
+                                                         avifROStreamCurrent(&s) + VISUALSAMPLEENTRY_SIZE,
+                                                         remainingBytes - VISUALSAMPLEENTRY_SIZE,
+                                                         diag));
         }
 
-        CHECK(avifROStreamSkip(&s, sampleEntryHeader.size));
+        AVIF_CHECK(avifROStreamSkip(&s, sampleEntryHeader.size));
     }
     return AVIF_TRUE;
 }
@@ -2665,25 +2666,25 @@ static avifBool avifParseSampleTableBox(avifTrack * track, const uint8_t * raw, 
 
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader header;
-        CHECK(avifROStreamReadBoxHeader(&s, &header));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
         if (!memcmp(header.type, "stco", 4)) {
-            CHECK(avifParseChunkOffsetBox(track->sampleTable, AVIF_FALSE, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseChunkOffsetBox(track->sampleTable, AVIF_FALSE, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "co64", 4)) {
-            CHECK(avifParseChunkOffsetBox(track->sampleTable, AVIF_TRUE, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseChunkOffsetBox(track->sampleTable, AVIF_TRUE, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "stsc", 4)) {
-            CHECK(avifParseSampleToChunkBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseSampleToChunkBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "stsz", 4)) {
-            CHECK(avifParseSampleSizeBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseSampleSizeBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "stss", 4)) {
-            CHECK(avifParseSyncSampleBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseSyncSampleBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "stts", 4)) {
-            CHECK(avifParseTimeToSampleBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseTimeToSampleBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "stsd", 4)) {
-            CHECK(avifParseSampleDescriptionBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseSampleDescriptionBox(track->sampleTable, avifROStreamCurrent(&s), header.size, diag));
         }
 
-        CHECK(avifROStreamSkip(&s, header.size));
+        AVIF_CHECK(avifROStreamSkip(&s, header.size));
     }
     return AVIF_TRUE;
 }
@@ -2694,13 +2695,13 @@ static avifBool avifParseMediaInformationBox(avifTrack * track, const uint8_t * 
 
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader header;
-        CHECK(avifROStreamReadBoxHeader(&s, &header));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
         if (!memcmp(header.type, "stbl", 4)) {
-            CHECK(avifParseSampleTableBox(track, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseSampleTableBox(track, avifROStreamCurrent(&s), header.size, diag));
         }
 
-        CHECK(avifROStreamSkip(&s, header.size));
+        AVIF_CHECK(avifROStreamSkip(&s, header.size));
     }
     return AVIF_TRUE;
 }
@@ -2711,15 +2712,15 @@ static avifBool avifParseMediaBox(avifTrack * track, const uint8_t * raw, size_t
 
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader header;
-        CHECK(avifROStreamReadBoxHeader(&s, &header));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
         if (!memcmp(header.type, "mdhd", 4)) {
-            CHECK(avifParseMediaHeaderBox(track, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseMediaHeaderBox(track, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "minf", 4)) {
-            CHECK(avifParseMediaInformationBox(track, avifROStreamCurrent(&s), header.size, diag));
+            AVIF_CHECK(avifParseMediaInformationBox(track, avifROStreamCurrent(&s), header.size, diag));
         }
 
-        CHECK(avifROStreamSkip(&s, header.size));
+        AVIF_CHECK(avifROStreamSkip(&s, header.size));
     }
     return AVIF_TRUE;
 }
@@ -2730,20 +2731,20 @@ static avifBool avifTrackReferenceBox(avifTrack * track, const uint8_t * raw, si
 
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader header;
-        CHECK(avifROStreamReadBoxHeader(&s, &header));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
         if (!memcmp(header.type, "auxl", 4)) {
             uint32_t toID;
-            CHECK(avifROStreamReadU32(&s, &toID));                       // unsigned int(32) track_IDs[];
-            CHECK(avifROStreamSkip(&s, header.size - sizeof(uint32_t))); // just take the first one
+            AVIF_CHECK(avifROStreamReadU32(&s, &toID));                       // unsigned int(32) track_IDs[];
+            AVIF_CHECK(avifROStreamSkip(&s, header.size - sizeof(uint32_t))); // just take the first one
             track->auxForID = toID;
         } else if (!memcmp(header.type, "prem", 4)) {
             uint32_t byID;
-            CHECK(avifROStreamReadU32(&s, &byID));                       // unsigned int(32) track_IDs[];
-            CHECK(avifROStreamSkip(&s, header.size - sizeof(uint32_t))); // just take the first one
+            AVIF_CHECK(avifROStreamReadU32(&s, &byID));                       // unsigned int(32) track_IDs[];
+            AVIF_CHECK(avifROStreamSkip(&s, header.size - sizeof(uint32_t))); // just take the first one
             track->premByID = byID;
         } else {
-            CHECK(avifROStreamSkip(&s, header.size));
+            AVIF_CHECK(avifROStreamSkip(&s, header.size));
         }
     }
     return AVIF_TRUE;
@@ -2757,19 +2758,19 @@ static avifBool avifParseTrackBox(avifDecoderData * data, const uint8_t * raw, s
 
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader header;
-        CHECK(avifROStreamReadBoxHeader(&s, &header));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
         if (!memcmp(header.type, "tkhd", 4)) {
-            CHECK(avifParseTrackHeaderBox(track, avifROStreamCurrent(&s), header.size, imageSizeLimit, imageDimensionLimit, data->diag));
+            AVIF_CHECK(avifParseTrackHeaderBox(track, avifROStreamCurrent(&s), header.size, imageSizeLimit, imageDimensionLimit, data->diag));
         } else if (!memcmp(header.type, "meta", 4)) {
-            CHECK(avifParseMetaBox(track->meta, avifROStreamCurrent(&s), header.size, data->diag));
+            AVIF_CHECK(avifParseMetaBox(track->meta, avifROStreamCurrent(&s), header.size, data->diag));
         } else if (!memcmp(header.type, "mdia", 4)) {
-            CHECK(avifParseMediaBox(track, avifROStreamCurrent(&s), header.size, data->diag));
+            AVIF_CHECK(avifParseMediaBox(track, avifROStreamCurrent(&s), header.size, data->diag));
         } else if (!memcmp(header.type, "tref", 4)) {
-            CHECK(avifTrackReferenceBox(track, avifROStreamCurrent(&s), header.size, data->diag));
+            AVIF_CHECK(avifTrackReferenceBox(track, avifROStreamCurrent(&s), header.size, data->diag));
         }
 
-        CHECK(avifROStreamSkip(&s, header.size));
+        AVIF_CHECK(avifROStreamSkip(&s, header.size));
     }
     return AVIF_TRUE;
 }
@@ -2780,13 +2781,13 @@ static avifBool avifParseMovieBox(avifDecoderData * data, const uint8_t * raw, s
 
     while (avifROStreamHasBytesLeft(&s, 1)) {
         avifBoxHeader header;
-        CHECK(avifROStreamReadBoxHeader(&s, &header));
+        AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
         if (!memcmp(header.type, "trak", 4)) {
-            CHECK(avifParseTrackBox(data, avifROStreamCurrent(&s), header.size, imageSizeLimit, imageDimensionLimit));
+            AVIF_CHECK(avifParseTrackBox(data, avifROStreamCurrent(&s), header.size, imageSizeLimit, imageDimensionLimit));
         }
 
-        CHECK(avifROStreamSkip(&s, header.size));
+        AVIF_CHECK(avifROStreamSkip(&s, header.size));
     }
     return AVIF_TRUE;
 }
@@ -2795,8 +2796,8 @@ static avifBool avifParseFileTypeBox(avifFileType * ftyp, const uint8_t * raw, s
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[ftyp]");
 
-    CHECK(avifROStreamRead(&s, ftyp->majorBrand, 4));
-    CHECK(avifROStreamReadU32(&s, &ftyp->minorVersion));
+    AVIF_CHECK(avifROStreamRead(&s, ftyp->majorBrand, 4));
+    AVIF_CHECK(avifROStreamReadU32(&s, &ftyp->minorVersion));
 
     size_t compatibleBrandsBytes = avifROStreamRemainingBytes(&s);
     if ((compatibleBrandsBytes % 4) != 0) {
@@ -2804,7 +2805,7 @@ static avifBool avifParseFileTypeBox(avifFileType * ftyp, const uint8_t * raw, s
         return AVIF_FALSE;
     }
     ftyp->compatibleBrands = avifROStreamCurrent(&s);
-    CHECK(avifROStreamSkip(&s, compatibleBrandsBytes));
+    AVIF_CHECK(avifROStreamSkip(&s, compatibleBrandsBytes));
     ftyp->compatibleBrandsCount = (int)compatibleBrandsBytes / 4;
 
     return AVIF_TRUE;
@@ -2816,7 +2817,7 @@ static avifBool avifFileTypeIsCompatible(avifFileType * ftyp);
 static avifResult avifParse(avifDecoder * decoder)
 {
     // Note: this top-level function is the only avifParse*() function that returns avifResult instead of avifBool.
-    // Be sure to use CHECKERR() in this function with an explicit error result instead of simply using CHECK().
+    // Be sure to use AVIF_CHECKERR() in this function with an explicit error result instead of simply using AVIF_CHECK().
 
     avifResult readResult;
     uint64_t parseOffset = 0;
@@ -2846,7 +2847,7 @@ static avifResult avifParse(avifDecoder * decoder)
         // Parse the header, and find out how many bytes it actually was
         BEGIN_STREAM(headerStream, headerContents.data, headerContents.size, &decoder->diag, "File-level box header");
         avifBoxHeader header;
-        CHECKERR(avifROStreamReadBoxHeaderPartial(&headerStream, &header), AVIF_RESULT_BMFF_PARSE_FAILED);
+        AVIF_CHECKERR(avifROStreamReadBoxHeaderPartial(&headerStream, &header), AVIF_RESULT_BMFF_PARSE_FAILED);
         parseOffset += headerStream.offset;
         assert((decoder->io->sizeHint == 0) || (parseOffset <= decoder->io->sizeHint));
 
@@ -2869,9 +2870,9 @@ static avifResult avifParse(avifDecoder * decoder)
         parseOffset += header.size;
 
         if (!memcmp(header.type, "ftyp", 4)) {
-            CHECKERR(!ftypSeen, AVIF_RESULT_BMFF_PARSE_FAILED);
+            AVIF_CHECKERR(!ftypSeen, AVIF_RESULT_BMFF_PARSE_FAILED);
             avifFileType ftyp;
-            CHECKERR(avifParseFileTypeBox(&ftyp, boxContents.data, boxContents.size, data->diag), AVIF_RESULT_BMFF_PARSE_FAILED);
+            AVIF_CHECKERR(avifParseFileTypeBox(&ftyp, boxContents.data, boxContents.size, data->diag), AVIF_RESULT_BMFF_PARSE_FAILED);
             if (!avifFileTypeIsCompatible(&ftyp)) {
                 return AVIF_RESULT_INVALID_FTYP;
             }
@@ -2880,13 +2881,13 @@ static avifResult avifParse(avifDecoder * decoder)
             needsMeta = avifFileTypeHasBrand(&ftyp, "avif");
             needsMoov = avifFileTypeHasBrand(&ftyp, "avis");
         } else if (!memcmp(header.type, "meta", 4)) {
-            CHECKERR(!metaSeen, AVIF_RESULT_BMFF_PARSE_FAILED);
-            CHECKERR(avifParseMetaBox(data->meta, boxContents.data, boxContents.size, data->diag), AVIF_RESULT_BMFF_PARSE_FAILED);
+            AVIF_CHECKERR(!metaSeen, AVIF_RESULT_BMFF_PARSE_FAILED);
+            AVIF_CHECKERR(avifParseMetaBox(data->meta, boxContents.data, boxContents.size, data->diag), AVIF_RESULT_BMFF_PARSE_FAILED);
             metaSeen = AVIF_TRUE;
         } else if (!memcmp(header.type, "moov", 4)) {
-            CHECKERR(!moovSeen, AVIF_RESULT_BMFF_PARSE_FAILED);
-            CHECKERR(avifParseMovieBox(data, boxContents.data, boxContents.size, decoder->imageSizeLimit, decoder->imageDimensionLimit),
-                     AVIF_RESULT_BMFF_PARSE_FAILED);
+            AVIF_CHECKERR(!moovSeen, AVIF_RESULT_BMFF_PARSE_FAILED);
+            AVIF_CHECKERR(avifParseMovieBox(data, boxContents.data, boxContents.size, decoder->imageSizeLimit, decoder->imageDimensionLimit),
+                          AVIF_RESULT_BMFF_PARSE_FAILED);
             moovSeen = AVIF_TRUE;
         }
 
@@ -2933,7 +2934,7 @@ avifBool avifPeekCompatibleFileType(const avifROData * input)
     BEGIN_STREAM(s, input->data, input->size, NULL, NULL);
 
     avifBoxHeader header;
-    CHECK(avifROStreamReadBoxHeader(&s, &header));
+    AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
     if (memcmp(header.type, "ftyp", 4)) {
         return AVIF_FALSE;
     }

--- a/src/stream.c
+++ b/src/stream.c
@@ -79,19 +79,19 @@ avifBool avifROStreamReadUX8(avifROStream * stream, uint64_t * v, uint64_t facto
         *v = 0;
     } else if (factor == 1) {
         uint8_t tmp;
-        CHECK(avifROStreamRead(stream, &tmp, 1));
+        AVIF_CHECK(avifROStreamRead(stream, &tmp, 1));
         *v = tmp;
     } else if (factor == 2) {
         uint16_t tmp;
-        CHECK(avifROStreamReadU16(stream, &tmp));
+        AVIF_CHECK(avifROStreamReadU16(stream, &tmp));
         *v = tmp;
     } else if (factor == 4) {
         uint32_t tmp;
-        CHECK(avifROStreamReadU32(stream, &tmp));
+        AVIF_CHECK(avifROStreamReadU32(stream, &tmp));
         *v = tmp;
     } else if (factor == 8) {
         uint64_t tmp;
-        CHECK(avifROStreamReadU64(stream, &tmp));
+        AVIF_CHECK(avifROStreamReadU64(stream, &tmp));
         *v = tmp;
     } else {
         // Unsupported factor
@@ -103,21 +103,21 @@ avifBool avifROStreamReadUX8(avifROStream * stream, uint64_t * v, uint64_t facto
 
 avifBool avifROStreamReadU16(avifROStream * stream, uint16_t * v)
 {
-    CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint16_t)));
+    AVIF_CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint16_t)));
     *v = avifNTOHS(*v);
     return AVIF_TRUE;
 }
 
 avifBool avifROStreamReadU32(avifROStream * stream, uint32_t * v)
 {
-    CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint32_t)));
+    AVIF_CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint32_t)));
     *v = avifNTOHL(*v);
     return AVIF_TRUE;
 }
 
 avifBool avifROStreamReadU64(avifROStream * stream, uint64_t * v)
 {
-    CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint64_t)));
+    AVIF_CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint64_t)));
     *v = avifNTOH64(*v);
     return AVIF_TRUE;
 }
@@ -159,16 +159,16 @@ avifBool avifROStreamReadBoxHeaderPartial(avifROStream * stream, avifBoxHeader *
     size_t startOffset = stream->offset;
 
     uint32_t smallSize;
-    CHECK(avifROStreamReadU32(stream, &smallSize));
-    CHECK(avifROStreamRead(stream, header->type, 4));
+    AVIF_CHECK(avifROStreamReadU32(stream, &smallSize));
+    AVIF_CHECK(avifROStreamRead(stream, header->type, 4));
 
     uint64_t size = smallSize;
     if (size == 1) {
-        CHECK(avifROStreamReadU64(stream, &size));
+        AVIF_CHECK(avifROStreamReadU64(stream, &size));
     }
 
     if (!memcmp(header->type, "uuid", 4)) {
-        CHECK(avifROStreamSkip(stream, 16));
+        AVIF_CHECK(avifROStreamSkip(stream, 16));
     }
 
     size_t bytesRead = stream->offset - startOffset;
@@ -182,7 +182,7 @@ avifBool avifROStreamReadBoxHeaderPartial(avifROStream * stream, avifBoxHeader *
 
 avifBool avifROStreamReadBoxHeader(avifROStream * stream, avifBoxHeader * header)
 {
-    CHECK(avifROStreamReadBoxHeaderPartial(stream, header));
+    AVIF_CHECK(avifROStreamReadBoxHeaderPartial(stream, header));
     if (header->size > avifROStreamRemainingBytes(stream)) {
         avifDiagnosticsPrintf(stream->diag, "%s: Child box too large, possibly truncated data", stream->diagContext);
         return AVIF_FALSE;
@@ -193,7 +193,7 @@ avifBool avifROStreamReadBoxHeader(avifROStream * stream, avifBoxHeader * header
 avifBool avifROStreamReadVersionAndFlags(avifROStream * stream, uint8_t * version, uint32_t * flags)
 {
     uint8_t versionAndFlags[4];
-    CHECK(avifROStreamRead(stream, versionAndFlags, 4));
+    AVIF_CHECK(avifROStreamRead(stream, versionAndFlags, 4));
     if (version) {
         *version = versionAndFlags[0];
     }
@@ -206,7 +206,7 @@ avifBool avifROStreamReadVersionAndFlags(avifROStream * stream, uint8_t * versio
 avifBool avifROStreamReadAndEnforceVersion(avifROStream * stream, uint8_t enforcedVersion)
 {
     uint8_t version;
-    CHECK(avifROStreamReadVersionAndFlags(stream, &version, NULL));
+    AVIF_CHECK(avifROStreamReadVersionAndFlags(stream, &version, NULL));
     if (version != enforcedVersion) {
         avifDiagnosticsPrintf(stream->diag, "%s: Expecting box version %u, got version %u", stream->diagContext, enforcedVersion, version);
         return AVIF_FALSE;


### PR DESCRIPTION
So that tests including include/avif/internal.h and depending on frameworks already defining CHECK do not trigger -Wmacro-redefined.