### PR TITLE
Clamp samples in y4mRead()

### DIFF
--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -217,8 +217,7 @@ static avifBool y4mClampSamples(avifImage * avif)
     const uint16_t maxSampleValue = (uint16_t)((1u << avif->depth) - 1u);
 
     avifBool samplesWereClamped = AVIF_FALSE;
-    // Alpha is never in limited range.
-    for (int plane = AVIF_CHAN_Y; plane <= AVIF_CHAN_V; ++plane) {
+    for (int plane = AVIF_CHAN_Y; plane <= AVIF_CHAN_A; ++plane) {
         uint32_t planeHeight = avifImagePlaneHeight(avif, plane); // 0 for UV if 4:0:0.
         uint32_t planeWidth = avifImagePlaneWidth(avif, plane);
         uint8_t * row = avifImagePlane(avif, plane);
@@ -419,7 +418,7 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
     // libavif API does not guarantee the absence of undefined behavior if samples exceed the specified avif->depth.
     // Avoid that by making sure input values are within the correct range.
     if (y4mClampSamples(avif)) {
-        fprintf(stderr, "WARNING: some samples were clamped to fit into %u bits per channel per sample\n", avif->depth);
+        fprintf(stderr, "WARNING: some samples were clamped to fit into %u bits per sample\n", avif->depth);
     }
 
     result = AVIF_TRUE;

--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -5,6 +5,7 @@
 
 #include "y4m.h"
 
+#include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -201,6 +202,76 @@ static int y4mReadLine(FILE * inputFile, avifRWData * raw, const char * displayF
     return -1;
 }
 
+// Limits each sample value to fit into avif->depth bits and avif->yuvRange.
+// Returns AVIF_TRUE if any sample was clamped this way.
+static avifBool y4mClampSamples(avifImage * avif)
+{
+    avifBool samplesWereClamped = AVIF_FALSE;
+    if (avifImageUsesU16(avif)) {
+        const uint16_t maxSampleValue = (uint16_t)((1u << avif->depth) - 1u);
+        uint16_t minSampleValues[4] = { 0, 0, 0, 0 };
+        uint16_t maxSampleValues[4] = { maxSampleValue, maxSampleValue, maxSampleValue, maxSampleValue };
+        if (avif->yuvRange == AVIF_RANGE_LIMITED) {
+            minSampleValues[AVIF_CHAN_Y] = 16 << (avif->depth - 8);
+            minSampleValues[AVIF_CHAN_U] = 16 << (avif->depth - 8);
+            minSampleValues[AVIF_CHAN_V] = 16 << (avif->depth - 8);
+            maxSampleValues[AVIF_CHAN_Y] = 235 << (avif->depth - 8);
+            maxSampleValues[AVIF_CHAN_U] = 240 << (avif->depth - 8);
+            maxSampleValues[AVIF_CHAN_V] = 240 << (avif->depth - 8);
+            // Alpha is never in limited range.
+        }
+
+        for (int plane = AVIF_CHAN_Y; plane <= AVIF_CHAN_A; ++plane) {
+            uint32_t planeHeight = avifImagePlaneHeight(avif, plane); // 0 for A if no alpha and 0 for UV if 4:0:0.
+            uint32_t planeWidth = avifImagePlaneWidth(avif, plane);
+            uint8_t * row = avifImagePlane(avif, plane);
+            uint32_t rowBytes = avifImagePlaneRowBytes(avif, plane);
+            for (uint32_t y = 0; y < planeHeight; ++y) {
+                uint16_t * row16 = (uint16_t *)row;
+                for (uint32_t x = 0; x < planeWidth; ++x) {
+                    if (row16[x] < minSampleValues[plane]) {
+                        row16[x] = minSampleValues[plane];
+                        samplesWereClamped = AVIF_TRUE;
+                    } else if (row16[x] > maxSampleValues[plane]) {
+                        row16[x] = maxSampleValues[plane];
+                        samplesWereClamped = AVIF_TRUE;
+                    }
+                }
+                row += rowBytes;
+            }
+        }
+    } else {
+        assert(avif->depth == 8);
+        if (avif->yuvRange == AVIF_RANGE_FULL) {
+            return AVIF_FALSE;
+        }
+
+        // Alpha is never in limited range.
+        const uint8_t minSampleValues[3] = { 16, 16, 16 };
+        const uint8_t maxSampleValues[3] = { 235, 240, 240 };
+
+        for (int plane = AVIF_CHAN_Y; plane <= AVIF_CHAN_V; ++plane) {
+            uint32_t planeHeight = avifImagePlaneHeight(avif, plane); // 0 for UV if 4:0:0.
+            uint32_t planeWidth = avifImagePlaneWidth(avif, plane);
+            uint8_t * row = avifImagePlane(avif, plane);
+            uint32_t rowBytes = avifImagePlaneRowBytes(avif, plane);
+            for (uint32_t y = 0; y < planeHeight; ++y) {
+                for (uint32_t x = 0; x < planeWidth; ++x) {
+                    if (row[x] < minSampleValues[plane]) {
+                        row[x] = minSampleValues[plane];
+                        samplesWereClamped = AVIF_TRUE;
+                    } else if (row[x] > maxSampleValues[plane]) {
+                        row[x] = maxSampleValues[plane];
+                        samplesWereClamped = AVIF_TRUE;
+                    }
+                }
+                row += rowBytes;
+            }
+        }
+    }
+    return samplesWereClamped;
+}
+
 #define ADVANCE(BYTES)    \
     do {                  \
         p += BYTES;       \
@@ -378,6 +449,12 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
             }
             row += rowBytes;
         }
