### PR TITLE
android_jni: Use specific files for StillImageTest

### DIFF
--- a/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/AnimatedImageTest.java
+++ b/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/AnimatedImageTest.java
@@ -1,16 +1,12 @@
 package org.aomedia.avif.android;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.aomedia.avif.android.TestUtils.Image;
 
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
-import androidx.test.platform.app.InstrumentationRegistry;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
@@ -24,39 +20,6 @@ import org.junit.runners.Parameterized.Parameters;
 public class AnimatedImageTest {
 
   private static final int AVIF_RESULT_OK = 0;
-
-  private static class Image {
-    public final String filename;
-    public final int width;
-    public final int height;
-    public final int depth;
-    public final boolean alphaPresent;
-    public final int frameCount;
-    public final int repetitionCount;
-    public final double frameDuration;
-    public final int threads;
-
-    public Image(
-        String filename,
-        int width,
-        int height,
-        int depth,
-        boolean alphaPresent,
-        int frameCount,
-        int repetitionCount,
-        double frameDuration,
-        int threads) {
-      this.filename = filename;
-      this.width = width;
-      this.height = height;
-      this.depth = depth;
-      this.alphaPresent = alphaPresent;
-      this.frameCount = frameCount;
-      this.repetitionCount = repetitionCount;
-      this.frameDuration = frameDuration;
-      this.threads = threads;
-    }
-  }
 
   private static final Image[] IMAGES = {
     // Parameter ordering: filename, width, height, depth, alphaPresent, frameCount,
@@ -91,7 +54,7 @@ public class AnimatedImageTest {
 
   @Test
   public void testAnimatedAvifDecode() throws IOException {
-    ByteBuffer buffer = getBuffer();
+    ByteBuffer buffer = TestUtils.getBuffer(ASSET_DIRECTORY, image.filename);
     assertThat(buffer).isNotNull();
     AvifDecoder decoder = AvifDecoder.create(buffer, image.threads);
     assertThat(decoder).isNotNull();
@@ -136,15 +99,5 @@ public class AnimatedImageTest {
     assertThat(AvifDecoder.resultToString(AVIF_RESULT_OK)).isEqualTo("OK");
     // Ensure that the version string starts with "libavif".
     assertThat(AvifDecoder.versionString()).startsWith("libavif");
-  }
-
-  private ByteBuffer getBuffer() throws IOException {
-    Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-    String assetPath = Paths.get(ASSET_DIRECTORY, image.filename).toString();
-    InputStream is = context.getAssets().open(assetPath);
-    ByteBuffer buffer = ByteBuffer.allocateDirect(is.available());
-    Channels.newChannel(is).read(buffer);
-    buffer.rewind();
-    return buffer;
   }
 }

--- a/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/StillImageTest.java
+++ b/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/StillImageTest.java
@@ -1,18 +1,13 @@
 package org.aomedia.avif.android;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.aomedia.avif.android.TestUtils.Image;
 
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
-import androidx.test.platform.app.InstrumentationRegistry;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.aomedia.avif.android.AvifDecoder.Info;
 import org.junit.Test;
@@ -25,18 +20,33 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class StillImageTest {
 
+  private static final Image[] IMAGES = {
+    // Parameter ordering: filename, width, height, depth, alphaPresent, threads.
+    new Image("fox.profile0.10bpc.yuv420.avif", 1204, 800, 10, false, 1),
+    new Image("fox.profile0.10bpc.yuv420.monochrome.avif", 1204, 800, 10, false, 1),
+    new Image("fox.profile0.8bpc.yuv420.avif", 1204, 800, 8, false, 1),
+    new Image("fox.profile0.8bpc.yuv420.monochrome.avif", 1204, 800, 8, false, 1),
+    new Image("fox.profile1.10bpc.yuv444.avif", 1204, 800, 10, false, 1),
+    new Image("fox.profile1.8bpc.yuv444.avif", 1204, 800, 8, false, 1),
+    new Image("fox.profile2.10bpc.yuv422.avif", 1204, 800, 10, false, 1),
+    new Image("fox.profile2.12bpc.yuv420.avif", 1204, 800, 12, false, 1),
+    new Image("fox.profile2.12bpc.yuv420.monochrome.avif", 1204, 800, 12, false, 1),
+    new Image("fox.profile2.12bpc.yuv422.avif", 1204, 800, 12, false, 1),
+    new Image("fox.profile2.12bpc.yuv444.avif", 1204, 800, 12, false, 1),
+    new Image("fox.profile2.8bpc.yuv422.avif", 1204, 800, 8, false, 1)
+  };
+
   private static final String ASSET_DIRECTORY = "avif";
 
   @Parameters
   public static List<Object[]> data() throws IOException {
     ArrayList<Object[]> list = new ArrayList<>();
-    for (String asset : getAssetFiles(ASSET_DIRECTORY)) {
-      String assetPath = Paths.get(ASSET_DIRECTORY, asset).toString();
+    for (Image image : IMAGES) {
       // Test ARGB_8888 for all files.
-      list.add(new Object[] {Config.ARGB_8888, assetPath});
+      list.add(new Object[] {Config.ARGB_8888, image});
       // For 8bpc files, test only RGB_565. For other files, test only RGBA_F16.
-      Config testConfig = assetPath.contains("8bpc") ? Config.RGB_565 : Config.RGBA_F16;
-      list.add(new Object[] {testConfig, assetPath});
+      Config testConfig = (image.depth == 8) ? Config.RGB_565 : Config.RGBA_F16;
+      list.add(new Object[] {testConfig, image});
     }
     return list;
   }
@@ -45,40 +55,20 @@ public class StillImageTest {
   public Bitmap.Config config;
 
   @Parameter(1)
-  public String assetPath;
-
-  @Test
-  public void testIsAvifImageReturnsTrue() throws IOException {
-    ByteBuffer buffer = getBuffer();
-    assertThat(buffer).isNotNull();
-    assertThat(AvifDecoder.isAvifImage(buffer)).isTrue();
-  }
+  public Image image;
 
   @Test
   public void testAvifDecode() throws IOException {
-    ByteBuffer buffer = getBuffer();
+    ByteBuffer buffer = TestUtils.getBuffer(ASSET_DIRECTORY, image.filename);
     assertThat(buffer).isNotNull();
+    assertThat(AvifDecoder.isAvifImage(buffer)).isTrue();
     Info info = new Info();
     assertThat(AvifDecoder.getInfo(buffer, buffer.remaining(), info)).isTrue();
-    assertThat(info.width).isGreaterThan(0);
-    assertThat(info.height).isGreaterThan(0);
-    assertThat(info.depth).isAnyOf(8, 10, 12);
+    assertThat(info.width).isEqualTo(image.width);
+    assertThat(info.height).isEqualTo(image.height);
+    assertThat(info.depth).isEqualTo(image.depth);
     Bitmap bitmap = Bitmap.createBitmap(info.width, info.height, config);
     assertThat(bitmap).isNotNull();
     assertThat(AvifDecoder.decode(buffer, buffer.remaining(), bitmap)).isTrue();
-  }
-
-  private ByteBuffer getBuffer() throws IOException {
-    Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-    InputStream is = context.getAssets().open(assetPath);
-    ByteBuffer buffer = ByteBuffer.allocateDirect(is.available());
-    Channels.newChannel(is).read(buffer);
-    buffer.rewind();
-    return buffer;
-  }
-
-  private static List<String> getAssetFiles(String directoryName) throws IOException {
-    Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-    return Arrays.asList(context.getAssets().list(directoryName));
   }
 }

--- a/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/TestUtils.java
+++ b/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/TestUtils.java
@@ -1,0 +1,73 @@
+package org.aomedia.avif.android;
+
+import android.content.Context;
+import androidx.test.platform.app.InstrumentationRegistry;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.file.Paths;
+
+/** Utility class used by the instrumented tests. */
+public class TestUtils {
+
+  // Utility class. Cannot be instantiated.
+  private TestUtils() {}
+
+  public static class Image {
+    public final String filename;
+    public final int width;
+    public final int height;
+    public final int depth;
+    public final boolean alphaPresent;
+    int frameCount;
+    int repetitionCount;
+    double frameDuration;
+    public final int threads;
+
+    public Image(
+        String filename, int width, int height, int depth, boolean alphaPresent, int threads) {
+      this(
+          filename,
+          width,
+          height,
+          depth,
+          alphaPresent,
+          /* frameCount= */ 0,
+          /* repetitionCount= */ 0,
+          /* frameDuration= */ 0.0,
+          threads);
+    }
+
+    public Image(
+        String filename,
+        int width,
+        int height,
+        int depth,
+        boolean alphaPresent,
+        int frameCount,
+        int repetitionCount,
+        double frameDuration,
+        int threads) {
+      this.filename = filename;
+      this.width = width;
+      this.height = height;
+      this.depth = depth;
+      this.alphaPresent = alphaPresent;
+      this.frameCount = frameCount;
+      this.repetitionCount = repetitionCount;
+      this.frameDuration = frameDuration;
+      this.threads = threads;
+    }
+  }
+
+  public static ByteBuffer getBuffer(String assetDirectory, String filename) throws IOException {
+    Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    String assetPath = Paths.get(assetDirectory, filename).toString();
+    InputStream is = context.getAssets().open(assetPath);
+    ByteBuffer buffer = ByteBuffer.allocateDirect(is.available());
+    Channels.newChannel(is).read(buffer);
+    buffer.rewind();
+    return buffer;
+  }
+}


### PR DESCRIPTION
Instead of iterating over the assets directory, used a fixed set of files. This will let the tests assert for dimensions and depth.  This will also prevent the tests from accidentally passing in case the assets directory is not included correctly.

Also introduce a utility class to refactor some of the common test code.