### PR TITLE
Run ubuntu:22.10 image and install cargo-c package

### DIFF
--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -2,7 +2,7 @@
 
 # Tests system-wide libavif shared library installation correct behavior, using Ubuntu in Docker. Run:
 #
-#     docker run -it ubuntu
+#     docker run -it ubuntu:rolling
 #
 # ... then run this script inside of there. When it finishes, avifenc and avifdec should
 # be in /usr/bin and offer all codecs chosen in the last cmake command in this script.
@@ -19,11 +19,10 @@ set -e
 
 # build env
 apt update
-DEBIAN_FRONTEND="noninteractive" apt install -y build-essential libjpeg-dev libpng-dev libssl-dev ninja-build cmake pkg-config git perl vim meson cargo nasm
+DEBIAN_FRONTEND="noninteractive" apt install -y build-essential libjpeg-dev libpng-dev libssl-dev ninja-build cmake pkg-config git perl vim meson cargo cargo-c nasm
 
 # Rust env
 export PATH="$HOME/.cargo/bin:$PATH"
-cargo install cargo-c
 
 # aom
 cd


### PR DESCRIPTION
In the current Docker ubuntu image (Ubuntu 22.04.1 LTS), I can't figure out how to make the "cargo install cargo-c" command work:
1. The current version of cargo-c, 0.9.15+cargo-0.67, requires rustc 1.66 or newer, but the rustc package is rustc 1.61.0.
2. Older versions of cargo-c, such as 0.9.14+cargo-0.66, allows rustc 1.61.0, but it generates compilation errors in ignore v0.4.19: error[E0658]: use of unstable library feature 'scoped_threads'
3. It seems that only the 'nightly' versions of rustc can be made to allow unstable library features.

It turns out that cargo-c is available as a package in Ubuntu 22.10: https://packages.ubuntu.com/search?keywords=cargo-c

Run the Docker ubuntu:rolling image, which currently points to Ubuntu 22.10: https://hub.docker.com/_/ubuntu/

Install cargo-c as a package.