### PR TITLE
Check OOM in avifImageCreate, avifEncoderCreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ avifEncoderSetCodecSpecificOption().
 * Update aom.cmd: v3.6.0
 * Update rav1e.cmd: v0.6.3
 * avifImageCreate(), avifImageCreateEmpty(), avifEncoderCreate() and other
-  internal functions now return NULL in case of AVIF_RESULT_OUT_OF_MEMORY.
+  internal functions now return NULL if a memory allocation failed.
 * avifEncoderSetCodecSpecificOption() now returns avifResult instead of void to
   report memory allocation failures.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 There are incompatible ABI changes in this release. The clli member was added
 to the avifImage struct. The repetitionCount member was added to the avifEncoder
 and avifDecoder structs. The quality and qualityAlpha members were added to the
-avifEncoder struct.
+avifEncoder struct. Check that functions returning pointers do not return NULL
+before accessing those pointers. Check the return value of
+avifEncoderSetCodecSpecificOption().
 
 ### Added
 * Add STATIC library target avif_internal to allow tests to access functions
@@ -45,6 +47,10 @@ avifEncoder struct.
   instances.
 * Update aom.cmd: v3.6.0
 * Update rav1e.cmd: v0.6.3
+* avifImageCreate(), avifImageCreateEmpty(), avifEncoderCreate() and other
+  internal functions now return NULL in case of AVIF_RESULT_OUT_OF_MEMORY.
+* avifEncoderSetCodecSpecificOption() now returns avifResult instead of void to
+  report memory allocation failures.
 
 ## [0.11.1] - 2022-10-19
 

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -418,7 +418,7 @@ static avifBool avifImageSplitGrid(const avifImage * gridSplitImage, uint32_t gr
             uint32_t gridIndex = gridX + (gridY * gridCols);
             avifImage * cellImage = avifImageCreateEmpty();
             if (!cellImage) {
-                fprintf(stderr, "ERROR: Cell creation failed: out-of-memory\n");
+                fprintf(stderr, "ERROR: Cell creation failed: out of memory\n");
                 return AVIF_FALSE;
             }
             gridCells[gridIndex] = cellImage;
@@ -520,7 +520,7 @@ int main(int argc, char * argv[])
     avifChromaDownsampling chromaDownsampling = AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC;
 
     if (!encoder) {
-        fprintf(stderr, "ERROR: Out-of-memory\n");
+        fprintf(stderr, "ERROR: Out of memory\n");
         returnCode = 1;
         goto cleanup;
     }
@@ -979,7 +979,7 @@ int main(int argc, char * argv[])
 
     image = avifImageCreateEmpty();
     if (!image) {
-        fprintf(stderr, "ERROR: Out-of-memory\n");
+        fprintf(stderr, "ERROR: Out of memory\n");
         returnCode = 1;
         goto cleanup;
     }
@@ -1208,7 +1208,7 @@ int main(int argc, char * argv[])
 
             avifImage * cellImage = avifImageCreateEmpty();
             if (!cellImage) {
-                fprintf(stderr, "ERROR: Out-of-memory\n");
+                fprintf(stderr, "ERROR: Out of memory\n");
                 returnCode = 1;
                 goto cleanup;
             }
@@ -1348,7 +1348,7 @@ int main(int argc, char * argv[])
             }
             nextImage = avifImageCreateEmpty();
             if (!nextImage) {
-                fprintf(stderr, "ERROR: Out-of-memory\n");
+                fprintf(stderr, "ERROR: Out of memory\n");
                 returnCode = 1;
                 goto cleanup;
             }

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -487,7 +487,6 @@ int main(int argc, char * argv[])
     avifBool ignoreExif = AVIF_FALSE;
     avifBool ignoreXMP = AVIF_FALSE;
     avifBool ignoreICC = AVIF_FALSE;
-    avifEncoder * encoder = avifEncoderCreate();
     avifImage * image = NULL;
     avifImage * nextImage = NULL;
     avifRWData raw = AVIF_DATA_EMPTY;
@@ -519,6 +518,7 @@ int main(int argc, char * argv[])
     avifMatrixCoefficients matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
     avifChromaDownsampling chromaDownsampling = AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC;
 
