### PR TITLE
Add AVIF_ prefix to three macros in internal.h

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -32,10 +32,10 @@ extern "C" {
 // ---------------------------------------------------------------------------
 // URNs and Content-Types
 
-#define URN_ALPHA0 "urn:mpeg:mpegB:cicp:systems:auxiliary:alpha"
-#define URN_ALPHA1 "urn:mpeg:hevc:2015:auxid:1"
+#define AVIF_URN_ALPHA0 "urn:mpeg:mpegB:cicp:systems:auxiliary:alpha"
+#define AVIF_URN_ALPHA1 "urn:mpeg:hevc:2015:auxid:1"
 
-#define CONTENT_TYPE_XMP "application/rdf+xml"
+#define AVIF_CONTENT_TYPE_XMP "application/rdf+xml"
 
 // ---------------------------------------------------------------------------
 // Utils

--- a/src/read.c
+++ b/src/read.c
@@ -30,7 +30,7 @@
 // }
 static const size_t VISUALSAMPLEENTRY_SIZE = 78;
 
-static const char xmpContentType[] = CONTENT_TYPE_XMP;
+static const char xmpContentType[] = AVIF_CONTENT_TYPE_XMP;
 static const size_t xmpContentTypeSize = sizeof(xmpContentType);
 
 // The only supported ipma box values for both version and flags are [0,1], so there technically
@@ -1503,7 +1503,7 @@ static avifResult avifDecoderFindMetadata(avifDecoder * decoder, avifMeta * meta
 
 static avifBool isAlphaURN(const char * urn)
 {
-    return !strcmp(urn, URN_ALPHA0) || !strcmp(urn, URN_ALPHA1);
+    return !strcmp(urn, AVIF_URN_ALPHA0) || !strcmp(urn, AVIF_URN_ALPHA1);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/write.c
+++ b/src/write.c
@@ -30,10 +30,10 @@ typedef struct avifOffsetFixup
 } avifOffsetFixup;
 AVIF_ARRAY_DECLARE(avifOffsetFixupArray, avifOffsetFixup, fixup);
 
-static const char alphaURN[] = URN_ALPHA0;
+static const char alphaURN[] = AVIF_URN_ALPHA0;
 static const size_t alphaURNSize = sizeof(alphaURN);
 
-static const char xmpContentType[] = CONTENT_TYPE_XMP;
+static const char xmpContentType[] = AVIF_CONTENT_TYPE_XMP;
 static const size_t xmpContentTypeSize = sizeof(xmpContentType);
 
 static avifBool avifImageIsOpaque(const avifImage * image);


### PR DESCRIPTION
With this change, everything in internal.h has the "avif" or "AVIF_" prefix. Since we have started to test internal functions declared in internal.h using GoogleTest, some unit test files may include both internal.h and external headers. Using a namespace prefix avoid name conflicts with external headers.