### PR TITLE
Install meson,cargo,nasm as Debian/Ubuntu packages

### DIFF
--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -19,20 +19,11 @@ set -e
 
 # build env
 apt update
-DEBIAN_FRONTEND="noninteractive" apt install -y build-essential libjpeg-dev libpng-dev libssl-dev ninja-build cmake pkg-config git perl vim curl python3-pip
-pip3 install meson
+DEBIAN_FRONTEND="noninteractive" apt install -y build-essential libjpeg-dev libpng-dev libssl-dev ninja-build cmake pkg-config git perl vim curl meson cargo nasm
 
 # Rust env
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source $HOME/.cargo/env
+export PATH="$HOME/.cargo/bin:$PATH"
 cargo install cargo-c
-
-# NASM
-cd
-curl -L https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.gz | tar xvz
-cd nasm-2.15.05
-./configure --prefix=/usr && make -j2 && make install
-nasm --version
 
 # aom
 cd


### PR DESCRIPTION
Install meson,cargo,nasm as Debian/Ubuntu packages

The current command used to install cargo is:
  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

This command executes a shell script that is not in the source
repository using `curl | bash`. This is a potential security
vulnerability. We should not pipe curl output directly to a shell.

The current command used to install meson is:
  pip3 install meson

Using pip install without manifest files (requirements.txt) and checksum
verification (--require-hashes) is a potential security vulnerability.

Bug: b/248582328
Bug: b/253297622