### PR TITLE
Use AVIF_LIBRARY_SUFFIX for libdav1d in CMake

### DIFF
--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -1,7 +1,7 @@
 # This is a copy of ci.yml for building shared libraries. It differs from ci.yml as follows:
 #
 #   * The os matrix consists of ubuntu-latest only.
-#   * Does not build dav1d, rav1e, SVT-AV1 nor libgav1.
+#   * Does not build rav1e, SVT-AV1 nor libgav1.
 
 name: CI
 on: [push, pull_request]
@@ -38,17 +38,24 @@ jobs:
       with:
         version: 2.15.05
     - uses: seanmiddleditch/gha-setup-ninja@v3
+    - run: pip install meson
     - name: Set shared libs
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: >
         sed -i'' -e 's/-DBUILD_SHARED_LIBS=OFF/-DBUILD_SHARED_LIBS=ON/' *.cmd
 
+        sed -i'' -e 's/--default-library=static/--default-library=shared/' dav1d.cmd
+
         sed -i'' -e 's/ninja yuv/ninja yuv_shared/' libyuv.cmd
     - name: Build aom
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash aom.cmd
+    - name: Build dav1d
+      if: steps.cache-ext.outputs.cache-hit != 'true'
+      working-directory: ./ext
+      run: bash dav1d.cmd
     - name: Build libyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
@@ -69,6 +76,7 @@ jobs:
         cmake .. -G Ninja
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
         -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON
+        -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON
         -DAVIF_LOCAL_LIBYUV=ON
         -DAVIF_LOCAL_LIBSHARPYUV=ON
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,12 +280,16 @@ if(AVIF_CODEC_DAV1D)
     if(AVIF_LOCAL_DAV1D)
         set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/src/libdav1d${AVIF_LIBRARY_SUFFIX}")
         if(NOT EXISTS "${LIB_FILENAME}")
-            # On windows, meson will produce a libdav1d.a instead of the expected libdav1d.dll/.lib.
-            # See https://github.com/mesonbuild/meson/issues/8153.
-            set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/src/libdav1d.a")
-        endif()
-        if(NOT EXISTS "${LIB_FILENAME}")
-            message(FATAL_ERROR "libavif: ${LIB_FILENAME}/.a is missing, bailing out")
+            if("${AVIF_LIBRARY_SUFFIX}" STREQUAL ".a")
+                message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
+            else()
+                # On windows, meson will produce a libdav1d.a instead of the expected libdav1d.dll/.lib.
+                # See https://github.com/mesonbuild/meson/issues/8153.
+                set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/src/libdav1d.a")
+                if(NOT EXISTS "${LIB_FILENAME}")
+                    message(FATAL_ERROR "libavif: ${LIB_FILENAME} (or libdav1d${AVIF_LIBRARY_SUFFIX}) is missing, bailing out")
+                endif()
+            endif()
         endif()
 
         set(AVIF_CODEC_INCLUDES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,9 +278,14 @@ if(AVIF_CODEC_DAV1D)
     set(AVIF_SRCS ${AVIF_SRCS} src/codec_dav1d.c)
 
     if(AVIF_LOCAL_DAV1D)
-        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/src/libdav1d.a")
+        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/src/libdav1d${AVIF_LIBRARY_SUFFIX}")
         if(NOT EXISTS "${LIB_FILENAME}")
-            message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
+            # On windows, meson will produce a libdav1d.a instead of the expected libdav1d.dll/.lib.
+            # See https://github.com/mesonbuild/meson/issues/8153.
+            set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/src/libdav1d.a")
+        endif()
+        if(NOT EXISTS "${LIB_FILENAME}")
+            message(FATAL_ERROR "libavif: ${LIB_FILENAME}/.a is missing, bailing out")
         endif()
 
         set(AVIF_CODEC_INCLUDES


### PR DESCRIPTION
Otherwise a locally built ext/dav1d will be missing libdav1d.so in a shared build of libavif on Unix platforms.
Add a fallback to .a for Windows platforms.

Build dav1d in ci-unix-shared-local.yml.