+    avifEncoder * encoder = avifEncoderCreate();
     if (!encoder) {
         fprintf(stderr, "ERROR: Out of memory\n");
         returnCode = 1;
@@ -779,12 +779,13 @@ int main(int argc, char * argv[])
                 value = ""; // Pass in a non-NULL, empty string. Codecs can use the
                             // mere existence of a key as a boolean value.
             }
-            if (avifEncoderSetCodecSpecificOption(encoder, tempBuffer, value) != AVIF_RESULT_OK) {
-                fprintf(stderr, "ERROR: Failed to set codec specific option: %s=%s\n", tempBuffer, value);
+            avifResult result = avifEncoderSetCodecSpecificOption(encoder, tempBuffer, value);
+            free(tempBuffer);
+            if (result != AVIF_RESULT_OK) {
+                fprintf(stderr, "ERROR: Failed to set codec specific option: %s\n", arg);
                 returnCode = 1;
                 goto cleanup;
             }
-            free(tempBuffer);
         } else if (!strcmp(arg, "--ignore-exif")) {
             ignoreExif = AVIF_TRUE;
         } else if (!strcmp(arg, "--ignore-xmp")) {

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -417,6 +417,10 @@ static avifBool avifImageSplitGrid(const avifImage * gridSplitImage, uint32_t gr
         for (uint32_t gridX = 0; gridX < gridCols; ++gridX) {
             uint32_t gridIndex = gridX + (gridY * gridCols);
             avifImage * cellImage = avifImageCreateEmpty();
+            if (!cellImage) {
+                fprintf(stderr, "ERROR: Cell creation failed: out-of-memory\n");
+                return AVIF_FALSE;
+            }
             gridCells[gridIndex] = cellImage;
 
             avifCropRect cellRect = { gridX * cellWidth, gridY * cellHeight, cellWidth, cellHeight };
@@ -514,6 +518,12 @@ int main(int argc, char * argv[])
     avifTransferCharacteristics transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
     avifMatrixCoefficients matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
     avifChromaDownsampling chromaDownsampling = AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC;
+
+    if (!encoder) {
+        fprintf(stderr, "ERROR: Out-of-memory\n");
+        returnCode = 1;
+        goto cleanup;
+    }
 
     int argIndex = 1;
     while (argIndex < argc) {
@@ -769,7 +779,11 @@ int main(int argc, char * argv[])
                 value = ""; // Pass in a non-NULL, empty string. Codecs can use the
                             // mere existence of a key as a boolean value.
             }
-            avifEncoderSetCodecSpecificOption(encoder, tempBuffer, value);
+            if (avifEncoderSetCodecSpecificOption(encoder, tempBuffer, value) != AVIF_RESULT_OK) {
+                fprintf(stderr, "ERROR: Failed to set codec specific option: %s=%s\n", tempBuffer, value);
+                returnCode = 1;
+                goto cleanup;
+            }
             free(tempBuffer);
         } else if (!strcmp(arg, "--ignore-exif")) {
             ignoreExif = AVIF_TRUE;
@@ -964,6 +978,11 @@ int main(int argc, char * argv[])
 #endif
 
     image = avifImageCreateEmpty();
+    if (!image) {
+        fprintf(stderr, "ERROR: Out-of-memory\n");
+        returnCode = 1;
+        goto cleanup;
+    }
 
     // Set these in advance so any upcoming RGB -> YUV use the proper coefficients
     image->colorPrimaries = colorPrimaries;
@@ -1188,6 +1207,11 @@ int main(int argc, char * argv[])
             }
 
             avifImage * cellImage = avifImageCreateEmpty();
+            if (!cellImage) {
+                fprintf(stderr, "ERROR: Out-of-memory\n");
+                returnCode = 1;
+                goto cleanup;
+            }
             cellImage->colorPrimaries = image->colorPrimaries;
             cellImage->transferCharacteristics = image->transferCharacteristics;
             cellImage->matrixCoefficients = image->matrixCoefficients;
@@ -1323,6 +1347,11 @@ int main(int argc, char * argv[])
                 avifImageDestroy(nextImage);
             }
             nextImage = avifImageCreateEmpty();
+            if (!nextImage) {
+                fprintf(stderr, "ERROR: Out-of-memory\n");
+                returnCode = 1;
+                goto cleanup;
+            }
             nextImage->colorPrimaries = image->colorPrimaries;
             nextImage->transferCharacteristics = image->transferCharacteristics;
             nextImage->matrixCoefficients = image->matrixCoefficients;

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -27,7 +27,7 @@ int main(int argc, char * argv[])
 
     avifImage * image = avifImageCreate(128, 128, 8, AVIF_PIXEL_FORMAT_YUV444); // these values dictate what goes into the final AVIF
     if (!image) {
-        fprintf(stderr, "Out-of-memory\n");
+        fprintf(stderr, "Out of memory\n");
         goto cleanup;
     }
     // Configure image here: (see avif/avif.h)
@@ -80,7 +80,7 @@ int main(int argc, char * argv[])
 
     encoder = avifEncoderCreate();
     if (!encoder) {
-        fprintf(stderr, "Out-of-memory\n");
+        fprintf(stderr, "Out of memory\n");
         goto cleanup;
     }
     // Configure your encoder here (see avif/avif.h):

--- a/examples/avif_example_encode.c
+++ b/examples/avif_example_encode.c
@@ -26,6 +26,10 @@ int main(int argc, char * argv[])
     memset(&rgb, 0, sizeof(rgb));
 
     avifImage * image = avifImageCreate(128, 128, 8, AVIF_PIXEL_FORMAT_YUV444); // these values dictate what goes into the final AVIF
+    if (!image) {
+        fprintf(stderr, "Out-of-memory\n");
+        goto cleanup;
+    }
     // Configure image here: (see avif/avif.h)
     // * colorPrimaries
     // * transferCharacteristics
@@ -75,6 +79,10 @@ int main(int argc, char * argv[])
     }
 
     encoder = avifEncoderCreate();
