### PR TITLE
Move avifImageSetMetadataExif() to exif.c

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -267,13 +267,6 @@ void avifImageSetProfileICC(avifImage * image, const uint8_t * icc, size_t iccSi
     avifRWDataSet(&image->icc, icc, iccSize);
 }
 
-void avifImageSetMetadataExif(avifImage * image, const uint8_t * exif, size_t exifSize)
-{
-    avifRWDataSet(&image->exif, exif, exifSize);
-    // Ignore any Exif parsing failure.
-    (void)avifImageExtractExifOrientationToIrotImir(image);
-}
-
 void avifImageSetMetadataXMP(avifImage * image, const uint8_t * xmp, size_t xmpSize)
 {
     avifRWDataSet(&image->xmp, xmp, xmpSize);

--- a/src/exif.c
+++ b/src/exif.c
@@ -117,3 +117,10 @@ avifResult avifImageExtractExifOrientationToIrotImir(avifImage * image)
     image->imir.mode = 0;  // ignored
     return AVIF_RESULT_OK;
 }
+
+void avifImageSetMetadataExif(avifImage * image, const uint8_t * exif, size_t exifSize)
+{
+    avifRWDataSet(&image->exif, exif, exifSize);
+    // Ignore any Exif parsing failure.
+    (void)avifImageExtractExifOrientationToIrotImir(image);
+}


### PR DESCRIPTION
Move avifImageSetMetadataExif() from avif.c to exif.c. This allows a libavif client such as Chromium that uses only the decoder to not include exif.c. In https://github.com/AOMediaCodec/libavif/pull/1154 avifImageSetMetadataExif() was modified to call
avifImageExtractExifOrientationToIrotImir(), which is defined in exif.c.

See https://chromium-review.googlesource.com/c/chromium/src/+/3945613.