### PR TITLE
Rename shared CI

### DIFF
--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -1,7 +1,7 @@
-name: CI-Android-JNI
+name: CI
 on: [push, pull_request]
 jobs:
-  build:
+  build-android-jni:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-unix-shared.yml
+++ b/.github/workflows/ci-unix-shared.yml
@@ -3,10 +3,10 @@
 #   * The os matrix consists of ubuntu-latest only.
 #   * Does not build dav1d, rav1e, SVT-AV1 nor libgav1.
 
-name: CI (shared libraries)
+name: CI
 on: [push, pull_request]
 jobs:
-  build:
+  build-shared:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -13,7 +13,7 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  build:
+  build-static:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  build:
+  build-static:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,7 +1,7 @@
-name: CIFuzz
+name: CI
 on: [pull_request]
 jobs:
-  Fuzzing:
+  fuzz:
     runs-on: ubuntu-latest
     steps:
     - name: Build Fuzzers

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,7 +1,7 @@
-name: Clang Format Checker
+name: CI
 on: [push]
 jobs:
-  clang-format-checking:
+  clang-format-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Make it appear different from the other unix ones in GitHub checks that do not show the workflow name.
Make naming consistent accross workflows.

Fixes https://github.com/AOMediaCodec/libavif/pull/1169#issuecomment-1286215956.