### PR TITLE
Add top-level read-only permissions

### DIFF
--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -1,5 +1,9 @@
 name: CI
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   build-android-jni:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -6,6 +6,10 @@
 
 name: CI
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   build-disable-gtest:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -3,6 +3,10 @@
 
 name: CI
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   build-shared-installed:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -5,6 +5,10 @@
 
 name: CI
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   build-shared-local:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -1,5 +1,9 @@
 name: CI
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   build-static:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,6 +12,10 @@
 
 name: CI
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   build-static:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,9 @@
 name: CI
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,9 @@
 name: CI
 on: [push]
+
+permissions:
+  contents: read
+
 jobs:
   clang-format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - "!**.md"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #1328.

As mentioned in the linked issue, this PR adds top-level read-only permissions to all GitHub workflows. These reduce the likelihood and harm of a supply-chain attack on the project.

I've taken a look at all the Actions used by your workflows and none of them seem to require anything more than `contents: read` permissions. If I've missed something, let me know and I'll quickly patch the PR.