### PR TITLE
Skip avifPixelFormatInfo.chromaShift if monochrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ List of incompatible ABI changes in this release:
 * avifEncoderSetCodecSpecificOption() now returns avifResult instead of void to
   report memory allocation failures.
 * At decoding, avifIOStats now returns the same values as at encoding.
+* avifGetPixelFormatInfo() now returns 0 for chromaShiftX and chromaShiftY when
+  the format is AVIF_PIXEL_FORMAT_YUV400. Previously it returned 1.
 
 ## [0.11.1] - 2022-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,6 @@ List of incompatible ABI changes in this release:
 * avifEncoderSetCodecSpecificOption() now returns avifResult instead of void to
   report memory allocation failures.
 * At decoding, avifIOStats now returns the same values as at encoding.
-* avifGetPixelFormatInfo() now returns 0 for chromaShiftX and chromaShiftY when
-  the format is AVIF_PIXEL_FORMAT_YUV400. Previously it returned 1.
 
 ## [0.11.1] - 2022-10-19
 

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -574,8 +574,10 @@ static avifBool avifImageSplitGrid(const avifImage * gridSplitImage, uint32_t gr
     uint32_t cellWidth, cellHeight;
     avifPixelFormatInfo formatInfo;
     avifGetPixelFormatInfo(gridSplitImage->yuvFormat, &formatInfo);
-    if (!avifGetBestCellSize("horizontally", gridSplitImage->width, gridCols, formatInfo.chromaShiftX, &cellWidth) ||
-        !avifGetBestCellSize("vertically", gridSplitImage->height, gridRows, formatInfo.chromaShiftY, &cellHeight)) {
+    const avifBool isSubsampledX = !formatInfo.monochrome && formatInfo.chromaShiftX;
+    const avifBool isSubsampledY = !formatInfo.monochrome && formatInfo.chromaShiftY;
+    if (!avifGetBestCellSize("horizontally", gridSplitImage->width, gridCols, isSubsampledX, &cellWidth) ||
+        !avifGetBestCellSize("vertically", gridSplitImage->height, gridRows, isSubsampledY, &cellHeight)) {
         return AVIF_FALSE;
     }
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -236,6 +236,9 @@ typedef struct avifPixelFormatInfo
     int chromaShiftY;
 } avifPixelFormatInfo;
 
+// Returns the avifPixelFormatInfo depending on the avifPixelFormat.
+// info does not need to be zero-initialized. Sets all monochrome, chromaShiftX and
+// chromaShiftY fields to 1 if format is AVIF_PIXEL_FORMAT_YUV400.
 AVIF_API void avifGetPixelFormatInfo(avifPixelFormat format, avifPixelFormatInfo * info);
 
 // ---------------------------------------------------------------------------

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -237,10 +237,11 @@ typedef struct avifPixelFormatInfo
 } avifPixelFormatInfo;
 
 // Returns the avifPixelFormatInfo depending on the avifPixelFormat.
-// The chromaShiftX and chromaShiftY fields should be ignored when monochrome is AVIF_TRUE.
-// The chromaShiftX and chromaShiftY fields are set to 1 if the format is AVIF_PIXEL_FORMAT_YUV400 to allow
+// When monochrome is AVIF_TRUE, chromaShiftX and chromaShiftY are set to 1 according to the AV1 specification but they should be ignored.
+//
+// Note: This function implements the second table on page 119 of the AV1 specification version 1.0.0 with Errata 1.
+// For monochrome 4:0:0, subsampling_x and subsampling are specified as 1 to allow
 // an AV1 implementation that only supports profile 0 to hardcode subsampling_x and subsampling_y to 1.
-// This function implements the second table on page 119 of the AV1 specification version 1.0.0 with Errata 1.
 AVIF_API void avifGetPixelFormatInfo(avifPixelFormat format, avifPixelFormatInfo * info);
 
 // ---------------------------------------------------------------------------

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -237,8 +237,10 @@ typedef struct avifPixelFormatInfo
 } avifPixelFormatInfo;
 
 // Returns the avifPixelFormatInfo depending on the avifPixelFormat.
