### PR TITLE
avifenc.c: Fix typo in "Encoding frame 1" message

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -726,7 +726,8 @@ static avifBool avifEncodeImagesFixedQuality(const avifSettings * settings,
 
         uint64_t firstDurationInTimescales = firstFile->duration ? firstFile->duration : settings->outputTiming.duration;
         if (input->useStdin || (input->filesCount > 1)) {
-            printf(" * Encoding frame 1 [%" PRIu64 "/%" PRIu64 " ts]: %s\n",
+            printf(" * Encoding frame %d [%" PRIu64 "/%" PRIu64 " ts]: %s\n",
+                   0,
                    firstDurationInTimescales,
                    settings->outputTiming.timescale,
                    firstFile->filename);


### PR DESCRIPTION
The first frame is frame 0, not frame 1.

Note: I use the %d format specifier and pass 0 as the argument so that the compiler can pool this printf string with the string of the other printf statement.