### PR TITLE
Two fixes for avifEncoder repetitionCount

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -392,6 +392,7 @@ avifEncoder * avifEncoderCreate(void)
     encoder->speed = AVIF_SPEED_DEFAULT;
     encoder->keyframeInterval = 0;
     encoder->timescale = 1;
+    encoder->repetitionCount = AVIF_REPETITION_COUNT_INFINITE;
     encoder->quality = AVIF_QUALITY_DEFAULT;
     encoder->qualityAlpha = AVIF_QUALITY_DEFAULT;
     encoder->minQuantizer = AVIF_QUANTIZER_BEST_QUALITY;
@@ -430,6 +431,7 @@ static void avifEncoderBackupSettings(avifEncoder * encoder)
     lastEncoder->speed = encoder->speed;
     lastEncoder->keyframeInterval = encoder->keyframeInterval;
     lastEncoder->timescale = encoder->timescale;
+    lastEncoder->repetitionCount = encoder->repetitionCount;
     lastEncoder->minQuantizer = encoder->minQuantizer;
     lastEncoder->maxQuantizer = encoder->maxQuantizer;
     lastEncoder->minQuantizerAlpha = encoder->minQuantizerAlpha;
@@ -455,7 +457,7 @@ static avifBool avifEncoderDetectChanges(const avifEncoder * encoder, avifEncode
 
     if ((lastEncoder->codecChoice != encoder->codecChoice) || (lastEncoder->maxThreads != encoder->maxThreads) ||
         (lastEncoder->speed != encoder->speed) || (lastEncoder->keyframeInterval != encoder->keyframeInterval) ||
-        (lastEncoder->timescale != encoder->timescale)) {
+        (lastEncoder->timescale != encoder->timescale) || (lastEncoder->repetitionCount != encoder->repetitionCount)) {
         return AVIF_FALSE;
     }
 

--- a/tests/gtest/avifchangesettingtest.cc
+++ b/tests/gtest/avifchangesettingtest.cc
@@ -130,6 +130,7 @@ TEST(ChangeSettingTest, UnchangeableSetting) {
   encoder->codecChoice = AVIF_CODEC_CHOICE_AOM;
   encoder->speed = AVIF_SPEED_FASTEST;
   encoder->timescale = 1;
+  ASSERT_EQ(encoder->repetitionCount, AVIF_REPETITION_COUNT_INFINITE);
   encoder->minQuantizer = 63;
   encoder->maxQuantizer = 63;
 
@@ -138,6 +139,16 @@ TEST(ChangeSettingTest, UnchangeableSetting) {
             AVIF_RESULT_OK);
 
   encoder->timescale = 2;
+  ASSERT_EQ(avifEncoderAddImage(encoder.get(), image.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_FORCE_KEYFRAME),
+            AVIF_RESULT_CANNOT_CHANGE_SETTING);
+
+  encoder->timescale = 1;
+  ASSERT_EQ(avifEncoderAddImage(encoder.get(), image.get(), 1,
+                                AVIF_ADD_IMAGE_FLAG_FORCE_KEYFRAME),
+            AVIF_RESULT_OK);
+
+  encoder->repetitionCount = 0;
   ASSERT_EQ(avifEncoderAddImage(encoder.get(), image.get(), 1,
                                 AVIF_ADD_IMAGE_FLAG_FORCE_KEYFRAME),
             AVIF_RESULT_CANNOT_CHANGE_SETTING);


### PR DESCRIPTION
In the C API, set the default of avifEncoder repetitionCount to AVIF_REPETITION_COUNT_INFINITE properly in avifEncoderCreate(). (The default is already set correctly in the avifenc program.)

Detect changes to avifEncoder repetitionCount and return the AVIF_RESULT_CANNOT_CHANGE_SETTING error if it changes between frames.