### PR TITLE
codec_aom: Set g_limit for progressive encoding

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -707,6 +707,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             cfg->kf_max_dist = 0;
         }
         if (encoder->extraLayerCount > 0) {
+            cfg->g_limit = encoder->extraLayerCount + 1;
             // For layered image, disable lagged encoding to always get output
             // frame for each input frame.
             cfg->g_lag_in_frames = 0;


### PR DESCRIPTION
In progressive encoding, the number of frames to encode is the number of layers. Set cfg->g_limit to that number.

It's not clear if setting cfg->g_limit will actually help the libaom encoder, but more information cannot hurt.