### PR TITLE
Add avifbasictest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,11 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifalphapremtest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifalphapremtest COMMAND avifalphapremtest)
 
+    add_executable(avifbasictest gtest/avifbasictest.cc)
+    target_link_libraries(avifbasictest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
+    target_include_directories(avifbasictest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifbasictest COMMAND avifbasictest)
+
     add_executable(avifchangesettingtest gtest/avifchangesettingtest.cc)
     target_link_libraries(avifchangesettingtest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avifchangesettingtest PRIVATE ${GTEST_INCLUDE_DIRS})

--- a/tests/gtest/avifbasictest.cc
+++ b/tests/gtest/avifbasictest.cc
@@ -1,0 +1,44 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+TEST(BasicTest, EncodeDecode) {
+  testutil::AvifImagePtr image =
+      testutil::CreateImage(/*width=*/12, /*height=*/34, /*depth=*/8,
+                            AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_ALL);
+  ASSERT_NE(image, nullptr);
+  testutil::FillImageGradient(image.get());
+
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  testutil::AvifRwData encoded;
+  avifResult result = avifEncoderWrite(encoder.get(), image.get(), &encoded);
+  ASSERT_EQ(result, AVIF_RESULT_OK) << avifResultToString(result);
+
+  testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
+                                 encoded.size);
+  ASSERT_EQ(result, AVIF_RESULT_OK) << avifResultToString(result);
+
+  // Verify that the input and decoded images are close.
+  ASSERT_GT(testutil::GetPsnr(*image, *decoded), 40.0);
+
+  // Uncomment the following to save the encoded image as an AVIF file.
+  //  std::ofstream("/tmp/avifbasictest.avif", std::ios::binary)
+  //      .write(reinterpret_cast<char*>(encoded.data), encoded.size);
+
+  // Uncomment the following to save the decoded image as a PNG file.
+  //  testutil::WriteImage(decoded.get(), "/tmp/avifbasictest.png");
+}
+
+}  // namespace
+}  // namespace libavif


### PR DESCRIPTION
Simple test that can be used as a demo or as a convenient starter template for other tests. Also useful for debugging untested or general issues.