### PR TITLE
Bump minimum libpng dependency to 1.6.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   except XMP payloads larger than 65502 bytes in JPEG.
 * The --grid flag in avifenc can be used for images that are not evenly divided
   into cells.
+* Apps must be built with libpng version 1.6.31 or above.
 
 ## [0.11.1] - 2022-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   except XMP payloads larger than 65502 bytes in JPEG.
 * The --grid flag in avifenc can be used for images that are not evenly divided
   into cells.
-* Apps must be built with libpng version 1.6.31 or above.
+* Apps must be built with libpng version 1.6.32 or above.
 
 ## [0.11.1] - 2022-10-19
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,7 +504,7 @@ option(AVIF_ENABLE_GTEST
 
 if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND AVIF_ENABLE_GTEST))
     find_package(ZLIB REQUIRED)
-    find_package(PNG REQUIRED)
+    find_package(PNG 1.6.31 REQUIRED) # 1.6.31 or above for PNG_eXIf_SUPPORTED and PNG_iTXt_SUPPORTED.
     find_package(JPEG REQUIRED)
 
     add_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,7 +504,7 @@ option(AVIF_ENABLE_GTEST
 
 if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND AVIF_ENABLE_GTEST))
     find_package(ZLIB REQUIRED)
-    find_package(PNG 1.6.31 REQUIRED) # 1.6.31 or above for PNG_eXIf_SUPPORTED and PNG_iTXt_SUPPORTED.
+    find_package(PNG 1.6.32 REQUIRED) # 1.6.32 or above for png_get_eXIf_1()/png_set_eXIf_1() and iTXt (for XMP).
     find_package(JPEG REQUIRED)
 
     add_library(

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -15,7 +15,7 @@
 #include <string.h>
 
 #if !defined(PNG_eXIf_SUPPORTED) || !defined(PNG_iTXt_SUPPORTED)
-#error "libpng 1.6.31 or above is required."
+#error "libpng 1.6.32 or above with PNG_eXIf_SUPPORTED and PNG_iTXt_SUPPORTED is required."
 #endif
 
 // See libpng-manual.txt, section XI.


### PR DESCRIPTION
Remove PNG_eXIf_SUPPORTED and PNG_iTXt_SUPPORTED conditionals in avifpng.c to simplify the code and to avoid generating new PNGs with legacy raw profile chunks.
Reject PNG export with XMP data containing any null character.