### PR TITLE
Rename the cache files for ci-disable-gtest.yml

### DIFF
--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ext
-        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}
+        key: ${{ runner.os }}-disable-gtest-${{ hashFiles('ext/*.cmd') }}
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v1.12
       with:

--- a/ext/googletest.cmd
+++ b/ext/googletest.cmd
@@ -15,5 +15,5 @@ cd build
 : # on Windows:
 : # https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
 cmake -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_GMOCK=OFF -Dgtest_force_shared_crt=ON ..
-ninja
+cmake --build .
 cd ../..

--- a/ext/googletest.cmd
+++ b/ext/googletest.cmd
@@ -15,5 +15,5 @@ cd build
 : # on Windows:
 : # https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
 cmake -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_GMOCK=OFF -Dgtest_force_shared_crt=ON ..
-cmake --build .
+ninja
 cd ../..


### PR DESCRIPTION
Add "-disable-gtest" to the cache file names for ci-disable-gtest.yml.

In https://github.com/AOMediaCodec/libavif/pull/1205 I neglected to use different cache file names in the new ci-disable-gtest.yml file, or mistakenly thought that it could use the cache files for ci.yml. Since ci-disable-gtest.yml doesn't build libgav1 and GoogleTest, its cache files are missing those two dependencies.

Make a simple change to ext/googletest.cmd to force the cache files to be recreated.