### PR TITLE
Use PNG_COLOR_TYPE_GRAY for 8-bit grayscale output

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -460,7 +460,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
             rowPointers[y] = &yPlane[y * yRowBytes];
         }
     } else {
-        for (uint32_t y = 0; y < rgb.height; ++y) {
+        for (uint32_t y = 0; y < avif->height; ++y) {
             rowPointers[y] = &rgb.pixels[y * rgb.rowBytes];
         }
     }


### PR DESCRIPTION
When writing a PNG output file, if the AVIF image is 8-bit monochrome with no alpha and the PNG output bit depth is 8, use the Y plane of the AVIF image directly for the PNG_COLOR_TYPE_GRAY color type.