### PR TITLE
Add quality and qualityAlpha to avifEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ avifEncoder struct.
 * Add clli metadata read and write support
 * Add repetitionCount member to avifEncoder and avifDecoder structs to specify
   the number of repetitions for animated image sequences.
-* Add quality and qualityAlpha to avifEncoder
+* Add quality and qualityAlpha to avifEncoder. Note: minQuantizer,
+  maxQuantizer, minQuantizerAlpha, and maxQuantizerAlpha are deprecated. Code
+  should be updated to set quality (and qualityAlpha if applicable) and leave
+  minQuantizer, maxQuantizer, minQuantizerAlpha, and maxQuantizerAlpha
+  initialized to the default values.
 
 ### Changed
 * Exif and XMP metadata is exported to PNG and JPEG files by default,
@@ -28,6 +32,12 @@ avifEncoder struct.
 * Update svt.cmd/svt.sh: v1.3.0
 * avifImageCopy() no longer accepts source U and V channels to be NULL for
   non-4:0:0 input if Y is not NULL and if AVIF_PLANES_YUV is specified.
+* The default values of the maxQuantizer and maxQuantizerAlpha members of
+  avifEncoder changed from AVIF_QUANTIZER_LOSSLESS (0) to
+  AVIF_QUANTIZER_WORST_QUALITY (63). The behavior changed if minQuantizer and
+  maxQuantizer are left initialized to the default values. Code should be
+  updated to set the quality member. Similarly for the alpha quantizers and
+  qualityAlpha.
 
 ## [0.11.1] - 2022-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 There are incompatible ABI changes in this release. The clli member was added
 to the avifImage struct. The repetitionCount member was added to the avifEncoder
-and avifDecoder structs.
+and avifDecoder structs. The quality and qualityAlpha members were added to the
+avifEncoder struct.
 
 ### Added
 * Add STATIC library target avif_internal to allow tests to access functions
@@ -16,6 +17,7 @@ and avifDecoder structs.
 * Add clli metadata read and write support
 * Add repetitionCount member to avifEncoder and avifDecoder structs to specify
   the number of repetitions for animated image sequences.
+* Add quality and qualityAlpha to avifEncoder
 
 ### Changed
 * Exif and XMP metadata is exported to PNG and JPEG files by default,

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -1099,8 +1099,8 @@ int main(int argc, char * argv[])
         usingAOM = AVIF_TRUE;
     }
     avifBool hasAlpha = (image->alphaPlane && image->alphaRowBytes);
-    avifBool losslessColorQuality = (quality == AVIF_QUALITY_LOSSLESS);
-    avifBool losslessAlphaQuality = (qualityAlpha == AVIF_QUALITY_LOSSLESS);
+    avifBool usingLosslessColor = (quality == AVIF_QUALITY_LOSSLESS);
+    avifBool usingLosslessAlpha = (qualityAlpha == AVIF_QUALITY_LOSSLESS);
     avifBool depthMatches = (sourceDepth == image->depth);
     avifBool using400 = (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400);
     avifBool using444 = (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444);
@@ -1108,7 +1108,7 @@ int main(int argc, char * argv[])
     avifBool usingIdentityMatrix = (image->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_IDENTITY);
 
     // Guess if the enduser is asking for lossless and enable it so that warnings can be emitted
