### PR TITLE
Add --target-size flag to avifenc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ avifEncoderSetCodecSpecificOption().
   should be updated to set quality (and qualityAlpha if applicable) and leave
   minQuantizer, maxQuantizer, minQuantizerAlpha, and maxQuantizerAlpha
   initialized to the default values.
+* The --targetSize flag in avifenc was added to adapt the quality so that the
+  output file size is as close to the given number of bytes as possible.
 * Add the public API function avifImageIsOpaque() in avif.h.
 * Add experimental API for progressive AVIF encoding.
 

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -489,7 +489,8 @@ static avifBool avifCodecSpecificOptionsAdd(avifCodecSpecificOptions * options, 
 
     const char * value = strchr(keyValue, '=');
     if (value) {
-        // Remove equals sign.
+        // Keep the parts on the left and on the right of the equal sign,
+        // but not the equal sign itself.
         options->values[options->count] = avifStrdup(value + 1);
         const size_t keyLength = strlen(keyValue) - strlen(value);
         options->keys[options->count] = malloc(keyLength + 1);
@@ -896,7 +897,7 @@ static avifBool avifEncodeImages(avifSettings * settings,
             avifRWDataFree(&closestEncoded);
             return AVIF_FALSE;
         }
-        printf("Encoded image of size %d bytes.\n", (int)encoded->size);
+        printf("Encoded image of size %" AVIF_FMT_ZU " bytes.\n", encoded->size);
 
         if (encoded->size == targetSize) {
             return AVIF_TRUE;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -184,6 +184,9 @@ if(AVIF_BUILD_APPS)
     add_test(NAME test_cmd_metadata COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd_metadata.sh ${CMAKE_BINARY_DIR}
                                             ${CMAKE_CURRENT_SOURCE_DIR}/data
     )
+    add_test(NAME test_cmd_targetsize COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd_targetsize.sh ${CMAKE_BINARY_DIR}
+                                              ${CMAKE_CURRENT_SOURCE_DIR}/data
+    )
 
     if(NOT AVIF_CODEC_AOM OR NOT AVIF_CODEC_AOM_ENCODE)
         # Only aom encoder supports lossless encoding.

--- a/tests/test_cmd_targetsize.sh
+++ b/tests/test_cmd_targetsize.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+#
+# tests for command lines (--target-size)
+
+set -ex
+
+if [[ "$#" -ge 1 ]]; then
+  # eval so that the passed in directory can contain variables.
+  BINARY_DIR="$(eval echo "$1")"
+else
+  # Assume "tests" is the current directory.
+  BINARY_DIR="$(pwd)/.."
+fi
+if [[ "$#" -ge 2 ]]; then
+  TESTDATA_DIR="$(eval echo "$2")"
+else
+  TESTDATA_DIR="$(pwd)/data"
+fi
+if [[ "$#" -ge 3 ]]; then
+  TMP_DIR="$(eval echo "$3")"
+else
+  TMP_DIR="$(mktemp -d)"
+fi
+
+AVIFENC="${BINARY_DIR}/avifenc"
+AVIFDEC="${BINARY_DIR}/avifdec"
+
+# Input file paths.
+INPUT_Y4M="${TESTDATA_DIR}/kodim03_yuv420_8bpc.y4m"
+# Output file names.
+ENCODED_FILE="avif_test_cmd_targetsize_encoded.avif"
+DECODED_SMALLEST_FILE="avif_test_cmd_targetsize_decoded_smallest.png"
+DECODED_BIGGEST_FILE="avif_test_cmd_targetsize_decoded_biggest.png"
+
+# Cleanup
+cleanup() {
+  pushd ${TMP_DIR}
+    rm -- "${ENCODED_FILE}" "${DECODED_SMALLEST_FILE}" "${DECODED_BIGGEST_FILE}"
+  popd
+}
+trap cleanup EXIT
+
+pushd ${TMP_DIR}
+  "${AVIFENC}" -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}"
+  DEFAULT_QUALITY_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
+
+  "${AVIFENC}" -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}" --target-size 0
+  "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_SMALLEST_FILE}"
+  SMALLEST_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
+
+  "${AVIFENC}" -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}" --target-size 999999999
+  "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_BIGGEST_FILE}"
+  BIGGEST_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
+
+  test ${SMALLEST_FILE_SIZE} -lt ${DEFAULT_QUALITY_FILE_SIZE} || exit 1
+  test ${DEFAULT_QUALITY_FILE_SIZE} -lt ${BIGGEST_FILE_SIZE} || exit 1
+
+  # Check that min/max file sizes match lowest/highest qualities.
+  "${AVIFENC}" -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}" -q 0
+  test $(wc -c < "${ENCODED_FILE}") -eq ${SMALLEST_FILE_SIZE} || exit 1
+  "${AVIFENC}" -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}" -q 100
+  test $(wc -c < "${ENCODED_FILE}") -eq ${BIGGEST_FILE_SIZE} || exit 1
+  # Negative test.
+  test $(wc -c < "${ENCODED_FILE}") -eq ${SMALLEST_FILE_SIZE} && exit 1
+
+  # Same as above but with a grid made of two tiles.
+  TILE0="${DECODED_SMALLEST_FILE}"
+  TILE1="${DECODED_BIGGEST_FILE}"
+
+  "${AVIFENC}" -s 9 --grid 2x1 "${TILE0}" "${TILE1}" -o "${ENCODED_FILE}"
+  DEFAULT_QUALITY_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
+
+  "${AVIFENC}" -s 9 --grid 2x1 "${TILE0}" "${TILE1}" -o "${ENCODED_FILE}" --target-size 0
+  SMALLEST_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
+
+  "${AVIFENC}" -s 9 --grid 2x1 "${TILE0}" "${TILE1}" -o "${ENCODED_FILE}" --target-size 999999999
+  BIGGEST_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
+
+  test ${SMALLEST_FILE_SIZE} -lt ${DEFAULT_QUALITY_FILE_SIZE} || exit 1
+  test ${DEFAULT_QUALITY_FILE_SIZE} -lt ${BIGGEST_FILE_SIZE} || exit 1
+
+  # The remaining tests in this file use animations that may trigger segmentation faults
+  # with libaom versions older than 3.6.0. Skip the tests if that is the case.
+  # TODO(yguyon): Investigate.
+  # The grep and cut commands are not pretty but seem to work on most platforms.
+  AOM_VERSION=$("${AVIFENC}" -V | grep -o "aom.*[0-9]*\.")        # "aom [enc/dec]:X.Y."
+  AOM_VERSION=$(echo "${AOM_VERSION}" | cut -d ":" -f 2)          # "X.Y" maybe prepended by a 'v'
+  AOM_VERSION=$(echo "${AOM_VERSION}" | grep -o "[0-9]*\.[0-9]*") # "X.Y"
+  AOM_MAJOR_VERSION=$(echo "${AOM_VERSION}" | cut -d "." -f 1)
+  AOM_MINOR_VERSION=$(echo "${AOM_VERSION}" | cut -d "." -f 2)
+  test ${AOM_MAJOR_VERSION} -ge 3 || exit 0 # older than 3.0.0
+  test ${AOM_MAJOR_VERSION} -ge 4 || test ${AOM_MINOR_VERSION} -ge 6 || exit 0 # older than 3.5.0
+
+  # Same as above but with an animation made of two frames.
+  FRAME0="${DECODED_SMALLEST_FILE}"
+  FRAME1="${DECODED_BIGGEST_FILE}"
+
+  "${AVIFENC}" -s 9 "${FRAME0}" "${FRAME1}" -o "${ENCODED_FILE}"
+  DEFAULT_QUALITY_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
+
+  "${AVIFENC}" -s 9 "${FRAME0}" "${FRAME1}" -o "${ENCODED_FILE}" --target-size 0
+  SMALLEST_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
+
+  "${AVIFENC}" -s 9 "${FRAME0}" "${FRAME1}" -o "${ENCODED_FILE}" --target-size 999999999
+  BIGGEST_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
+
+  test ${SMALLEST_FILE_SIZE} -lt ${DEFAULT_QUALITY_FILE_SIZE} || exit 1
+  test ${DEFAULT_QUALITY_FILE_SIZE} -lt ${BIGGEST_FILE_SIZE} || exit 1
+popd
+
+exit 0