-// info does not need to be zero-initialized. Sets all monochrome, chromaShiftX and
-// chromaShiftY fields to 1 if format is AVIF_PIXEL_FORMAT_YUV400.
+// The chromaShiftX and chromaShiftY fields should be ignored when monochrome is AVIF_TRUE.
+// The chromaShiftX and chromaShiftY fields are set to 1 if the format is AVIF_PIXEL_FORMAT_YUV400 to allow
+// an AV1 implementation that only supports profile 0 to hardcode subsampling_x and subsampling_y to 1.
+// This function implements the second table on page 119 of the AV1 specification version 1.0.0 with Errata 1.
 AVIF_API void avifGetPixelFormatInfo(avifPixelFormat format, avifPixelFormatInfo * info);
 
 // ---------------------------------------------------------------------------

--- a/src/avif.c
+++ b/src/avif.c
@@ -58,8 +58,8 @@ void avifGetPixelFormatInfo(avifPixelFormat format, avifPixelFormatInfo * info)
 
         case AVIF_PIXEL_FORMAT_YUV400:
             info->monochrome = AVIF_TRUE;
-            // 4:0:0 is stored as monochrome and half chroma subsampling in each dimension in AV1
-            // according to the specification. See sections 5.5.2. and 6.4.2.
+            // 4:0:0 is stored as monochrome and the nonexistent chroma is considered as subsampled in
+            // each dimension according to the AV1 specification. See sections 5.5.2. and 6.4.2.
             info->chromaShiftX = 1;
             info->chromaShiftY = 1;
             break;

--- a/src/avif.c
+++ b/src/avif.c
@@ -58,6 +58,10 @@ void avifGetPixelFormatInfo(avifPixelFormat format, avifPixelFormatInfo * info)
 
         case AVIF_PIXEL_FORMAT_YUV400:
             info->monochrome = AVIF_TRUE;
+            // 4:0:0 is stored as monochrome and half chroma subsampling in each dimension in AV1
+            // according to the specification. See sections 5.5.2. and 6.4.2.
+            info->chromaShiftX = 1;
+            info->chromaShiftY = 1;
             break;
 
         case AVIF_PIXEL_FORMAT_NONE:

--- a/src/avif.c
+++ b/src/avif.c
@@ -58,8 +58,8 @@ void avifGetPixelFormatInfo(avifPixelFormat format, avifPixelFormatInfo * info)
 
         case AVIF_PIXEL_FORMAT_YUV400:
             info->monochrome = AVIF_TRUE;
-            // 4:0:0 is stored as monochrome and the nonexistent chroma is considered as subsampled in
-            // each dimension according to the AV1 specification. See sections 5.5.2. and 6.4.2.
+            // The nonexistent chroma is considered as subsampled in each dimension
+            // according to the AV1 specification. See sections 5.5.2. and 6.4.2.
             info->chromaShiftX = 1;
             info->chromaShiftY = 1;
             break;

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -972,8 +972,9 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             bps = 16;
         }
         aomImage.bps = bps;
-        aomImage.x_chroma_shift = (alpha || codec->internal->formatInfo.monochrome) ? 1 : codec->internal->formatInfo.chromaShiftX;
-        aomImage.y_chroma_shift = (alpha || codec->internal->formatInfo.monochrome) ? 1 : codec->internal->formatInfo.chromaShiftY;
+        // See avifImageCalcAOMFmt(). libaom doesn't have AOM_IMG_FMT_I400, so we use AOM_IMG_FMT_I420 as a substitute for monochrome.
+        aomImage.x_chroma_shift = alpha ? 1 : codec->internal->formatInfo.chromaShiftX;
+        aomImage.y_chroma_shift = alpha ? 1 : codec->internal->formatInfo.chromaShiftY;
     }
 
     avifBool monochromeRequested = AVIF_FALSE;

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -972,7 +972,6 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             bps = 16;
         }
         aomImage.bps = bps;