-    if (!lossless && losslessColorQuality && (!hasAlpha || losslessAlphaQuality)) {
+    if (!lossless && usingLosslessColor && (!hasAlpha || usingLosslessAlpha)) {
         // The enduser is probably expecting lossless. Turn it on and emit warnings
         printf("Quality set to %d, assuming --lossless to enable warnings on potential lossless issues.\n", AVIF_QUALITY_LOSSLESS);
         lossless = AVIF_TRUE;
@@ -1121,14 +1121,14 @@ int main(int argc, char * argv[])
             lossless = AVIF_FALSE;
         }
 
-        if (!losslessColorQuality) {
+        if (!usingLosslessColor) {
             fprintf(stderr,
                     "WARNING: [--lossless] Color quality (-q or --qcolor) not set to %d. Color output might not be lossless.\n",
                     AVIF_QUALITY_LOSSLESS);
             lossless = AVIF_FALSE;
         }
 
-        if (hasAlpha && !losslessAlphaQuality) {
+        if (hasAlpha && !usingLosslessAlpha) {
             fprintf(stderr,
                     "WARNING: [--lossless] Alpha present and alpha quality (--qalpha) not set to %d. Alpha output might not be lossless.\n",
                     AVIF_QUALITY_LOSSLESS);

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -77,15 +77,15 @@ int main(int argc, char * argv[])
     encoder = avifEncoderCreate();
     // Configure your encoder here (see avif/avif.h):
     // * maxThreads
-    // * minQuantizer
-    // * maxQuantizer
-    // * minQuantizerAlpha
-    // * maxQuantizerAlpha
+    // * quality
+    // * qualityAlpha
     // * tileRowsLog2
     // * tileColsLog2
     // * speed
     // * keyframeInterval
     // * timescale
+    encoder->quality = 60;
+    encoder->qualityAlpha = AVIF_QUALITY_LOSSLESS;
 
     // Call avifEncoderAddImage() for each image in your sequence
     // Only set AVIF_ADD_IMAGE_FLAG_SINGLE if you're not encoding a sequence

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -78,6 +78,11 @@ typedef int avifBool;
 // a 12 hour AVIF image sequence, running at 60 fps (a basic sanity check as this is quite ridiculous)
 #define AVIF_DEFAULT_IMAGE_COUNT_LIMIT (12 * 3600 * 60)
 
+#define AVIF_QUALITY_DEFAULT -1
+#define AVIF_QUALITY_LOSSLESS 100
+#define AVIF_QUALITY_WORST 0
+#define AVIF_QUALITY_BEST 100
+
 #define AVIF_QUANTIZER_LOSSLESS 0
 #define AVIF_QUANTIZER_BEST_QUALITY 0
 #define AVIF_QUANTIZER_WORST_QUALITY 63
@@ -1066,7 +1071,14 @@ struct avifCodecSpecificOptions;
 // * If avifEncoderWrite() returns AVIF_RESULT_OK, output must be freed with avifRWDataFree()
 // * If (maxThreads < 2), multithreading is disabled
 //   * NOTE: Please see the "Understanding maxThreads" comment block above
-// * Quality range: [AVIF_QUANTIZER_BEST_QUALITY - AVIF_QUANTIZER_WORST_QUALITY]
+// * Quality range: [AVIF_QUALITY_WORST - AVIF_QUALITY_BEST]
+// * Quantizer range: [AVIF_QUANTIZER_BEST_QUALITY - AVIF_QUANTIZER_WORST_QUALITY]
+// * In older versions of libavif, the avifEncoder struct doesn't have the quality and qualityAlpha
+//   fields. For backward compatibility, if the quality field is not set, the default value of
+//   quality is based on the average of minQuantizer and maxQuantizer. Similarly the default value
+//   of qualityAlpha is based on the average of minQuantizerAlpha and maxQuantizerAlpha. New code
+//   should set quality and qualityAlpha and leave minQuantizer, maxQuantizer, minQuantizerAlpha,
+//   and maxQuantizerAlpha initialized to their default values.
 // * To enable tiling, set tileRowsLog2 > 0 and/or tileColsLog2 > 0.
 //   Tiling values range [0-6], where the value indicates a request for 2^n tiles in that dimension.
 //   If autoTiling is set to AVIF_TRUE, libavif ignores tileRowsLog2 and tileColsLog2 and
@@ -1093,6 +1105,8 @@ typedef struct avifEncoder
                           // played back `n + 1` times. Defaults to AVIF_REPETITION_COUNT_INFINITE.
 
     // changeable encoder settings
+    int quality;
+    int qualityAlpha;
     int minQuantizer;
     int maxQuantizer;
     int minQuantizerAlpha;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -289,6 +289,8 @@ typedef enum avifEncoderChange
     AVIF_ENCODER_CHANGE_MAX_QUANTIZER_ALPHA = (1u << 3),
     AVIF_ENCODER_CHANGE_TILE_ROWS_LOG2 = (1u << 4),
     AVIF_ENCODER_CHANGE_TILE_COLS_LOG2 = (1u << 5),
+    AVIF_ENCODER_CHANGE_QUANTIZER = (1u << 6),
+    AVIF_ENCODER_CHANGE_QUANTIZER_ALPHA = (1u << 7),
 
     AVIF_ENCODER_CHANGE_CODEC_SPECIFIC = (1u << 31)
 } avifEncoderChange;
@@ -308,6 +310,8 @@ typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec,
 // encoder->tileRowsLog2, encoder->tileColsLog2, and encoder->autoTiling. The caller of
 // avifCodecEncodeImageFunc is responsible for automatic tiling if encoder->autoTiling is set to
 // AVIF_TRUE. The actual tiling values are passed to avifCodecEncodeImageFunc as parameters.
+// Similarly, avifCodecEncodeImageFunc should use |quantizer| instead of encoder->quality and
+// encoder->qualityAlpha.
 //
 // Note: The caller of avifCodecEncodeImageFunc always passes encoder->data->tileRowsLog2 and
 // encoder->data->tileColsLog2 as the tileRowsLog2 and tileColsLog2 arguments. Because
@@ -320,6 +324,7 @@ typedef avifResult (*avifCodecEncodeImageFunc)(struct avifCodec * codec,
                                                avifBool alpha,
                                                int tileRowsLog2,
                                                int tileColsLog2,
+                                               int quantizer,
                                                avifEncoderChanges encoderChanges,
                                                avifAddImageFlags addImageFlags,
                                                avifCodecEncodeOutput * output);

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -310,8 +310,8 @@ typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec,
 // encoder->tileRowsLog2, encoder->tileColsLog2, and encoder->autoTiling. The caller of
 // avifCodecEncodeImageFunc is responsible for automatic tiling if encoder->autoTiling is set to
 // AVIF_TRUE. The actual tiling values are passed to avifCodecEncodeImageFunc as parameters.
-// Similarly, avifCodecEncodeImageFunc should use |quantizer| instead of encoder->quality and
-// encoder->qualityAlpha.
+// Similarly, avifCodecEncodeImageFunc should use the quantizer parameter instead of
+// encoder->quality and encoder->qualityAlpha.
 //
 // Note: The caller of avifCodecEncodeImageFunc always passes encoder->data->tileRowsLog2 and
 // encoder->data->tileColsLog2 as the tileRowsLog2 and tileColsLog2 arguments. Because

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -706,7 +706,6 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             minQuantizer = encoder->minQuantizer;
             maxQuantizer = encoder->maxQuantizer;
         }
-        quantizer = AVIF_CLAMP(quantizer, 0, 63);
         minQuantizer = AVIF_CLAMP(minQuantizer, 0, 63);
         maxQuantizer = AVIF_CLAMP(maxQuantizer, 0, 63);
         if ((cfg->rc_end_usage == AOM_VBR) || (cfg->rc_end_usage == AOM_CBR)) {

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -804,7 +804,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
                     cfg->rc_max_quantizer = AVIF_QUANTIZER_LOSSLESS;
                 } else {
                     cfg->rc_min_quantizer = AVIF_MAX(quantizer - 4, (int)cfg->rc_min_quantizer);
-                    cfg->rc_max_quantizer = AVIF_MIN(quantizer + 4, (int)cfg->rc_min_quantizer);
+                    cfg->rc_max_quantizer = AVIF_MIN(quantizer + 4, (int)cfg->rc_max_quantizer);
                 }
                 quantizerUpdated = AVIF_TRUE;
             }

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -55,6 +55,7 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
                                         avifBool alpha,
                                         int tileRowsLog2,
                                         int tileColsLog2,
+                                        int quantizer,
                                         avifEncoderChanges encoderChanges,
                                         uint32_t addImageFlags,
                                         avifCodecEncodeOutput * output)