+    if (!encoder) {
+        fprintf(stderr, "Out-of-memory\n");
+        goto cleanup;
+    }
     // Configure your encoder here (see avif/avif.h):
     // * maxThreads
     // * quality

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -539,7 +539,7 @@ typedef struct avifImage
     avifRWData xmp;
 } avifImage;
 
-// If avifImageCreate() or avifImageCreateEmpty() returns NULL, an AVIF_RESULT_OUT_OF_MEMORY error happened.
+// avifImageCreate() and avifImageCreateEmpty() return NULL if arguments are invalid or if a memory allocation failed.
 AVIF_API avifImage * avifImageCreate(uint32_t width, uint32_t height, uint32_t depth, avifPixelFormat yuvFormat);
 AVIF_API avifImage * avifImageCreateEmpty(void); // helper for making an image to decode into
 AVIF_API avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes); // deep copy
@@ -1149,7 +1149,7 @@ typedef struct avifEncoder
     struct avifCodecSpecificOptions * csOptions;
 } avifEncoder;
 
-// If avifEncoderCreate() returns NULL, an AVIF_RESULT_OUT_OF_MEMORY error happened.
+// avifEncoderCreate() returns NULL if a memory allocation failed.
 AVIF_API avifEncoder * avifEncoderCreate(void);
 AVIF_API avifResult avifEncoderWrite(avifEncoder * encoder, const avifImage * image, avifRWData * output);
 AVIF_API void avifEncoderDestroy(avifEncoder * encoder);

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -539,6 +539,7 @@ typedef struct avifImage
     avifRWData xmp;
 } avifImage;
 
+// If avifImageCreate() or avifImageCreateEmpty() returns NULL, an AVIF_RESULT_OUT_OF_MEMORY error happened.
 AVIF_API avifImage * avifImageCreate(uint32_t width, uint32_t height, uint32_t depth, avifPixelFormat yuvFormat);
 AVIF_API avifImage * avifImageCreateEmpty(void); // helper for making an image to decode into
 AVIF_API avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes); // deep copy
@@ -1148,6 +1149,7 @@ typedef struct avifEncoder
     struct avifCodecSpecificOptions * csOptions;
 } avifEncoder;
 