--- a/tests/test_cmd_targetsize.sh
+++ b/tests/test_cmd_targetsize.sh
@@ -66,16 +66,16 @@ pushd ${TMP_DIR}
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_BIGGEST_FILE}"
   BIGGEST_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
 
-  test ${SMALLEST_FILE_SIZE} -lt ${DEFAULT_QUALITY_FILE_SIZE} || exit 1
-  test ${DEFAULT_QUALITY_FILE_SIZE} -lt ${BIGGEST_FILE_SIZE} || exit 1
+  [[ ${SMALLEST_FILE_SIZE} -lt ${DEFAULT_QUALITY_FILE_SIZE} ]] || exit 1
+  [[ ${DEFAULT_QUALITY_FILE_SIZE} -lt ${BIGGEST_FILE_SIZE} ]] || exit 1
 
   # Check that min/max file sizes match lowest/highest qualities.
   "${AVIFENC}" -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}" -q 0
-  test $(wc -c < "${ENCODED_FILE}") -eq ${SMALLEST_FILE_SIZE} || exit 1
+  [[ $(wc -c < "${ENCODED_FILE}") -eq ${SMALLEST_FILE_SIZE} ]] || exit 1
   "${AVIFENC}" -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}" -q 100
-  test $(wc -c < "${ENCODED_FILE}") -eq ${BIGGEST_FILE_SIZE} || exit 1
+  [[ $(wc -c < "${ENCODED_FILE}") -eq ${BIGGEST_FILE_SIZE} ]] || exit 1
   # Negative test.
