### PR TITLE
Track which images steal planes from codecs

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -373,6 +373,11 @@ typedef struct avifCodec
     avifCodecEncodeImageFunc encodeImage;
     avifCodecEncodeFinishFunc encodeFinish;
     avifCodecDestroyInternalFunc destroyInternal;
+
+    // IMPORTANT: The tracking of stealers assumes the images (decoder->image and tile->image)
+    // outlive the codecs.
+    avifImage * yuvStealer;
+    avifImage * alphaStealer;
 } avifCodec;
 
 avifCodec * avifCodecCreate(avifCodecChoice choice, avifCodecFlags requiredFlags);

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -219,6 +219,7 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
             image->yuvRowBytes[yuvPlane] = codec->internal->image->stride[yuvPlane];
         }
         image->imageOwnsYUVPlanes = AVIF_FALSE;
+        codec->yuvStealer = image;
     } else {
         // Alpha plane - ensure image is correct size, fill color
 
@@ -238,6 +239,7 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
         image->alphaRowBytes = codec->internal->image->stride[0];
         *isLimitedRangeAlpha = (codec->internal->image->range == AOM_CR_STUDIO_RANGE);
         image->imageOwnsAlphaPlane = AVIF_FALSE;
+        codec->alphaStealer = image;
     }
 
     return AVIF_TRUE;

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -178,6 +178,7 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
         image->transferCharacteristics = (avifTransferCharacteristics)dav1dImage->seq_hdr->trc;
         image->matrixCoefficients = (avifMatrixCoefficients)dav1dImage->seq_hdr->mtrx;
 
+        // Steal the pointers from the decoder's image directly
         avifImageFreePlanes(image, AVIF_PLANES_YUV);
         int yuvPlaneCount = (yuvFormat == AVIF_PIXEL_FORMAT_YUV400) ? 1 : 3;
         for (int yuvPlane = 0; yuvPlane < yuvPlaneCount; ++yuvPlane) {
@@ -185,6 +186,7 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
             image->yuvRowBytes[yuvPlane] = (uint32_t)dav1dImage->stride[(yuvPlane == AVIF_CHAN_Y) ? 0 : 1];
         }
         image->imageOwnsYUVPlanes = AVIF_FALSE;
+        codec->yuvStealer = image;
     } else {
         // Alpha plane - ensure image is correct size, fill color
 
@@ -204,6 +206,7 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
         image->alphaRowBytes = (uint32_t)dav1dImage->stride[0];
         *isLimitedRangeAlpha = (codec->internal->colorRange == AVIF_RANGE_LIMITED);
         image->imageOwnsAlphaPlane = AVIF_FALSE;
+        codec->alphaStealer = image;
     }
     return AVIF_TRUE;
 }

--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -125,6 +125,7 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec,
             image->yuvRowBytes[yuvPlane] = gav1Image->stride[yuvPlane];
         }
         image->imageOwnsYUVPlanes = AVIF_FALSE;
+        codec->yuvStealer = image;
     } else {
         // Alpha plane - ensure image is correct size, fill color
 
@@ -144,6 +145,7 @@ static avifBool gav1CodecGetNextImage(struct avifCodec * codec,
         image->alphaRowBytes = gav1Image->stride[0];
         *isLimitedRangeAlpha = (codec->internal->colorRange == AVIF_RANGE_LIMITED);
         image->imageOwnsAlphaPlane = AVIF_FALSE;
+        codec->alphaStealer = image;
     }
 
     return AVIF_TRUE;


### PR DESCRIPTION
When we call codec->getNextImage() or destroy a codec, the planes stolen from the codec will become invalid. Track which images steal planes from a codec, and set their planes to NULL before we call codec->getNextImage() or after we destroy the codec.

This change would have caused avifgridapitest and avifincrtest to fail and caught b/278249578.