### PR TITLE
Fix a minor comment typo: INT_MIN => INT32_MIN

### DIFF
--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -11,7 +11,7 @@
 #include "avifpng.h"
 #include "y4m.h"
 
-// |a| and |b| hold int32_t values. The int64_t type is used so that we can negate INT_MIN without
+// |a| and |b| hold int32_t values. The int64_t type is used so that we can negate INT32_MIN without
 // overflowing int32_t.
 static int64_t calcGCD(int64_t a, int64_t b)
 {

--- a/src/avif.c
+++ b/src/avif.c
@@ -512,7 +512,7 @@ static clapFraction calcCenter(int32_t dim)
     return f;
 }
 
-// |a| and |b| hold int32_t values. The int64_t type is used so that we can negate INT_MIN without
+// |a| and |b| hold int32_t values. The int64_t type is used so that we can negate INT32_MIN without
 // overflowing int32_t.
 static int64_t calcGCD(int64_t a, int64_t b)
 {


### PR DESCRIPTION
Since int is the same as int32_t in all the compilers we use today, INT_MIN and INT32_MIN have the same value. But it is more correct to use INT32_MIN in this comment.

This comment was originally added in
https://github.com/AOMediaCodec/libavif/pull/973.