-  test $(wc -c < "${ENCODED_FILE}") -eq ${SMALLEST_FILE_SIZE} && exit 1
+  [[ $(wc -c < "${ENCODED_FILE}") -eq ${SMALLEST_FILE_SIZE} ]] && exit 1
 
   # Same as above but with a grid made of two tiles.
   TILE0="${DECODED_SMALLEST_FILE}"
@@ -90,8 +90,8 @@ pushd ${TMP_DIR}
   "${AVIFENC}" -s 9 --grid 2x1 "${TILE0}" "${TILE1}" -o "${ENCODED_FILE}" --target-size 999999999
   BIGGEST_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
 
-  test ${SMALLEST_FILE_SIZE} -lt ${DEFAULT_QUALITY_FILE_SIZE} || exit 1
-  test ${DEFAULT_QUALITY_FILE_SIZE} -lt ${BIGGEST_FILE_SIZE} || exit 1
+  [[ ${SMALLEST_FILE_SIZE} -lt ${DEFAULT_QUALITY_FILE_SIZE} ]] || exit 1
+  [[ ${DEFAULT_QUALITY_FILE_SIZE} -lt ${BIGGEST_FILE_SIZE} ]] || exit 1
 
   # The remaining tests in this file use animations that may trigger segmentation faults
   # with libaom versions older than 3.6.0. Skip the tests if that is the case.
@@ -102,8 +102,8 @@ pushd ${TMP_DIR}
   AOM_VERSION=$(echo "${AOM_VERSION}" | grep -o "[0-9]*\.[0-9]*") # "X.Y"
   AOM_MAJOR_VERSION=$(echo "${AOM_VERSION}" | cut -d "." -f 1)
   AOM_MINOR_VERSION=$(echo "${AOM_VERSION}" | cut -d "." -f 2)
-  test ${AOM_MAJOR_VERSION} -ge 3 || exit 0 # older than 3.0.0
-  test ${AOM_MAJOR_VERSION} -ge 4 || test ${AOM_MINOR_VERSION} -ge 6 || exit 0 # older than 3.5.0
+  [[ ${AOM_MAJOR_VERSION} -ge 3 ]] || exit 0 # older than 3.0.0
+  [[ ${AOM_MAJOR_VERSION} -ge 4 ]] || [[ ${AOM_MINOR_VERSION} -ge 6 ]] || exit 0 # older than 3.5.0
 
   # Same as above but with an animation made of two frames.
   FRAME0="${DECODED_SMALLEST_FILE}"
@@ -118,8 +118,8 @@ pushd ${TMP_DIR}
   "${AVIFENC}" -s 9 "${FRAME0}" "${FRAME1}" -o "${ENCODED_FILE}" --target-size 999999999
   BIGGEST_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
 
-  test ${SMALLEST_FILE_SIZE} -lt ${DEFAULT_QUALITY_FILE_SIZE} || exit 1
-  test ${DEFAULT_QUALITY_FILE_SIZE} -lt ${BIGGEST_FILE_SIZE} || exit 1
+  [[ ${SMALLEST_FILE_SIZE} -lt ${DEFAULT_QUALITY_FILE_SIZE} ]] || exit 1
+  [[ ${DEFAULT_QUALITY_FILE_SIZE} -lt ${BIGGEST_FILE_SIZE} ]] || exit 1
 popd
 
 exit 0


### PR DESCRIPTION
The two first commits are avifenc refactors containing necessary changes for the third commit:
- Moving encoding code to a `avifEncodeImages()` that can be called once for each quality to try
- Encapsulating local variables into an `avifSettings` struct to avoid huge function signatures
- Caching input images (especially from `stdin`)