### PR TITLE
avifincrtest_helpers: Cast 64-bit offset to size_t

### DIFF
--- a/tests/gtest/avifincrtest_helpers.cc
+++ b/tests/gtest/avifincrtest_helpers.cc
@@ -126,13 +126,15 @@ struct PartialData {
 
 // Implementation of avifIOReadFunc simulating a stream from an array. See
 // avifIOReadFunc documentation. io->data is expected to point to PartialData.
-avifResult PartialRead(struct avifIO* io, uint32_t read_flags, uint64_t offset,
-                       size_t size, avifROData* out) {
+avifResult PartialRead(struct avifIO* io, uint32_t read_flags,
+                       uint64_t offset64, size_t size, avifROData* out) {
   PartialData* data = reinterpret_cast<PartialData*>(io->data);
-  if ((read_flags != 0) || !data || (data->full_size < offset)) {
+  if ((read_flags != 0) || !data || (data->full_size < offset64)) {
     return AVIF_RESULT_IO_ERROR;
   }
-  if (data->full_size < (offset + size)) {
+  const size_t offset = static_cast<size_t>(offset64);
+  // Use |offset| instead of |offset64| from this point on.
+  if (size > (data->full_size - offset)) {
     size = data->full_size - offset;
   }
   if (data->available.size < (offset + size)) {


### PR DESCRIPTION
Cast the 64-bit offset parameter of PartialRead() to a size_t local variable after verifying that the offset is less than or equal to data->full_size (a size_t). From that point on, use the size_t local variable as the offset exclusively. Note that size_t is a 32-bit unsigned integer on 32-bit platforms.

Audit the entire PartialRead() function for integer overflows.

Fix https://github.com/AOMediaCodec/libavif/issues/1165.