### PR TITLE
Two comment edits

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -17,7 +17,7 @@ extern "C" {
 // AVIF_BUILDING_SHARED_LIBS should only be defined when libavif is being built
 // as a shared library.
 // AVIF_DLL should be defined if libavif is a shared library. If you are using
-// libavif as CMake dependency, through CMake package config file or through
+// libavif as a CMake dependency, through a CMake package config file or through
 // pkg-config, this is defined automatically.
 //
 // Here's what AVIF_API will be defined as in shared build:
@@ -567,7 +567,7 @@ AVIF_API avifBool avifRGBFormatHasAlpha(avifRGBFormat format);
 typedef enum avifChromaUpsampling
 {
     AVIF_CHROMA_UPSAMPLING_AUTOMATIC = 0,    // Chooses best trade off of speed/quality (uses BILINEAR libyuv if available,
-                                             // or fallbacks to NEAREST libyuv if available, or fallbacks to BILINEAR built-in)
+                                             // or falls back to NEAREST libyuv if available, or falls back to BILINEAR built-in)
     AVIF_CHROMA_UPSAMPLING_FASTEST = 1,      // Chooses speed over quality (same as NEAREST)
     AVIF_CHROMA_UPSAMPLING_BEST_QUALITY = 2, // Chooses the best quality upsampling, given settings (same as BILINEAR)
     AVIF_CHROMA_UPSAMPLING_NEAREST = 3,      // Uses nearest-neighbor filter

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -534,7 +534,7 @@ AVIF_API void avifImageStealPlanes(avifImage * dstImage, avifImage * srcImage, a
 // If libavif is built with a version of libyuv offering a fast conversion between RGB and YUV for
 // the given inputs, libavif will use it. See reformat_libyuv.c for the details.
 // libyuv is faster but may have slightly less precision than built-in conversion, so avoidLibYUV
-// should be set to AVIF_TRUE when AVIF_CHROMA_UPSAMPLING_BEST_QUALITY or
+// can be set to AVIF_TRUE when AVIF_CHROMA_UPSAMPLING_BEST_QUALITY or
 // AVIF_CHROMA_DOWNSAMPLING_BEST_QUALITY is used, to get the most precise but slowest results.
 
 // Note to libavif maintainers: The lookup tables in avifImageYUVToRGBLibYUV
@@ -1094,7 +1094,7 @@ AVIF_API avifResult avifEncoderAddImageGrid(avifEncoder * encoder,
 AVIF_API avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output);
 
 // Codec-specific, optional "advanced" tuning settings, in the form of string key/value pairs,
-// to be consumed by the codec at the next avifEncoderAddImage() call.
+// to be consumed by the codec in the next avifEncoderAddImage() call.
 // See the codec documentation to know if a setting is persistent or applied only to the next frame.
 // key must be non-NULL, but passing a NULL value will delete the pending key, if it exists.
 // Setting an incorrect or unknown option for the current codec will cause errors of type


### PR DESCRIPTION
1. In "avoidLibYUV should be set to AVIF_TRUE ...", change "should" to "can" to make it clear this is optional, not a recommendation.

2. In "to be consumed by the codec at the next avifEncoderAddImage() call", change "at" to "in".