### PR TITLE
Write 'auxi' box for animated images with alpha channel

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -1589,6 +1589,12 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             avifRWStreamWriteZeros(&s, 3); // unsigned int(26) reserved; (two zero bits are written along with ccstValue).
             avifRWStreamFinishBox(&s, ccst);
 
+            if (item->alpha) {
+                avifBoxMarker auxi = avifRWStreamWriteFullBox(&s, "auxi", AVIF_BOX_SIZE_TBD, 0, 0);
+                avifRWStreamWriteChars(&s, alphaURN, alphaURNSize); //  string aux_track_type;
+                avifRWStreamFinishBox(&s, auxi);
+            }
+
             avifRWStreamFinishBox(&s, av01);
             avifRWStreamFinishBox(&s, stsd);
 


### PR DESCRIPTION
When alpha channel is present on animated images, the 'auxi' box is mandatory as it tells the decoder what kind of auxiliary track it is.

The current decoder gets the value from the still image item properties. But if a decoder ignores the still image fields and treats the animated AVIF as a video sequence, it has no way of knowing what kind of information the auxiliary track contains.

This patch resolves the following compliance warden error: [heif][Rule #1] Section 7.5.3.1
The nature of the auxiliary track is announced by the AuxiliaryTypeInfoBox that shall be included in the sample entry of the auxiliary track.