### PR TITLE
avifDecoderDecodeTiles Use `tile` in non-grid path

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -4003,7 +4003,8 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
         } else {
             // Non-grid path. Just steal the planes from the only "tile".
             assert(info->tileCount == 1);
-            avifImage * src = decoder->data->tiles.tile[info->firstTileIndex].image;
+            assert(tileIndex == 0);
+            avifImage * src = tile->image;
             if ((decoder->image->width != src->width) || (decoder->image->height != src->height) ||
                 (decoder->image->depth != src->depth)) {
                 if (tile->input->alpha) {


### PR DESCRIPTION
The non-grid path of avifDecoderDecodeTiles() uses the expression
    decoder->data->tiles.tile[info->firstTileIndex]

I believe that is the variable `tile` (dereferenced). This requires tileIndex == 0, so add an assertion for that. That assertion can be removed in the future.