### PR TITLE
Enable libaom-specific AV1E_SET_SKIP_POSTPROC_FILTERING by default

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -750,6 +750,15 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
                 return AVIF_RESULT_UNKNOWN_ERROR;
             }
         }
+
+#if defined(AOM_USAGE_ALL_INTRA) && defined(AOM_CTRL_AV1E_SET_SKIP_POSTPROC_FILTERING)
+        if (cfg->g_usage == AOM_USAGE_ALL_INTRA) {
+            // Enable AV1E_SET_SKIP_POSTPROC_FILTERING for still-picture encoding, which is
+            // different from libaom's default.
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_SKIP_POSTPROC_FILTERING, 1);
+        }
+#endif
+
         if (!avifProcessAOMOptionsPostInit(codec, alpha)) {
             return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
         }


### PR DESCRIPTION
This PR enables AV1E_SET_SKIP_POSTPROC_FILTERING by default as the application of post-processing filters on the reconstructed frame can be skipped in case of still-picture encoding as the frame is never referenced.