### PR TITLE
Have avifImageSetMetadataExif extract orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ return values of avifImageCopy() and avifImageAllocatePlanes().
   upsampling chroma from 4:2:0 or 4:2:2 and has no impact on the use of libyuv.
   Set avifRGBImage::avoidLibYUV accordingly to control the use of libyuv.
 * Exif and XMP metadata is imported from PNG and JPEG files.
+* avifImageSetMetadataExif() parses the Exif metadata and converts any Exif
+  orientation found into transformFlags, irot and imir values.
 
 ### Removed
 * alphaRange field was removed from the avifImage struct. It it presumed that
@@ -40,9 +42,6 @@ return values of avifImageCopy() and avifImageAllocatePlanes().
 * Add imageDimensionLimit field to avifDecoder struct
 * Add autoTiling field to avifEncoder struct
 * Add AVIF_CHROMA_DOWNSAMPLING_SHARP_YUV value to avifChromaDownsampling enum
-* Add avifImageExtractExifOrientationToIrotImir() which parses the Exif metadata
-  of an image and converts any Exif orientation found into transformFlags, irot
-  and imir values.
 * avifdec: Add --dimension-limit, which specifies the image dimension limit
   (width or height) that should be tolerated
 * avifenc: Add --sharpyuv, which enables "sharp" RGB to YUV420 conversion, which

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -891,8 +891,6 @@ int main(int argc, char * argv[])
     }
     if (exifOverride.size) {
         avifImageSetMetadataExif(image, exifOverride.data, exifOverride.size);
-        // Ignore any Exif parsing failure.
-        (void)avifImageExtractExifOrientationToIrotImir(image);
     }
     if (xmpOverride.size) {
         avifImageSetMetadataXMP(image, xmpOverride.data, xmpOverride.size);

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -388,8 +388,6 @@ avifBool avifJPEGRead(const char * inputFilename,
                     goto cleanup;
                 }
                 avifImageSetMetadataExif(avif, marker->data + tagExif.size, marker->data_length - tagExif.size);
-                // Ignore any Exif parsing failure.
-                (void)avifImageExtractExifOrientationToIrotImir(avif);
                 found = AVIF_TRUE;
             }
         }

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -123,8 +123,6 @@ static avifBool avifExtractExifAndXMP(png_structp png, png_infop info, avifBool 
                 return AVIF_FALSE;
             }
             avifImageSetMetadataExif(avif, exif, exifSize);
-            // Ignore any Exif parsing failure.
-            (void)avifImageExtractExifOrientationToIrotImir(avif);
             *ignoreExif = AVIF_TRUE; // Ignore any other Exif chunk.
         }
     }

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -31,7 +31,7 @@ int main(int argc, char * argv[])
     // * transferCharacteristics
     // * matrixCoefficients
     // * avifImageSetProfileICC()