+    }
+
+    // libavif API does not guarantee the absence of undefined behavior if samples exceed the specified
+    // avif->depth and avif->range. Avoid that by making sure input values are within the correct range.
+    if (y4mClampSamples(avif)) {
+        fprintf(stderr, "WARNING: some samples were clamped to fit into %u bits per channel per sample\n", avif->depth);
     }
 
     result = AVIF_TRUE;

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -91,6 +91,7 @@ void FillImagePlain(avifImage* image, const uint32_t yuva[4]) {
 }
 
 void FillImageGradient(avifImage* image) {
+  assert(image->yuvRange == AVIF_RANGE_FULL);
   for (avifChannelIndex c :
        {AVIF_CHAN_Y, AVIF_CHAN_U, AVIF_CHAN_V, AVIF_CHAN_A}) {
     const uint32_t plane_width = avifImagePlaneWidth(image, c);

--- a/tests/gtest/avify4mtest.cc
+++ b/tests/gtest/avify4mtest.cc
@@ -29,9 +29,9 @@ TEST_P(Y4mTest, EncodeDecode) {
   const avifRange yuv_range = std::get<4>(GetParam());
   const bool create_alpha = std::get<5>(GetParam());
   std::ostringstream file_path;
-  file_path << testing::TempDir() << "avify4mtest_" << width << "_" << height
-            << "_" << bit_depth << "_" << yuv_format << "_" << yuv_range << "_"
-            << create_alpha;
+  file_path << testing::TempDir() << "avify4mtest_encodedecode_" << width << "_"
+            << height << "_" << bit_depth << "_" << yuv_format << "_"
+            << yuv_range << "_" << create_alpha;
 
   testutil::AvifImagePtr image = testutil::CreateImage(
       width, height, bit_depth, yuv_format,
@@ -54,6 +54,42 @@ TEST_P(Y4mTest, EncodeDecode) {
                       /*sourceTiming=*/nullptr, /*iter=*/nullptr));
 
   EXPECT_TRUE(testutil::AreImagesEqual(*image, *decoded));
+}
+
+TEST_P(Y4mTest, OutOfRange) {
+  const int width = std::get<0>(GetParam());
+  const int height = std::get<1>(GetParam());
+  const int bit_depth = std::get<2>(GetParam());
+  const avifPixelFormat yuv_format = std::get<3>(GetParam());
+  const avifRange yuv_range = std::get<4>(GetParam());
+  const bool create_alpha = std::get<5>(GetParam());
+  std::ostringstream file_path;
+  file_path << testing::TempDir() << "avify4mtest_outofrange_" << width << "_"
+            << height << "_" << bit_depth << "_" << yuv_format << "_"
+            << yuv_range << "_" << create_alpha;
+
+  testutil::AvifImagePtr image = testutil::CreateImage(
+      width, height, bit_depth, yuv_format,
+      create_alpha ? AVIF_PLANES_ALL : AVIF_PLANES_YUV, yuv_range);
+  ASSERT_NE(image, nullptr);
+
+  // Insert out-of-range values on purpose if possible.
+  const uint32_t yuva8[] = {255, 0, 255, 255};
+  const uint32_t yuva16[] = {0, (1u << 16) - 1u, 0, (1u << 16) - 1u};
+  testutil::FillImagePlain(image.get(),
+                           avifImageUsesU16(image.get()) ? yuva16 : yuva8);
+  ASSERT_TRUE(y4mWrite(file_path.str().c_str(), image.get()));
+
+  // y4mRead() should clamp the values to respect the specified depth and range.
+  testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  ASSERT_TRUE(y4mRead(file_path.str().c_str(), decoded.get(),
+                      /*sourceTiming=*/nullptr, /*iter=*/nullptr));
+
+  // Pass it through the libavif API to make sure reading a bad y4m does not
+  // trigger undefined behavior.
+  const testutil::AvifRwData encoded = testutil::Encode(image.get());
+  EXPECT_NE(testutil::Decode(encoded.data, encoded.size), nullptr);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Passing out-of-range values to libavif API may trigger undefined behavior. Rather than fixing the whole pipeline and maybe slowing it down, make sure the input respects the specified depth and range.

b/228859724#comment3