@@ -139,17 +140,15 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
         }
 
         int minQuantizer = AVIF_CLAMP(encoder->minQuantizer, 0, 63);
-        int maxQuantizer = AVIF_CLAMP(encoder->maxQuantizer, 0, 63);
         if (alpha) {
             minQuantizer = AVIF_CLAMP(encoder->minQuantizerAlpha, 0, 63);
-            maxQuantizer = AVIF_CLAMP(encoder->maxQuantizerAlpha, 0, 63);
         }
         minQuantizer = (minQuantizer * 255) / 63; // Rescale quantizer values as rav1e's QP range is [0,255]
-        maxQuantizer = (maxQuantizer * 255) / 63;
+        quantizer = (quantizer * 255) / 63;
         if (rav1e_config_parse_int(rav1eConfig, "min_quantizer", minQuantizer) == -1) {
             goto cleanup;
         }
-        if (rav1e_config_parse_int(rav1eConfig, "quantizer", maxQuantizer) == -1) {
+        if (rav1e_config_parse_int(rav1eConfig, "quantizer", quantizer) == -1) {
             goto cleanup;
         }
         if (tileRowsLog2 != 0) {

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -48,6 +48,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
                                       avifBool alpha,
                                       int tileRowsLog2,
                                       int tileColsLog2,
+                                      int quantizer,
                                       avifEncoderChanges encoderChanges,
                                       uint32_t addImageFlags,
                                       avifCodecEncodeOutput * output)
@@ -136,7 +137,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
             svt_config->min_qp_allowed = AVIF_CLAMP(encoder->minQuantizer, 0, 63);
             svt_config->max_qp_allowed = AVIF_CLAMP(encoder->maxQuantizer, 0, 63);
         }
