### PR TITLE
Add clli metadata read support

### DIFF
--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -121,6 +121,7 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
         }
     }
     printf(" * Progressive    : %s\n", avifProgressiveStateToString(progressiveState));
+    printf(" * CLLI           : %u, %u\n", (uint32_t)avif->clli.maxCLL, (uint32_t)avif->clli.maxPALL);
 }
 
 void avifImageDump(const avifImage * avif, uint32_t gridCols, uint32_t gridRows, avifProgressiveState progressiveState)

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -121,7 +121,9 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
         }
     }
     printf(" * Progressive    : %s\n", avifProgressiveStateToString(progressiveState));
-    printf(" * CLLI           : %u, %u\n", (uint32_t)avif->clli.maxCLL, (uint32_t)avif->clli.maxPALL);
+    if (avif->clli.maxCLL > 0 || avif->clli.maxPALL > 0) {
+        printf(" * CLLI           : %u, %u\n", (uint32_t)avif->clli.maxCLL, (uint32_t)avif->clli.maxPALL);
+    }
 }
 
 void avifImageDump(const avifImage * avif, uint32_t gridCols, uint32_t gridRows, avifProgressiveState progressiveState)

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -424,6 +424,14 @@ AVIF_API avifBool avifCleanApertureBoxConvertCropRect(avifCleanApertureBox * cla
                                                       avifPixelFormat yuvFormat,
                                                       avifDiagnostics * diag);
 
+typedef struct avifContentLightLevelInformationBox
+{
+    // 'clli' from ISO/IEC 23000-22:2019 (MIAF) 7.4.4.2.2
+    
+    uint16_t maxCLL;           // unsigned int(16) max_content_light_level
+    uint16_t maxPALL;          // unsigned int(16) max_pic_average_light_level
+} avifContentLightLevelInformationBox;
+
 // ---------------------------------------------------------------------------
 // avifImage
 
@@ -471,6 +479,11 @@ typedef struct avifImage
     avifCleanApertureBox clap;
     avifImageRotation irot;
     avifImageMirror imir;
