### PR TITLE
Mark WriteImage() as Do not remove

### DIFF
--- a/tests/gtest/avifimagetest.cc
+++ b/tests/gtest/avifimagetest.cc
@@ -40,5 +40,15 @@ TEST(AvifImageTest, Invalid) {
       IsValidAvifImageCreate(0, 0, /*depth=*/17, AVIF_PIXEL_FORMAT_YUV400));
 }
 
+TEST(AvifImageTest, WriteImage) {
+  testutil::AvifImagePtr image =
+      testutil::CreateImage(/*width=*/12, /*height=*/34, /*depth=*/10,
+                            AVIF_PIXEL_FORMAT_YUV444, AVIF_PLANES_ALL);
+  ASSERT_NE(image, nullptr);
+  testutil::FillImageGradient(image.get());
+  ASSERT_TRUE(testutil::WriteImage(
+      image.get(), (testing::TempDir() + "/avifimagetest.png").c_str()));
+}
+
 }  // namespace
 }  // namespace libavif

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -340,9 +341,15 @@ AvifImagePtr ReadImage(const char* folder_path, const char* file_name,
 }
 
 bool WriteImage(const avifImage* image, const char* file_path) {
-  return avifPNGWrite(file_path, image, /*requestedDepth=*/0,
-                      AVIF_CHROMA_UPSAMPLING_BEST_QUALITY,
-                      /*compressionLevel=*/0);
+  if (!image || !file_path) return false;
+  const size_t str_len = std::strlen(file_path);
+  if (str_len >= 4 && !std::strncmp(file_path + str_len - 4, ".png", 4)) {
+    return avifPNGWrite(file_path, image, /*requestedDepth=*/0,
+                        AVIF_CHROMA_UPSAMPLING_BEST_QUALITY,
+                        /*compressionLevel=*/0);
+  }
+  // Other formats are not supported.
+  return false;
 }
 
 AvifRwData Encode(const avifImage* image, int speed) {

--- a/tests/gtest/aviftest_helpers.h
+++ b/tests/gtest/aviftest_helpers.h
@@ -92,6 +92,7 @@ AvifImagePtr ReadImage(
     avifBool ignore_icc = false, avifBool ignore_exif = false,
     avifBool ignore_xmp = false);
 // Convenient wrapper around avifPNGWrite() for debugging purposes.
+// Do not remove.
 bool WriteImage(const avifImage* image, const char* file_path);
 
 // Encodes the image with default parameters.


### PR DESCRIPTION
Only PNG is handled by WriteImage() for now so only save to file paths ending with ".png".
Add coverage of WriteImage() in avifimagetest.cc.