### PR TITLE
Experimental AVIF bit depth extension

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -834,6 +834,9 @@ typedef enum avifStrictFlag
     // https://crbug.com/1246678.
     AVIF_STRICT_ALPHA_ISPE_REQUIRED = (1 << 2),
 
+    // TODO(yguyon): Generalize AVIF_STRICT_ALPHA_ISPE_REQUIRED to bit depth extension
+    //               or add AVIF_STRICT_SUBDEPTH_ISPE_REQUIRED
+
     // Maximum strictness; enables all bits above. This is avifDecoder's default.
     AVIF_STRICT_ENABLED = AVIF_STRICT_PIXI_REQUIRED | AVIF_STRICT_CLAP_VALID | AVIF_STRICT_ALPHA_ISPE_REQUIRED
 } avifStrictFlag;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -43,6 +43,9 @@ extern "C" {
 #define AVIF_URN_ALPHA0 "urn:mpeg:mpegB:cicp:systems:auxiliary:alpha"
 #define AVIF_URN_ALPHA1 "urn:mpeg:hevc:2015:auxid:1"
 
+// TODO(yguyon): Add reference to specification
+#define AVIF_URN_SUBDEPTH_8LSB "urn:mpeg:mpegB:cicp:systems:auxiliary:8lsb"
+
 #define AVIF_CONTENT_TYPE_XMP "application/rdf+xml"
 
 // ---------------------------------------------------------------------------
@@ -92,7 +95,29 @@ void avifImageCopyNoAlloc(avifImage * dstImage, const avifImage * srcImage);
 // Copies the samples from srcImage to dstImage. dstImage must be allocated.
 // srcImage and dstImage must have the same width, height, and depth.
 // If the AVIF_PLANES_YUV bit is set in planes, then srcImage and dstImage must have the same yuvFormat and yuvRange.
-void avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes);
+avifResult avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes);
+
+// ---------------------------------------------------------------------------
+// Subdepth
+
+typedef enum avifSubdepthMode
+{
+    // The image can be encoded as is with an AV1 codec.
+    AVIF_SUBDEPTH_NONE,
+    // The image is split into two images because its bit depth is not supported by AV1.
+    AVIF_SUBDEPTH_8_MOST_SIGNIFICANT_BITS,
+    AVIF_SUBDEPTH_8_LEAST_SIGNIFICANT_BITS
+} avifSubdepthMode;
+
+// Same as avifImageCopySamples() with source and destination bit masks and shifts.
+avifResult avifImageCopySamplesExtended(avifImage * dstImage,
+                                        enum avifSubdepthMode dstSubdepthMode,
+                                        const avifImage * srcImage,
+                                        enum avifSubdepthMode srcSubdepthMode,
+                                        avifPlanesFlags planes);
+
+// ---------------------------------------------------------------------------
+// Alpha
 
 typedef struct avifAlphaParams
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,11 @@ if(AVIF_ENABLE_GTEST)
         find_package(GTest REQUIRED)
     endif()
 
+    add_executable(avif16bittest gtest/avif16bittest.cc)
+    target_link_libraries(avif16bittest avif_internal aviftest_helpers ${GTEST_LIBRARIES})
+    target_include_directories(avif16bittest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avif16bittest COMMAND avif16bittest ${CMAKE_CURRENT_SOURCE_DIR}/data/)
+
     add_executable(avifallocationtest gtest/avifallocationtest.cc)
     target_link_libraries(avifallocationtest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avifallocationtest PRIVATE ${GTEST_INCLUDE_DIRS})
