### PR TITLE
Add "IWYU pragma: export" to avif/internal.h

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -4,7 +4,7 @@
 #ifndef AVIF_INTERNAL_H
 #define AVIF_INTERNAL_H
 
-#include "avif/avif.h"
+#include "avif/avif.h" // IWYU pragma: export
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The pragma says avif/internal.h is to be considered the provider of any symbol from avif/avif.h. See
https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-export

Our current policy is as follows:
1. If a file uses only public libavif symbols, include avif/avif.h.
2. If a file uses not only public but also private libavif symbols,
   include avif/internal.h only.