### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send us a [private vulnerability report](https://github.com/AOMediaCodec/libavif/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+We ask that you give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #1341.

As described in the issue, a security policy allows security researchers to responsibly disclose any vulnerabilities they might find.

This version has both an email (a placeholder, since I couldn't find a relevant one) and GitHub's private reporting feature (beta). I've also added a mention of 90 days to remediation, which is pretty standard.

Let me know if you'd rather use just one form of disclosure or change the remediation timeline or... anything you need!