### PR TITLE
Require min and max quanitizers be both specified

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -805,6 +805,17 @@ int main(int argc, char * argv[])
         ++argIndex;
     }
 
+    if ((minQuantizer < 0) != (maxQuantizer < 0)) {
+        fprintf(stderr, "--min and --max must be either both specified or both unspecified.\n");
+        returnCode = 1;
+        goto cleanup;
+    }
+    if ((minQuantizerAlpha < 0) != (maxQuantizerAlpha < 0)) {
+        fprintf(stderr, "--minalpha and --maxalpha must be either both specified or both unspecified.\n");
+        returnCode = 1;
+        goto cleanup;
+    }
+
     // Check lossy/lossless parameters and set to default if needed.
     if (lossless) {
         // Pixel format.

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -74,6 +74,8 @@ pushd ${TMP_DIR}
   # Passing a filename starting with a dash without using -- should fail.
   "${AVIFENC}" -s 10 "${INPUT_Y4M}" "${ENCODED_FILE_WITH_DASH}" && exit 1
   "${AVIFDEC}" --info "${ENCODED_FILE_WITH_DASH}" && exit 1
+  "${AVIFENC}" -s 10 --min 24 "${INPUT_Y4M}" "${ENCODED_FILE}" && exit 1
+  "${AVIFENC}" -s 10 --max 26 "${INPUT_Y4M}" "${ENCODED_FILE}" && exit 1
 popd
 
 exit 0

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -74,8 +74,13 @@ pushd ${TMP_DIR}
   # Passing a filename starting with a dash without using -- should fail.
   "${AVIFENC}" -s 10 "${INPUT_Y4M}" "${ENCODED_FILE_WITH_DASH}" && exit 1
   "${AVIFDEC}" --info "${ENCODED_FILE_WITH_DASH}" && exit 1
+
+  # --min and --max must be both specified.
   "${AVIFENC}" -s 10 --min 24 "${INPUT_Y4M}" "${ENCODED_FILE}" && exit 1
   "${AVIFENC}" -s 10 --max 26 "${INPUT_Y4M}" "${ENCODED_FILE}" && exit 1
+  # --minalpha and --maxalpha must be both specified.
+  "${AVIFENC}" -s 10 --minalpha 0 "${INPUT_PNG}" "${ENCODED_FILE}" && exit 1
+  "${AVIFENC}" -s 10 --maxalpha 0 "${INPUT_PNG}" "${ENCODED_FILE}" && exit 1
 popd
 
 exit 0

--- a/tests/test_cmd_lossless.sh
+++ b/tests/test_cmd_lossless.sh
@@ -62,12 +62,12 @@ pushd ${TMP_DIR}
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}"
 
   # Combining some arguments with lossless should fail.
-  for option in "-y 400" "--min 1" "-r limited" "--cicp 2/2/8"; do
+  for option in "-y 400" "--min 0 --max 1" "-r limited" "--cicp 2/2/8"; do
     "${AVIFENC}" $option -s 10 -l "${DECODED_FILE}" -o "${ENCODED_FILE}" && exit 1
   done
 
   # Combining some arguments with lossless should work.
-  for option in "-y 444" "--min 0" "-r full"; do
+  for option in "-y 444" "--min 0 --max 0" "-r full"; do
     "${AVIFENC}" $option -s 10 -l "${DECODED_FILE}" -o "${ENCODED_FILE}"
   done
 


### PR DESCRIPTION
Require the min and max quantizers be both specified or both unspecified. Since the default values of the min and max quantizers are not well known (24 and 26 respectively) and may be changed, avifenc users should not set only one of them. So this new requirement is unlikely to break many existing scripts.