### PR TITLE
android_jni: Toolchain updates

### DIFF
--- a/.github/workflows/ci-android-emulator-tests.yml
+++ b/.github/workflows/ci-android-emulator-tests.yml
@@ -23,7 +23,8 @@ jobs:
         uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r23b
+          # r25c is the same as 25.2.9519653.
+          ndk-version: r25c
           add-to-path: false
       - name: Setup ninja
         uses: seanmiddleditch/gha-setup-ninja@v3
@@ -46,7 +47,9 @@ jobs:
           working-directory: android_jni
           api-level: 30
           force-avd-creation: false
-          cmake: 3.18.1
-          ndk: 23.2.8568313
+          # This is the same version of cmake that is found in build.gradle.
+          # This will be used to build libavif and the JNI bindings.
+          cmake: 3.22.1
+          ndk: 25.2.9519653
           arch: x86_64
           script: ./gradlew cAT

--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -17,7 +17,8 @@ jobs:
         uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r21e
+          # r25c is the same as 25.2.9519653.
+          ndk-version: r25c
           add-to-path: false
       - name: Setup ninja
         uses: seanmiddleditch/gha-setup-ninja@v3
@@ -39,7 +40,7 @@ jobs:
       - name: Install CMake in the Android SDK
         # This is the same version of cmake that is found in build.gradle. This
         # will be used to build libavif and the JNI bindings.
-        run: sdkmanager "cmake;3.18.1"
+        run: sdkmanager "cmake;3.22.1"
       - name: Build the libavif JNI Wrapper
         working-directory: android_jni
         run: ./gradlew --no-daemon assembleRelease

--- a/android_jni/avifandroidjni/build.gradle
+++ b/android_jni/avifandroidjni/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 android {
+    namespace 'org.aomedia.avif.android'
     compileSdk 30
 
     defaultConfig {
@@ -25,9 +26,7 @@ android {
     }
     externalNativeBuild {
         cmake {
-            // Lowest version of cmake that is available on the Android SDK that
-            // is greater than or equal to 3.13 is 3.18.1.
-            version '3.18.1'
+            version '3.22.1'
             path 'src/main/jni/CMakeLists.txt'
         }
     }

--- a/android_jni/avifandroidjni/src/androidTest/AndroidManifest.xml
+++ b/android_jni/avifandroidjni/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.aomedia.avif.android" android:versionCode="1" android:versionName="1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0">
   <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30"/>
   <application android:label="libavif JNI Test" android:taskAffinity="">
   </application>

--- a/android_jni/avifandroidjni/src/main/AndroidManifest.xml
+++ b/android_jni/avifandroidjni/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.aomedia.avif.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/android_jni/build.gradle
+++ b/android_jni/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.4"
+        classpath "com.android.tools.build:gradle:7.4.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android_jni/gradle/wrapper/gradle-wrapper.properties
+++ b/android_jni/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This commit updates the following:
* cmake 3.18.1 => 3.22.1
  - Avoids the following warning: An old version of CMake is being used that cannot automatically detect compiler attributes.  Compiler identification is being bypassed. Some values may be wrong or missing. Update to CMake 3.19 or newer to use CMake's built-in compiler identification.
* ndk 21/23 -> 25
  - latest stable NDK release
* android gradle plugin 7.0.4 => 7.4.1
  - latest gradle plugin that supports java 11. Also avoid the following warnings: This version only understands SDK XML versions up to 2 but an SDK XML file of version 3 was encountered.
* gradle wrapper 7.0.2 -> 7.5
  - default gradle version used by android gradle plugin 7.4.1.

Also move the package name from AndroidManifest.xml to build.gradle since that the recommended way now [1].

[1] https://developer.android.com/build/configure-app-module#set-namespace