### PR TITLE
Write 'auxv' as handler_type for alpha channel track

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -1480,10 +1480,10 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             avifRWStreamFinishBox(&s, mdhd);
 
             avifBoxMarker hdlrTrak = avifRWStreamWriteFullBox(&s, "hdlr", AVIF_BOX_SIZE_TBD, 0, 0);
-            avifRWStreamWriteU32(&s, 0);              // unsigned int(32) pre_defined = 0;
-            avifRWStreamWriteChars(&s, "pict", 4);    // unsigned int(32) handler_type;
-            avifRWStreamWriteZeros(&s, 12);           // const unsigned int(32)[3] reserved = 0;
-            avifRWStreamWriteChars(&s, "libavif", 8); // string name; (writing null terminator)
+            avifRWStreamWriteU32(&s, 0);                                  // unsigned int(32) pre_defined = 0;
+            avifRWStreamWriteChars(&s, item->alpha ? "auxv" : "pict", 4); // unsigned int(32) handler_type;
+            avifRWStreamWriteZeros(&s, 12);                               // const unsigned int(32)[3] reserved = 0;
+            avifRWStreamWriteChars(&s, "libavif", 8);                     // string name; (writing null terminator)
             avifRWStreamFinishBox(&s, hdlrTrak);
 
             avifBoxMarker minf = avifRWStreamWriteBox(&s, "minf", AVIF_BOX_SIZE_TBD);


### PR DESCRIPTION
For animated AVIF sequences, alpha channel track has to have the handler_type set to 'auxv'.

This is mentioned in Section 7.5.3.1 of the HEIF specification.

libavif's parser ignores the 'hdlr' box that occurs inside the 'mdia' box. So this change is backward compatible (i.e.) files produced after this change will still be parse'able by earlier libavif versions.