### PR TITLE
Allocate avifReformatState tables dynamically

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -136,10 +136,6 @@ typedef struct avifReformatState
 
     avifPixelFormatInfo formatInfo;
 
-    // LUTs for going from YUV limited/full unorm -> full range RGB FP32
-    float unormFloatTableY[1 << 12];
-    float unormFloatTableUV[1 << 12];
-
     avifReformatMode mode;
     // Used by avifImageYUVToRGB() only. avifImageRGBToYUV() uses a local variable (alphaMode) instead.
     avifAlphaMultiplyMode toRGBAlphaMode;

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -466,7 +466,11 @@ static avifBool avifCreateYUVToRGBLookUpTables(float ** unormFloatTableY, float 
             *unormFloatTableUV = *unormFloatTableY;
         } else {
             *unormFloatTableUV = avifAlloc(cpCount * sizeof(**unormFloatTableUV));
-            AVIF_CHECK(*unormFloatTableUV);
+            if (!*unormFloatTableUV) {
+                avifFree(*unormFloatTableY);
+                *unormFloatTableY = NULL;
+                return AVIF_FALSE;
+            }
             for (uint32_t cp = 0; cp < cpCount; ++cp) {
                 // Review this when implementing YCgCo limited range support.
                 (*unormFloatTableUV)[cp] = ((float)cp - state->biasUV) / state->rangeUV;


### PR DESCRIPTION
Instead of a fixed-length array that may be larger than necessary and uses 1<<12 * 2 = 8kB of stack memory which may be limited on some environments.