### PR TITLE
Lower threshold to skip YUV-RGB converison tests

### DIFF
--- a/tests/oss-fuzz/avif_decode_fuzzer.cc
+++ b/tests/oss-fuzz/avif_decode_fuzzer.cc
@@ -32,7 +32,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
     if (result == AVIF_RESULT_OK) {
         for (int loop = 0; loop < 2; ++loop) {
             while (avifDecoderNextImage(decoder) == AVIF_RESULT_OK) {
-                if (((decoder->image->width * decoder->image->height) > (39 * 1024 * 1024)) || (loop != 0) ||
+                if (((decoder->image->width * decoder->image->height) > (35 * 1024 * 1024)) || (loop != 0) ||
                     (decoder->imageIndex != 0)) {
                     // Skip the YUV<->RGB conversion tests, which are time-consuming for large
                     // images. It suffices to run these tests only for loop == 0 and only for the


### PR DESCRIPTION
Lower the threshold for skipping the YUV<->RGB conversion tests from 39 * 1024 * 1024 to 35 * 1024 * 1024.

A test image of size 11267 x 3328 (bit depth=12, YUV 4:4:4) causes a sanitizer build to spend 3 to 6 seconds in avifImageYUVToRGB() and avifImageRGBToYUV().

Bug: b/246105768