### PR TITLE
 Fix build error with msvc x86

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -950,7 +950,7 @@ static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, const a
                     return AVIF_RESULT_BMFF_PARSE_FAILED;
                 }
                 startOffset += remainingOffset;
-                extentSize -= remainingOffset;
+                extentSize = (size_t)((uint64_t)extentSize - remainingOffset);
                 remainingOffset = 0;
             }
         }

--- a/src/read.c
+++ b/src/read.c
@@ -950,7 +950,7 @@ static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, const a
                     return AVIF_RESULT_BMFF_PARSE_FAILED;
                 }
                 startOffset += remainingOffset;
-                extentSize = (size_t)((uint64_t)extentSize - remainingOffset);
+                extentSize -= (size_t)remainingOffset;
                 remainingOffset = 0;
             }
         }


### PR DESCRIPTION
Fixes the following warnings and compile error when building libavif-v0.11.1 with Visual Studio 2022 v17.4 for x86 (32-bit):
```
read.c
D:\Build\_build\libavif-v0.11.1\src\read.c(948): error C2220: the following warning is treated as an error
D:\Build\_build\libavif-v0.11.1\src\read.c(948): warning C4244: '-=': conversion from 'uint64_t' to 'size_t', possible loss of data
```