### PR TITLE
avifrgbtoyuvtest: Test AVIF_LIBSHARPYUV_ENABLED

### DIFF
--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -429,6 +429,7 @@ INSTANTIATE_TEST_SUITE_P(MonochromeLossless12b, RGBToYUVTest,
 
 // Can be used to print the drift of all RGB to YUV conversion possibilities.
 // Also used for coverage.
+#if defined(AVIF_LIBSHARPYUV_ENABLED)
 INSTANTIATE_TEST_SUITE_P(
     SharpYuv8Bit, RGBToYUVTest,
     Combine(
@@ -474,6 +475,7 @@ INSTANTIATE_TEST_SUITE_P(
                                                // color shift.
         /*min_psnr=*/Values(34.)  // SharpYuv distortion is acceptable.
         ));
+#endif  // defined(AVIF_LIBSHARPYUV_ENABLED)
 
 // Can be used to print the drift of all RGB to YUV conversion possibilities.
 // Also used for coverage.


### PR DESCRIPTION
The test suites (SharpYuv8Bit, SharpYuv10Bit, and SharpYuv12Bit) that use AVIF_CHROMA_DOWNSAMPLING_SHARP_YUV should only be run if the macro AVIF_LIBSHARPYUV_ENABLED is defined, otherwise the avifImageRGBToYUV() calls in those tests will fail with AVIF_RESULT_NOT_IMPLEMENTED (25).

Fix https://github.com/AOMediaCodec/libavif/issues/1164.