### PR TITLE
Avoid setting the ICC profile when given an image in YUV400 format.

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -439,7 +439,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
     }
 
     png_set_IHDR(png, info, avif->width, avif->height, rgb.depth, colorType, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-    if (avif->icc.data && (avif->icc.size > 0)) {
+    if (avif->icc.data && (avif->icc.size > 0) && (avif->yuvFormat != AVIF_PIXEL_FORMAT_YUV400)) {
         png_set_iCCP(png, info, "libavif", 0, (png_iccp_datap)avif->icc.data, (png_uint_32)avif->icc.size);
     }
     png_write_info(png, info);


### PR DESCRIPTION
I'm using apps/avifdec and got an error  when converting an avif file in YUV400 pixel format to a png file.
```
Decoding with AV1 codec 'dav1d' (1 worker thread), please wait...
Image decoded: 00003.avif
Image details:
 * Resolution     : 1350x1920
 * Bit Depth      : 8
 * Format         : YUV400
 * Alpha          : Absent
 * Range          : Full
 * Color Primaries: 2
 * Transfer Char. : 2
 * Matrix Coeffs. : 6
 * ICC Profile    : Present (408 bytes)
 * XMP Metadata   : Absent
 * Exif Metadata  : Absent
 * Transformations: None
 * Progressive    : Unavailable
libpng error: profile 'libavif': 'GRAY': Gray color space not permitted on RGB PNG
Error writing PNG: 00003.png
```
Modified to avoid this.