### PR TITLE
Experimental implicit HEIF boxes in AVIF

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -177,6 +177,18 @@ typedef enum avifResult
 AVIF_API const char * avifResultToString(avifResult result);
 
 // ---------------------------------------------------------------------------
+// avifEncoderHeaderStrategy
+
+typedef enum avifEncoderHeaderStrategy
+{
+    // Encodes as "avif" brand version 0 and all its required boxes for maximum compatibility.
+    AVIF_ENCODER_FULL_HEADER,
+    // Encodes as "avif" brand version 1 which requires fewer boxes by default, to reduce the encoded file size.
+    // WARNING: Experimental feature. Produces files that are incompatible with older decoders.
+    AVIF_ENCODER_MINIMIZE_HEADER,
+} avifEncoderHeaderStrategy;
+
+// ---------------------------------------------------------------------------
 // avifROData/avifRWData: Generic raw memory storage
 
 typedef struct avifROData
@@ -1132,6 +1144,9 @@ typedef struct avifScalingMode
 //   call to avifEncoderAddImage().
 typedef struct avifEncoder
 {
+    // Defaults to AVIF_ENCODER_FULL_HEADER
+    avifEncoderHeaderStrategy headerStrategy;
+
     // Defaults to AVIF_CODEC_CHOICE_AUTO: Preference determined by order in availableCodecs table (avif.c)
     avifCodecChoice codecChoice;
 

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -431,6 +431,7 @@ typedef size_t avifBoxMarker;
 
 typedef struct avifBoxHeader
 {
+    // Size of the box in bytes, excluding the number of bytes read to know the size and the type.
     size_t size;
     uint8_t type[4];
 } avifBoxHeader;
@@ -487,7 +488,8 @@ void avifRWStreamWriteU32(avifRWStream * stream, uint32_t v);
 void avifRWStreamWriteU64(avifRWStream * stream, uint64_t v);
 void avifRWStreamWriteZeros(avifRWStream * stream, size_t byteCount);
 
-// This is to make it clear that the box size is currently unknown, and will be determined later (with a call to avifRWStreamFinishBox)
+// This is to make it clear that the box size is currently unknown, and will be determined later
+// (with a call to avifRWStreamFinishBox() during writing or when the stream is completely decoded during reading).
 #define AVIF_BOX_SIZE_TBD 0
 
 // Used for both av1C and av2C.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -158,6 +158,11 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifreadimagetest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifreadimagetest COMMAND avifreadimagetest ${CMAKE_CURRENT_SOURCE_DIR}/data/)
 
+    add_executable(avifreducedheadertest gtest/avifreducedheadertest.cc)
+    target_link_libraries(avifreducedheadertest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
+    target_include_directories(avifreducedheadertest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifreducedheadertest COMMAND avifreducedheadertest)
+
     add_executable(avifrgbtoyuvtest gtest/avifrgbtoyuvtest.cc)
     target_link_libraries(avifrgbtoyuvtest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avifrgbtoyuvtest PRIVATE ${GTEST_INCLUDE_DIRS})
@@ -274,7 +279,7 @@ if(AVIF_CODEC_AVM)
         if(AVIF_ENABLE_GTEST)
             set_tests_properties(
                 avifallocationtest avifbasictest avifchangesettingtest avifcllitest avifgridapitest avifincrtest avifiostatstest
-                avifmetadatatest avifprogressivetest avify4mtest PROPERTIES DISABLED True
+                avifmetadatatest avifprogressivetest avifreducedheadertest avify4mtest PROPERTIES DISABLED True
             )
         endif()
 

--- a/tests/gtest/avifreducedheadertest.cc
+++ b/tests/gtest/avifreducedheadertest.cc
@@ -1,0 +1,55 @@
+// Copyright 2022 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+//------------------------------------------------------------------------------
+
+TEST(AvifReducedHeaderTest, SimpleOpaque) {
+  testutil::AvifImagePtr image =
+      testutil::CreateImage(/*width=*/12, /*height=*/34, /*depth=*/10,
+                            AVIF_PIXEL_FORMAT_YUV444, AVIF_PLANES_YUV);
+  ASSERT_NE(image, nullptr);
+  testutil::FillImageGradient(image.get());  // The pixels do not matter.
+
+  // Encode.
+  testutil::AvifRwData encoded_avif_reduced_header;
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  encoder->headerStrategy = AVIF_ENCODER_MINIMIZE_HEADER;
+  ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(),
+                             &encoded_avif_reduced_header),
+            AVIF_RESULT_OK);
+
+  // Decode.
+  const testutil::AvifImagePtr decoded_reduced_header = testutil::Decode(
+      encoded_avif_reduced_header.data, encoded_avif_reduced_header.size);
+  ASSERT_NE(decoded_reduced_header, nullptr);
+
+  // Compare.
+  testutil::AvifRwData encoded_avif_full_header = testutil::Encode(image.get());
+  ASSERT_NE(encoded_avif_full_header.data, nullptr);
+  EXPECT_LT(encoded_avif_reduced_header.size, encoded_avif_full_header.size);
+
+  const testutil::AvifImagePtr decoded_full_header = testutil::Decode(
+      encoded_avif_full_header.data, encoded_avif_full_header.size);
+  ASSERT_NE(decoded_full_header, nullptr);
+
+  // Only the container changed, the pixels and features should be identical.
+  EXPECT_TRUE(testutil::AreImagesEqual(*decoded_full_header.get(),
+                                       *decoded_reduced_header.get()));
+}
+
+// TODO(yguyon): Alpha test
+
+// TODO(yguyon): Grid test
+
+//------------------------------------------------------------------------------
+
+}  // namespace
+}  // namespace libavif


### PR DESCRIPTION
Remove a few hundred bytes of container boilerplate for simple images. Most image features can be extracted from the AV1 OBUs in the mdat box for the main use cases (non-grid, non-progressive, opaque or translucid still images with no color profile, no Exif/XMP metadata and default CICP values).

Warning: This feature is experimental and forbidden by the current AVIF specification.

Parts of this PR and/or TODOs may be implemented into separate PRs before making this one ready for review.