### PR TITLE
Remove % from AVIF_FMT_ZU

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -1275,8 +1275,8 @@ int main(int argc, char * argv[])
     }
 
     printf("Encoded successfully.\n");
-    printf(" * Color AV1 total size: " AVIF_FMT_ZU " bytes\n", encoder->ioStats.colorOBUSize);
-    printf(" * Alpha AV1 total size: " AVIF_FMT_ZU " bytes\n", encoder->ioStats.alphaOBUSize);
+    printf(" * Color AV1 total size: %" AVIF_FMT_ZU " bytes\n", encoder->ioStats.colorOBUSize);
+    printf(" * Alpha AV1 total size: %" AVIF_FMT_ZU " bytes\n", encoder->ioStats.alphaOBUSize);
     FILE * f = fopen(outputFilename, "wb");
     if (!f) {
         fprintf(stderr, "ERROR: Failed to open file for write: %s\n", outputFilename);
@@ -1284,7 +1284,7 @@ int main(int argc, char * argv[])
         goto cleanup;
     }
     if (fwrite(raw.data, 1, raw.size, f) != raw.size) {
-        fprintf(stderr, "Failed to write " AVIF_FMT_ZU " bytes: %s\n", raw.size, outputFilename);
+        fprintf(stderr, "Failed to write %" AVIF_FMT_ZU " bytes: %s\n", raw.size, outputFilename);
         returnCode = 1;
     } else {
         printf("Wrote AVIF: %s\n", outputFilename);

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -39,7 +39,7 @@ static avifBool avifHexStringToBytes(const char * hexString, size_t hexStringLen
         }
         if (!isxdigit(hexString[i]) || !isxdigit(hexString[i + 1])) {
             avifRWDataFree(bytes);
-            fprintf(stderr, "Metadata extraction failed: invalid character at " AVIF_FMT_ZU "\n", i);
+            fprintf(stderr, "Metadata extraction failed: invalid character at %" AVIF_FMT_ZU "\n", i);
             return AVIF_FALSE;
         }
         const char twoHexDigits[] = { hexString[i], hexString[i + 1], '\0' };
@@ -50,7 +50,7 @@ static avifBool avifHexStringToBytes(const char * hexString, size_t hexStringLen
 
     if (numBytes != numExpectedBytes) {
         avifRWDataFree(bytes);
-        fprintf(stderr, "Metadata extraction failed: expected " AVIF_FMT_ZU " tokens but got " AVIF_FMT_ZU "\n", numExpectedBytes, numBytes);
+        fprintf(stderr, "Metadata extraction failed: expected %" AVIF_FMT_ZU " tokens but got %" AVIF_FMT_ZU "\n", numExpectedBytes, numBytes);
         return AVIF_FALSE;
     }
     return AVIF_TRUE;
@@ -69,7 +69,7 @@ static avifBool avifCopyRawProfile(const char * profile, size_t profileLength, a
     for (size_t i = 1; i < profileLength; ++i) { // i starts at 1 because the first '\n' was already checked above.
         if (profile[i] == '\0') {
             // This should not happen as libpng provides this guarantee but extra safety does not hurt.
-            fprintf(stderr, "Metadata extraction failed: malformed raw profile, unexpected null character at " AVIF_FMT_ZU "\n", i);
+            fprintf(stderr, "Metadata extraction failed: malformed raw profile, unexpected null character at %" AVIF_FMT_ZU "\n", i);
             return AVIF_FALSE;
         }
         if (profile[i] == '\n') {

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -64,17 +64,17 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
     printf(" * Matrix Coeffs. : %u\n", avif->matrixCoefficients);
 
     if (avif->icc.size != 0) {
-        printf(" * ICC Profile    : Present (" AVIF_FMT_ZU " bytes)\n", avif->icc.size);
+        printf(" * ICC Profile    : Present (%" AVIF_FMT_ZU " bytes)\n", avif->icc.size);
     } else {
         printf(" * ICC Profile    : Absent\n");
     }
     if (avif->xmp.size != 0) {
-        printf(" * XMP Metadata   : Present (" AVIF_FMT_ZU " bytes)\n", avif->xmp.size);
+        printf(" * XMP Metadata   : Present (%" AVIF_FMT_ZU " bytes)\n", avif->xmp.size);
     } else {
         printf(" * XMP Metadata   : Absent\n");
     }
     if (avif->exif.size != 0) {
-        printf(" * Exif Metadata  : Present (" AVIF_FMT_ZU " bytes)\n", avif->exif.size);
+        printf(" * Exif Metadata  : Present (%" AVIF_FMT_ZU " bytes)\n", avif->exif.size);
     } else {
         printf(" * Exif Metadata  : Absent\n");
     }

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -23,9 +23,9 @@ extern "C" {
 // Related mingw-w64 commit: bfd33f6c0ec5e652cc9911857dd1492ece8d8383
 
 #if !defined(_UCRT) && (defined(__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO == 0)
-#define AVIF_FMT_ZU "%Iu"
+#define AVIF_FMT_ZU "Iu"
 #else
-#define AVIF_FMT_ZU "%zu"
+#define AVIF_FMT_ZU "zu"
 #endif
 
 void avifImageDump(const avifImage * avif, uint32_t gridCols, uint32_t gridRows, avifProgressiveState progressiveState);


### PR DESCRIPTION
To match the inttypes.h print macros.