### PR TITLE
Use mktemp instead of /tmp in test_cmd.sh

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,6 @@ if(AVIF_BUILD_APPS)
     add_executable(are_images_equal gtest/are_images_equal.cc)
     target_link_libraries(are_images_equal aviftest_helpers)
     add_test(NAME test_cmd COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd.sh ${CMAKE_BINARY_DIR}
-                                   ${CMAKE_CURRENT_SOURCE_DIR}/data /tmp
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/data
     )
 endif()

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -34,7 +34,7 @@ fi
 if [[ "$#" -ge 3 ]]; then
   TMP_DIR="$(eval echo "$3")"
 else
-  TMP_DIR=/tmp
+  TMP_DIR="$(mktemp -d)"
 fi
 
 AVIFENC="${BINARY_DIR}/avifenc"


### PR DESCRIPTION
It should avoid test file conflicts for multiple testing environments started at the same time.