### PR TITLE
avifenc: Fix an off by one error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and avifDecoder structs.
 * Add STATIC library target avif_internal to allow tests to access functions
   from internal.h when BUILD_SHARED_LIBS is ON.
 * Add clli metadata read and write support
-* repetitionCount member added to avifEncoder and avifDecoder struct to specify
+* Add repetitionCount member to avifEncoder and avifDecoder structs to specify
   the number of repetitions for animated image sequences.
 
 ### Changed

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -1256,6 +1256,7 @@ int main(int argc, char * argv[])
         int nextImageIndex = -1;
         while ((nextFile = avifInputGetNextFile(&input)) != NULL) {
             ++nextImageIndex;
+            isImageSequence = AVIF_TRUE;
 
             uint64_t nextDurationInTimescales = nextFile->duration ? nextFile->duration : outputTiming.duration;
 
@@ -1334,9 +1335,6 @@ int main(int argc, char * argv[])
                 returnCode = 1;
                 goto cleanup;
             }
-        }
-        if (nextImageIndex > 0) {
-            isImageSequence = AVIF_TRUE;
         }
     }
 


### PR DESCRIPTION
Computation of isImageSequence in avifenc has an off by one error.

Since there is an encode before the while loop, >0 check is incorrect and it must be >=0. A simpler way to check for image sequence is to simply see if we enter the while loop or not.

Also, fix a typo in CHANGELOG.md.