### PR TITLE
ext/libyuv: Update to 464c51a0 (version 1864)

### DIFF
--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -17,7 +17,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout 4a3c79cb
+git checkout 464c51a0
 
 mkdir build
 cd build


### PR DESCRIPTION
This includes a fix for some 32-bit neon conversions when compiled with -flto (crbug.com/1424089). Note that libavif is NOT compiled with that flag by default. So this PR is just a precaution.