### PR TITLE
Revert avifImageRGBToYUV() API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ return values of avifImageCopy() and avifImageAllocatePlanes().
   void to report invalid parameters or memory allocation failures.
 * avifImageRGBToYUV() now uses libyuv fast paths by default. It may slightly
   change conversion results. The old behavior can be restored by setting
-  avifRGBImage::chromaDownsampling to AVIF_CHROMA_DOWNSAMPLING_BEST_QUALITY.
+  avifRGBImage::chromaDownsampling to AVIF_CHROMA_DOWNSAMPLING_BEST_QUALITY
+  and avifRGBImage::avoidLibYUV to AVIF_TRUE.
 * avifRGBImage::chromaUpsampling now only applies to conversions that need
-  upsampling chroma from 4:2:0 or 4:2:2.
+  upsampling chroma from 4:2:0 or 4:2:2 and has no impact on the use of libyuv.
 
 ### Removed
 * alphaRange field was removed from the avifImage struct. It it presumed that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 There are incompatible ABI changes in this release. The alphaRange member was
-removed from avifImage struct. The chromaDownsampling member was added to the
-avifRGBImage struct. The imageDimensionLimit member was added to the avifDecoder
-struct. avifImageCopy() and avifImageAllocatePlanes() signatures changed. It is
-necessary to recompile your code. Also check the return values of
-avifImageCopy() and avifImageAllocatePlanes().
+removed from avifImage struct. The chromaDownsampling and avoidLibYUV members
+were added to the avifRGBImage struct. The imageDimensionLimit member was added
+to the avifDecoder struct. avifImageCopy() and avifImageAllocatePlanes()
+signatures changed. It is necessary to recompile your code. Also check the
+return values of avifImageCopy() and avifImageAllocatePlanes().
 
 ### Changed
 * Update aom.cmd: v3.4.0
@@ -24,6 +24,8 @@ avifImageCopy() and avifImageAllocatePlanes().
 * avifImageRGBToYUV() now uses libyuv fast paths by default. It may slightly
   change conversion results. The old behavior can be restored by setting
   avifRGBImage::chromaDownsampling to AVIF_CHROMA_DOWNSAMPLING_BEST_QUALITY.
+* avifRGBImage::chromaUpsampling now only applies to conversions that need
+  upsampling chroma from 4:2:0 or 4:2:2.
 
 ### Removed
 * alphaRange field was removed from the avifImage struct. It it presumed that
@@ -34,6 +36,7 @@ avifImageCopy() and avifImageAllocatePlanes().
 * Add chromaDownsampling field to avifRGBImage struct
 * Add imageDimensionLimit field to avifDecoder struct
 * Add autoTiling field to avifEncoder struct
+* Add AVIF_CHROMA_DOWNSAMPLING_SHARP_YUV value to avifChromaDownsampling enum
 * avifdec: Add --dimension-limit, which specifies the image dimension limit
   (width or height) that should be tolerated
 * avifenc: Add --sharpyuv, which enables "sharp" RGB to YUV420 conversion, which

--- a/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
+++ b/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
@@ -166,8 +166,7 @@ FUNC(jboolean, decode, jobject encoded, int length, jobject bitmap) {
   }
   rgb_image.pixels = static_cast<uint8_t*>(bitmap_pixels);
   rgb_image.rowBytes = bitmap_info.stride;