@@ -282,8 +287,18 @@ if(AVIF_CODEC_AVM)
         set_tests_properties(aviftest PROPERTIES DISABLED True)
         if(AVIF_ENABLE_GTEST)
             set_tests_properties(
-                avifallocationtest avifbasictest avifchangesettingtest avifcllitest avifgridapitest avifincrtest avifiostatstest
-                avifmetadatatest avifprogressivetest avify4mtest PROPERTIES DISABLED True
+                avif16bittest
+                avifallocationtest
+                avifbasictest
+                avifchangesettingtest
+                avifcllitest
+                avifgridapitest
+                avifincrtest
+                avifiostatstest
+                avifmetadatatest
+                avifprogressivetest
+                avify4mtest
+                PROPERTIES DISABLED True
             )
         endif()
 

--- a/tests/gtest/avif16bittest.cc
+++ b/tests/gtest/avif16bittest.cc
@@ -1,0 +1,112 @@
+// Copyright 2022 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <cstring>
+
+#include "avif/avif.h"
+#include "avif/internal.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+//------------------------------------------------------------------------------
+
+// Used to pass the data folder path to the GoogleTest suites.
+const char* data_path = nullptr;
+
+//------------------------------------------------------------------------------
+
+TEST(BitDepthTest, Avif16bitLossy) {
+  const testutil::AvifImagePtr image =
+      testutil::ReadImage(data_path, "weld_16bit.png", AVIF_PIXEL_FORMAT_NONE,
+                          /*requested_depth=*/16);
+  ASSERT_NE(image, nullptr);
+
+  const testutil::AvifRwData encoded =
+      testutil::Encode(image.get(), AVIF_SPEED_FASTEST, AVIF_QUALITY_WORST);
+  const testutil::AvifImagePtr decoded =
+      testutil::Decode(encoded.data, encoded.size);
+  ASSERT_NE(decoded, nullptr);
+
+  ASSERT_EQ(image->depth, decoded->depth);
+  ASSERT_EQ(image->width, decoded->width);
+  ASSERT_EQ(image->height, decoded->height);
+  EXPECT_FALSE(testutil::AreImagesEqual(*image, *decoded));
+}
+
+//------------------------------------------------------------------------------
+
+TEST(BitDepthTest, Avif16bitLossless) {
+  const testutil::AvifImagePtr image =
+      testutil::ReadImage(data_path, "weld_16bit.png", AVIF_PIXEL_FORMAT_NONE,
+                          /*requested_depth=*/16);
+  ASSERT_NE(image, nullptr);
+
+  const testutil::AvifRwData encoded =
+      testutil::Encode(image.get(), AVIF_SPEED_FASTEST, AVIF_QUALITY_LOSSLESS);
+  const testutil::AvifImagePtr decoded =
+      testutil::Decode(encoded.data, encoded.size);
+  ASSERT_NE(decoded, nullptr);
+
+  EXPECT_TRUE(testutil::AreImagesEqual(*image, *decoded));
+}
+
+//------------------------------------------------------------------------------
+
+TEST(BitDepthTest, Avif16bitRetroCompatible) {
+  const testutil::AvifImagePtr image =
+      testutil::ReadImage(data_path, "weld_16bit.png", AVIF_PIXEL_FORMAT_NONE,
+                          /*requested_depth=*/16);
+  ASSERT_NE(image, nullptr);
+
+  testutil::AvifRwData encoded =
+      testutil::Encode(image.get(), AVIF_SPEED_FASTEST, AVIF_QUALITY_WORST);
+
+  // Replace all subdepth tags by "zzzzzz" garbage. This simulates an old
+  // decoder that does not recognize the subdepth feature.
+  const size_t kTagLength = std::strlen(AVIF_URN_SUBDEPTH_8LSB);
+  for (size_t i = 0; i + kTagLength <= encoded.size; ++i) {
+    if (!std::memcmp(&encoded.data[i], AVIF_URN_SUBDEPTH_8LSB, kTagLength)) {
+      std::fill(&encoded.data[i], &encoded.data[i] + kTagLength, 'z');
+    }
+  }
+
+  const testutil::AvifImagePtr decoded =
+      testutil::Decode(encoded.data, encoded.size);
+  ASSERT_NE(decoded, nullptr);
+
+  // Only the 8 most significant bits of each sample can be retrieved.
+  // They should be encoded losslessly no matter the quantizer settings.
+  testutil::AvifImagePtr image_8msb = testutil::CreateImage(
+      image->width, image->height, 8, image->yuvFormat,
+      image->alphaPlane ? AVIF_PLANES_ALL : AVIF_PLANES_YUV, image->yuvRange);
+  ASSERT_NE(image_8msb, nullptr);
+  ASSERT_EQ(avifImageCopySamplesExtended(
+                image_8msb.get(), AVIF_SUBDEPTH_8_MOST_SIGNIFICANT_BITS,
+                image.get(), AVIF_SUBDEPTH_NONE, AVIF_PLANES_ALL),
+            AVIF_RESULT_OK);
+  EXPECT_TRUE(testutil::AreImagesEqual(*image_8msb, *decoded));
+}
+
+//------------------------------------------------------------------------------
+
+// TODO(yguyon): Test 16-bit alpha
+
+//------------------------------------------------------------------------------
+
+}  // namespace
+}  // namespace libavif
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "There must be exactly one argument containing the path to "
+                 "the test data folder"
+              << std::endl;
+    return 1;
+  }
+  libavif::data_path = argv[1];
+  return RUN_ALL_TESTS();
+}

