### PR TITLE
Bring back deprecated avifImageRGBToYUV() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-There are incompatible ABI changes in this release. The alphaRange member was
-removed from avifImage struct. The chromaDownsampling member was added to the
-avifRGBImage struct. The imageDimensionLimit member was added to the avifDecoder
-struct. avifImageCopy() and avifImageAllocatePlanes() signatures changed. It is
-necessary to recompile your code. Also check the return values of
+There are incompatible ABI changes in this release:
+* The alphaRange member was removed from avifImage struct.
+* avifChromaDownsampling was deprecated and is no longer an enum.
+* The imageDimensionLimit member was added to the avifDecoder struct.
+* avifImageCopy() and avifImageAllocatePlanes() signatures changed.
+
+It is necessary to recompile your code. Also check the return values of
 avifImageCopy() and avifImageAllocatePlanes().
 
 ### Changed
@@ -21,9 +23,9 @@ avifImageCopy() and avifImageAllocatePlanes().
 * Update libyuv.cmd: 9b17af9b (version 1838)
 * avifImageCopy() and avifImageAllocatePlanes() now return avifResult instead of
   void to report invalid parameters or memory allocation failures.
-* avifImageRGBToYUV() now uses libyuv fast paths by default. It may slightly
-  change conversion results. The old behavior can be restored by setting
-  avifRGBImage::chromaDownsampling to AVIF_CHROMA_DOWNSAMPLING_BEST_QUALITY.
+* avifRGBImageToYUV() and avifRGBImageFromYUV() were added with avifRGBToYUVFlags
+  and avifYUVToRGBFlags.
+* avifImageRGBToYUV() and avifImageYUVToRGB() are deprecated.
 
 ### Removed
 * alphaRange field was removed from the avifImage struct. It it presumed that

--- a/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
+++ b/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
@@ -166,7 +166,7 @@ FUNC(jboolean, decode, jobject encoded, int length, jobject bitmap) {
   }
   rgb_image.pixels = static_cast<uint8_t*>(bitmap_pixels);
   rgb_image.rowBytes = bitmap_info.stride;
