### PR TITLE
Add avifIOStats.quality and qualityAlpha

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -818,8 +818,13 @@ typedef uint32_t avifStrictFlags;
 // Useful stats related to a read/write
 typedef struct avifIOStats
 {
+    // Size in bytes of the AV1 image item or track data containing color samples.
     size_t colorOBUSize;
+    // Size in bytes of the AV1 image item or track data containing alpha samples.
     size_t alphaOBUSize;
+    // Final quality settings used at encoding. Undefined at decoding.
+    int quality;
+    int qualityAlpha;
 } avifIOStats;
 
 struct avifDecoderData;

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -188,6 +188,10 @@ avifBool avifDimensionsTooLarge(uint32_t width, uint32_t height, uint32_t imageS
 // unit tests.
 void avifSetTileConfiguration(int threads, uint32_t width, uint32_t height, int * tileRowsLog2, int * tileColsLog2);
 
+// Mapping between quantizer and quality.
+int avifQualityToQuantizer(int quality, int minQuantizer, int maxQuantizer);
+int avifQuantizerToQuality(int quantizer);
+
 // ---------------------------------------------------------------------------
 // Scaling
 

--- a/src/read.c
+++ b/src/read.c
@@ -3748,9 +3748,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             }
         }
 
-        decoder->ioStats.colorOBUSize = colorItem->size;
-        decoder->ioStats.alphaOBUSize = alphaItem ? alphaItem->size : 0;
-
         decoder->image->width = colorItem->width;
         decoder->image->height = colorItem->height;
         decoder->alphaPresent = (alphaItem != NULL);
@@ -3776,6 +3773,12 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             if (!sample->size) {
                 // Every sample must have some data
                 return AVIF_RESULT_BMFF_PARSE_FAILED;
+            }
+
+            if (tile->input->alpha) {
+                decoder->ioStats.alphaOBUSize += sample->size;
+            } else {
+                decoder->ioStats.colorOBUSize += sample->size;
             }
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,11 @@ if(AVIF_ENABLE_GTEST)
     target_link_libraries(avifincrtest aviftest_helpers avifincrtest_helpers)
     add_test(NAME avifincrtest COMMAND avifincrtest ${CMAKE_CURRENT_SOURCE_DIR}/data/)
 
+    add_executable(avifiostatstest gtest/avifiostatstest.cc)
+    target_link_libraries(avifiostatstest avif_internal aviftest_helpers ${GTEST_LIBRARIES})
+    target_include_directories(avifiostatstest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifiostatstest COMMAND avifiostatstest ${CMAKE_CURRENT_SOURCE_DIR}/data/)
+
     add_executable(avifmetadatatest gtest/avifmetadatatest.cc)
     target_link_libraries(avifmetadatatest aviftest_helpers ${GTEST_LIBRARIES})
     target_include_directories(avifmetadatatest PRIVATE ${GTEST_INCLUDE_DIRS})
@@ -127,6 +132,11 @@ if(AVIF_ENABLE_GTEST)
     target_link_libraries(avifprogressivetest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avifprogressivetest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifprogressivetest COMMAND avifprogressivetest)
+
+    add_executable(avifqualitytest gtest/avifqualitytest.cc)
+    target_link_libraries(avifqualitytest avif_internal aviftest_helpers ${GTEST_BOTH_LIBRARIES})
+    target_include_directories(avifqualitytest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifqualitytest COMMAND avifqualitytest)
 
     add_executable(avifreadimagetest gtest/avifreadimagetest.cc)
     target_link_libraries(avifreadimagetest aviftest_helpers ${GTEST_LIBRARIES})