+
+    // CLLI information - Content light level information. Used to represent
+    // maximum and average light level of an image. Useful for tone mapping
+    // HDR images, especially when using SMPTE2084 (PQ).
+    avifContentLightLevelInformationBox clli;
 
     // Metadata - set with avifImageSetMetadata*() before write, check .size>0 for existence after read
     avifRWData exif;

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -427,9 +427,9 @@ AVIF_API avifBool avifCleanApertureBoxConvertCropRect(avifCleanApertureBox * cla
 typedef struct avifContentLightLevelInformationBox
 {
     // 'clli' from ISO/IEC 23000-22:2019 (MIAF) 7.4.4.2.2
-    
-    uint16_t maxCLL;           // unsigned int(16) max_content_light_level
-    uint16_t maxPALL;          // unsigned int(16) max_pic_average_light_level
+
+    uint16_t maxCLL;  // unsigned int(16) max_content_light_level
+    uint16_t maxPALL; // unsigned int(16) max_pic_average_light_level
 } avifContentLightLevelInformationBox;
 
 // ---------------------------------------------------------------------------
@@ -481,7 +481,7 @@ typedef struct avifImage
     avifImageMirror imir;
 
     // CLLI information:
-	// Content Light Level Information. Used to represent maximum and average light level of an
+    // Content Light Level Information. Used to represent maximum and average light level of an
     // image. Useful for tone mapping HDR images, especially when using transfer characteristics
     // SMPTE2084 (PQ). The default value of (0, 0) means the content light level information is
     // unknown or unavailable.

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -424,12 +424,27 @@ AVIF_API avifBool avifCleanApertureBoxConvertCropRect(avifCleanApertureBox * cla
                                                       avifPixelFormat yuvFormat,
                                                       avifDiagnostics * diag);
 
+// ---------------------------------------------------------------------------
+// avifContentLightLevelInformationBox
+
 typedef struct avifContentLightLevelInformationBox
 {
-    // 'clli' from ISO/IEC 23000-22:2019 (MIAF) 7.4.4.2.2
+    // 'clli' from ISO/IEC 23000-22:2019 (MIAF) 7.4.4.2.2. The SEI message semantics written above
+    //  each entry were originally described in ISO/IEC 23008-2.
 
-    uint16_t maxCLL;  // unsigned int(16) max_content_light_level
-    uint16_t maxPALL; // unsigned int(16) max_pic_average_light_level
+    // max_content_light_level, when not equal to 0, indicates an upper bound on the maximum light
+    // level among all individual samples in a 4:4:4 representation of red, green, and blue colour
+    // primary intensities (in the linear light domain) for the pictures of the CLVS, in units of
+    // candelas per square metre. When equal to 0, no such upper bound is indicated by
+    // max_content_light_level.
+    uint16_t maxCLL;
+
+    // max_pic_average_light_level, when not equal to 0, indicates an upper bound on the maximum
+    // average light level among the samples in a 4:4:4 representation of red, green, and blue
+    // colour primary intensities (in the linear light domain) for any individual picture of the
+    // CLVS, in units of candelas per square metre. When equal to 0, no such upper bound is
+    // indicated by max_pic_average_light_level.
+    uint16_t maxPALL;
 } avifContentLightLevelInformationBox;
 
 // ---------------------------------------------------------------------------
@@ -484,7 +499,7 @@ typedef struct avifImage
     // Content Light Level Information. Used to represent maximum and average light level of an
     // image. Useful for tone mapping HDR images, especially when using transfer characteristics
     // SMPTE2084 (PQ). The default value of (0, 0) means the content light level information is
-    // unknown or unavailable.
+    // unknown or unavailable, and will cause libavif to avoid writing a clli box for it.
     avifContentLightLevelInformationBox clli;
 
     // Metadata - set with avifImageSetMetadata*() before write, check .size>0 for existence after read

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -480,9 +480,11 @@ typedef struct avifImage
     avifImageRotation irot;
     avifImageMirror imir;
 
-    // CLLI information - Content light level information. Used to represent
-    // maximum and average light level of an image. Useful for tone mapping
-    // HDR images, especially when using SMPTE2084 (PQ).
+    // CLLI information:
+	// Content Light Level Information. Used to represent maximum and average light level of an
+    // image. Useful for tone mapping HDR images, especially when using transfer characteristics
+    // SMPTE2084 (PQ). The default value of (0, 0) means the content light level information is
+    // unknown or unavailable.
     avifContentLightLevelInformationBox clli;
 
     // Metadata - set with avifImageSetMetadata*() before write, check .size>0 for existence after read

--- a/src/read.c
+++ b/src/read.c
@@ -1766,8 +1766,8 @@ static avifBool avifParseContentLightLevelInformationBox(avifProperty * prop, co
 
     avifContentLightLevelInformationBox * clli = &prop->u.clli;
 
-    AVIF_CHECK(avifROStreamReadU16(&s, &clli->maxCLL));
-    AVIF_CHECK(avifROStreamReadU16(&s, &clli->maxPALL));
+    AVIF_CHECK(avifROStreamReadU16(&s, &clli->maxCLL));  // unsigned int(16) max_content_light_level
+    AVIF_CHECK(avifROStreamReadU16(&s, &clli->maxPALL)); // unsigned int(16) max_pic_average_light_level
     return AVIF_TRUE;
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -1764,11 +1764,10 @@ static avifBool avifParseContentLightLevelInformationBox(avifProperty * prop, co
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[clli]");
 
-    avifContentLightLevelInformationBox *clli = &prop->u.clli;
+    avifContentLightLevelInformationBox * clli = &prop->u.clli;
 
     AVIF_CHECK(avifROStreamReadU16(&s, &clli->maxCLL));
     AVIF_CHECK(avifROStreamReadU16(&s, &clli->maxPALL));
-
     return AVIF_TRUE;
 }
 
@@ -2057,8 +2056,8 @@ static avifBool avifParseItemPropertyAssociation(avifMeta * meta, const uint8_t 
             // Copy property to item
             const avifProperty * srcProp = &meta->properties.prop[propertyIndex];
 
-            static const char * supportedTypes[] = { "ispe", "auxC", "colr", "av1C", "pasp", "clap",
-                                                     "irot", "imir", "pixi", "a1op", "lsel", "a1lx", "clli" };
+            static const char * supportedTypes[] = { "ispe", "auxC", "colr", "av1C", "pasp", "clap", "irot",
+                                                     "imir", "pixi", "a1op", "lsel", "a1lx", "clli" };
             size_t supportedTypesCount = sizeof(supportedTypes) / sizeof(supportedTypes[0]);
             avifBool supportedType = AVIF_FALSE;
             for (size_t i = 0; i < supportedTypesCount; ++i) {

--- a/src/read.c
+++ b/src/read.c
@@ -130,6 +130,7 @@ typedef struct avifProperty
         avifOperatingPointSelectorProperty a1op;
         avifLayerSelectorProperty lsel;
         avifAV1LayeredImageIndexingProperty a1lx;
+        avifContentLightLevelInformationBox clli;
     } u;
 } avifProperty;
 AVIF_ARRAY_DECLARE(avifPropertyArray, avifProperty, prop);
@@ -1759,6 +1760,18 @@ static avifBool avifParseColourInformationBox(avifProperty * prop, uint64_t rawO
     return AVIF_TRUE;
 }
 
+static avifBool avifParseContentLightLevelInformationBox(avifProperty * prop, const uint8_t * raw, size_t rawLen, avifDiagnostics * diag)
+{
+    BEGIN_STREAM(s, raw, rawLen, diag, "Box[clli]");
+
+    avifContentLightLevelInformationBox *clli = &prop->u.clli;
+
+    AVIF_CHECK(avifROStreamReadU16(&s, &clli->maxCLL));
+    AVIF_CHECK(avifROStreamReadU16(&s, &clli->maxPALL));
+
+    return AVIF_TRUE;
+}
+
 static avifBool avifParseAV1CodecConfigurationBox(const uint8_t * raw, size_t rawLen, avifCodecConfigurationBox * av1C, avifDiagnostics * diag)
 {
     BEGIN_STREAM(s, raw, rawLen, diag, "Box[av1C]");
@@ -1956,6 +1969,8 @@ static avifBool avifParseItemPropertyContainerBox(avifPropertyArray * properties
             AVIF_CHECK(avifParseLayerSelectorProperty(prop, avifROStreamCurrent(&s), header.size, diag));
         } else if (!memcmp(header.type, "a1lx", 4)) {
             AVIF_CHECK(avifParseAV1LayeredImageIndexingProperty(prop, avifROStreamCurrent(&s), header.size, diag));
+        } else if (!memcmp(header.type, "clli", 4)) {
+            AVIF_CHECK(avifParseContentLightLevelInformationBox(prop, avifROStreamCurrent(&s), header.size, diag));
         }
 
         AVIF_CHECK(avifROStreamSkip(&s, header.size));
@@ -2043,7 +2058,7 @@ static avifBool avifParseItemPropertyAssociation(avifMeta * meta, const uint8_t 
             const avifProperty * srcProp = &meta->properties.prop[propertyIndex];
 
             static const char * supportedTypes[] = { "ispe", "auxC", "colr", "av1C", "pasp", "clap",
-                                                     "irot", "imir", "pixi", "a1op", "lsel", "a1lx" };
+                                                     "irot", "imir", "pixi", "a1op", "lsel", "a1lx", "clli" };
             size_t supportedTypesCount = sizeof(supportedTypes) / sizeof(supportedTypes[0]);
             avifBool supportedType = AVIF_FALSE;
             for (size_t i = 0; i < supportedTypesCount; ++i) {
@@ -3758,6 +3773,11 @@ avifResult avifDecoderReset(avifDecoder * decoder)
     } else {
         // An av1C box is mandatory in all valid AVIF configurations. Bail out.
         return AVIF_RESULT_BMFF_PARSE_FAILED;
+    }
+
+    const avifProperty * clliProp = avifPropertyArrayFind(colorProperties, "clli");
+    if (clliProp) {
+        decoder->image->clli = clliProp->u.clli;
     }
 
     return avifDecoderFlush(decoder);

--- a/src/write.c
+++ b/src/write.c
@@ -527,6 +527,20 @@ static void avifEncoderWriteColorProperties(avifRWStream * outputStream,
         ipmaPush(ipma, avifItemPropertyDedupFinish(dedup, outputStream), AVIF_FALSE);
     }
 
+    // Write Content Light Level Information, if present
+    if (imageMetadata->clli.maxCLL || imageMetadata->clli.maxPALL) {
+        if (dedup) {
+            avifItemPropertyDedupStart(dedup);
+        }
+        avifBoxMarker clli = avifRWStreamWriteBox(s, "clli", AVIF_BOX_SIZE_TBD);
+        avifRWStreamWriteU16(s, imageMetadata->clli.maxCLL);  // unsigned int(16) max_content_light_level;
+        avifRWStreamWriteU16(s, imageMetadata->clli.maxPALL); // unsigned int(16) max_pic_average_light_level;
+        avifRWStreamFinishBox(s, clli);
+        if (dedup) {
+            ipmaPush(ipma, avifItemPropertyDedupFinish(dedup, outputStream), AVIF_FALSE);
+        }
+    }
+
     // Write (Optional) Transformations
     if (imageMetadata->transformFlags & AVIF_TRANSFORM_PASP) {
         if (dedup) {


### PR DESCRIPTION
The purpose of this pull request and commit is to add read (decode) support for the Content Light Level Information box as described in MIAF section 7.4.4.2 and AVIF section 2.2.3. This metadata is important when tone mapping HDR images, especially when using the PQ transfer curve.

This functionality is needed to fix this Chromium bug:

https://bugs.chromium.org/p/chromium/issues/detail?id=1380533
