### PR TITLE
Require EditBox to contain exactly one EditListBox

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2848,6 +2848,10 @@ static avifBool avifParseEditBox(avifTrack * track, const uint8_t * raw, size_t 
         }
         AVIF_CHECK(avifROStreamSkip(&s, header.size));
     }
+    if (!elstBoxSeen) {
+        avifDiagnosticsPrintf(diag, "Box[edts] contains no [elst] Box.");
+        return AVIF_FALSE;
+    }
     return AVIF_TRUE;
 }
 


### PR DESCRIPTION
The avifParseTrackBox() function has the following code after parsing the boxes contained in the TrackBox:

    if (!edtsBoxSeen) {
        track->repetitionCount = AVIF_REPETITION_COUNT_UNKNOWN;
    } else if (track->isRepeating) {
	... sets track->repetitionCount based on track->trackDuration
	... and track->segmentDuration
    } else {
        track->repetitionCount = 0;
    }

The if (!edtsBoxSeen) test actually tests elstBoxSeen, because track->isRepeating and track->segmentDuration come from an EditListBox. Make edtsBoxSeen equal to elstBoxSeen by requiring an EditBox to contain exactly one EditListBox.