### PR TITLE
Skip ProgressiveTest.DimensionChange

### DIFF
--- a/tests/gtest/avifprogressivetest.cc
+++ b/tests/gtest/avifprogressivetest.cc
@@ -85,6 +85,13 @@ TEST_F(ProgressiveTest, DimensionChange) {
   if (avifLibYUVVersion() == 0) {
     GTEST_SKIP() << "libyuv not available, skip test.";
   }
+  // TODO(wtc): Investigate why the following assertion in libaom failed:
+  //   av1/encoder/mcomp.c:1717: av1_full_pixel_search: Assertion
+  //   `ms_params->ms_buffers.ref->stride == ms_params->search_sites->stride'
+  //   failed.
+  // ms_params->ms_buffers.ref->stride is 832, and
+  // ms_params->search_sites->stride is 0.
+  GTEST_SKIP() << "Skip test because of an assertion failure in libaom";
 
   encoder_->extraLayerCount = 1;
   encoder_->minQuantizer = 0;


### PR DESCRIPTION
It hits an assertion failure in libaom.