### PR TITLE
Use different cache file for shared library build

### DIFF
--- a/.github/workflows/ci-unix-shared.yml
+++ b/.github/workflows/ci-unix-shared.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ext
-        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}
+        key: ${{ runner.os }}-shared-${{ hashFiles('ext/*.cmd') }}
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v1.12
       with:
@@ -39,26 +39,26 @@ jobs:
         version: 2.15.05
     - uses: seanmiddleditch/gha-setup-ninja@v3
     - name: Set shared libs
-      # if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: >
         sed -i'' -e 's/-DBUILD_SHARED_LIBS=OFF/-DBUILD_SHARED_LIBS=ON/' *.cmd
 
         sed -i'' -e 's/ninja yuv/ninja yuv_shared/' libyuv.cmd
     - name: Build aom
-      # if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash aom.cmd
     - name: Build libyuv
-      # if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash libyuv.cmd
     - name: Build libsharpyuv
-      # if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash libsharpyuv.cmd
     - name: Build GoogleTest
-      # if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash googletest.cmd
 

--- a/ext/googletest.cmd
+++ b/ext/googletest.cmd
@@ -15,5 +15,5 @@ cd build
 : # on Windows:
 : # https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
 cmake -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_GMOCK=OFF -Dgtest_force_shared_crt=ON ..
-cmake --build .
+ninja
 cd ../..


### PR DESCRIPTION
Add "-shared" to the cache file name for the shared library build.

Make a simple change to ext/googletest.cmd to force the cache files to be recreated.