### PR TITLE
Do not install the curl package (no longer used)

### DIFF
--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -19,7 +19,7 @@ set -e
 
 # build env
 apt update
-DEBIAN_FRONTEND="noninteractive" apt install -y build-essential libjpeg-dev libpng-dev libssl-dev ninja-build cmake pkg-config git perl vim curl meson cargo nasm
+DEBIAN_FRONTEND="noninteractive" apt install -y build-essential libjpeg-dev libpng-dev libssl-dev ninja-build cmake pkg-config git perl vim meson cargo nasm
 
 # Rust env
 export PATH="$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
When I removed the uses of curl in
https://github.com/AOMediaCodec/libavif/pull/1159, I forgot to remove the installation of the curl package.

Bug: b/248582328