-        // Monochrome is handled below. Use 4:2:0 for now.
         aomImage.x_chroma_shift = (alpha || codec->internal->formatInfo.monochrome) ? 1 : codec->internal->formatInfo.chromaShiftX;
         aomImage.y_chroma_shift = (alpha || codec->internal->formatInfo.monochrome) ? 1 : codec->internal->formatInfo.chromaShiftY;
     }

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -973,8 +973,8 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
         }
         aomImage.bps = bps;
         // See avifImageCalcAOMFmt(). libaom doesn't have AOM_IMG_FMT_I400, so we use AOM_IMG_FMT_I420 as a substitute for monochrome.
-        aomImage.x_chroma_shift = alpha ? 1 : codec->internal->formatInfo.chromaShiftX;
-        aomImage.y_chroma_shift = alpha ? 1 : codec->internal->formatInfo.chromaShiftY;
+        aomImage.x_chroma_shift = (alpha || codec->internal->formatInfo.monochrome) ? 1 : codec->internal->formatInfo.chromaShiftX;
+        aomImage.y_chroma_shift = (alpha || codec->internal->formatInfo.monochrome) ? 1 : codec->internal->formatInfo.chromaShiftY;
     }
 
     avifBool monochromeRequested = AVIF_FALSE;

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -536,7 +536,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
     assert((alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP) || aPlane);
 
     for (uint32_t j = 0; j < image->height; ++j) {
-        const uint32_t uvJ = j >> state->formatInfo.chromaShiftY;
+        const uint32_t uvJ = j >> (state->formatInfo.monochrome ? 0 : state->formatInfo.chromaShiftY);
         const uint8_t * ptrY8 = &yPlane[j * yRowBytes];
         const uint8_t * ptrU8 = uPlane ? &uPlane[(uvJ * uRowBytes)] : NULL;
         const uint8_t * ptrV8 = vPlane ? &vPlane[(uvJ * vRowBytes)] : NULL;
@@ -551,7 +551,6 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
         uint8_t * ptrB = &rgb->pixels[state->rgbOffsetBytesB + (j * rgb->rowBytes)];
 
         for (uint32_t i = 0; i < image->width; ++i) {
-            uint32_t uvI = i >> state->formatInfo.chromaShiftX;
             float Y, Cb = 0.5f, Cr = 0.5f;
 
             // Calculate Y
@@ -566,6 +565,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
 
             // Calculate Cb and Cr
             if (hasColor) {
+                const uint32_t uvI = i >> state->formatInfo.chromaShiftX;
                 if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
                     uint16_t unormU, unormV;
 

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -536,7 +536,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
     assert((alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP) || aPlane);
 
     for (uint32_t j = 0; j < image->height; ++j) {
-        const uint32_t uvJ = j >> (state->formatInfo.monochrome ? 0 : state->formatInfo.chromaShiftY);
+        const uint32_t uvJ = j >> (hasColor ? state->formatInfo.chromaShiftY : 0);
         const uint8_t * ptrY8 = &yPlane[j * yRowBytes];
         const uint8_t * ptrU8 = uPlane ? &uPlane[(uvJ * uRowBytes)] : NULL;
         const uint8_t * ptrV8 = vPlane ? &vPlane[(uvJ * vRowBytes)] : NULL;

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -536,7 +536,8 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
     assert((alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP) || aPlane);
 
     for (uint32_t j = 0; j < image->height; ++j) {
-        const uint32_t uvJ = j >> (hasColor ? state->formatInfo.chromaShiftY : 0);
+        // uvJ is used only when hasColor is true.
+        const uint32_t uvJ = hasColor ? (j >> state->formatInfo.chromaShiftY) : 0;
         const uint8_t * ptrY8 = &yPlane[j * yRowBytes];
         const uint8_t * ptrU8 = uPlane ? &uPlane[(uvJ * uRowBytes)] : NULL;
         const uint8_t * ptrV8 = vPlane ? &vPlane[(uvJ * vRowBytes)] : NULL;

--- a/src/scale.c
+++ b/src/scale.c
@@ -82,8 +82,10 @@ avifBool avifImageScale(avifImage * image,
     image->imageOwnsAlphaPlane = AVIF_FALSE;
 
     const uint32_t srcWidth = image->width;
-    image->width = dstWidth;
     const uint32_t srcHeight = image->height;
+    const uint32_t srcUVWidth = avifImagePlaneWidth(image, AVIF_CHAN_U);
+    const uint32_t srcUVHeight = avifImagePlaneHeight(image, AVIF_CHAN_U);
+    image->width = dstWidth;
     image->height = dstHeight;
 
     if (srcYUVPlanes[0] || srcAlphaPlane) {
@@ -106,13 +108,6 @@ avifBool avifImageScale(avifImage * image,
             return AVIF_FALSE;
         }
 
-        avifPixelFormatInfo formatInfo;
-        avifGetPixelFormatInfo(image->yuvFormat, &formatInfo);
-        const uint32_t srcUVWidth = (srcWidth + formatInfo.chromaShiftX) >> formatInfo.chromaShiftX;
-        const uint32_t srcUVHeight = (srcHeight + formatInfo.chromaShiftY) >> formatInfo.chromaShiftY;
-        const uint32_t dstUVWidth = (dstWidth + formatInfo.chromaShiftX) >> formatInfo.chromaShiftX;
-        const uint32_t dstUVHeight = (dstHeight + formatInfo.chromaShiftY) >> formatInfo.chromaShiftY;
-
         for (int i = 0; i < AVIF_PLANE_COUNT_YUV; ++i) {
             if (!srcYUVPlanes[i]) {
                 continue;
@@ -120,8 +115,8 @@ avifBool avifImageScale(avifImage * image,
 
             const uint32_t srcW = (i == AVIF_CHAN_Y) ? srcWidth : srcUVWidth;
             const uint32_t srcH = (i == AVIF_CHAN_Y) ? srcHeight : srcUVHeight;
-            const uint32_t dstW = (i == AVIF_CHAN_Y) ? dstWidth : dstUVWidth;
-            const uint32_t dstH = (i == AVIF_CHAN_Y) ? dstHeight : dstUVHeight;
+            const uint32_t dstW = avifImagePlaneWidth(image, AVIF_CHAN_U);
+            const uint32_t dstH = avifImagePlaneHeight(image, AVIF_CHAN_U);
             if (image->depth > 8) {
                 uint16_t * const srcPlane = (uint16_t *)srcYUVPlanes[i];
                 const uint32_t srcStride = srcYUVRowBytes[i] / 2;

--- a/src/scale.c
+++ b/src/scale.c
@@ -115,8 +115,8 @@ avifBool avifImageScale(avifImage * image,
 
             const uint32_t srcW = (i == AVIF_CHAN_Y) ? srcWidth : srcUVWidth;
             const uint32_t srcH = (i == AVIF_CHAN_Y) ? srcHeight : srcUVHeight;
-            const uint32_t dstW = avifImagePlaneWidth(image, AVIF_CHAN_U);
-            const uint32_t dstH = avifImagePlaneHeight(image, AVIF_CHAN_U);
+            const uint32_t dstW = avifImagePlaneWidth(image, i);
+            const uint32_t dstH = avifImagePlaneHeight(image, i);
             if (image->depth > 8) {
                 uint16_t * const srcPlane = (uint16_t *)srcYUVPlanes[i];
                 const uint32_t srcStride = srcYUVRowBytes[i] / 2;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,11 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifrgbtoyuvtest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifrgbtoyuvtest COMMAND avifrgbtoyuvtest)
 
+    add_executable(avifscaletest gtest/avifscaletest.cc)
+    target_link_libraries(avifscaletest avif_internal aviftest_helpers ${GTEST_LIBRARIES})
+    target_include_directories(avifscaletest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifscaletest COMMAND avifscaletest ${CMAKE_CURRENT_SOURCE_DIR}/data/)
+
     add_executable(aviftilingtest gtest/aviftilingtest.cc)
     target_link_libraries(aviftilingtest avif_internal ${GTEST_BOTH_LIBRARIES})
     target_include_directories(aviftilingtest PRIVATE ${GTEST_INCLUDE_DIRS})

--- a/tests/gtest/avifscaletest.cc
+++ b/tests/gtest/avifscaletest.cc
@@ -56,13 +56,15 @@ TEST_P(ScaleTest, Roundtrip) {
   const uint32_t scaled_height = static_cast<uint32_t>(image->height * 2.14);
   const uint32_t kImageSizeLimit = std::numeric_limits<uint32_t>::max();
   const uint32_t kImageDimensionLimit = std::numeric_limits<uint32_t>::max();
-  avifDiagnostics diag = {0};
+  avifDiagnostics diag;
+  avifDiagnosticsClearError(&diag);
   ASSERT_TRUE(avifImageScale(scaled_image.get(), scaled_width, scaled_height,
                              kImageSizeLimit, kImageDimensionLimit, &diag))
       << diag.error;
   EXPECT_EQ(scaled_image->width, scaled_width);
   EXPECT_EQ(scaled_image->height, scaled_height);
 
+  avifDiagnosticsClearError(&diag);
   ASSERT_TRUE(avifImageScale(scaled_image.get(), image->width, image->height,
                              kImageSizeLimit, kImageDimensionLimit, &diag))
       << diag.error;

--- a/tests/gtest/avifscaletest.cc
+++ b/tests/gtest/avifscaletest.cc
@@ -1,0 +1,93 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <cstdint>
+#include <limits>
+
+#include "avif/avif.h"
+#include "avif/internal.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+using testing::Combine;
+using testing::Values;
+
+namespace libavif {
+namespace {
+
+// Used to pass the data folder path to the GoogleTest suites.
+const char* data_path = nullptr;
+
+//------------------------------------------------------------------------------
+
+class ScaleTest
+    : public testing::TestWithParam<
+          std::tuple</*bit_depth=*/int, /*yuv_format=*/avifPixelFormat,
+                     /*create_alpha=*/bool>> {};
+
+TEST_P(ScaleTest, Roundtrip) {
+  const int bit_depth = std::get<0>(GetParam());
+  const avifPixelFormat yuv_format = std::get<1>(GetParam());
+  const bool create_alpha = std::get<2>(GetParam());
+
+  const bool kIgnoreMetadata = true;
+  const testutil::AvifImagePtr image =
+      testutil::ReadImage(data_path, "paris_exif_xmp_icc.jpg", yuv_format,
+                          bit_depth, AVIF_CHROMA_DOWNSAMPLING_BEST_QUALITY,
+                          kIgnoreMetadata, kIgnoreMetadata, kIgnoreMetadata);
+  ASSERT_NE(image, nullptr);
+  if (create_alpha && !image->alphaPlane) {
+    // Simulate alpha plane with a view on luma.
+    image->alphaPlane = image->yuvPlanes[AVIF_CHAN_Y];
+    image->alphaRowBytes = image->yuvRowBytes[AVIF_CHAN_Y];
+    image->imageOwnsAlphaPlane = false;
+  }
+
+  testutil::AvifImagePtr scaled_image(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(scaled_image, nullptr);
+  ASSERT_EQ(avifImageCopy(scaled_image.get(), image.get(), AVIF_PLANES_ALL),
+            AVIF_RESULT_OK);
+
+  const uint32_t scaled_width = static_cast<uint32_t>(image->width * 0.9);
+  const uint32_t scaled_height = static_cast<uint32_t>(image->height * 2.14);
+  const uint32_t kImageSizeLimit = std::numeric_limits<uint32_t>::max();
+  const uint32_t kImageDimensionLimit = std::numeric_limits<uint32_t>::max();
+  avifDiagnostics diag = {0};
+  ASSERT_TRUE(avifImageScale(scaled_image.get(), scaled_width, scaled_height,
+                             kImageSizeLimit, kImageDimensionLimit, &diag));
+  EXPECT_EQ(scaled_image->width, scaled_width);
+  EXPECT_EQ(scaled_image->height, scaled_height);
+
+  ASSERT_TRUE(avifImageScale(scaled_image.get(), image->width, image->height,
+                             kImageSizeLimit, kImageDimensionLimit, &diag));
+  EXPECT_EQ(scaled_image->width, image->width);
+  EXPECT_EQ(scaled_image->height, image->height);
+
+  const double psnr = testutil::GetPsnr(*image, *scaled_image);
+  EXPECT_GT(psnr, 30.0);
+  EXPECT_LT(psnr, 45.0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Some, ScaleTest,
+    Combine(/*bit_depth=*/Values(8, 10, 12),
+            Values(AVIF_PIXEL_FORMAT_YUV444, AVIF_PIXEL_FORMAT_YUV422,
+                   AVIF_PIXEL_FORMAT_YUV420, AVIF_PIXEL_FORMAT_YUV400),
+            /*create_alpha=*/Values(true, false)));
+
+//------------------------------------------------------------------------------
+
+}  // namespace
+}  // namespace libavif
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "There must be exactly one argument containing the path to "
+                 "the test data folder"
+              << std::endl;
+    return 1;
+  }
+  libavif::data_path = argv[1];
+  return RUN_ALL_TESTS();
+}

--- a/tests/gtest/avifscaletest.cc
+++ b/tests/gtest/avifscaletest.cc
@@ -26,6 +26,10 @@ class ScaleTest
                      /*create_alpha=*/bool>> {};
 
 TEST_P(ScaleTest, Roundtrip) {
+  if (avifLibYUVVersion() == 0) {
+    GTEST_SKIP() << "libyuv not available, skip test.";
+  }
+
   const int bit_depth = std::get<0>(GetParam());
   const avifPixelFormat yuv_format = std::get<1>(GetParam());
   const bool create_alpha = std::get<2>(GetParam());

--- a/tests/gtest/avifscaletest.cc
+++ b/tests/gtest/avifscaletest.cc
@@ -54,12 +54,14 @@ TEST_P(ScaleTest, Roundtrip) {
   const uint32_t kImageDimensionLimit = std::numeric_limits<uint32_t>::max();
   avifDiagnostics diag = {0};
   ASSERT_TRUE(avifImageScale(scaled_image.get(), scaled_width, scaled_height,
-                             kImageSizeLimit, kImageDimensionLimit, &diag));
+                             kImageSizeLimit, kImageDimensionLimit, &diag))
+      << diag.error;
   EXPECT_EQ(scaled_image->width, scaled_width);
   EXPECT_EQ(scaled_image->height, scaled_height);
 
   ASSERT_TRUE(avifImageScale(scaled_image.get(), image->width, image->height,
-                             kImageSizeLimit, kImageDimensionLimit, &diag));
+                             kImageSizeLimit, kImageDimensionLimit, &diag))
+      << diag.error;
   EXPECT_EQ(scaled_image->width, image->width);
   EXPECT_EQ(scaled_image->height, image->height);
 

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -5,10 +5,13 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "avif/avif.h"
+#include "avifpng.h"
 #include "avifutil.h"
 
 namespace libavif {
@@ -200,6 +203,100 @@ bool AreImagesEqual(const avifImage& image1, const avifImage& image2,
          AreByteSequencesEqual(image1.xmp, image2.xmp);
 }
 
+namespace {
+
+template <typename Sample>
+uint64_t SquaredDiffSum(const Sample* samples1, const Sample* samples2,
+                        uint32_t num_samples) {
+  uint64_t sum = 0;
+  for (uint32_t i = 0; i < num_samples; ++i) {
+    const int32_t diff = static_cast<int32_t>(samples1[i]) - samples2[i];
+    sum += diff * diff;
+  }
+  return sum;
+}
+
+}  // namespace
+
+double GetPsnr(const avifImage& image1, const avifImage& image2,
+               bool ignore_alpha) {
+  if (image1.width != image2.width || image1.height != image2.height ||
+      image1.depth != image2.depth || image1.yuvFormat != image2.yuvFormat ||
+      image1.yuvRange != image2.yuvRange) {
+    return -1;
+  }
+  assert(image1.width * image1.height > 0);
+
+  uint64_t squared_diff_sum = 0;
+  uint32_t num_samples = 0;
+  const uint32_t max_sample_value = (1 << image1.depth) - 1;
+  for (avifChannelIndex c :
+       {AVIF_CHAN_Y, AVIF_CHAN_U, AVIF_CHAN_V, AVIF_CHAN_A}) {
+    if (ignore_alpha && c == AVIF_CHAN_A) continue;
+
+    const uint32_t plane_width = std::max(avifImagePlaneWidth(&image1, c),
+                                          avifImagePlaneWidth(&image2, c));
+    const uint32_t plane_height = std::max(avifImagePlaneHeight(&image1, c),
+                                           avifImagePlaneHeight(&image2, c));
+    if (plane_width == 0 || plane_height == 0) continue;
+
+    const uint8_t* row1 = avifImagePlane(&image1, c);
+    const uint8_t* row2 = avifImagePlane(&image2, c);
+    if (!row1 != !row2 && c != AVIF_CHAN_A) {
+      return -1;
+    }
+    uint32_t row_bytes1 = avifImagePlaneRowBytes(&image1, c);
+    uint32_t row_bytes2 = avifImagePlaneRowBytes(&image2, c);
+
+    // Consider missing alpha planes as samples set to the maximum value.
+    std::vector<uint8_t> opaque_alpha_samples;
+    if (!row1 != !row2) {
+      opaque_alpha_samples.resize(std::max(row_bytes1, row_bytes2));
+      if (avifImageUsesU16(&image1)) {
+        uint16_t* opaque_alpha_samples_16b =
+            reinterpret_cast<uint16_t*>(opaque_alpha_samples.data());
+        std::fill(opaque_alpha_samples_16b,
+                  opaque_alpha_samples_16b + plane_width,
+                  static_cast<int16_t>(max_sample_value));
+      } else {
+        std::fill(opaque_alpha_samples.begin(), opaque_alpha_samples.end(),
+                  255);
+      }
+      if (!row1) {
+        row1 = opaque_alpha_samples.data();
+        row_bytes1 = 0;
+      } else {
+        row2 = opaque_alpha_samples.data();
+        row_bytes2 = 0;
+      }
+    }
+
+    for (uint32_t y = 0; y < plane_height; ++y) {
+      if (avifImageUsesU16(&image1)) {
+        squared_diff_sum += SquaredDiffSum(
+            reinterpret_cast<const uint16_t*>(row1),
+            reinterpret_cast<const uint16_t*>(row2), plane_width);
+      } else {
+        squared_diff_sum += SquaredDiffSum(row1, row2, plane_width);
+      }
+      row1 += row_bytes1;
+      row2 += row_bytes2;
+      num_samples += plane_width;
+    }
+  }
+
+  if (squared_diff_sum == 0) {
+    return 99.0;
+  }
+  const double normalized_error =
+      squared_diff_sum /
+      (static_cast<double>(num_samples) * max_sample_value * max_sample_value);
+  if (normalized_error <= std::numeric_limits<double>::epsilon()) {
+    return 98.99;  // Very small distortion but not lossless.
+  }
+  return std::min(-10 * std::log10(normalized_error), 98.99);
+}
+
 bool AreImagesEqual(const avifRGBImage& image1, const avifRGBImage& image2) {
   if (image1.width != image2.width || image1.height != image2.height ||
       image1.depth != image2.depth || image1.format != image2.format ||
@@ -237,6 +334,12 @@ AvifImagePtr ReadImage(const char* folder_path, const char* file_name,
     return {nullptr, nullptr};
   }
   return image;
+}
+
+bool WriteImage(const avifImage* image, const char* file_path) {
+  return avifPNGWrite(file_path, image, /*requestedDepth=*/0,
+                      AVIF_CHROMA_UPSAMPLING_BEST_QUALITY,
+                      /*compressionLevel=*/0);
 }
 
 AvifRwData Encode(const avifImage* image, int speed) {

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -260,7 +260,7 @@ double GetPsnr(const avifImage& image1, const avifImage& image2,
                   static_cast<int16_t>(max_sample_value));
       } else {
         std::fill(opaque_alpha_samples.begin(), opaque_alpha_samples.end(),
-                  255);
+                  uint8_t{255});
       }
       if (!row1) {
         row1 = opaque_alpha_samples.data();

--- a/tests/gtest/aviftest_helpers.h
+++ b/tests/gtest/aviftest_helpers.h
@@ -72,6 +72,12 @@ bool AreImagesEqual(const avifImage& image1, const avifImage& image2,
 // Returns true if both images have the same features and pixel values.
 bool AreImagesEqual(const avifRGBImage& image1, const avifRGBImage& image2);
 
+// Returns the Peak Signal-to-Noise Ratio of image1 compared to image2.
+// A value of 99dB means all samples are exactly the same.
+// A negative value means that the input images cannot be compared.
+double GetPsnr(const avifImage& image1, const avifImage& image2,
+               bool ignore_alpha = false);
+
 //------------------------------------------------------------------------------
 // Shorter versions of libavif functions
 
@@ -85,6 +91,8 @@ AvifImagePtr ReadImage(
         AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC,
     avifBool ignore_icc = false, avifBool ignore_exif = false,
     avifBool ignore_xmp = false);
+// Convenient wrapper around avifPNGWrite() for debugging purposes.
+bool WriteImage(const avifImage* image, const char* file_path);
 
 // Encodes the image with default parameters.
 // Returns an empty payload in case of error.

--- a/tests/test_cmd_grid.sh
+++ b/tests/test_cmd_grid.sh
@@ -66,6 +66,10 @@ pushd ${TMP_DIR}
   "${AVIFENC}" -s 8 "${INPUT_PNG}" --grid 2x2 -o "${ENCODED_FILE_2x2}"
   "${AVIFDEC}" "${ENCODED_FILE_2x2}" "${DECODED_FILE_2x2}"
 
+  echo "Testing monochrome grid with odd width"
+  "${AVIFENC}" -s 8 "${INPUT_PNG}" --grid 2x2 --yuv 400 -o "${ENCODED_FILE_2x2}"
+  "${AVIFDEC}" "${ENCODED_FILE_2x2}" "${DECODED_FILE_2x2}"
+
   echo "Testing max grid"
   "${AVIFENC}" -s 8 "${INPUT_PNG}" --grid 7x5 -o "${ENCODED_FILE_7x5}"
   "${AVIFDEC}" "${ENCODED_FILE_7x5}" "${DECODED_FILE_7x5}"

--- a/tests/test_cmd_grid.sh
+++ b/tests/test_cmd_grid.sh
@@ -66,7 +66,7 @@ pushd ${TMP_DIR}
   "${AVIFENC}" -s 8 "${INPUT_PNG}" --grid 2x2 -o "${ENCODED_FILE_2x2}"
   "${AVIFDEC}" "${ENCODED_FILE_2x2}" "${DECODED_FILE_2x2}"
 
-  echo "Testing monochrome grid with odd width"
+  echo "Testing monochrome grid with odd width (403 px)"
   "${AVIFENC}" -s 8 "${INPUT_PNG}" --grid 2x2 --yuv 400 -o "${ENCODED_FILE_2x2}"
   "${AVIFDEC}" "${ENCODED_FILE_2x2}" "${DECODED_FILE_2x2}"
 


### PR DESCRIPTION
Also change avifGetPixelFormatInfo() so that chromaShiftX and chromaShiftY are 0 if monochrome is set. It should not be accessed anyway but setting chroma to half the size of luma makes little sense when there is no chroma. The following comment was removed in 6ad6a2b:
  // ignored, but some codecs might use 420 for mono