### PR TITLE
Convert std::stoi(argv[3]) to bool explicitly

### DIFF
--- a/tests/gtest/are_images_equal.cc
+++ b/tests/gtest/are_images_equal.cc
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
     return 1;
   }
   if (!libavif::testutil::AreImagesEqual(*decoded[0], *decoded[1],
-                                         std::stoi(argv[3]))) {
+                                         std::stoi(argv[3]) != 0)) {
     std::cerr << "Images " << argv[1] << " and " << argv[2] << " are different."
               << std::endl;
     return 1;


### PR DESCRIPTION
MSVC warned about this when all warnings were enabled. Although we are using /W4 with MSVC now, I think it's good to fix this warning.

An alternative is to return an error if std::stoi(argv[3]) is not 0 or 1.