-    // * avifImageSetMetadataExif() + avifImageExtractExifOrientationToIrotImir()
+    // * avifImageSetMetadataExif()
     // * avifImageSetMetadataXMP()
     // * yuvRange
     // * alphaPremultiplied

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -481,17 +481,13 @@ AVIF_API avifResult avifImageSetViewRect(avifImage * dstImage, const avifImage *
 AVIF_API void avifImageDestroy(avifImage * image);
 
 AVIF_API void avifImageSetProfileICC(avifImage * image, const uint8_t * icc, size_t iccSize);
-
-// Set Exif metadata. It is highly recommended to match image->transformFlags, image->irot and image->imir to any Exif
-// orientation contained in image->exif before encoding it to AVIF. See avifImageExtractExifOrientationToIrotImir().
+// Sets Exif metadata. Attempts to parse the Exif metadata for Exif orientation. Sets
+// image->transformFlags, image->irot and image->imir if the Exif metadata is parsed successfully,
+// otherwise leaves image->transformFlags, image->irot and image->imir unchanged.
 // Warning: If the Exif payload is set and invalid, avifEncoderWrite() may return AVIF_RESULT_INVALID_EXIF_PAYLOAD.
 AVIF_API void avifImageSetMetadataExif(avifImage * image, const uint8_t * exif, size_t exifSize);
-// Set XMP metadata.
+// Sets XMP metadata.
 AVIF_API void avifImageSetMetadataXMP(avifImage * image, const uint8_t * xmp, size_t xmpSize);
-
-// Attempts to parse the image->exif payload for Exif orientation and sets image->transformFlags, image->irot and
-// image->imir on success. Returns AVIF_RESULT_INVALID_EXIF_PAYLOAD on failure.
-AVIF_API avifResult avifImageExtractExifOrientationToIrotImir(avifImage * image);
 
 AVIF_API avifResult avifImageAllocatePlanes(avifImage * image, avifPlanesFlags planes); // Ignores any pre-existing planes
 AVIF_API void avifImageFreePlanes(avifImage * image, avifPlanesFlags planes);           // Ignores already-freed planes

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -209,6 +209,9 @@ avifBool avifAreGridDimensionsValid(avifPixelFormat yuvFormat, uint32_t imageW, 
 
 // Validates the first bytes of the Exif payload and finds the TIFF header offset.
 avifResult avifGetExifTiffHeaderOffset(const avifRWData * exif, uint32_t * offset);
+// Attempts to parse the image->exif payload for Exif orientation and sets image->transformFlags, image->irot and
+// image->imir on success. Returns AVIF_RESULT_INVALID_EXIF_PAYLOAD on failure.
+avifResult avifImageExtractExifOrientationToIrotImir(avifImage * image);
 
 // ---------------------------------------------------------------------------
 // avifCodecDecodeInput

--- a/src/avif.c
+++ b/src/avif.c
@@ -176,7 +176,7 @@ avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifP
 
     avifImageSetProfileICC(dstImage, srcImage->icc.data, srcImage->icc.size);
 
-    avifImageSetMetadataExif(dstImage, srcImage->exif.data, srcImage->exif.size);
+    avifRWDataSet(&dstImage->exif, srcImage->exif.data, srcImage->exif.size);
     avifImageSetMetadataXMP(dstImage, srcImage->xmp.data, srcImage->xmp.size);
 
     if ((planes & AVIF_PLANES_YUV) && srcImage->yuvPlanes[AVIF_CHAN_Y]) {
@@ -270,6 +270,8 @@ void avifImageSetProfileICC(avifImage * image, const uint8_t * icc, size_t iccSi
 void avifImageSetMetadataExif(avifImage * image, const uint8_t * exif, size_t exifSize)
 {
     avifRWDataSet(&image->exif, exif, exifSize);
+    // Ignore any Exif parsing failure.
+    (void)avifImageExtractExifOrientationToIrotImir(image);
 }
 
 void avifImageSetMetadataXMP(avifImage * image, const uint8_t * xmp, size_t xmpSize)

--- a/src/read.c
+++ b/src/read.c
@@ -1483,7 +1483,7 @@ static avifResult avifDecoderFindMetadata(avifDecoder * decoder, avifMeta * meta
             AVIF_CHECKERR(avifROStreamReadU32(&exifBoxStream, &exifTiffHeaderOffset),
                           AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) exif_tiff_header_offset;
 
-            avifImageSetMetadataExif(image, avifROStreamCurrent(&exifBoxStream), avifROStreamRemainingBytes(&exifBoxStream));
+            avifRWDataSet(&image->exif, avifROStreamCurrent(&exifBoxStream), avifROStreamRemainingBytes(&exifBoxStream));
         } else if (!decoder->ignoreXMP && !memcmp(item->type, "mime", 4) &&
                    !memcmp(item->contentType.contentType, xmpContentType, xmpContentTypeSize)) {
             avifROData xmpContents;

--- a/tests/gtest/avifmetadatatest.cc
+++ b/tests/gtest/avifmetadatatest.cc
@@ -4,7 +4,7 @@
 #include <array>
 #include <tuple>
 
-#include "avif/avif.h"
+#include "avif/internal.h"
 #include "aviftest_helpers.h"
 #include "gtest/gtest.h"
 
@@ -61,11 +61,16 @@ TEST_P(AvifMetadataTest, EncodeDecode) {
     avifImageSetProfileICC(image.get(), kSampleIcc.data(), kSampleIcc.size());
   }
   if (use_exif) {
+    const avifTransformFlags old_transform_flags = image->transformFlags;
+    const uint8_t old_irot_angle = image->irot.angle;
+    const uint8_t old_imir_mode = image->imir.mode;
     avifImageSetMetadataExif(image.get(), kSampleExif.data(),
                              kSampleExif.size());
-    // kSampleExif is not a valid Exif payload, just some part of it.
-    ASSERT_EQ(avifImageExtractExifOrientationToIrotImir(image.get()),
-              AVIF_RESULT_INVALID_EXIF_PAYLOAD);
+    // kSampleExif is not a valid Exif payload, just some part of it. These
+    // fields should not be modified.
+    EXPECT_EQ(image->transformFlags, old_transform_flags);
+    EXPECT_EQ(image->irot.angle, old_irot_angle);
+    EXPECT_EQ(image->imir.mode, old_imir_mode);
   }
   if (use_xmp) {
     avifImageSetMetadataXMP(image.get(), kSampleXmp.data(), kSampleXmp.size());


### PR DESCRIPTION
Have avifImageSetMetadataExif() parse the Exif metadata and extract the Exif orientation to irot and imir properties.

Remove avifImageExtractExifOrientationToIrotImir() from the public API but keep it as an internal function.

Call avifRWDataSet(&image->exif, exif, exifSize) directly when we just need to set image->exif.

Based on the reverse of the following commit of Yannis Guyon's: https://github.com/AOMediaCodec/libavif/pull/1099/commits/9b631db687834aeb8a52884d109f4529cc69a824