### PR TITLE
change encoder speed in gdk-pixbuf plug-in

### DIFF
--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -466,7 +466,7 @@ static gboolean avif_image_saver(FILE          *f,
     encoder->maxQuantizer = max_quantizer;
     encoder->minQuantizerAlpha = 0;
     encoder->maxQuantizerAlpha = alpha_quantizer;
-    encoder->speed = 7;
+    encoder->speed = 6;
 
     res = avifEncoderWrite(encoder, avif, &raw);
     avifEncoderDestroy(encoder);


### PR DESCRIPTION
Speed 6 is now recommended default, encoders got improved. It seems better choice now than 7.