--- a/tests/gtest/avifiostatstest.cc
+++ b/tests/gtest/avifiostatstest.cc
@@ -1,0 +1,184 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <array>
+
+#include "avif/avif.h"
+#include "avif/internal.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+// Used to pass the data folder path to the GoogleTest suites.
+const char* data_path = nullptr;
+
+//------------------------------------------------------------------------------
+
+bool GetIoStatsFromEncode(avifIOStats& encoder_io_stats, int quality,
+                          int qualityAlpha, bool translucent,
+                          int num_frames = 1, bool encode_as_grid = false) {
+  testutil::AvifImagePtr image =
+      testutil::ReadImage(data_path, "paris_exif_xmp_icc.jpg");
+  AVIF_CHECK(image != nullptr);
+  if (translucent) {
+    // Make up some alpha from luma.
+    image->alphaPlane = image->yuvPlanes[AVIF_CHAN_Y];
+    image->alphaRowBytes = image->yuvRowBytes[AVIF_CHAN_Y];
+    AVIF_CHECK(!image->imageOwnsAlphaPlane);
+  }
+
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  AVIF_CHECK(encoder != nullptr);
+  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->quality = quality;
+  encoder->qualityAlpha = qualityAlpha;
+  for (int frame = 0; frame < num_frames; ++frame) {
+    if (encode_as_grid) {
+      const avifCropRect left_rect{0, 0, image->width / 2, image->height};
+      testutil::AvifImagePtr left_cell(avifImageCreateEmpty(),
+                                       avifImageDestroy);
+      AVIF_CHECK(avifImageSetViewRect(left_cell.get(), image.get(),
+                                      &left_rect) == AVIF_RESULT_OK);
+      const avifCropRect right_rect{image->width / 2, 0, image->width / 2,
+                                    image->height};
+      testutil::AvifImagePtr right_cell(avifImageCreateEmpty(),
+                                        avifImageDestroy);
+      AVIF_CHECK(avifImageSetViewRect(right_cell.get(), image.get(),
+                                      &right_rect) == AVIF_RESULT_OK);
+      const std::array<avifImage*, 2> pointers{left_cell.get(),
+                                               right_cell.get()};
+      AVIF_CHECK(avifEncoderAddImageGrid(encoder.get(), /*gridCols=*/2,
+                                         /*gridRows=*/1, pointers.data(),
+                                         AVIF_ADD_IMAGE_FLAG_NONE) ==
+                 AVIF_RESULT_OK);
+    } else {
+      AVIF_CHECK(avifEncoderAddImage(encoder.get(), image.get(),
+                                     /*durationInTimescales=*/1,
+                                     AVIF_ADD_IMAGE_FLAG_NONE) ==
+                 AVIF_RESULT_OK);
+    }
+
+    // Watermark each frame.
+    image->yuvPlanes[AVIF_CHAN_Y][0] =
+        (image->yuvPlanes[AVIF_CHAN_Y][0] + 1u) % 256u;
+  }
+
+  testutil::AvifRwData encoded;
+  AVIF_CHECK(avifEncoderFinish(encoder.get(), &encoded) == AVIF_RESULT_OK);
+  encoder_io_stats = encoder->ioStats;
+
+  // Make sure decoding gives the same stats.
+  testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  AVIF_CHECK(decoder != nullptr);
+  AVIF_CHECK(avifDecoderSetIOMemory(decoder.get(), encoded.data,
+                                    encoded.size) == AVIF_RESULT_OK);
+  AVIF_CHECK(avifDecoderParse(decoder.get()) == AVIF_RESULT_OK);
+  EXPECT_EQ(decoder->ioStats.colorOBUSize, encoder_io_stats.colorOBUSize);
+  EXPECT_EQ(decoder->ioStats.alphaOBUSize, encoder_io_stats.alphaOBUSize);
+  return true;
+}
+
+//------------------------------------------------------------------------------
+
+TEST(IoStatsTest, ColorObuSize) {
+  avifIOStats io_stats;
+  ASSERT_TRUE(GetIoStatsFromEncode(io_stats, AVIF_QUALITY_DEFAULT,
+                                   AVIF_QUALITY_DEFAULT,
+                                   /*translucent=*/false));
+  EXPECT_GT(io_stats.colorOBUSize, 500u);
+  EXPECT_EQ(io_stats.alphaOBUSize, 0u);
+}
+
+TEST(IoStatsTest, AlphaObuSize) {
+  avifIOStats io_stats;
+  ASSERT_TRUE(GetIoStatsFromEncode(io_stats, AVIF_QUALITY_WORST,
+                                   AVIF_QUALITY_WORST, /*translucent=*/true));
+  EXPECT_GT(io_stats.colorOBUSize, 500u);
+  EXPECT_GT(io_stats.alphaOBUSize, 500u);
+}
+
+// Disabled because segfault happens with some libaom versions (such as 3.5.0)
+// but not others (such as 3.6.0). TODO(yguyon): Find the commit that fixed it.
+TEST(DISABLED_IoStatsTest, AnimationObuSize) {
+  avifIOStats io_stats;
+  ASSERT_TRUE(GetIoStatsFromEncode(io_stats, AVIF_QUALITY_LOSSLESS,
+                                   AVIF_QUALITY_LOSSLESS,
+                                   /*translucent=*/true));
+
+  avifIOStats io_stats_grid;
+  ASSERT_TRUE(GetIoStatsFromEncode(io_stats_grid, AVIF_QUALITY_LOSSLESS,
+                                   AVIF_QUALITY_LOSSLESS, /*translucent=*/true,
+                                   /*num_frames=*/3));
+  EXPECT_GT(io_stats_grid.colorOBUSize, io_stats.colorOBUSize);
+  EXPECT_GT(io_stats_grid.alphaOBUSize, io_stats.alphaOBUSize);
+}
+
+TEST(IoStatsTest, GridObuSize) {
+  avifIOStats io_stats;
+  ASSERT_TRUE(GetIoStatsFromEncode(io_stats, AVIF_QUALITY_BEST,
+                                   AVIF_QUALITY_BEST, /*translucent=*/true));
+
+  avifIOStats io_stats_grid;
+  ASSERT_TRUE(GetIoStatsFromEncode(io_stats_grid, AVIF_QUALITY_BEST,
+                                   AVIF_QUALITY_BEST, /*translucent=*/true,
+                                   /*num_frames=*/1, /*encode_as_grid=*/true));
+  EXPECT_GT(io_stats_grid.colorOBUSize, io_stats.colorOBUSize / 2);
+  EXPECT_LT(io_stats_grid.colorOBUSize, io_stats.colorOBUSize * 3 / 2);
+  EXPECT_GT(io_stats_grid.alphaOBUSize, io_stats.alphaOBUSize / 2);
+  EXPECT_LT(io_stats_grid.alphaOBUSize, io_stats.alphaOBUSize * 3 / 2);
+}
+
+TEST(IoStatsTest, GridAnimation) {
+  avifIOStats io_stats;
+  // Animated grids are not allowed.
+  ASSERT_FALSE(GetIoStatsFromEncode(io_stats, AVIF_QUALITY_BEST,
+                                    AVIF_QUALITY_BEST, /*translucent=*/false,
+                                    /*num_frames=*/3, /*encode_as_grid=*/true));
+}
+
+//------------------------------------------------------------------------------
+
+TEST(IoStatsTest, Quality) {
+  avifIOStats io_stats;
+  ASSERT_TRUE(GetIoStatsFromEncode(io_stats, AVIF_QUALITY_DEFAULT,
+                                   AVIF_QUALITY_DEFAULT,
+                                   /*translucent=*/false));
+  ASSERT_GT(io_stats.quality, AVIF_QUALITY_WORST);
+  ASSERT_LT(io_stats.quality, AVIF_QUALITY_BEST);
+  ASSERT_EQ(io_stats.qualityAlpha, AVIF_QUALITY_DEFAULT);
+}
+
+TEST(IoStatsTest, QualityWorstAlphaBest) {
+  avifIOStats io_stats;
+  ASSERT_TRUE(GetIoStatsFromEncode(io_stats, AVIF_QUALITY_WORST,
+                                   AVIF_QUALITY_BEST, /*translucent=*/true));
+  ASSERT_EQ(io_stats.quality, AVIF_QUALITY_WORST);
+  ASSERT_EQ(io_stats.qualityAlpha, AVIF_QUALITY_BEST);
+}
+
+TEST(IoStatsTest, Quality42) {
+  avifIOStats io_stats;
+  ASSERT_TRUE(GetIoStatsFromEncode(io_stats, 42, AVIF_QUALITY_DEFAULT,
+                                   /*translucent=*/false));
+  // Quality 42 may be equivalent to quality 41 or 43 quantizer-wise.
+  ASSERT_NEAR(io_stats.quality, 42, 1.0);
+}
+
+//------------------------------------------------------------------------------
+
+}  // namespace
+}  // namespace libavif
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "There must be exactly one argument containing the path to "
+                 "the test data folder"
+              << std::endl;
+    return 1;
+  }
+  libavif::data_path = argv[1];
+  return RUN_ALL_TESTS();
+}