-  res = avifImageYUVToRGB(decoder.decoder->image, &rgb_image,
-                          AVIF_YUV_TO_RGB_DEFAULT);
+  res = avifImageYUVToRGB(decoder.decoder->image, &rgb_image);
   AndroidBitmap_unlockPixels(env, bitmap);
   if (res != AVIF_RESULT_OK) {
     LOGE("Failed to convert YUV Pixels to RGB. Status: %d", res);

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -62,7 +62,7 @@ int main(int argc, char * argv[])
     int pngCompressionLevel = -1; // -1 is a sentinel to avifPNGWrite() to skip calling png_set_compression_level()
     avifCodecChoice codecChoice = AVIF_CODEC_CHOICE_AUTO;
     avifBool infoOnly = AVIF_FALSE;
-    avifYUVToRGBFlags upsamplingFlags = AVIF_YUV_TO_RGB_DEFAULT;
+    avifChromaUpsampling upsamplingFlags = AVIF_CHROMA_UPSAMPLING_AUTOMATIC;
     avifBool ignoreICC = AVIF_FALSE;
     avifBool rawColor = AVIF_FALSE;
     avifBool allowProgressive = AVIF_FALSE;
@@ -153,11 +153,11 @@ int main(int argc, char * argv[])
         } else if (!strcmp(arg, "-u") || !strcmp(arg, "--upsampling")) {
             NEXTARG();
             if (!strcmp(arg, "automatic")) {
-                upsamplingFlags = AVIF_YUV_TO_RGB_DEFAULT;
+                upsamplingFlags = AVIF_CHROMA_UPSAMPLING_AUTOMATIC;
             } else if (!strcmp(arg, "fastest")) {
-                upsamplingFlags = AVIF_CHROMA_UPSAMPLING_NEAREST;
+                upsamplingFlags = AVIF_CHROMA_UPSAMPLING_FASTEST;
             } else if (!strcmp(arg, "best")) {
-                upsamplingFlags = AVIF_YUV_TO_RGB_AVOID_LIBYUV | AVIF_CHROMA_UPSAMPLING_BILINEAR;
+                upsamplingFlags = AVIF_CHROMA_UPSAMPLING_BEST_QUALITY;
             } else if (!strcmp(arg, "nearest")) {
                 upsamplingFlags = AVIF_CHROMA_UPSAMPLING_NEAREST;
             } else if (!strcmp(arg, "bilinear")) {

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -266,7 +266,7 @@ static avifAppFileFormat avifInputReadImage(avifInput * input,
                                             avifImage * image,
                                             uint32_t * outDepth,
                                             avifAppSourceTiming * sourceTiming,
-                                            avifRGBToYUVFlags flags)
+                                            avifChromaDownsampling flags)
 {
     if (sourceTiming) {
         // A source timing of all 0s is a sentinel value hinting that the value is unset / should be
@@ -484,7 +484,7 @@ int main(int argc, char * argv[])
     avifColorPrimaries colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
     avifTransferCharacteristics transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
     avifMatrixCoefficients matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
-    avifRGBToYUVFlags flags = AVIF_RGB_TO_YUV_DEFAULT;
+    avifChromaDownsampling flags = AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC;
 
     int argIndex = 1;
     while (argIndex < argc) {

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -243,7 +243,7 @@ avifBool avifJPEGRead(const char * inputFilename,
                       avifImage * avif,
                       avifPixelFormat requestedFormat,
                       uint32_t requestedDepth,
-                      avifRGBToYUVFlags flags,
+                      avifChromaDownsampling flags,
                       avifBool ignoreICC,
                       avifBool ignoreExif,
                       avifBool ignoreXMP)
@@ -318,6 +318,7 @@ avifBool avifJPEGRead(const char * inputFilename,
         avif->depth = requestedDepth ? requestedDepth : 8;
         avifRGBImageSetDefaults(&rgb, avif);
         rgb.format = AVIF_RGB_FORMAT_RGB;
+        rgb.chromaDownsampling = flags;
         rgb.depth = 8;
         avifRGBImageAllocatePixels(&rgb);
 
@@ -328,7 +329,7 @@ avifBool avifJPEGRead(const char * inputFilename,
             memcpy(pixelRow, buffer[0], rgb.rowBytes);
             ++row;
         }
-        if (avifImageRGBToYUV(avif, &rgb, flags) != AVIF_RESULT_OK) {
+        if (avifImageRGBToYUV(avif, &rgb) != AVIF_RESULT_OK) {
             fprintf(stderr, "Conversion to YUV failed: %s\n", inputFilename);
             goto cleanup;
         }
@@ -381,7 +382,7 @@ cleanup:
     return ret;
 }
 
-avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int jpegQuality, avifYUVToRGBFlags conversionFlags)
+avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int jpegQuality, avifChromaUpsampling flags)
 {
     avifBool ret = AVIF_FALSE;
     FILE * f = NULL;
@@ -395,9 +396,10 @@ avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int 
     avifRGBImage rgb;
     avifRGBImageSetDefaults(&rgb, avif);
     rgb.format = AVIF_RGB_FORMAT_RGB;
+    rgb.chromaUpsampling = flags;
     rgb.depth = 8;
     avifRGBImageAllocatePixels(&rgb);
-    if (avifImageYUVToRGB(avif, &rgb, conversionFlags) != AVIF_RESULT_OK) {
+    if (avifImageYUVToRGB(avif, &rgb) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);
         goto cleanup;
     }

--- a/apps/shared/avifjpeg.h
+++ b/apps/shared/avifjpeg.h
@@ -14,11 +14,11 @@ avifBool avifJPEGRead(const char * inputFilename,
                       avifImage * avif,
                       avifPixelFormat requestedFormat,
                       uint32_t requestedDepth,
-                      avifRGBToYUVFlags flags,
+                      avifChromaDownsampling flags,
                       avifBool ignoreICC,
                       avifBool ignoreExif,
                       avifBool ignoreXMP);
-avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int jpegQuality, avifYUVToRGBFlags conversionFlags);
+avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int jpegQuality, avifChromaUpsampling flags);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -205,7 +205,7 @@ avifBool avifPNGRead(const char * inputFilename,
                      avifImage * avif,
                      avifPixelFormat requestedFormat,
                      uint32_t requestedDepth,
-                     avifRGBToYUVFlags flags,
+                     avifChromaDownsampling flags,
                      avifBool ignoreICC,
                      avifBool ignoreExif,
                      avifBool ignoreXMP,
@@ -328,6 +328,7 @@ avifBool avifPNGRead(const char * inputFilename,
     }
 
     avifRGBImageSetDefaults(&rgb, avif);
+    rgb.chromaDownsampling = flags;
     rgb.depth = imgBitDepth;
     avifRGBImageAllocatePixels(&rgb);
     rowPointers = (png_bytep *)malloc(sizeof(png_bytep) * rgb.height);
@@ -335,7 +336,7 @@ avifBool avifPNGRead(const char * inputFilename,
         rowPointers[y] = &rgb.pixels[y * rgb.rowBytes];
     }
     png_read_image(png, rowPointers);
-    if (avifImageRGBToYUV(avif, &rgb, flags) != AVIF_RESULT_OK) {
+    if (avifImageRGBToYUV(avif, &rgb) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to YUV failed: %s\n", inputFilename);
         goto cleanup;
     }
@@ -367,7 +368,7 @@ cleanup:
     return readResult;
 }
 
-avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint32_t requestedDepth, avifYUVToRGBFlags conversionFlags, int compressionLevel)
+avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint32_t requestedDepth, avifChromaUpsampling flags, int compressionLevel)
 {
     volatile avifBool writeResult = AVIF_FALSE;
     png_structp png = NULL;
@@ -388,6 +389,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
     }
 
     avifRGBImageSetDefaults(&rgb, avif);
+    rgb.chromaUpsampling = flags;
     rgb.depth = rgbDepth;
     int colorType = PNG_COLOR_TYPE_RGBA;
     if (!avif->alphaPlane) {
@@ -395,7 +397,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
         rgb.format = AVIF_RGB_FORMAT_RGB;
     }
     avifRGBImageAllocatePixels(&rgb);
-    if (avifImageYUVToRGB(avif, &rgb, conversionFlags) != AVIF_RESULT_OK) {
+    if (avifImageYUVToRGB(avif, &rgb) != AVIF_RESULT_OK) {
         fprintf(stderr, "Conversion to RGB failed: %s\n", outputFilename);
         goto cleanup;
     }

--- a/apps/shared/avifpng.h
+++ b/apps/shared/avifpng.h
@@ -15,16 +15,12 @@ avifBool avifPNGRead(const char * inputFilename,
                      avifImage * avif,
                      avifPixelFormat requestedFormat,
                      uint32_t requestedDepth,
-                     avifRGBToYUVFlags flags,
+                     avifChromaDownsampling flags,
                      avifBool ignoreICC,
                      avifBool ignoreExif,
                      avifBool ignoreXMP,
                      uint32_t * outPNGDepth);
-avifBool avifPNGWrite(const char * outputFilename,
-                      const avifImage * avif,
-                      uint32_t requestedDepth,
-                      avifYUVToRGBFlags conversionFlags,
-                      int compressionLevel);
+avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint32_t requestedDepth, avifChromaUpsampling flags, int compressionLevel);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -227,7 +227,7 @@ avifAppFileFormat avifGuessFileFormat(const char * filename)
 avifAppFileFormat avifReadImage(const char * filename,
                                 avifPixelFormat requestedFormat,
                                 int requestedDepth,
-                                avifRGBToYUVFlags flags,
+                                avifChromaDownsampling flags,
                                 avifBool ignoreICC,
                                 avifBool ignoreExif,
                                 avifBool ignoreXMP,

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -63,7 +63,7 @@ struct y4mFrameIterator;
 avifAppFileFormat avifReadImage(const char * filename,
                                 avifPixelFormat requestedFormat,
                                 int requestedDepth,
-                                avifRGBToYUVFlags flags,
+                                avifChromaDownsampling flags,
                                 avifBool ignoreICC,
                                 avifBool ignoreExif,
                                 avifBool ignoreXMP,

--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -124,7 +124,7 @@ static gboolean avif_context_try_load(struct avif_context * context, GError ** e
     rgb.pixels = gdk_pixbuf_get_pixels(output);
     rgb.rowBytes = gdk_pixbuf_get_rowstride(output);
 
-    ret = avifImageYUVToRGB(image, &rgb, AVIF_YUV_TO_RGB_DEFAULT);
+    ret = avifImageYUVToRGB(image, &rgb);
     if (ret != AVIF_RESULT_OK) {
         g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
                     "Failed to convert YUV to RGB: %s", avifResultToString(ret));
@@ -448,7 +448,7 @@ static gboolean avif_image_saver(FILE          *f,
         rgb.format = AVIF_RGB_FORMAT_RGB;
     }
 
-    res = avifImageRGBToYUV(avif, &rgb, AVIF_RGB_TO_YUV_DEFAULT);
+    res = avifImageRGBToYUV(avif, &rgb);
     if ( res != AVIF_RESULT_OK ) {
         g_set_error(error,
                     GDK_PIXBUF_ERROR,

--- a/examples/avif_example_decode_file.c
+++ b/examples/avif_example_decode_file.c
@@ -53,14 +53,14 @@ int main(int argc, char * argv[])
         // * this frame's sequence timing
 
         avifRGBImageSetDefaults(&rgb, decoder->image);
-        // Override YUV(A)->RGB(A) defaults here: depth, format, ignoreAlpha, alphaPremultiplied, etc
+        // Override YUV(A)->RGB(A) defaults here:
+        //   depth, format, chromaUpsampling, avoidLibYUV, ignoreAlpha, alphaPremultiplied, etc.
 
         // Alternative: set rgb.pixels and rgb.rowBytes yourself, which should match your chosen rgb.format
         // Be sure to use uint16_t* instead of uint8_t* for rgb.pixels/rgb.rowBytes if (rgb.depth > 8)
         avifRGBImageAllocatePixels(&rgb);
 
-        // Other flags than AVIF_YUV_TO_RGB_DEFAULT, such as AVIF_CHROMA_UPSAMPLING_NEAREST, can be passed.
-        if (avifImageYUVToRGB(decoder->image, &rgb, AVIF_YUV_TO_RGB_DEFAULT) != AVIF_RESULT_OK) {
+        if (avifImageYUVToRGB(decoder->image, &rgb) != AVIF_RESULT_OK) {
             fprintf(stderr, "Conversion from YUV failed: %s\n", inputFilename);
             goto cleanup;
         }

--- a/examples/avif_example_decode_memory.c
+++ b/examples/avif_example_decode_memory.c
@@ -75,14 +75,14 @@ int main(int argc, char * argv[])
         // * this frame's sequence timing
 
         avifRGBImageSetDefaults(&rgb, decoder->image);
-        // Override YUV(A)->RGB(A) defaults here: depth, format, ignoreAlpha, alphaPremultiplied, etc
+        // Override YUV(A)->RGB(A) defaults here:
+        //   depth, format, chromaUpsampling, avoidLibYUV, ignoreAlpha, alphaPremultiplied, etc.
 
         // Alternative: set rgb.pixels and rgb.rowBytes yourself, which should match your chosen rgb.format
         // Be sure to use uint16_t* instead of uint8_t* for rgb.pixels/rgb.rowBytes if (rgb.depth > 8)
         avifRGBImageAllocatePixels(&rgb);
 
-        // Other flags than AVIF_YUV_TO_RGB_DEFAULT, such as AVIF_CHROMA_UPSAMPLING_NEAREST, can be passed.
-        if (avifImageYUVToRGB(decoder->image, &rgb, AVIF_YUV_TO_RGB_DEFAULT) != AVIF_RESULT_OK) {
+        if (avifImageYUVToRGB(decoder->image, &rgb) != AVIF_RESULT_OK) {
             fprintf(stderr, "Conversion from YUV failed: %s\n", inputFilename);
             goto cleanup;
         }

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -57,7 +57,8 @@ int main(int argc, char * argv[])
         printf("Encoding from converted RGBA\n");
 
         avifRGBImageSetDefaults(&rgb, image);
-        // Override RGB(A)->YUV(A) defaults here: depth, format, ignoreAlpha, alphaPremultiplied, etc
+        // Override RGB(A)->YUV(A) defaults here:
+        //   depth, format, chromaDownsampling, avoidLibYUV, ignoreAlpha, alphaPremultiplied, etc.
 
         // Alternative: set rgb.pixels and rgb.rowBytes yourself, which should match your chosen rgb.format
         // Be sure to use uint16_t* instead of uint8_t* for rgb.pixels/rgb.rowBytes if (rgb.depth > 8)
@@ -66,8 +67,7 @@ int main(int argc, char * argv[])
         // Fill your RGB(A) data here
         memset(rgb.pixels, 255, rgb.rowBytes * image->height);
 
-        // Other flags than AVIF_RGB_TO_YUV_DEFAULT, such as AVIF_RGB_TO_YUV_AVOID_LIBYUV, can be passed.
-        avifResult convertResult = avifImageRGBToYUV(image, &rgb, AVIF_RGB_TO_YUV_DEFAULT);
+        avifResult convertResult = avifImageRGBToYUV(image, &rgb);
         if (convertResult != AVIF_RESULT_OK) {
             fprintf(stderr, "Failed to convert to YUV(A): %s\n", avifResultToString(convertResult));
             goto cleanup;

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -558,12 +558,36 @@ typedef enum avifRGBFormat
 AVIF_API uint32_t avifRGBFormatChannelCount(avifRGBFormat format);
 AVIF_API avifBool avifRGBFormatHasAlpha(avifRGBFormat format);
 
+typedef enum avifChromaUpsampling
+{
+    AVIF_CHROMA_UPSAMPLING_AUTOMATIC = 0, // Chooses best trade off of speed/quality (prefers BILINEAR libyuv, then NEAREST libyuv, then BILINEAR built-in)
+    AVIF_CHROMA_UPSAMPLING_FASTEST = 1,      // Chooses speed over quality (same as NEAREST)
+    AVIF_CHROMA_UPSAMPLING_BEST_QUALITY = 2, // Chooses the best quality upsampling, given settings (avoids libyuv, uses BILINEAR)
+    AVIF_CHROMA_UPSAMPLING_NEAREST = 3,      // Uses nearest-neighbor filter (prefers libyuv)
+    AVIF_CHROMA_UPSAMPLING_BILINEAR = 4      // Uses bilinear filter (prefers libyuv)
+} avifChromaUpsampling;
+
+typedef enum avifChromaDownsampling
+{
+    AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC = 0,    // Chooses best trade off of speed/quality (same as AVERAGE)
+    AVIF_CHROMA_DOWNSAMPLING_FASTEST = 1,      // Chooses speed over quality (same as AVERAGE)
+    AVIF_CHROMA_DOWNSAMPLING_BEST_QUALITY = 2, // Chooses the best quality upsampling (avoids libyuv, uses AVERAGE)
+    AVIF_CHROMA_DOWNSAMPLING_AVERAGE = 3,      // Uses averaging filter (prefers libyuv)
+    AVIF_CHROMA_DOWNSAMPLING_SHARP_YUV = 4     // Uses sharp yuv filter (libsharpyuv), available for 4:2:0 only, ignored for 4:2:2
+} avifChromaDownsampling;
+
 typedef struct avifRGBImage
 {
-    uint32_t width;              // must match associated avifImage
-    uint32_t height;             // must match associated avifImage
-    uint32_t depth;              // legal depths [8, 10, 12, 16]. if depth>8, pixels must be uint16_t internally
-    avifRGBFormat format;        // all channels are always full range
+    uint32_t width;                        // must match associated avifImage
+    uint32_t height;                       // must match associated avifImage
+    uint32_t depth;                        // legal depths [8, 10, 12, 16]. if depth>8, pixels must be uint16_t internally
+    avifRGBFormat format;                  // all channels are always full range
+    avifChromaUpsampling chromaUpsampling; // How to upsample from 4:2:0 or 4:2:2 UV when converting to RGB (ignored for 4:4:4 and 4:0:0).
+                                           // Ignored when converting to YUV. Defaults to AVIF_CHROMA_UPSAMPLING_AUTOMATIC.
+    avifChromaDownsampling chromaDownsampling; // How to downsample to 4:2:0 or 4:2:2 UV when converting from RGB (ignored for 4:4:4 and 4:0:0).
+                                               // Ignored when converting to RGB. Defaults to AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC.
+    avifBool avoidLibYUV;                      // Avoids libyuv for converting between RGB and YUV, upsampling or downsampling,
+                                               // even if libyuv is available. Defaults to AVIF_FALSE.
     avifBool ignoreAlpha;        // Used for XRGB formats, treats formats containing alpha (such as ARGB) as if they were
                                  // RGB, treating the alpha bits as if they were all 1.
     avifBool alphaPremultiplied; // indicates if RGB value is pre-multiplied by alpha. Default: false
@@ -583,44 +607,9 @@ AVIF_API uint32_t avifRGBImagePixelSize(const avifRGBImage * rgb);
 AVIF_API void avifRGBImageAllocatePixels(avifRGBImage * rgb);
 AVIF_API void avifRGBImageFreePixels(avifRGBImage * rgb);
 
-// Conversion options.
-typedef enum avifRGBToYUVFlag
-{
-    AVIF_RGB_TO_YUV_DEFAULT = 0, // Uses the first available downsampling filter among:
-                                 //   libyuv average, built-in average
-
-    // libyuv preference
-
-    AVIF_RGB_TO_YUV_AVOID_LIBYUV = (1 << 0), // Only picks built-in paths. The default is to prefer libyuv if available.
-
-    // Conversion from RGB to YUV 4:2:2 or YUV 4:2:0 (ignored in all other cases)
-
-    // Chroma downsampling filter. Set at most one:
-    AVIF_CHROMA_DOWNSAMPLING_AVERAGE = (1 << 10),   // only use the averaging filter (libyuv or built-in)
-    AVIF_CHROMA_DOWNSAMPLING_SHARP_YUV = (1 << 11), // only use sharp yuv filter (libsharpyuv),
-                                                    // available for 4:2:0 only, ignored for 4:2:2
-} avifRGBToYUVFlag;
-typedef uint32_t avifRGBToYUVFlags;
-typedef enum avifYUVToRGBFlag
-{
-    AVIF_YUV_TO_RGB_DEFAULT = 0, // Uses the first available upsampling filter among:
-                                 //   libyuv bilinear, libyuv nearest-neighbor, built-in bilinear
-
-    // libyuv preference
-
-    AVIF_YUV_TO_RGB_AVOID_LIBYUV = (1 << 0), // Only picks built-in paths. The default is to prefer libyuv if available.
-
-    // Conversion from YUV 4:2:2 or YUV 4:2:0 to RGB (ignored in all other cases)
-
-    // Chroma upsampling filter. Set at most one:
-    AVIF_CHROMA_UPSAMPLING_NEAREST = (1 << 10), // only use the fast nearest-neighbor filter (libyuv or built-in)
-    AVIF_CHROMA_UPSAMPLING_BILINEAR = (1 << 11) // only use the good-quality bilinear filter (libyuv or built-in)
-} avifYUVToRGBFlag;
-typedef uint32_t avifYUVToRGBFlags;
-
-// Conversion functions.
-AVIF_API avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb, avifRGBToYUVFlags flags);
-AVIF_API avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb, avifYUVToRGBFlags flags);
+// The main conversion functions
+AVIF_API avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb);
+AVIF_API avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb);
 
 // Premultiply handling functions.
 // (Un)premultiply is automatically done by the main conversion functions above,

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -149,7 +149,7 @@ avifResult avifImageRGBToYUVLibYUV(avifImage * image, const avifRGBImage * rgb);
 // * AVIF_RESULT_OK              - Converted successfully with libyuv
 // * AVIF_RESULT_NOT_IMPLEMENTED - The fast path for this combination is not implemented with libyuv, use built-in YUV conversion
 // * [any other error]           - Return error to caller
-avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb, avifYUVToRGBFlags flags);
+avifResult avifImageYUVToRGBLibYUV(const avifImage * image, avifRGBImage * rgb);
 
 // Returns:
 // * AVIF_RESULT_OK              - Converted successfully with libsharpyuv

--- a/src/avif.c
+++ b/src/avif.c
@@ -457,6 +457,9 @@ void avifRGBImageSetDefaults(avifRGBImage * rgb, const avifImage * image)
     rgb->height = image->height;
     rgb->depth = image->depth;
     rgb->format = AVIF_RGB_FORMAT_RGBA;
+    rgb->chromaUpsampling = AVIF_CHROMA_UPSAMPLING_AUTOMATIC;
+    rgb->chromaDownsampling = AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC;
+    rgb->avoidLibYUV = AVIF_FALSE;
     rgb->ignoreAlpha = AVIF_FALSE;
     rgb->pixels = NULL;
     rgb->rowBytes = 0;

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -236,10 +236,7 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
         converted = AVIF_TRUE;
     }
 
-    const avifBool avoidLibYUV =
-        (rgb->avoidLibYUV || (rgb->chromaDownsampling == AVIF_CHROMA_DOWNSAMPLING_BEST_QUALITY &&
-                              (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420 || image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422)));
-    if (!converted && !avoidLibYUV && (alphaMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP)) {
+    if (!converted && !rgb->avoidLibYUV && (alphaMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP)) {
         avifResult libyuvResult = avifImageRGBToYUVLibYUV(image, rgb);
         if (libyuvResult == AVIF_RESULT_OK) {
             converted = AVIF_TRUE;
@@ -1212,10 +1209,7 @@ avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
 
     avifAlphaMultiplyMode alphaMultiplyMode = state.toRGBAlphaMode;
     avifBool convertedWithLibYUV = AVIF_FALSE;
-    const avifBool avoidLibYUV =
-        (rgb->avoidLibYUV || (rgb->chromaUpsampling == AVIF_CHROMA_UPSAMPLING_BEST_QUALITY &&
-                              (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420 || image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422)));
-    if (!avoidLibYUV && ((alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP) || avifRGBFormatHasAlpha(rgb->format))) {
+    if (!rgb->avoidLibYUV && ((alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP) || avifRGBFormatHasAlpha(rgb->format))) {
         avifResult libyuvResult = avifImageYUVToRGBLibYUV(image, rgb);
         if (libyuvResult == AVIF_RESULT_OK) {
             convertedWithLibYUV = AVIF_TRUE;

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -203,8 +203,8 @@ int main(int argc, char * argv[])
                                 }
                             }
 
-                            avifImageRGBToYUV(image, &srcRGB, AVIF_RGB_TO_YUV_DEFAULT);
-                            avifImageYUVToRGB(image, &dstRGB, AVIF_YUV_TO_RGB_DEFAULT);
+                            avifImageRGBToYUV(image, &srcRGB);
+                            avifImageYUVToRGB(image, &dstRGB);
 
                             for (int y = 0; y < dim; ++y) {
                                 const uint8_t * srcRow = &srcRGB.pixels[y * srcRGB.rowBytes];
@@ -344,23 +344,23 @@ int main(int argc, char * argv[])
                         avifImageFreePlanes(image, AVIF_PLANES_ALL);
                         image->depth = yuvDepth;
                         image->yuvRange = yuvRange;
-                        avifImageRGBToYUV(image, &srcRGB, AVIF_RGB_TO_YUV_DEFAULT);
+                        avifImageRGBToYUV(image, &srcRGB);
 
                         avifRGBImage intermediateRGB;
                         avifRGBImageSetDefaults(&intermediateRGB, image);
                         intermediateRGB.depth = rgbDepth;
                         intermediateRGB.format = rgbFormat;
                         avifRGBImageAllocatePixels(&intermediateRGB);
-                        avifImageYUVToRGB(image, &intermediateRGB, AVIF_YUV_TO_RGB_DEFAULT);
+                        avifImageYUVToRGB(image, &intermediateRGB);
 
                         avifImageFreePlanes(image, AVIF_PLANES_ALL);
-                        avifImageRGBToYUV(image, &intermediateRGB, AVIF_RGB_TO_YUV_DEFAULT);
+                        avifImageRGBToYUV(image, &intermediateRGB);
 
                         avifRGBImage dstRGB;
                         avifRGBImageSetDefaults(&dstRGB, image);
                         dstRGB.depth = yuvDepth;
                         avifRGBImageAllocatePixels(&dstRGB);
-                        avifImageYUVToRGB(image, &dstRGB, AVIF_YUV_TO_RGB_DEFAULT);
+                        avifImageYUVToRGB(image, &dstRGB);
 
                         avifBool moveOn = AVIF_FALSE;
                         for (uint32_t j = 0; j < originalHeight; ++j) {

--- a/tests/gtest/are_images_equal.cc
+++ b/tests/gtest/are_images_equal.cc
@@ -31,10 +31,10 @@ int main(int argc, char** argv) {
     // Make sure no color conversion happens.
     decoded[i]->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
     if (avifReadImage(argv[i + 1], requestedFormat, kRequestedDepth,
-                      AVIF_RGB_TO_YUV_DEFAULT, /*ignoreICC=*/AVIF_FALSE,
-                      /*ignoreExif=*/AVIF_FALSE, /*ignoreXMP=*/AVIF_FALSE,
-                      decoded[i].get(), &depth[i], nullptr,
-                      nullptr) == AVIF_APP_FILE_FORMAT_UNKNOWN) {
+                      AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC,
+                      /*ignoreICC=*/AVIF_FALSE, /*ignoreExif=*/AVIF_FALSE,
+                      /*ignoreXMP=*/AVIF_FALSE, decoded[i].get(), &depth[i],
+                      nullptr, nullptr) == AVIF_APP_FILE_FORMAT_UNKNOWN) {
       std::cerr << "Image " << argv[i + 1] << " cannot be read." << std::endl;
       return 2;
     }

--- a/tests/gtest/avifmetadatatest.cc
+++ b/tests/gtest/avifmetadatatest.cc
@@ -121,8 +121,8 @@ TEST_P(MetadataTest, Read) {
   const bool expect_xmp = std::get<6>(GetParam());
 
   const testutil::AvifImagePtr image = testutil::ReadImage(
-      data_path, file_name, AVIF_PIXEL_FORMAT_NONE, 0, AVIF_RGB_TO_YUV_DEFAULT,
-      !use_icc, !use_exif, !use_xmp);
+      data_path, file_name, AVIF_PIXEL_FORMAT_NONE, 0,
+      AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC, !use_icc, !use_exif, !use_xmp);
   ASSERT_NE(image, nullptr);
   EXPECT_NE(image->width * image->height, 0u);
 

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -233,7 +233,7 @@ bool AreImagesEqual(const avifImage& image1, const avifImage& image2,
 
 AvifImagePtr ReadImage(const char* folder_path, const char* file_name,
                        avifPixelFormat requested_format, int requested_depth,
-                       avifRGBToYUVFlags flags, avifBool ignore_icc,
+                       avifChromaDownsampling flags, avifBool ignore_icc,
                        avifBool ignore_exif, avifBool ignore_xmp) {
   testutil::AvifImagePtr image(avifImageCreateEmpty(), avifImageDestroy);
   if (!image ||

--- a/tests/gtest/aviftest_helpers.h
+++ b/tests/gtest/aviftest_helpers.h
@@ -75,7 +75,8 @@ bool AreImagesEqual(const avifImage& image1, const avifImage& image2,
 AvifImagePtr ReadImage(
     const char* folder_path, const char* file_name,
     avifPixelFormat requested_format = AVIF_PIXEL_FORMAT_NONE,
-    int requested_depth = 0, avifRGBToYUVFlags flags = AVIF_RGB_TO_YUV_DEFAULT,
+    int requested_depth = 0,
+    avifChromaDownsampling flags = AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC,
     avifBool ignore_icc = false, avifBool ignore_exif = false,
     avifBool ignore_xmp = false);
 

--- a/tests/oss-fuzz/avif_decode_fuzzer.cc
+++ b/tests/oss-fuzz/avif_decode_fuzzer.cc
@@ -8,7 +8,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
     static avifRGBFormat rgbFormats[] = { AVIF_RGB_FORMAT_RGB, AVIF_RGB_FORMAT_RGBA };
     static size_t rgbFormatsCount = sizeof(rgbFormats) / sizeof(rgbFormats[0]);
 
-    static avifYUVToRGBFlags upsamplingFlags[] = { AVIF_CHROMA_UPSAMPLING_BILINEAR, AVIF_CHROMA_UPSAMPLING_NEAREST };
+    static avifChromaUpsampling upsamplingFlags[] = { AVIF_CHROMA_UPSAMPLING_BILINEAR, AVIF_CHROMA_UPSAMPLING_NEAREST };
     static size_t upsamplingFlagsCount = sizeof(upsamplingFlags) / sizeof(upsamplingFlags[0]);
 
     static uint32_t rgbDepths[] = { 8, 10 };
@@ -47,10 +47,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
                         for (size_t rgbDepthsIndex = 0; rgbDepthsIndex < rgbDepthsCount; ++rgbDepthsIndex) {
                             // Convert to RGB
                             rgb.format = rgbFormats[rgbFormatsIndex];
+                            rgb.chromaUpsampling = upsamplingFlags[upsamplingFlagsIndex];
+                            rgb.avoidLibYUV = AVIF_TRUE;
                             rgb.depth = rgbDepths[rgbDepthsIndex];
                             avifRGBImageAllocatePixels(&rgb);
-                            avifResult rgbResult =
-                                avifImageYUVToRGB(decoder->image, &rgb, AVIF_YUV_TO_RGB_AVOID_LIBYUV | upsamplingFlags[upsamplingFlagsIndex]);
+                            avifResult rgbResult = avifImageYUVToRGB(decoder->image, &rgb);
                             // Since avifImageRGBToYUV() ignores upsamplingFlags, we only need
                             // to test avifImageRGBToYUV() with a single upsamplingFlagsIndex.
                             if ((rgbResult == AVIF_RESULT_OK) && (upsamplingFlagsIndex == 0)) {
@@ -60,7 +61,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
                                                                             decoder->image->height,
                                                                             yuvDepths[yuvDepthsIndex],
                                                                             decoder->image->yuvFormat);
-                                    avifResult yuvResult = avifImageRGBToYUV(tempImage, &rgb, AVIF_RGB_TO_YUV_AVOID_LIBYUV);
+                                    avifResult yuvResult = avifImageRGBToYUV(tempImage, &rgb);
                                     if (yuvResult != AVIF_RESULT_OK) {
                                     }
                                     avifImageDestroy(tempImage);


### PR DESCRIPTION
To avoid backward compatibility issues.
Add avoidLibYUV member to avifRGBImage.

The new API was introduced in https://github.com/AOMediaCodec/libavif/pull/1026.
A related discussion can be found at https://github.com/AOMediaCodec/libavif/pull/1108.