### PR TITLE
Add support for threaded YUV to RGB conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ to the avifImage struct. The repetitionCount member was added to the avifEncoder
 and avifDecoder structs. The quality and qualityAlpha members were added to the
 avifEncoder struct. Check that functions returning pointers do not return NULL
 before accessing those pointers. Check the return value of
-avifEncoderSetCodecSpecificOption().
+avifEncoderSetCodecSpecificOption(). The maxThreads member was added to the
+avifRGBImage struct.
 
 ### Added
 * Add STATIC library target avif_internal to allow tests to access functions
@@ -26,6 +27,7 @@ avifEncoderSetCodecSpecificOption().
   initialized to the default values.
 * Add the public API function avifImageIsOpaque() in avif.h.
 * Add experimental API for progressive AVIF encoding.
+* Add API for multi-threaded YUV to RGB color conversion.
 
 ### Changed
 * Exif and XMP metadata is exported to PNG and JPEG files by default,

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -665,6 +665,9 @@ typedef struct avifRGBImage
                           // the alpha bits as if they were all 1.
     avifBool alphaPremultiplied; // indicates if RGB value is pre-multiplied by alpha. Default: false
     avifBool isFloat; // indicates if RGBA values are in half float (f16) format. Valid only when depth == 16. Default: false
+    int maxThreads; // Number of threads to be used for the YUV to RGB conversion. Note that this value is ignored for RGB to YUV
+                    // conversion. Setting this to zero has the same effect as setting it to one. Negative values are invalid.
+                    // Default: 1.
 
     uint8_t * pixels;
     uint32_t rowBytes;

--- a/src/avif.c
+++ b/src/avif.c
@@ -550,6 +550,7 @@ void avifRGBImageSetDefaults(avifRGBImage * rgb, const avifImage * image)
                                           // setting this to match image->alphaPremultiplied or forcing this to true
                                           // after calling avifRGBImageSetDefaults(),
     rgb->isFloat = AVIF_FALSE;
+    rgb->maxThreads = 1;
 }
 
 void avifRGBImageAllocatePixels(avifRGBImage * rgb)

--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -11,6 +11,7 @@
 #include "gtest/gtest.h"
 
 using ::testing::Combine;
+using ::testing::Range;
 using ::testing::Values;
 using ::testing::ValuesIn;
 
@@ -733,6 +734,105 @@ INSTANTIATE_TEST_SUITE_P(
             /*rgb_step=*/Values(3),  // way faster and 99% similar to rgb_step=1
             /*max_abs_average_diff=*/Values(10.),
             /*min_psnr=*/Values(10.)));