--- a/tests/gtest/avifgridapitest.cc
+++ b/tests/gtest/avifgridapitest.cc
@@ -91,7 +91,8 @@ avifResult EncodeDecodeGrid(const std::vector<std::vector<Cell>>& cell_rows,
       if (result != AVIF_RESULT_OK) {
         return result;
       }
-      avifImageCopySamples(/*dstImage=*/view.get(), it->get(), AVIF_PLANES_ALL);
+      AVIF_CHECKRES(avifImageCopySamples(/*dstImage=*/view.get(), it->get(),
+                                         AVIF_PLANES_ALL));
       assert(!view->imageOwnsYUVPlanes);
       ++it;
       rect.x += rect.width;

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -353,10 +353,16 @@ bool WriteImage(const avifImage* image, const char* file_path) {
   return false;
 }
 
-AvifRwData Encode(const avifImage* image, int speed) {
+AvifRwData Encode(const avifImage* image, int speed, int quality) {
   testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
   if (!encoder) return {};
   encoder->speed = speed;
+  if (quality == -1) {
+    // Leave default quantizer settings.
+  } else {
+    encoder->quality = quality;
+    encoder->qualityAlpha = quality;
+  }
   testutil::AvifRwData bytes;
   if (avifEncoderWrite(encoder.get(), image, &bytes) != AVIF_RESULT_OK) {
     return {};

--- a/tests/gtest/aviftest_helpers.h
+++ b/tests/gtest/aviftest_helpers.h
@@ -97,7 +97,8 @@ bool WriteImage(const avifImage* image, const char* file_path);
 
 // Encodes the image with default parameters.
 // Returns an empty payload in case of error.
-AvifRwData Encode(const avifImage* image, int speed = AVIF_SPEED_DEFAULT);
+AvifRwData Encode(const avifImage* image, int speed = AVIF_SPEED_DEFAULT,
+                  int quality = -1);
 
 // Decodes the bytes to an image with default parameters.
 // Returns nullptr in case of error.


### PR DESCRIPTION
Allow encoding and decoding images of more than 12 bits, the limit of the AV1 format. This commit experiments 16-bit AVIF images, made of one primary lossless 8-bit image and one auxiliary lossy/lossless bit depth extension 8-bit image. Grids and alpha are supported.

Warning: This feature is experimental and not covered by the current AVIF specification. The AVIF specification change proposal is https://github.com/AOMediaCodec/av1-avif/pull/208.

Parts of this PR and/or TODOs may be implemented into separate PRs before making this one ready for review.