-        svt_config->qp = (svt_config->min_qp_allowed + svt_config->max_qp_allowed) / 2;
+        svt_config->qp = AVIF_CLAMP(quantizer, 0, 63);
 
         if (tileRowsLog2 != 0) {
             svt_config->tile_rows = tileRowsLog2;

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -137,7 +137,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
             svt_config->min_qp_allowed = AVIF_CLAMP(encoder->minQuantizer, 0, 63);
             svt_config->max_qp_allowed = AVIF_CLAMP(encoder->maxQuantizer, 0, 63);
         }
-        svt_config->qp = AVIF_CLAMP(quantizer, 0, 63);
+        svt_config->qp = quantizer;
 
         if (tileRowsLog2 != 0) {
             svt_config->tile_rows = tileRowsLog2;

--- a/src/write.c
+++ b/src/write.c
@@ -211,7 +211,8 @@ typedef struct avifEncoderData
     int tileRowsLog2;
     int tileColsLog2;
     avifEncoder lastEncoder;
-    // lastQuantizer and lastQuantizerAlpha are the quantizer and quantizerAlpha values used last time
+    // lastQuantizer and lastQuantizerAlpha are the quantizer and quantizerAlpha values used last
+    // time
     int lastQuantizer;
     int lastQuantizerAlpha;
     // lastTileRowsLog2 and lastTileColsLog2 are the actual tiling values used last time

--- a/src/write.c
+++ b/src/write.c
@@ -830,13 +830,14 @@ static avifImage * avifImageCopyAndPad(const avifImage * srcImage, uint32_t dstW
 
 static int avifQualityToQuantizer(int quality, int minQuantizer, int maxQuantizer)
 {
-    quality = AVIF_CLAMP(quality, -1, 100);
     int quantizer;
     if (quality == AVIF_QUALITY_DEFAULT) {
         // In older libavif releases, avifEncoder didn't have the quality and qualityAlpha fields.
         // Supply a default value for quantizer.
         quantizer = (minQuantizer + maxQuantizer) / 2;
+        quantizer = AVIF_CLAMP(quantizer, 0, 63);
     } else {
+        quality = AVIF_CLAMP(quality, 0, 100);
         quantizer = ((100 - quality) * 63 + 50) / 100;
     }
     return quantizer;

--- a/tests/gtest/avifgridapitest.cc
+++ b/tests/gtest/avifgridapitest.cc
@@ -42,10 +42,8 @@ avifResult EncodeDecodeGrid(const std::vector<std::vector<Cell>>& cell_rows,
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
   encoder->speed = AVIF_SPEED_FASTEST;
-  encoder->minQuantizer = AVIF_QUANTIZER_LOSSLESS;
-  encoder->maxQuantizer = AVIF_QUANTIZER_LOSSLESS;
-  encoder->minQuantizerAlpha = AVIF_QUANTIZER_LOSSLESS;
-  encoder->minQuantizerAlpha = AVIF_QUANTIZER_LOSSLESS;
+  encoder->quality = AVIF_QUALITY_LOSSLESS;
+  encoder->qualityAlpha = AVIF_QUALITY_LOSSLESS;
   // cell_image_ptrs exists only to match the libavif API.
   std::vector<avifImage*> cell_image_ptrs(cell_images.size());
   for (size_t i = 0; i < cell_images.size(); ++i) {

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -51,11 +51,12 @@ INPUT_Y4M="${TESTDATA_DIR}/kodim03_yuv420_8bpc.y4m"
 ENCODED_FILE="avif_test_cmd_encoded.avif"
 ENCODED_FILE_WITH_DASH="-avif_test_cmd_encoded.avif"
 DECODED_FILE="avif_test_cmd_decoded.png"
+OUT_MSG="avif_test_cmd_out_msg.txt"
 
 # Cleanup
 cleanup() {
   pushd ${TMP_DIR}
-    rm -- "${ENCODED_FILE}" "${ENCODED_FILE_WITH_DASH}" "${DECODED_FILE}"
+    rm -- "${ENCODED_FILE}" "${ENCODED_FILE_WITH_DASH}" "${DECODED_FILE}" "${OUT_MSG}"
   popd
 }
 trap cleanup EXIT
@@ -81,6 +82,21 @@ pushd ${TMP_DIR}
   # --minalpha and --maxalpha must be both specified.
   "${AVIFENC}" -s 10 --minalpha 0 "${INPUT_PNG}" "${ENCODED_FILE}" && exit 1
   "${AVIFENC}" -s 10 --maxalpha 0 "${INPUT_PNG}" "${ENCODED_FILE}" && exit 1
+
+  # The default quality is 60. The default alpha quality is 100 (lossless).
+  "${AVIFENC}" -s 10 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
+  grep " color quality \[60 " "${OUT_MSG}"
+  grep " alpha quality \[100 " "${OUT_MSG}"
+  "${AVIFENC}" -s 10 -q 85 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
+  grep " color quality \[85 " "${OUT_MSG}"
+  grep " alpha quality \[100 " "${OUT_MSG}"
+  # The average of 15 and 25 is 20. Quantizer 20 maps to quality 68.
+  "${AVIFENC}" -s 10 --min 15 --max 25 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
+  grep " color quality \[68 " "${OUT_MSG}"
+  grep " alpha quality \[100 " "${OUT_MSG}"
+  "${AVIFENC}" -s 10 -q 65 --min 15 --max 25 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
+  grep " color quality \[65 " "${OUT_MSG}"
+  grep " alpha quality \[100 " "${OUT_MSG}"
 popd
 
 exit 0


### PR DESCRIPTION
Change the default of minQuantizer and minQuantizerAlpha to
AVIF_QUANTIZER_BEST_QUALITY (0). Change the default of maxQuantizer and
maxQuantizerAlpha to AVIF_QUANTIZER_WORST_QUALITY (63).

The default of quality is based on the average of minQuantizer and
maxQuantizer. Similarly the default of qualityAlpha is based on the
average of minQuantizerAlpha and maxQuantizerAlpha.

Map quality and qualityAlpha in the range of 0..100 linearly to
quantizer values (QP) in the range of 63..0.