### PR TITLE
Remove const from function parameters

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -113,8 +113,8 @@ typedef struct avifAlphaParams
 
 } avifAlphaParams;
 
-avifBool avifFillAlpha(const avifAlphaParams * const params);
-avifBool avifReformatAlpha(const avifAlphaParams * const params);
+avifBool avifFillAlpha(const avifAlphaParams * params);
+avifBool avifReformatAlpha(const avifAlphaParams * params);
 
 typedef enum avifReformatMode
 {

--- a/src/alpha.c
+++ b/src/alpha.c
@@ -6,7 +6,7 @@
 #include <assert.h>
 #include <string.h>
 
-avifBool avifFillAlpha(const avifAlphaParams * const params)
+avifBool avifFillAlpha(const avifAlphaParams * params)
 {
     if (params->dstDepth > 8) {
         const uint16_t maxChannel = (uint16_t)((1 << params->dstDepth) - 1);
@@ -31,7 +31,7 @@ avifBool avifFillAlpha(const avifAlphaParams * const params)
     return AVIF_TRUE;
 }
 
-avifBool avifReformatAlpha(const avifAlphaParams * const params)
+avifBool avifReformatAlpha(const avifAlphaParams * params)
 {
     const int srcMaxChannel = (1 << params->srcDepth) - 1;
     const int dstMaxChannel = (1 << params->dstDepth) - 1;


### PR DESCRIPTION
Fix the ClangTidy warning "readability-avoid-const-params-in-decls":
  parameter 'params' is const-qualified in the function declaration;
  const-qualification of parameters only has an effect in function
  definitions

Unfortunately in C the const qualification of function parameters in declarations and definitions must match. So we need to remove const from both declarations and definitions.