### PR TITLE
Copy clli in avifImageCopyNoAlloc()

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -162,6 +162,7 @@ static void avifImageCopyNoAlloc(avifImage * dstImage, const avifImage * srcImag
     dstImage->colorPrimaries = srcImage->colorPrimaries;
     dstImage->transferCharacteristics = srcImage->transferCharacteristics;
     dstImage->matrixCoefficients = srcImage->matrixCoefficients;
+    dstImage->clli = srcImage->clli;
 
     dstImage->transformFlags = srcImage->transformFlags;
     dstImage->pasp = srcImage->pasp;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,11 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifchangesettingtest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifchangesettingtest COMMAND avifchangesettingtest)
 
+    add_executable(avifcllitest gtest/avifcllitest.cc)
+    target_link_libraries(avifcllitest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
+    target_include_directories(avifcllitest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifcllitest COMMAND avifcllitest)
+
     add_executable(avifgridapitest gtest/avifgridapitest.cc)
     target_link_libraries(avifgridapitest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avifgridapitest PRIVATE ${GTEST_INCLUDE_DIRS})

--- a/tests/gtest/avifcllitest.cc
+++ b/tests/gtest/avifcllitest.cc
@@ -15,9 +15,10 @@ TEST(ClliTest, Simple) {
   ASSERT_NE(image, nullptr);
   testutil::FillImageGradient(image.get());  // The pixels do not matter.
 
-  for (uint16_t max_content_light_level : {0, 1, 65535}) {
-    for (uint16_t max_pic_average_light_level : {0, 1, 65535}) {
-      image->clli = {max_content_light_level, max_pic_average_light_level};
+  for (int max_content_light_level : {0, 1, 65535}) {
+    for (int max_pic_average_light_level : {0, 1, 65535}) {
+      image->clli.maxCLL = max_content_light_level;
+      image->clli.maxPALL = max_pic_average_light_level;
 
       const testutil::AvifRwData encoded = testutil::Encode(image.get());
       const testutil::AvifImagePtr decoded =

--- a/tests/gtest/avifcllitest.cc
+++ b/tests/gtest/avifcllitest.cc
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+TEST(ClliTest, Simple) {
+  testutil::AvifImagePtr image =
+      testutil::CreateImage(/*width=*/8, /*height=*/8, /*depth=*/8,
+                            AVIF_PIXEL_FORMAT_YUV444, AVIF_PLANES_YUV);
+  ASSERT_NE(image, nullptr);
+  testutil::FillImageGradient(image.get());  // The pixels do not matter.
+
+  for (uint16_t max_content_light_level : {0, 1, 65535}) {
+    for (uint16_t max_pic_average_light_level : {0, 1, 65535}) {
+      image->clli = {max_content_light_level, max_pic_average_light_level};
+
+      const testutil::AvifRwData encoded = testutil::Encode(image.get());
+      const testutil::AvifImagePtr decoded =
+          testutil::Decode(encoded.data, encoded.size);
+      ASSERT_NE(decoded, nullptr);
+      ASSERT_EQ(decoded->clli.maxCLL, image->clli.maxCLL);
+      ASSERT_EQ(decoded->clli.maxPALL, image->clli.maxPALL);
+    }
+  }
+}
+
+}  // namespace
+}  // namespace libavif

--- a/tests/gtest/avifcllitest.cc
+++ b/tests/gtest/avifcllitest.cc
@@ -17,8 +17,8 @@ TEST(ClliTest, Simple) {
 
   for (int max_content_light_level : {0, 1, 65535}) {
     for (int max_pic_average_light_level : {0, 1, 65535}) {
-      image->clli.maxCLL = max_content_light_level;
-      image->clli.maxPALL = max_pic_average_light_level;
+      image->clli.maxCLL = static_cast<uint16_t>(max_content_light_level);
+      image->clli.maxPALL = static_cast<uint16_t>(max_pic_average_light_level);
 
       const testutil::AvifRwData encoded = testutil::Encode(image.get());
       const testutil::AvifImagePtr decoded =


### PR DESCRIPTION
Add avifcllitest.
Follow up of https://github.com/AOMediaCodec/libavif/pull/1194 and https://github.com/AOMediaCodec/libavif/pull/1212.