+
+// Converts YUV pixels to RGB using one thread and multiple threads and checks
+// whether the results of both are identical.
+class YUVToRGBThreadingTest
+    : public testing::TestWithParam<std::tuple<
+          /*rgb_depth=*/int, /*yuv_depth=*/int,
+          /*width=*/int, /*height=*/int, avifRGBFormat, avifPixelFormat,
+          /*threads=*/int, /*avoidLibYUV=*/bool, avifChromaUpsampling>> {};
+
+TEST_P(YUVToRGBThreadingTest, TestIdentical) {
+  const int rgb_depth = std::get<0>(GetParam());
+  const int yuv_depth = std::get<1>(GetParam());
+  const int width = std::get<2>(GetParam());
+  const int height = std::get<3>(GetParam());
+  const avifRGBFormat rgb_format = std::get<4>(GetParam());
+  const avifPixelFormat yuv_format = std::get<5>(GetParam());
+  const int maxThreads = std::get<6>(GetParam());
+  const bool avoidLibYUV = std::get<7>(GetParam());
+  const avifChromaUpsampling chromaUpsampling = std::get<8>(GetParam());
+
+  if (rgb_depth > 8 && rgb_format == AVIF_RGB_FORMAT_RGB_565) {
+    return;
+  }
+
+  testutil::AvifImagePtr yuv(
+      avifImageCreate(width, height, yuv_depth, yuv_format), avifImageDestroy);
+  ASSERT_NE(yuv, nullptr);
+  yuv->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
+  yuv->yuvRange = AVIF_RANGE_FULL;
+
+  // Fill YUV planes with random values.
+  srand(0xAABBCCDD);
+  const int yuv_max = (1 << yuv_depth);
+  ASSERT_EQ(avifImageAllocatePlanes(yuv.get(), AVIF_PLANES_YUV),
+            AVIF_RESULT_OK);
+  avifPixelFormatInfo pixel_format_info;
+  avifGetPixelFormatInfo(yuv_format, &pixel_format_info);
+  const int plane_count = pixel_format_info.monochrome ? 1 : 3;
+  for (int plane = 0; plane < plane_count; ++plane) {
+    uint8_t* row = avifImagePlane(yuv.get(), plane);
+    for (uint32_t y = 0; y < avifImagePlaneHeight(yuv.get(), plane);
+         ++y, row += yuv.get()->yuvRowBytes[plane]) {
+      for (uint32_t x = 0; x < avifImagePlaneWidth(yuv.get(), plane); ++x) {
+        if (yuv_depth == 8) {
+          row[x] = (uint8_t)(rand() % yuv_max);
+        } else {
+          ((uint16_t*)row)[x] = (uint16_t)(rand() % yuv_max);
+        }
+      }
+    }
+  }
+
+  // Convert to RGB with 1 thread.
+  testutil::AvifRgbImage rgb(yuv.get(), rgb_depth, rgb_format);
+  rgb.avoidLibYUV = avoidLibYUV;
+  rgb.chromaUpsampling = chromaUpsampling;
+  ASSERT_EQ(avifImageYUVToRGB(yuv.get(), &rgb), AVIF_RESULT_OK);
+
+  // Convert to RGB with multiple threads.
+  testutil::AvifRgbImage rgb_threaded(yuv.get(), rgb_depth, rgb_format);
+  rgb_threaded.avoidLibYUV = avoidLibYUV;
+  rgb_threaded.chromaUpsampling = chromaUpsampling;
+  rgb_threaded.maxThreads = maxThreads;
+  ASSERT_EQ(avifImageYUVToRGB(yuv.get(), &rgb_threaded), AVIF_RESULT_OK);
+
+  EXPECT_TRUE(testutil::AreImagesEqual(rgb, rgb_threaded));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    YUVToRGBThreadingTestInstance, YUVToRGBThreadingTest,
+    Combine(/*rgb_depth=*/Values(8, 16),
+            /*yuv_depth=*/Values(8, 10),
+            /*width=*/Values(1, 2, 127, 200),
+            /*height=*/Values(1, 2, 127, 200),
+            Values(AVIF_RGB_FORMAT_RGB, AVIF_RGB_FORMAT_ARGB),
+            Range(AVIF_PIXEL_FORMAT_YUV444, AVIF_PIXEL_FORMAT_COUNT),
+            // Test an odd and even number for threads. Not adding all possible
+            // thread values to keep the number of test instances low.
+            /*threads=*/Values(2, 7),
+            /*avoidLibYUV=*/Values(true, false),
+            Values(AVIF_CHROMA_UPSAMPLING_FASTEST,
+                   AVIF_CHROMA_UPSAMPLING_BILINEAR)));
+
+// This will generate a large number of test instances and hence it is disabled
+// by default. It can be run manually if necessary.
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_ExhaustiveYUVToRGBThreadingTestInstance, YUVToRGBThreadingTest,
+    Combine(/*rgb_depth=*/Values(8, 10, 12, 16),
+            /*yuv_depth=*/Values(8, 10, 12),
+            /*width=*/Values(1, 2, 127, 200),
+            /*height=*/Values(1, 2, 127, 200),
+            Range(AVIF_RGB_FORMAT_RGB, AVIF_RGB_FORMAT_COUNT),
+            Range(AVIF_PIXEL_FORMAT_YUV444, AVIF_PIXEL_FORMAT_COUNT),
+            /*threads=*/Range(0, 9),
+            /*avoidLibYUV=*/Values(true, false),
+            Values(AVIF_CHROMA_UPSAMPLING_AUTOMATIC,
+                   AVIF_CHROMA_UPSAMPLING_FASTEST,
+                   AVIF_CHROMA_UPSAMPLING_NEAREST,
+                   AVIF_CHROMA_UPSAMPLING_BILINEAR)));
 
 }  // namespace
 }  // namespace libavif

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -200,6 +200,26 @@ bool AreImagesEqual(const avifImage& image1, const avifImage& image2,
          AreByteSequencesEqual(image1.xmp, image2.xmp);
 }
 
+bool AreImagesEqual(const avifRGBImage& image1, const avifRGBImage& image2) {
+  if (image1.width != image2.width || image1.height != image2.height ||
+      image1.depth != image2.depth || image1.format != image2.format ||
+      image1.alphaPremultiplied != image2.alphaPremultiplied ||
+      image1.isFloat != image2.isFloat) {
+    return false;
+  }
+  const uint8_t* row1 = image1.pixels;
+  const uint8_t* row2 = image2.pixels;
+  const unsigned int row_width = image1.width * avifRGBImagePixelSize(&image1);
+  for (unsigned int y = 0; y < image1.height; ++y) {
+    if (!std::equal(row1, row1 + row_width, row2)) {
+      return false;
+    }
+    row1 += image1.rowBytes;
+    row2 += image2.rowBytes;
+  }
+  return true;
+}
+
 void CopyImageSamples(const avifImage& from, avifImage* to) {
   assert(from.width == to->width);
   assert(from.height == to->height);

--- a/tests/gtest/aviftest_helpers.h
+++ b/tests/gtest/aviftest_helpers.h
@@ -73,6 +73,9 @@ bool AreByteSequencesEqual(const avifRWData& data1, const avifRWData& data2);
 bool AreImagesEqual(const avifImage& image1, const avifImage& image2,
                     bool ignore_alpha = false);
 
+// Returns true if both images have the same features and pixel values.
+bool AreImagesEqual(const avifRGBImage& image1, const avifRGBImage& image2);
+
 //------------------------------------------------------------------------------
 // Shorter versions of libavif functions
 


### PR DESCRIPTION
Add a new function avifImageYUVToRGBThreaded which takes a maxThreads parameter and potentially uses up to that many threads to parallelize the conversion.

If there are n jobs, each job works on a portion of the image in parallel (each job will work on an image of size
width x (height / 4)).

Microbenchmarking shows that the function scales almost linearly with the number of threads on larger images (2k or above). For smaller images, performance is either neutral or slightly better.