### PR TITLE
Bump ext/libyuv to version 1850

### DIFF
--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -14,7 +14,7 @@
 git clone --single-branch https://chromium.googlesource.com/libyuv/libyuv
 
 cd libyuv
-git checkout f9fda6e7
+git checkout 4a3c79cb
 
 mkdir build
 cd build


### PR DESCRIPTION
It includes a fix for building yuv_shared locally on Mac.