### PR TITLE
avifgridapitest: Use the correct pointer for comparison

### DIFF
--- a/tests/gtest/avifgridapitest.cc
+++ b/tests/gtest/avifgridapitest.cc
@@ -103,7 +103,7 @@ avifResult EncodeDecodeGrid(const std::vector<std::vector<Cell>>& cell_rows,
     rect.y += rect.height;
   }
   if ((rect.x != image->width) || (rect.y != image->height) ||
-      !testutil::AreImagesEqual(*image, *image)) {
+      !testutil::AreImagesEqual(*image, *grid)) {
     return AVIF_RESULT_UNKNOWN_ERROR;
   }
   return AVIF_RESULT_OK;


### PR DESCRIPTION
The decoded image has to be compared against the source image. I think it is a typo and it originated in 90548bb1: https://github.com/AOMediaCodec/libavif/pull/1143