### PR TITLE
Some cleanup of the new CLLI code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+There are incompatible ABI changes in this release. The clli member was added
+to the avifImage struct.
+
 ### Added
 * Add STATIC library target avif_internal to allow tests to access functions
   from internal.h when BUILD_SHARED_LIBS is ON.
+* Add clli metadata read and write support
 
 ### Changed
 * Exif and XMP metadata is exported to PNG and JPEG files by default,

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -122,7 +122,7 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
     }
     printf(" * Progressive    : %s\n", avifProgressiveStateToString(progressiveState));
     if (avif->clli.maxCLL > 0 || avif->clli.maxPALL > 0) {
-        printf(" * CLLI           : %u, %u\n", (uint32_t)avif->clli.maxCLL, (uint32_t)avif->clli.maxPALL);
+        printf(" * CLLI           : %hu, %hu\n", avif->clli.maxCLL, avif->clli.maxPALL);
     }
 }
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -490,6 +490,13 @@ typedef struct avifImage
     avifTransferCharacteristics transferCharacteristics;
     avifMatrixCoefficients matrixCoefficients;
 
+    // CLLI information:
+    // Content Light Level Information. Used to represent maximum and average light level of an
+    // image. Useful for tone mapping HDR images, especially when using transfer characteristics
+    // SMPTE2084 (PQ). The default value of (0, 0) means the content light level information is
+    // unknown or unavailable, and will cause libavif to avoid writing a clli box for it.
+    avifContentLightLevelInformationBox clli;
+
     // Transformations - These metadata values are encoded/decoded when transformFlags are set
     // appropriately, but do not impact/adjust the actual pixel buffers used (images won't be
     // pre-cropped or mirrored upon decode). Basic explanations from the standards are offered in
@@ -503,13 +510,6 @@ typedef struct avifImage
     avifCleanApertureBox clap;
     avifImageRotation irot;
     avifImageMirror imir;
-
-    // CLLI information:
-    // Content Light Level Information. Used to represent maximum and average light level of an
-    // image. Useful for tone mapping HDR images, especially when using transfer characteristics
-    // SMPTE2084 (PQ). The default value of (0, 0) means the content light level information is
-    // unknown or unavailable, and will cause libavif to avoid writing a clli box for it.
-    avifContentLightLevelInformationBox clli;
 
     // Metadata - set with avifImageSetMetadata*() before write, check .size>0 for existence after read
     avifRWData exif;

--- a/src/read.c
+++ b/src/read.c
@@ -3697,6 +3697,11 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         }
     }
 
+    const avifProperty * clliProp = avifPropertyArrayFind(colorProperties, "clli");
+    if (clliProp) {
+        decoder->image->clli = clliProp->u.clli;
+    }
+
     // Transformations
     const avifProperty * paspProp = avifPropertyArrayFind(colorProperties, "pasp");
     if (paspProp) {
@@ -3772,11 +3777,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
     } else {
         // An av1C box is mandatory in all valid AVIF configurations. Bail out.
         return AVIF_RESULT_BMFF_PARSE_FAILED;
-    }
-
-    const avifProperty * clliProp = avifPropertyArrayFind(colorProperties, "clli");
-    if (clliProp) {
-        decoder->image->clli = clliProp->u.clli;
     }
 
     return avifDecoderFlush(decoder);


### PR DESCRIPTION
Small changes to the new CLLI code recently added in https://github.com/AOMediaCodec/libavif/pull/1194.

Document the CLLI metadata read and write support in the CHANGELOG.

Print uint16_t (unsigned short) values using the %hu format.

Put the clli member next to the other color-related members in the avifImage struct.