### PR TITLE
Use new libyuv function I420ToRGB24MatrixFilter()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ return values of avifImageCopy() and avifImageAllocatePlanes().
 * Update rav1e.cmd: v0.5.1
 * Update svt.cmd/svt.sh: v1.2.1
 * Update libgav1.cmd: v0.18.0
-* Update libyuv.cmd: 9b17af9b (version 1838)
+* Update libyuv.cmd: f71c8355 (version 1841)
 * avifImageCopy() and avifImageAllocatePlanes() now return avifResult instead of
   void to report invalid parameters or memory allocation failures.
 * avifImageRGBToYUV() now uses libyuv fast paths by default. It may slightly

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -14,7 +14,7 @@
 git clone --single-branch https://chromium.googlesource.com/libyuv/libyuv
 
 cd libyuv
-git checkout 9b17af9b
+git checkout f71c8355
 
 mkdir build
 cd build

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -63,6 +63,11 @@ unsigned int avifLibYUVVersion(void)
 // These defines are used to create a NULL reference to libyuv functions that
 // did not exist prior to a particular version of libyuv.
 // Versions prior to 1755 are considered too old and not used (see CMakeLists.txt).
+#if LIBYUV_VERSION < 1841
+// I420ToRGB24MatrixFilter() was added in libyuv version 1841.
+// See https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3900298.
+#define I420ToRGB24MatrixFilter NULL
+#endif
 #if LIBYUV_VERSION < 1840
 #define ABGRToJ400 NULL
 #endif
@@ -561,10 +566,10 @@ avifResult avifImageYUVToRGBLibYUV8bpc(const avifImage * image,
                                             enum FilterMode);
         YUVToRGBMatrixFilter lutYuvToRgbMatrixFilter[AVIF_RGB_FORMAT_COUNT][AVIF_PIXEL_FORMAT_COUNT] = {
             // { NONE, YUV444, YUV422, YUV420, YUV400 }                           // AVIF_RGB_FORMAT_
-            { NULL, NULL, NULL, NULL, NULL },                                     // RGB
+            { NULL, NULL, NULL, I420ToRGB24MatrixFilter, NULL },                  // RGB
             { NULL, NULL, I422ToARGBMatrixFilter, I420ToARGBMatrixFilter, NULL }, // RGBA
             { NULL, NULL, NULL, NULL, NULL },                                     // ARGB
-            { NULL, NULL, NULL, NULL, NULL },                                     // BGR
+            { NULL, NULL, NULL, I420ToRGB24MatrixFilter, NULL },                  // BGR
             { NULL, NULL, I422ToARGBMatrixFilter, I420ToARGBMatrixFilter, NULL }, // BGRA
             { NULL, NULL, NULL, NULL, NULL },                                     // ABGR
             { NULL, NULL, NULL, NULL, NULL },                                     // RGB_565


### PR DESCRIPTION
I420ToRGB24MatrixFilter() was added in libyuv version 1841. Use it in avifImageYUVToRGB().

Update ext/libyuv.cmd to check out f71c8355 (version 1841).