### PR TITLE
Change avifImageCreate to take uint32_t parameters

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -474,7 +474,7 @@ typedef struct avifImage
     avifRWData xmp;
 } avifImage;
 
-AVIF_API avifImage * avifImageCreate(int width, int height, int depth, avifPixelFormat yuvFormat);
+AVIF_API avifImage * avifImageCreate(uint32_t width, uint32_t height, uint32_t depth, avifPixelFormat yuvFormat);
 AVIF_API avifImage * avifImageCreateEmpty(void); // helper for making an image to decode into
 AVIF_API avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes); // deep copy
 AVIF_API avifResult avifImageSetViewRect(avifImage * dstImage, const avifImage * srcImage, const avifCropRect * rect); // shallow copy, no metadata

--- a/src/avif.c
+++ b/src/avif.c
@@ -131,7 +131,7 @@ static void avifImageSetDefaults(avifImage * image)
     image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
 }
 
-avifImage * avifImageCreate(int width, int height, int depth, avifPixelFormat yuvFormat)
+avifImage * avifImageCreate(uint32_t width, uint32_t height, uint32_t depth, avifPixelFormat yuvFormat)
 {
     avifImage * image = (avifImage *)avifAlloc(sizeof(avifImage));
     avifImageSetDefaults(image);


### PR DESCRIPTION
Change the width, height, and depth parameters of avifImageCreate() to be uint32_t instead of int, because they are assigned to the corresponding members of avifImage, which are uint32_t.