-  res = avifImageYUVToRGB(decoder.decoder->image, &rgb_image,
+  res = avifRGBImageFromYUV(decoder.decoder->image, &rgb_image,
                           AVIF_YUV_TO_RGB_DEFAULT);
   AndroidBitmap_unlockPixels(env, bitmap);
   if (res != AVIF_RESULT_OK) {

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -328,7 +328,7 @@ avifBool avifJPEGRead(const char * inputFilename,
             memcpy(pixelRow, buffer[0], rgb.rowBytes);
             ++row;
         }
-        if (avifImageRGBToYUV(avif, &rgb, flags) != AVIF_RESULT_OK) {
+        if (avifRGBImageToYUV(&rgb, avif, flags) != AVIF_RESULT_OK) {
             fprintf(stderr, "Conversion to YUV failed: %s\n", inputFilename);
             goto cleanup;
         }
@@ -397,7 +397,7 @@ avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int 
     rgb.format = AVIF_RGB_FORMAT_RGB;
     rgb.depth = 8;
     avifRGBImageAllocatePixels(&rgb);
-    if (avifImageYUVToRGB(avif, &rgb, conversionFlags) != AVIF_RESULT_OK) {
+    if (avifRGBImageFromYUV(avif, &rgb, conversionFlags) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);
         goto cleanup;
     }

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -335,7 +335,7 @@ avifBool avifPNGRead(const char * inputFilename,
         rowPointers[y] = &rgb.pixels[y * rgb.rowBytes];
     }
     png_read_image(png, rowPointers);
-    if (avifImageRGBToYUV(avif, &rgb, flags) != AVIF_RESULT_OK) {
+    if (avifRGBImageToYUV(&rgb, avif, flags) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to YUV failed: %s\n", inputFilename);
         goto cleanup;
     }
@@ -395,7 +395,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
         rgb.format = AVIF_RGB_FORMAT_RGB;
     }
     avifRGBImageAllocatePixels(&rgb);
-    if (avifImageYUVToRGB(avif, &rgb, conversionFlags) != AVIF_RESULT_OK) {
+    if (avifRGBImageFromYUV(avif, &rgb, conversionFlags) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);
         goto cleanup;
     }

--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -124,7 +124,7 @@ static gboolean avif_context_try_load(struct avif_context * context, GError ** e
     rgb.pixels = gdk_pixbuf_get_pixels(output);
     rgb.rowBytes = gdk_pixbuf_get_rowstride(output);
 
-    ret = avifImageYUVToRGB(image, &rgb, AVIF_YUV_TO_RGB_DEFAULT);
+    ret = avifRGBImageFromYUV(image, &rgb, AVIF_YUV_TO_RGB_DEFAULT);
     if (ret != AVIF_RESULT_OK) {
         g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
                     "Failed to convert YUV to RGB: %s", avifResultToString(ret));
@@ -448,7 +448,7 @@ static gboolean avif_image_saver(FILE          *f,
         rgb.format = AVIF_RGB_FORMAT_RGB;
     }
 
-    res = avifImageRGBToYUV(avif, &rgb, AVIF_RGB_TO_YUV_DEFAULT);
+    res = avifRGBImageToYUV(avif, &rgb, AVIF_RGB_TO_YUV_DEFAULT);
     if ( res != AVIF_RESULT_OK ) {
         g_set_error(error,
                     GDK_PIXBUF_ERROR,

--- a/examples/avif_example_decode_file.c
+++ b/examples/avif_example_decode_file.c
@@ -60,7 +60,7 @@ int main(int argc, char * argv[])
         avifRGBImageAllocatePixels(&rgb);
 
         // Other flags than AVIF_YUV_TO_RGB_DEFAULT, such as AVIF_CHROMA_UPSAMPLING_NEAREST, can be passed.
-        if (avifImageYUVToRGB(decoder->image, &rgb, AVIF_YUV_TO_RGB_DEFAULT) != AVIF_RESULT_OK) {
+        if (avifRGBImageFromYUV(decoder->image, &rgb, AVIF_YUV_TO_RGB_DEFAULT) != AVIF_RESULT_OK) {
             fprintf(stderr, "Conversion from YUV failed: %s\n", inputFilename);
             goto cleanup;
         }

--- a/examples/avif_example_decode_memory.c
+++ b/examples/avif_example_decode_memory.c
@@ -82,7 +82,7 @@ int main(int argc, char * argv[])
         avifRGBImageAllocatePixels(&rgb);
 
         // Other flags than AVIF_YUV_TO_RGB_DEFAULT, such as AVIF_CHROMA_UPSAMPLING_NEAREST, can be passed.
-        if (avifImageYUVToRGB(decoder->image, &rgb, AVIF_YUV_TO_RGB_DEFAULT) != AVIF_RESULT_OK) {
+        if (avifRGBImageFromYUV(decoder->image, &rgb, AVIF_YUV_TO_RGB_DEFAULT) != AVIF_RESULT_OK) {
             fprintf(stderr, "Conversion from YUV failed: %s\n", inputFilename);
             goto cleanup;
         }

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -67,7 +67,7 @@ int main(int argc, char * argv[])
         memset(rgb.pixels, 255, rgb.rowBytes * image->height);
 
         // Other flags than AVIF_RGB_TO_YUV_DEFAULT, such as AVIF_RGB_TO_YUV_AVOID_LIBYUV, can be passed.
-        avifResult convertResult = avifImageRGBToYUV(image, &rgb, AVIF_RGB_TO_YUV_DEFAULT);
+        avifResult convertResult = avifRGBImageToYUV(&rgb, image, AVIF_RGB_TO_YUV_DEFAULT);
         if (convertResult != AVIF_RESULT_OK) {
             fprintf(stderr, "Failed to convert to YUV(A): %s\n", avifResultToString(convertResult));
             goto cleanup;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -135,7 +135,7 @@ typedef struct avifReformatState
     float unormFloatTableUV[1 << 12];
 
     avifReformatMode mode;
-    // Used by avifImageYUVToRGB() only. avifImageRGBToYUV() uses a local variable (alphaMode) instead.
+    // Used by avifRGBImageFromYUV() only. avifRGBImageToYUV() uses a local variable (alphaMode) instead.
     avifAlphaMultiplyMode toRGBAlphaMode;
 } avifReformatState;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,11 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifchangesettingtest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifchangesettingtest COMMAND avifchangesettingtest)
 
+    add_executable(avifdeprecatedapitest gtest/avifdeprecatedapitest.cc)
+    target_link_libraries(avifdeprecatedapitest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
+    target_include_directories(avifdeprecatedapitest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifdeprecatedapitest COMMAND avifdeprecatedapitest)
+
     add_executable(avifgridapitest gtest/avifgridapitest.cc)
     target_link_libraries(avifgridapitest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avifgridapitest PRIVATE ${GTEST_INCLUDE_DIRS})

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -203,8 +203,8 @@ int main(int argc, char * argv[])
                                 }
                             }
 
-                            avifImageRGBToYUV(image, &srcRGB, AVIF_RGB_TO_YUV_DEFAULT);
-                            avifImageYUVToRGB(image, &dstRGB, AVIF_YUV_TO_RGB_DEFAULT);
+                            avifRGBImageToYUV(&srcRGB, image, AVIF_RGB_TO_YUV_DEFAULT);
+                            avifRGBImageFromYUV(image, &dstRGB, AVIF_YUV_TO_RGB_DEFAULT);
 
                             for (int y = 0; y < dim; ++y) {
                                 const uint8_t * srcRow = &srcRGB.pixels[y * srcRGB.rowBytes];
@@ -344,23 +344,23 @@ int main(int argc, char * argv[])
                         avifImageFreePlanes(image, AVIF_PLANES_ALL);
                         image->depth = yuvDepth;
                         image->yuvRange = yuvRange;
-                        avifImageRGBToYUV(image, &srcRGB, AVIF_RGB_TO_YUV_DEFAULT);
+                        avifRGBImageToYUV(&srcRGB, image, AVIF_RGB_TO_YUV_DEFAULT);
 
                         avifRGBImage intermediateRGB;
                         avifRGBImageSetDefaults(&intermediateRGB, image);
                         intermediateRGB.depth = rgbDepth;
                         intermediateRGB.format = rgbFormat;
                         avifRGBImageAllocatePixels(&intermediateRGB);
-                        avifImageYUVToRGB(image, &intermediateRGB, AVIF_YUV_TO_RGB_DEFAULT);
+                        avifRGBImageFromYUV(image, &intermediateRGB, AVIF_YUV_TO_RGB_DEFAULT);
 
                         avifImageFreePlanes(image, AVIF_PLANES_ALL);
-                        avifImageRGBToYUV(image, &intermediateRGB, AVIF_RGB_TO_YUV_DEFAULT);
+                        avifRGBImageToYUV(&intermediateRGB, image, AVIF_RGB_TO_YUV_DEFAULT);
 
                         avifRGBImage dstRGB;
                         avifRGBImageSetDefaults(&dstRGB, image);
                         dstRGB.depth = yuvDepth;
                         avifRGBImageAllocatePixels(&dstRGB);
-                        avifImageYUVToRGB(image, &dstRGB, AVIF_YUV_TO_RGB_DEFAULT);
+                        avifRGBImageFromYUV(image, &dstRGB, AVIF_YUV_TO_RGB_DEFAULT);
 
                         avifBool moveOn = AVIF_FALSE;
                         for (uint32_t j = 0; j < originalHeight; ++j) {

--- a/tests/gtest/avifdeprecatedapitest.cc
+++ b/tests/gtest/avifdeprecatedapitest.cc
@@ -1,0 +1,26 @@
+// Copyright 2022 Google LLC. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+TEST(DeprecatedApiTest, avifImageRGBToYUV) {
+  testutil::AvifImagePtr yuv =
+      testutil::CreateImage(123, 456, 10, AVIF_PIXEL_FORMAT_YUV422,
+                            AVIF_PLANES_ALL, AVIF_RANGE_LIMITED);
+  ASSERT_NE(yuv, nullptr);
+  testutil::FillImageGradient(yuv.get());
+
+  testutil::AvifRgbImage rgb(yuv.get(), yuv->depth, AVIF_RGB_FORMAT_RGBA);
+  rgb.chromaUpsampling = AVIF_CHROMA_UPSAMPLING_FASTEST;
+  ASSERT_EQ(avifImageYUVToRGB(yuv.get(), &rgb), AVIF_RESULT_OK);
+  rgb.chromaDownsampling = AVIF_CHROMA_DOWNSAMPLING_BEST_QUALITY;
+  ASSERT_EQ(avifImageRGBToYUV(yuv.get(), &rgb), AVIF_RESULT_OK);
+}
+
+}  // namespace
+}  // namespace libavif

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -21,7 +21,7 @@ constexpr int AVIF_CHAN_A = AVIF_CHAN_V + 1;
 
 //------------------------------------------------------------------------------
 
-AvifRgbImage::AvifRgbImage(const avifImage* yuv, int rgbDepth,
+AvifRgbImage::AvifRgbImage(const avifImage* yuv, uint32_t rgbDepth,
                            avifRGBFormat rgbFormat) {
   avifRGBImageSetDefaults(this, yuv);
   depth = rgbDepth;

--- a/tests/gtest/aviftest_helpers.h
+++ b/tests/gtest/aviftest_helpers.h
@@ -29,7 +29,8 @@ class AvifRwData : public avifRWData {
 
 class AvifRgbImage : public avifRGBImage {
  public:
-  AvifRgbImage(const avifImage* yuv, int rgbDepth, avifRGBFormat rgbFormat);
+  AvifRgbImage(const avifImage* yuv, uint32_t rgbDepth,
+               avifRGBFormat rgbFormat);
   ~AvifRgbImage() { avifRGBImageFreePixels(this); }
 };
 

--- a/tests/oss-fuzz/avif_decode_fuzzer.cc
+++ b/tests/oss-fuzz/avif_decode_fuzzer.cc
@@ -50,9 +50,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
                             rgb.depth = rgbDepths[rgbDepthsIndex];
                             avifRGBImageAllocatePixels(&rgb);
                             avifResult rgbResult =
-                                avifImageYUVToRGB(decoder->image, &rgb, AVIF_YUV_TO_RGB_AVOID_LIBYUV | upsamplingFlags[upsamplingFlagsIndex]);
-                            // Since avifImageRGBToYUV() ignores upsamplingFlags, we only need
-                            // to test avifImageRGBToYUV() with a single upsamplingFlagsIndex.
+                                avifRGBImageFromYUV(decoder->image,
+                                                    &rgb,
+                                                    AVIF_YUV_TO_RGB_AVOID_LIBYUV | upsamplingFlags[upsamplingFlagsIndex]);
+                            // Since avifRGBImageToYUV() ignores upsamplingFlags, we only need
+                            // to test avifRGBImageToYUV() with a single upsamplingFlagsIndex.
                             if ((rgbResult == AVIF_RESULT_OK) && (upsamplingFlagsIndex == 0)) {
                                 for (size_t yuvDepthsIndex = 0; yuvDepthsIndex < yuvDepthsCount; ++yuvDepthsIndex) {
                                     // ... and back to YUV
@@ -60,7 +62,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
                                                                             decoder->image->height,
                                                                             yuvDepths[yuvDepthsIndex],
                                                                             decoder->image->yuvFormat);
-                                    avifResult yuvResult = avifImageRGBToYUV(tempImage, &rgb, AVIF_RGB_TO_YUV_AVOID_LIBYUV);
+                                    avifResult yuvResult = avifRGBImageToYUV(&rgb, tempImage, AVIF_RGB_TO_YUV_AVOID_LIBYUV);
                                     if (yuvResult != AVIF_RESULT_OK) {
                                     }
                                     avifImageDestroy(tempImage);


### PR DESCRIPTION
For backward compatibility and smoother update of projects depending on libavif.

The C API does not allow function overloading so there must be a new name. avifRGBImageToYUV() and avifRGBImageFromYUV() were picked because they are similar to avifRGBImageAllocatePixels(),
avifRGBImagePremultiplyAlpha() etc.

Use this opportunity to refactor argument order and naming.