--- a/tests/gtest/avifiostatstest.cc
+++ b/tests/gtest/avifiostatstest.cc
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <array>
+#include <iostream>
+#include <ostream>
 
 #include "avif/avif.h"
 #include "avif/internal.h"
@@ -36,19 +38,19 @@ bool GetIoStatsFromEncode(avifIOStats& encoder_io_stats, int quality,
   encoder->qualityAlpha = qualityAlpha;
   for (int frame = 0; frame < num_frames; ++frame) {
     if (encode_as_grid) {
-      const avifCropRect left_rect{0, 0, image->width / 2, image->height};
+      const avifCropRect left_rect = {0, 0, image->width / 2, image->height};
       testutil::AvifImagePtr left_cell(avifImageCreateEmpty(),
                                        avifImageDestroy);
       AVIF_CHECK(avifImageSetViewRect(left_cell.get(), image.get(),
                                       &left_rect) == AVIF_RESULT_OK);
-      const avifCropRect right_rect{image->width / 2, 0, image->width / 2,
-                                    image->height};
+      const avifCropRect right_rect = {image->width / 2, 0, image->width / 2,
+                                       image->height};
       testutil::AvifImagePtr right_cell(avifImageCreateEmpty(),
                                         avifImageDestroy);
       AVIF_CHECK(avifImageSetViewRect(right_cell.get(), image.get(),
                                       &right_rect) == AVIF_RESULT_OK);
-      const std::array<avifImage*, 2> pointers{left_cell.get(),
-                                               right_cell.get()};
+      const std::array<avifImage*, 2> pointers = {left_cell.get(),
+                                                  right_cell.get()};
       AVIF_CHECK(avifEncoderAddImageGrid(encoder.get(), /*gridCols=*/2,
                                          /*gridRows=*/1, pointers.data(),
                                          AVIF_ADD_IMAGE_FLAG_NONE) ==

--- a/tests/gtest/avifqualitytest.cc
+++ b/tests/gtest/avifqualitytest.cc
@@ -1,0 +1,91 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+#include "avif/internal.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+TEST(QualityTest, ToQuantizer) {
+  int previous_quantizer = AVIF_QUANTIZER_WORST_QUALITY;
+  for (int quality = AVIF_QUALITY_WORST; quality <= AVIF_QUALITY_BEST;
+       ++quality) {
+    const int quantizer = avifQualityToQuantizer(
+        quality, /*minQuantizer=*/AVIF_QUANTIZER_BEST_QUALITY,
+        /*maxQuantizer=*/AVIF_QUANTIZER_BEST_QUALITY);
+    EXPECT_GE(quantizer, AVIF_QUANTIZER_BEST_QUALITY);
+    EXPECT_LE(quantizer, AVIF_QUANTIZER_WORST_QUALITY);
+
+    // Roundtrip. There are more quality values than quantizers so some
+    // collisions are expected.
+    EXPECT_NEAR(avifQuantizerToQuality(quantizer), quality, 1.0);
+
+    // minQuantizer and maxQuantizer have no impact with an explicit quality.
+    EXPECT_EQ(quantizer,
+              avifQualityToQuantizer(quality, AVIF_QUANTIZER_WORST_QUALITY,
+                                     AVIF_QUANTIZER_WORST_QUALITY));
+
+    EXPECT_LE(quantizer, previous_quantizer);
+    previous_quantizer = quantizer;
+  }
+}
+
+TEST(QualityTest, DefaultToQuantizer) {
+  for (int min_quantizer = AVIF_QUANTIZER_BEST_QUALITY;
+       min_quantizer <= AVIF_QUANTIZER_WORST_QUALITY; ++min_quantizer) {
+    for (int max_quantizer = AVIF_QUANTIZER_BEST_QUALITY;
+         max_quantizer <= AVIF_QUANTIZER_WORST_QUALITY; ++max_quantizer) {
+      const int quantizer = avifQualityToQuantizer(
+          AVIF_QUALITY_DEFAULT, min_quantizer, max_quantizer);
+      EXPECT_GE(quantizer, AVIF_QUANTIZER_BEST_QUALITY);
+      EXPECT_LE(quantizer, AVIF_QUANTIZER_WORST_QUALITY);
+    }
+  }
+}
+
+TEST(QualityTest, FromQuantizer) {
+  for (int quantizer = AVIF_QUANTIZER_BEST_QUALITY;
+       quantizer <= AVIF_QUANTIZER_WORST_QUALITY; ++quantizer) {
+    const int quality = avifQuantizerToQuality(quantizer);
+    EXPECT_GE(quantizer, AVIF_QUALITY_WORST);
+    EXPECT_LE(quantizer, AVIF_QUALITY_BEST);
+
+    // Roundtrip.
+    EXPECT_EQ(quantizer,
+              avifQualityToQuantizer(quality, AVIF_QUANTIZER_WORST_QUALITY,
+                                     AVIF_QUANTIZER_BEST_QUALITY));
+  }
+}
+
+TEST(QualityTest, WorstBest) {
+  EXPECT_EQ(
+      avifQualityToQuantizer(AVIF_QUALITY_WORST, AVIF_QUANTIZER_WORST_QUALITY,
+                             AVIF_QUANTIZER_WORST_QUALITY),
+      AVIF_QUANTIZER_WORST_QUALITY);
+  EXPECT_EQ(
+      avifQualityToQuantizer(AVIF_QUALITY_BEST, AVIF_QUANTIZER_BEST_QUALITY,
+                             AVIF_QUANTIZER_BEST_QUALITY),
+      AVIF_QUANTIZER_BEST_QUALITY);
+
+  EXPECT_EQ(avifQuantizerToQuality(AVIF_QUANTIZER_WORST_QUALITY),
+            AVIF_QUALITY_WORST);
+  EXPECT_EQ(avifQuantizerToQuality(AVIF_QUANTIZER_BEST_QUALITY),
+            AVIF_QUALITY_BEST);
+}
+
+TEST(QualityTest, DefaultWorstBest) {
+  EXPECT_EQ(
+      avifQualityToQuantizer(AVIF_QUALITY_DEFAULT, AVIF_QUANTIZER_WORST_QUALITY,
+                             AVIF_QUANTIZER_WORST_QUALITY),
+      AVIF_QUANTIZER_WORST_QUALITY);
+  EXPECT_EQ(
+      avifQualityToQuantizer(AVIF_QUALITY_DEFAULT, AVIF_QUANTIZER_BEST_QUALITY,
+                             AVIF_QUANTIZER_BEST_QUALITY),
+      AVIF_QUANTIZER_BEST_QUALITY);
+}
+
+}  // namespace
+}  // namespace libavif


### PR DESCRIPTION
Move avifQualityToQuantizer to internal.h.
Add avifQuantizerToQuality() to internal.h.
Add avifqualitytest.cc.

Fix ioStats.colorOBUSize and ioStats.alphaOBUSize at decoding.
Add avifiostatstest.cc.