### PR TITLE
Distinguish between sequence and progressive

### DIFF
--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -135,7 +135,7 @@ void avifImageDump(const avifImage * avif, uint32_t gridCols, uint32_t gridRows,
 void avifContainerDump(const avifDecoder * decoder)
 {
     avifImageDumpInternal(decoder->image, 0, 0, decoder->alphaPresent, decoder->progressiveState);
-    if (decoder->imageCount > 1) {
+    if ((decoder->progressiveState == AVIF_PROGRESSIVE_STATE_UNAVAILABLE) && (decoder->imageCount > 1)) {
         if (decoder->repetitionCount == AVIF_REPETITION_COUNT_INFINITE) {
             printf(" * Repeat Count   : Infinite\n");
         } else if (decoder->repetitionCount == AVIF_REPETITION_COUNT_UNKNOWN) {


### PR DESCRIPTION
In avifImageDump(), improve the check for an image sequence by excluding the progressive decoding case.