### PR TITLE
Do not allow parameter overrides in lossless.

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -827,11 +827,9 @@ int main(int argc, char * argv[])
             fprintf(stderr, "Codec can only be AOM in lossless mode.\n");
             returnCode = 1;
         }
-        // rav1e doesn't support lossless
-        // transform yet:
+        // rav1e doesn't support lossless transform yet:
         // https://github.com/xiph/rav1e/issues/151
-        // SVT-AV1 doesn't support lossless
-        // encoding yet:
+        // SVT-AV1 doesn't support lossless encoding yet:
         // https://gitlab.com/AOMediaCodec/SVT-AV1/-/issues/1636
         codecChoice = AVIF_CODEC_CHOICE_AOM;
         // Range.

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -814,11 +814,11 @@ int main(int argc, char * argv[])
                     "mode.\n");
             returnCode = 1;
         }
-        input.requestedFormat = AVIF_PIXEL_FORMAT_YUV444; // don't subsample when using
-                                                          // AVIF_MATRIX_COEFFICIENTS_IDENTITY
+        // Don't subsample when using AVIF_MATRIX_COEFFICIENTS_IDENTITY.
+        input.requestedFormat = AVIF_PIXEL_FORMAT_YUV444;
         // Quantizers.
-        if (minQuantizer != -1 || maxQuantizer != -1 || minQuantizerAlpha != -1 || maxQuantizerAlpha != -1) {
-            fprintf(stderr, "Quantizers cannot be set in lossless mode.\n");
+        if (minQuantizer > 0 || maxQuantizer > 0 || minQuantizerAlpha > 0 || maxQuantizerAlpha > 0) {
+            fprintf(stderr, "Quantizers cannot be set in lossless mode, except to 0.\n");
             returnCode = 1;
         }
         minQuantizer = maxQuantizer = minQuantizerAlpha = maxQuantizerAlpha = AVIF_QUANTIZER_LOSSLESS;
@@ -827,12 +827,13 @@ int main(int argc, char * argv[])
             fprintf(stderr, "Codec can only be AOM in lossless mode.\n");
             returnCode = 1;
         }
-        codecChoice = AVIF_CODEC_CHOICE_AOM; // rav1e doesn't support lossless
-                                             // transform yet:
-                                             // https://github.com/xiph/rav1e/issues/151
-                                             // SVT-AV1 doesn't support lossless
-                                             // encoding yet:
-                                             // https://gitlab.com/AOMediaCodec/SVT-AV1/-/issues/1636
+        // rav1e doesn't support lossless
+        // transform yet:
+        // https://github.com/xiph/rav1e/issues/151
+        // SVT-AV1 doesn't support lossless
+        // encoding yet:
+        // https://gitlab.com/AOMediaCodec/SVT-AV1/-/issues/1636
+        codecChoice = AVIF_CODEC_CHOICE_AOM;
         // Range.
         if (requestedRange != AVIF_RANGE_FULL) {
             fprintf(stderr, "Range has to be full in lossless mode.\n");

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -496,8 +496,7 @@ int main(int argc, char * argv[])
     // See: ISO/IEC 23000-22:2019 Amendment 2, or the comment in avifCalcYUVCoefficients()
     avifColorPrimaries colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
     avifTransferCharacteristics transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
-    const int matrixCoefficientsUnset = 100; // 100 is way above any possible matric coefficient
-    avifMatrixCoefficients matrixCoefficients = matrixCoefficientsUnset;
+    avifMatrixCoefficients matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
     avifChromaDownsampling chromaDownsampling = AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC;
 
     int argIndex = 1;
@@ -840,7 +839,7 @@ int main(int argc, char * argv[])
             returnCode = 1;
         }
         // Matrix coefficients.
-        if (matrixCoefficients != matrixCoefficientsUnset && matrixCoefficients != AVIF_MATRIX_COEFFICIENTS_IDENTITY) {
+        if (cicpExplicitlySet && matrixCoefficients != AVIF_MATRIX_COEFFICIENTS_IDENTITY) {
             fprintf(stderr, "Matrix coefficients have to be identity in lossless mode.\n");
             returnCode = 1;
         }
@@ -860,9 +859,6 @@ int main(int argc, char * argv[])
         }
         if (maxQuantizerAlpha == -1) {
             maxQuantizerAlpha = AVIF_QUANTIZER_LOSSLESS;
-        }
-        if (matrixCoefficients == matrixCoefficientsUnset) {
-            matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
         }
     }
 

--- a/tests/test_cmd_lossless.sh
+++ b/tests/test_cmd_lossless.sh
@@ -62,7 +62,7 @@ pushd ${TMP_DIR}
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}"
 
   # Combining some arguments with lossless should fail.
-  for option in "-y 400" "--min 64" "-r limited" "--cicp 2/2/8"; do
+  for option in "-y 400" "--min 1" "-r limited" "--cicp 2/2/8"; do
     "${AVIFENC}" $option -s 10 -l "${DECODED_FILE}" -o "${ENCODED_FILE}" && exit 1
   done
 

--- a/tests/test_cmd_lossless.sh
+++ b/tests/test_cmd_lossless.sh
@@ -61,6 +61,11 @@ pushd ${TMP_DIR}
   "${AVIFENC}" -s 8 "${INPUT_PNG}" -o "${ENCODED_FILE}"
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}"
 
+  # Combining some arguments with lossless should fail.
+  for option in "-y 400" "--min 0" "-r limited" "--cicp 2/2/8"; do
+    "${AVIFENC}" $option -s 10 -l "${DECODED_FILE}" -o "${ENCODED_FILE}" && exit 1
+  done
+
   # Lossless test. The decoded pixels should be the same as the original image.
   echo "Testing basic lossless"
   # TODO(yguyon): Make this test pass with INPUT_PNG instead of DECODED_FILE.

--- a/tests/test_cmd_lossless.sh
+++ b/tests/test_cmd_lossless.sh
@@ -62,8 +62,13 @@ pushd ${TMP_DIR}
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}"
 
   # Combining some arguments with lossless should fail.
-  for option in "-y 400" "--min 0" "-r limited" "--cicp 2/2/8"; do
+  for option in "-y 400" "--min 64" "-r limited" "--cicp 2/2/8"; do
     "${AVIFENC}" $option -s 10 -l "${DECODED_FILE}" -o "${ENCODED_FILE}" && exit 1
+  done
+
+  # Combining some arguments with lossless should work.
+  for option in "-y 444" "--min 0" "-r full"; do
+    "${AVIFENC}" $option -s 10 -l "${DECODED_FILE}" -o "${ENCODED_FILE}"
   done
 
   # Lossless test. The decoded pixels should be the same as the original image.


### PR DESCRIPTION
This patch fixes:
- the fact that the order of parameters matters for lossless
- the fact that we allow a mix of -l and parameters contradictory with lossless