### PR TITLE
Move toRGBAlphaMode out of avifReformatState

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -136,8 +136,6 @@ typedef struct avifReformatState
     avifPixelFormatInfo formatInfo;
 
     avifReformatMode mode;
-    // Used by avifImageYUVToRGB() only. avifImageRGBToYUV() uses a local variable (alphaMode) instead.
-    avifAlphaMultiplyMode toRGBAlphaMode;
 } avifReformatState;
 
 // Returns:


### PR DESCRIPTION
The toRGBAlphaMode member of the avifReformatState struct is only used by avifImageYUVToRGB(). Move toRGBAlphaMode out of avifReformatState and replace it with the existing local variable alphaMultiplyMode in avifImageYUVToRGB(). alphaMultiplyMode also needs to be passed to avifImageYUVAnyToRGBAnySlow() as an input parameter.