### PR TITLE
Rename the AVIF_UNKNOWN_DURATION64/32 macros

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -473,8 +473,8 @@ typedef struct avifSequenceHeader
 } avifSequenceHeader;
 avifBool avifSequenceHeaderParse(avifSequenceHeader * header, const avifROData * sample);
 
-#define AVIF_UNKNOWN_DURATION64 UINT64_MAX
-#define AVIF_UNKNOWN_DURATION32 UINT32_MAX
+#define AVIF_INDEFINITE_DURATION64 UINT64_MAX
+#define AVIF_INDEFINITE_DURATION32 UINT32_MAX
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/read.c
+++ b/src/read.c
@@ -2472,7 +2472,7 @@ static avifBool avifParseTrackHeaderBox(avifTrack * track,
         AVIF_CHECK(avifROStreamReadU32(&s, &trackID));       // unsigned int(32) track_ID;
         AVIF_CHECK(avifROStreamReadU32(&s, &ignored32));     // const unsigned int(32) reserved = 0;
         AVIF_CHECK(avifROStreamReadU32(&s, &trackDuration)); // unsigned int(32) duration;
-        track->trackDuration = (trackDuration == AVIF_UNKNOWN_DURATION32) ? AVIF_UNKNOWN_DURATION64 : trackDuration;
+        track->trackDuration = (trackDuration == AVIF_INDEFINITE_DURATION32) ? AVIF_INDEFINITE_DURATION64 : trackDuration;
     } else {
         // Unsupported version
         avifDiagnosticsPrintf(diag, "Box[tkhd] has an unsupported version [%u]", version);
@@ -2884,9 +2884,9 @@ static avifBool avifParseTrackBox(avifDecoderData * data, uint64_t rawOffset, co
     if (!edtsBoxSeen) {
         track->repetitionCount = AVIF_REPETITION_COUNT_UNKNOWN;
     } else if (track->isRepeating) {
-        if (track->trackDuration == AVIF_UNKNOWN_DURATION64) {
-            // If isRepeating is true and track duration is unknown, then set the repetition count to infinite (Section 9.6.1 of
-            // ISO/IEC 23008-12 Part 12).
+        if (track->trackDuration == AVIF_INDEFINITE_DURATION64) {
+            // If isRepeating is true and the track duration is unknown/indefinite, then set the repetition count to infinite
+            // (Section 9.6.1 of ISO/IEC 23008-12 Part 12).
             track->repetitionCount = AVIF_REPETITION_COUNT_INFINITE;
         } else {
             // Section 9.6.1. of ISO/IEC 23008-12 Part 12: 1, the entire edit list is repeated a sufficient number of times to

--- a/src/write.c
+++ b/src/write.c
@@ -1545,7 +1545,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
         }
         uint64_t durationInTimescales;
         if (encoder->repetitionCount == AVIF_REPETITION_COUNT_INFINITE) {
-            durationInTimescales = AVIF_UNKNOWN_DURATION64;
+            durationInTimescales = AVIF_INDEFINITE_DURATION64;
         } else {
             uint64_t loopCount = encoder->repetitionCount + 1;
             assert(framesDurationInTimescales != 0);
@@ -1623,9 +1623,9 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             avifBoxMarker elst = avifRWStreamWriteFullBox(&s, "elst", AVIF_BOX_SIZE_TBD, 1, elstFlags);
             avifRWStreamWriteU32(&s, 1);                          // unsigned int(32) entry_count;
             avifRWStreamWriteU64(&s, framesDurationInTimescales); // unsigned int(64) segment_duration;
-            avifRWStreamWriteU64(&s, 0);                          // unsigned int(64) media_time;
-            avifRWStreamWriteU16(&s, 1);                          // unsigned int(16) media_rate_integer;
-            avifRWStreamWriteU16(&s, 0);                          // unsigned int(16) media_rate_fraction = 0;
+            avifRWStreamWriteU64(&s, 0);                          // int(64) media_time;
+            avifRWStreamWriteU16(&s, 1);                          // int(16) media_rate_integer;
+            avifRWStreamWriteU16(&s, 0);                          // int(16) media_rate_fraction = 0;
             avifRWStreamFinishBox(&s, elst);
             avifRWStreamFinishBox(&s, edts);
 


### PR DESCRIPTION
The AVIF_UNKNOWN_DURATION64/32 macros are renamed
AVIF_INDEFINITE_DURATION64/32 because their values (all 1s) are described as indefinite duration in ISO/IEC 14496-12:2022. AVIF_UNKNOWN_DURATION64/32 look similar to the
AVIF_REPETITION_COUNT_UNKNOWN macro and could be confusing.

In src/write.c, correct the comments for the fields in the EditListBox (elst).