### PR TITLE
Use INPUT_PNG in the lossless test

### DIFF
--- a/tests/test_cmd_lossless.sh
+++ b/tests/test_cmd_lossless.sh
@@ -73,10 +73,9 @@ pushd ${TMP_DIR}
 
   # Lossless test. The decoded pixels should be the same as the original image.
   echo "Testing basic lossless"
-  # TODO(yguyon): Make this test pass with INPUT_PNG instead of DECODED_FILE.
-  "${AVIFENC}" -s 10 -l "${DECODED_FILE}" -o "${ENCODED_FILE}"
+  "${AVIFENC}" -s 10 -l "${INPUT_PNG}" -o "${ENCODED_FILE}"
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE_LOSSLESS}"
-  "${ARE_IMAGES_EQUAL}" "${DECODED_FILE}" "${DECODED_FILE_LOSSLESS}" 0
+  "${ARE_IMAGES_EQUAL}" "${INPUT_PNG}" "${DECODED_FILE_LOSSLESS}" 0
 popd
 
 exit 0


### PR DESCRIPTION
After commit bc276e7edb2d7aa16a4baec2ec434966fca2a9ef we can use INPUT_PNG (paris_icc_exif_xmp.png, which has Exif and XMP metadata) in the lossless test, because DECODED_FILE_LOSSLESS will also have the Exif and XMP metadata from INPUT_PNG.