+// If avifEncoderCreate() returns NULL, an AVIF_RESULT_OUT_OF_MEMORY error happened.
 AVIF_API avifEncoder * avifEncoderCreate(void);
 AVIF_API avifResult avifEncoderWrite(avifEncoder * encoder, const avifImage * image, avifRWData * output);
 AVIF_API void avifEncoderDestroy(avifEncoder * encoder);
@@ -1203,7 +1205,7 @@ AVIF_API avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output
 // key must be non-NULL, but passing a NULL value will delete the pending key, if it exists.
 // Setting an incorrect or unknown option for the current codec will cause errors of type
 // AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION from avifEncoderWrite() or avifEncoderAddImage().
-AVIF_API void avifEncoderSetCodecSpecificOption(avifEncoder * encoder, const char * key, const char * value);
+AVIF_API avifResult avifEncoderSetCodecSpecificOption(avifEncoder * encoder, const char * key, const char * value);
 
 // Helpers
 AVIF_API avifBool avifImageUsesU16(const avifImage * image);

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -272,10 +272,12 @@ typedef struct avifCodecSpecificOption
     char * value; // Free-form string to be interpreted by the codec
 } avifCodecSpecificOption;
 AVIF_ARRAY_DECLARE(avifCodecSpecificOptions, avifCodecSpecificOption, entries);
+
+// Returns NULL in case of AVIF_RESULT_OUT_OF_MEMORY error.
 avifCodecSpecificOptions * avifCodecSpecificOptionsCreate(void);
 void avifCodecSpecificOptionsClear(avifCodecSpecificOptions * csOptions);
 void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions);
-void avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const char * key, const char * value); // if(value==NULL), key is deleted
+avifResult avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, const char * key, const char * value); // if(value==NULL), key is deleted
 
 // ---------------------------------------------------------------------------
 // avifCodec (abstraction layer to use different AV1 implementations)

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -273,7 +273,7 @@ typedef struct avifCodecSpecificOption
 } avifCodecSpecificOption;
 AVIF_ARRAY_DECLARE(avifCodecSpecificOptions, avifCodecSpecificOption, entries);
 
-// Returns NULL in case of AVIF_RESULT_OUT_OF_MEMORY error.
+// Returns NULL if a memory allocation failed.
 avifCodecSpecificOptions * avifCodecSpecificOptionsCreate(void);
 void avifCodecSpecificOptionsClear(avifCodecSpecificOptions * csOptions);
 void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions);

