### PR TITLE
GitHub workflows: Install stable Rust compiler

### DIFF
--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -22,6 +22,11 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
 
     - name: Cache external dependencies
       id: cache-ext

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,6 +28,11 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
 
     - name: Cache external dependencies
       id: cache-ext

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
 
     - name: Cache external dependencies
       id: cache-ext


### PR DESCRIPTION
Copied from
https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md.

cargo-c v0.9.15+cargo-0.67 requires rustc 1.66 or newer. The rustc
installed in the ubuntu-latest os image is rustc 1.65.0.

ci-disable-gtest.yml, ci-windows.yml, and ci.yml build rav1e, so only
these three workflows are modified.