### PR TITLE
Add SHARED libavif CI with installed dependencies

### DIFF
--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -1,5 +1,5 @@
-# This is a copy of ci-unix-shared-local.yml for building shared libraries, but
-# using installed dependencies instead of locally built ones.
+# This is a copy of ci-unix-shared-local.yml for building shared libraries
+# with an additional build configuration (using installed deps and dav1d).
 
 name: CI
 on: [push, pull_request]
@@ -39,7 +39,7 @@ jobs:
     - name: Update apt
       run: sudo apt-get update
     - name: Install dependencies
-      run: sudo apt-get install libaom-dev libyuv-dev
+      run: sudo apt-get install libaom-dev libdav1d-dev libyuv-dev
       # `sudo apt-get install googletest libgtest-dev` leads to the following:
       #   "libgtest.a(gtest-all.cc.o): undefined reference to `std::__throw_bad_array_new_length()'"
       # so build it locally instead.
@@ -55,6 +55,8 @@ jobs:
         cmake .. -G Ninja
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
         -DAVIF_CODEC_AOM=ON
+        -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_AOM_ENCODE=ON
+        -DAVIF_CODEC_DAV1D=ON
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON
     - name: Build libavif (ninja)

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -1,0 +1,68 @@
+# This is a copy of ci-unix-shared-local.yml for building shared libraries, but
+# using installed dependencies instead of locally built ones.
+
+name: CI
+on: [push, pull_request]
+jobs:
+  build-shared-installed:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set GCC & G++ 10 compiler (on Linux)
+      if: runner.os == 'Linux'
+      run: echo "CC=gcc-10" >> $GITHUB_ENV && echo "CXX=g++-10" >> $GITHUB_ENV
+
+    - name: Cache external dependencies
+      id: cache-ext
+      uses: actions/cache@v3
+      with:
+        path: ext
+        key: ${{ runner.os }}-shared-installed-${{ hashFiles('ext/*.cmd') }}
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v1.12
+      with:
+        cmake-version: '3.13.x'
+    - name: Print cmake version
+      run: cmake --version
+    - uses: seanmiddleditch/gha-setup-ninja@v3
+    - name: Set shared libs
+      if: steps.cache-ext.outputs.cache-hit != 'true'
+      working-directory: ./ext
+      run: sed -i'' -e 's/-DBUILD_SHARED_LIBS=OFF/-DBUILD_SHARED_LIBS=ON/' *.cmd
+    - name: Add recent repository for libyuv-dev
+      if: steps.cache-ext.outputs.cache-hit != 'true'
+      run: echo "deb http://azure.archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+    - name: Update apt
+      if: steps.cache-ext.outputs.cache-hit != 'true'
+      run: sudo apt-get update
+    - name: Install dependencies
+      if: steps.cache-ext.outputs.cache-hit != 'true'
+      run: sudo apt-get install libaom-dev libyuv-dev
+      # `sudo apt-get install googletest libgtest-dev` leads to the following:
+      #   "libgtest.a(gtest-all.cc.o): undefined reference to `std::__throw_bad_array_new_length()'"
+      # so build it locally instead.
+    - name: Build GoogleTest
+      if: steps.cache-ext.outputs.cache-hit != 'true'
+      working-directory: ./ext
+      run: bash googletest.cmd
+
+    - name: Prepare libavif (cmake)
+      run: >
+        mkdir build && cd build
+
+        cmake .. -G Ninja
+        -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
+        -DAVIF_CODEC_AOM=ON
+        -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
+        -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON
+    - name: Build libavif (ninja)
+      working-directory: ./build
+      run: ninja
+    - name: Run AVIF Tests
+      working-directory: ./build
+      run: ctest -j $(getconf _NPROCESSORS_ONLN)

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -35,13 +35,10 @@ jobs:
       working-directory: ./ext
       run: sed -i'' -e 's/-DBUILD_SHARED_LIBS=OFF/-DBUILD_SHARED_LIBS=ON/' *.cmd
     - name: Add recent repository for libyuv-dev
-      if: steps.cache-ext.outputs.cache-hit != 'true'
       run: echo "deb http://azure.archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
     - name: Update apt
-      if: steps.cache-ext.outputs.cache-hit != 'true'
       run: sudo apt-get update
     - name: Install dependencies
-      if: steps.cache-ext.outputs.cache-hit != 'true'
       run: sudo apt-get install libaom-dev libyuv-dev
       # `sudo apt-get install googletest libgtest-dev` leads to the following:
       #   "libgtest.a(gtest-all.cc.o): undefined reference to `std::__throw_bad_array_new_length()'"

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -6,7 +6,7 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  build-shared:
+  build-shared-local:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -27,7 +27,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ext
-        key: ${{ runner.os }}-shared-${{ hashFiles('ext/*.cmd') }}
+        key: ${{ runner.os }}-shared-local-${{ hashFiles('ext/*.cmd') }}
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v1.12
       with:


### PR DESCRIPTION
Only done for `aom`, `libyuv`, `googletest` on `ubuntu-latest` as a first step.

It does not work:

> libgtest.a(gtest-all.cc.o): undefined reference to `std::__throw_bad_array_new_length()'

I do not know the root cause. The alternative to installing dependencies would be building them locally, see https://github.com/AOMediaCodec/libavif/pull/1169.