--- a/src/avif.c
+++ b/src/avif.c
@@ -134,6 +134,15 @@ void avifImageSetDefaults(avifImage * image)
 
 avifImage * avifImageCreate(uint32_t width, uint32_t height, uint32_t depth, avifPixelFormat yuvFormat)
 {
+    // width and height are checked by avifImageAllocatePlanes().
+    if (depth > 16) {
+        // avifImage only supports up to 16 bits per sample. See avifImageUsesU16().
+        return NULL;
+    }
+    if ((yuvFormat < AVIF_PIXEL_FORMAT_NONE) || (yuvFormat > AVIF_PIXEL_FORMAT_YUV400)) {
+        return NULL;
+    }
+
     avifImage * image = (avifImage *)avifAlloc(sizeof(avifImage));
     if (!image) {
         return NULL;
@@ -839,7 +848,7 @@ avifBool avifAreGridDimensionsValid(avifPixelFormat yuvFormat, uint32_t imageW, 
 // ---------------------------------------------------------------------------
 // avifCodecSpecificOption
 
-// Returns NULL in case of AVIF_RESULT_OUT_OF_MEMORY error.
+// Returns NULL if a memory allocation failed.
 static char * avifStrdup(const char * str)
 {
     size_t len = strlen(str);

--- a/src/avif.c
+++ b/src/avif.c
@@ -134,7 +134,7 @@ void avifImageSetDefaults(avifImage * image)
 
 avifImage * avifImageCreate(uint32_t width, uint32_t height, uint32_t depth, avifPixelFormat yuvFormat)
 {
-    // width and height are checked by avifImageAllocatePlanes().
+    // width and height are checked when actually used, for example by avifImageAllocatePlanes().
     if (depth > 16) {
         // avifImage only supports up to 16 bits per sample. See avifImageUsesU16().
         return NULL;
@@ -886,10 +886,6 @@ void avifCodecSpecificOptionsClear(avifCodecSpecificOptions * csOptions)
 
 void avifCodecSpecificOptionsDestroy(avifCodecSpecificOptions * csOptions)
 {
-    if (!csOptions) {
-        return;
-    }
-
     avifCodecSpecificOptionsClear(csOptions);
     avifArrayDestroy(csOptions);
     avifFree(csOptions);

--- a/src/read.c
+++ b/src/read.c
@@ -3408,6 +3408,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         avifImageDestroy(decoder->image);
     }
     decoder->image = avifImageCreateEmpty();
+    AVIF_CHECKERR(decoder->image, AVIF_RESULT_OUT_OF_MEMORY);
     decoder->progressiveState = AVIF_PROGRESSIVE_STATE_UNAVAILABLE;
     data->cicpSet = AVIF_FALSE;
 

--- a/src/write.c
+++ b/src/write.c
@@ -235,7 +235,7 @@ typedef struct avifEncoderData
 
 static void avifEncoderDataDestroy(avifEncoderData * data);
 
-// Returns NULL in case of AVIF_RESULT_OUT_OF_MEMORY error.
+// Returns NULL if a memory allocation failed.
 static avifEncoderData * avifEncoderDataCreate()
 {
     avifEncoderData * data = (avifEncoderData *)avifAlloc(sizeof(avifEncoderData));
@@ -793,7 +793,7 @@ static avifResult avifEncoderDataCreateXMPItem(avifEncoderData * data, const avi
 }
 
 // Same as avifImageCopy() but pads the dstImage with border pixel values to reach dstWidth and dstHeight.
-// Returns NULL in case of AVIF_RESULT_OUT_OF_MEMORY error.
+// Returns NULL if a memory allocation failed.
 static avifImage * avifImageCopyAndPad(const avifImage * srcImage, uint32_t dstWidth, uint32_t dstHeight)
 {
     avifImage * dstImage = avifImageCreateEmpty();

--- a/src/write.c
+++ b/src/write.c
@@ -304,7 +304,9 @@ static void avifEncoderDataDestroy(avifEncoderData * data)
         avifRWDataFree(&item->metadataPayload);
         avifArrayDestroy(&item->mdatFixups);
     }
-    avifImageDestroy(data->imageMetadata);
+    if (data->imageMetadata) {
+        avifImageDestroy(data->imageMetadata);
+    }
     avifArrayDestroy(&data->items);
     avifArrayDestroy(&data->frames);
     avifFree(data);
@@ -434,8 +436,12 @@ avifEncoder * avifEncoderCreate(void)
 
 void avifEncoderDestroy(avifEncoder * encoder)
 {
-    avifCodecSpecificOptionsDestroy(encoder->csOptions);
-    avifEncoderDataDestroy(encoder->data);
+    if (encoder->csOptions) {
+        avifCodecSpecificOptionsDestroy(encoder->csOptions);
+    }
+    if (encoder->data) {
+        avifEncoderDataDestroy(encoder->data);
+    }
     avifFree(encoder);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,11 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifgridapitest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifgridapitest COMMAND avifgridapitest)
 
+    add_executable(avifimagetest gtest/avifimagetest.cc)
+    target_link_libraries(avifimagetest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
+    target_include_directories(avifimagetest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifimagetest COMMAND avifimagetest)
+
     add_library(avifincrtest_helpers OBJECT gtest/avifincrtest_helpers.cc)
     target_link_libraries(avifincrtest_helpers avif ${AVIF_PLATFORM_LIBRARIES} ${GTEST_LIBRARIES})
     target_include_directories(avifincrtest_helpers PUBLIC ${GTEST_INCLUDE_DIRS})

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -151,7 +151,7 @@ int main(int argc, char * argv[])
 
                         avifImage * image = avifImageCreate(dim, dim, yuvDepth, AVIF_PIXEL_FORMAT_YUV444);
                         if (!image) {
-                            fprintf(stderr, "Out of memory\n");
+                            printf("ERROR: Out of memory\n");
                             return 1;
                         }
                         image->colorPrimaries = cicp->cp;
@@ -303,7 +303,7 @@ int main(int argc, char * argv[])
 
         avifImage * image = avifImageCreate(originalWidth, originalHeight, 8, AVIF_PIXEL_FORMAT_YUV444);
         if (!image) {
-            fprintf(stderr, "Out of memory\n");
+            printf("ERROR: Out of memory\n");
             return 1;
         }
 

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -150,6 +150,10 @@ int main(int argc, char * argv[])
                         int maxDrift = 0;
 
                         avifImage * image = avifImageCreate(dim, dim, yuvDepth, AVIF_PIXEL_FORMAT_YUV444);
+                        if (!image) {
+                            fprintf(stderr, "Out-of-memory\n");
+                            return 1;
+                        }
                         image->colorPrimaries = cicp->cp;
                         image->transferCharacteristics = cicp->tc;
                         image->matrixCoefficients = cicp->mc;
@@ -298,6 +302,10 @@ int main(int argc, char * argv[])
         avifBool showAllResults = AVIF_TRUE;
 
         avifImage * image = avifImageCreate(originalWidth, originalHeight, 8, AVIF_PIXEL_FORMAT_YUV444);
+        if (!image) {
+            fprintf(stderr, "Out-of-memory\n");
+            return 1;
+        }
 
         for (int yuvDepthIndex = 0; yuvDepthIndex < yuvDepthsCount; ++yuvDepthIndex) {
             uint32_t yuvDepth = yuvDepths[yuvDepthIndex];

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -151,7 +151,7 @@ int main(int argc, char * argv[])
 
                         avifImage * image = avifImageCreate(dim, dim, yuvDepth, AVIF_PIXEL_FORMAT_YUV444);
                         if (!image) {
-                            fprintf(stderr, "Out-of-memory\n");
+                            fprintf(stderr, "Out of memory\n");
                             return 1;
                         }
                         image->colorPrimaries = cicp->cp;
@@ -303,7 +303,7 @@ int main(int argc, char * argv[])
 
         avifImage * image = avifImageCreate(originalWidth, originalHeight, 8, AVIF_PIXEL_FORMAT_YUV444);
         if (!image) {
-            fprintf(stderr, "Out-of-memory\n");
+            fprintf(stderr, "Out of memory\n");
             return 1;
         }
 

--- a/tests/gtest/avifalphapremtest.cc
+++ b/tests/gtest/avifalphapremtest.cc
@@ -33,6 +33,7 @@ TEST(AlphaMultiplyTest, OpaqueIsNoOp) {
 
     // View on YUV (no alpha), to make sure the color values are identical.
     testutil::AvifImagePtr no_alpha(avifImageCreateEmpty(), avifImageDestroy);
+    ASSERT_NE(no_alpha, nullptr);
     const avifCropRect rect = {0, 0, opaque_alpha->width, opaque_alpha->height};
     ASSERT_EQ(avifImageSetViewRect(no_alpha.get(), opaque_alpha.get(), &rect),
               AVIF_RESULT_OK);

--- a/tests/gtest/avifchangesettingtest.cc
+++ b/tests/gtest/avifchangesettingtest.cc
@@ -33,15 +33,20 @@ void TestEncodeDecode(avifCodecChoice codec,
   encoder->timescale = 1;
 
   for (const auto& option : init_cs_options) {
-    avifEncoderSetCodecSpecificOption(encoder.get(), option.first.c_str(),
-                                      option.second.c_str());
+    ASSERT_EQ(avifEncoderSetCodecSpecificOption(
+                  encoder.get(), option.first.c_str(), option.second.c_str()),
+              AVIF_RESULT_OK);
   }
 
   if (use_cq) {
     encoder->minQuantizer = 0;
     encoder->maxQuantizer = 63;
-    avifEncoderSetCodecSpecificOption(encoder.get(), "end-usage", "q");
-    avifEncoderSetCodecSpecificOption(encoder.get(), "cq-level", "63");
+    ASSERT_EQ(
+        avifEncoderSetCodecSpecificOption(encoder.get(), "end-usage", "q"),
+        AVIF_RESULT_OK);
+    ASSERT_EQ(
+        avifEncoderSetCodecSpecificOption(encoder.get(), "cq-level", "63"),
+        AVIF_RESULT_OK);
   } else {
     encoder->minQuantizer = 63;
     encoder->maxQuantizer = 63;
@@ -52,7 +57,8 @@ void TestEncodeDecode(avifCodecChoice codec,
             AVIF_RESULT_OK);
 
   if (use_cq) {
-    avifEncoderSetCodecSpecificOption(encoder.get(), "cq-level", "0");
+    ASSERT_EQ(avifEncoderSetCodecSpecificOption(encoder.get(), "cq-level", "0"),
+              AVIF_RESULT_OK);
   } else {
     encoder->minQuantizer = 0;
     encoder->maxQuantizer = 0;

--- a/tests/gtest/avifimagetest.cc
+++ b/tests/gtest/avifimagetest.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <cstdint>

--- a/tests/gtest/avifimagetest.cc
+++ b/tests/gtest/avifimagetest.cc
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <cstdint>
+#include <limits>
+
+#include "avif/avif.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+TEST(AvifImageTest, CreateEmpty) {
+  testutil::AvifImagePtr empty(avifImageCreateEmpty(), avifImageDestroy);
+  EXPECT_NE(empty, nullptr);
+}
+
+bool IsValidAvifImageCreate(uint32_t width, uint32_t height, uint32_t depth,
+                            avifPixelFormat format) {
+  testutil::AvifImagePtr image(avifImageCreate(width, height, depth, format),
+                               avifImageDestroy);
+  return image != nullptr;
+}
+
+TEST(AvifImageTest, Create) {
+  EXPECT_TRUE(IsValidAvifImageCreate(0, 0, 0, AVIF_PIXEL_FORMAT_NONE));
+  EXPECT_TRUE(
+      IsValidAvifImageCreate(1, 1, /*depth=*/1, AVIF_PIXEL_FORMAT_NONE));
+  EXPECT_TRUE(
+      IsValidAvifImageCreate(64, 64, /*depth=*/8, AVIF_PIXEL_FORMAT_NONE));
+  EXPECT_TRUE(IsValidAvifImageCreate(std::numeric_limits<uint32_t>::max(),
+                                     std::numeric_limits<uint32_t>::max(),
+                                     /*depth=*/16, AVIF_PIXEL_FORMAT_NONE));
+}
+
+TEST(AvifImageTest, Invalid) {
+  EXPECT_FALSE(IsValidAvifImageCreate(0, 0, 0, AVIF_PIXEL_FORMAT_COUNT));
+  EXPECT_FALSE(
+      IsValidAvifImageCreate(0, 0, /*depth=*/17, AVIF_PIXEL_FORMAT_YUV400));
+}
+
+}  // namespace
+}  // namespace libavif

--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -132,6 +132,7 @@ void ConvertWholeRange(int rgb_depth, int yuv_depth, avifRGBFormat rgb_format,
   static constexpr int height = 4;
   std::unique_ptr<avifImage, decltype(&avifImageDestroy)> yuv(
       avifImageCreate(width, height, yuv_depth, yuv_format), avifImageDestroy);
+  ASSERT_NE(yuv, nullptr);
   yuv->matrixCoefficients = matrix_coefficients;
   yuv->yuvRange = yuv_range;
   testutil::AvifRgbImage src_rgb(yuv.get(), rgb_depth, rgb_format);
@@ -249,6 +250,7 @@ void ConvertWholeBuffer(int rgb_depth, int yuv_depth, avifRGBFormat rgb_format,
       std::unique_ptr<avifImage, decltype(&avifImageDestroy)> yuv(
           avifImageCreate(width, height, yuv_depth, yuv_format),
           avifImageDestroy);
+      ASSERT_NE(yuv, nullptr);
       yuv->matrixCoefficients = matrix_coefficients;
       yuv->yuvRange = yuv_range;
       testutil::AvifRgbImage src_rgb(yuv.get(), rgb_depth, rgb_format);


### PR DESCRIPTION
The goal is to remove the abort() call from avifAlloc() once all libavif functions check potential out-of-memory errors.

Bug: https://github.com/AOMediaCodec/libavif/issues/820