### PR TITLE
ext: Add dav1d_android.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,12 @@ if(AVIF_CODEC_DAV1D)
     set(AVIF_SRCS ${AVIF_SRCS} src/codec_dav1d.c)
 
     if(AVIF_LOCAL_DAV1D)
-        set(LIB_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/src/libdav1d${AVIF_LIBRARY_SUFFIX}")
+        set(AVIF_DAV1D_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build")
+        # If ${ANDROID_ABI} is set, look for the library under that subdirectory.
+        if(DEFINED ANDROID_ABI)
+            set(AVIF_DAV1D_BUILD_DIR "${AVIF_DAV1D_BUILD_DIR}/${ANDROID_ABI}")
+        endif()
+	set(LIB_FILENAME "${AVIF_DAV1D_BUILD_DIR}/src/libdav1d${AVIF_LIBRARY_SUFFIX}")
         if(NOT EXISTS "${LIB_FILENAME}")
             if("${AVIF_LIBRARY_SUFFIX}" STREQUAL ".a")
                 message(FATAL_ERROR "libavif: ${LIB_FILENAME} is missing, bailing out")
@@ -293,8 +298,8 @@ if(AVIF_CODEC_DAV1D)
         endif()
 
         set(AVIF_CODEC_INCLUDES
-            ${AVIF_CODEC_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build"
-            "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include" "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/build/include/dav1d"
+            ${AVIF_CODEC_INCLUDES} "${AVIF_DAV1D_BUILD_DIR}"
+	    "${AVIF_DAV1D_BUILD_DIR}/include" "${AVIF_DAV1D_BUILD_DIR}/include/dav1d"
             "${CMAKE_CURRENT_SOURCE_DIR}/ext/dav1d/include"
         )
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})

--- a/android_jni/README.md
+++ b/android_jni/README.md
@@ -31,13 +31,25 @@ $ export ANDROID_SDK_ROOT="/path/to/android/sdk"
 $ export ANDROID_NDK_HOME="/path/to/android/ndk"
 ```
 
-Step 3 - Checkout and build libgav1
+Step 3 - Checkout and build libgav1 or dav1d
 
 ```
 $ cd ext
 $ ./libgav1_android.sh "${ANDROID_NDK_HOME}"
 $ cd ..
 ```
+
+If you want to use dav1d instead:
+
+```
+$ cd ext
+$ ./dav1d_android.sh "${ANDROID_NDK_HOME}"
+$ cd ..
+```
+
+Update [CMakeLists.txt](avifandroidjni/src/main/jni/CMakeLists.txt) as follows:
+ * Set `AVIF_LOCAL_LIBGAV1` and `AVIF_CODEC_LIBGAV1` to `OFF`.
+ * Set `AVIF_LOCAL_DAV1D` and `AVIF_CODEC_DAV1D` to `ON`.
 
 Step 4 - Build the JNI Wrapper and generate the AAR package
 

--- a/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
+++ b/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
@@ -15,8 +15,14 @@ project(avif_android_jni)
 # To override the variables in the libavif subproject:
 # https://stackoverflow.com/questions/3766740/overriding-a-default-option-value-in-cmake-from-a-parent-cmakelists-txt
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+
+# To disable libgav1, change the following two variables to OFF.
 set(AVIF_LOCAL_LIBGAV1 ON CACHE BOOL "" FORCE)
 set(AVIF_CODEC_LIBGAV1 ON CACHE BOOL "" FORCE)
+
+# To disable dav1d, change the following two variables to ON.
+set(AVIF_LOCAL_DAV1D OFF CACHE BOOL "" FORCE)
+set(AVIF_CODEC_DAV1D OFF CACHE BOOL "" FORCE)
 
 # The current CMake file lives in:
 # $LIBAVIF_ROOT/android_jni/avifandroidjni/src/main/jni.

--- a/ext/dav1d.cmd
+++ b/ext/dav1d.cmd
@@ -8,6 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
+: # When updating the dav1d version, make the same change to dav1d_android.sh.
 git clone -b 1.1.0 --depth 1 https://code.videolan.org/videolan/dav1d.git
 
 cd dav1d

--- a/ext/dav1d_android.sh
+++ b/ext/dav1d_android.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This script will build dav1d for the default ABI targets supported by android.
+# This script only works on linux. You must pass the path to the android NDK as
+# a parameter to this script.
+#
+# Android NDK: https://developer.android.com/ndk/downloads
+#
+# The git tag below is known to work, and will occasionally be updated. Feel
+# free to use a more recent commit.
+
+if [ $# -ne 1 ]; then
+  echo "Usage: ${0} <path_to_android_ndk>"
+  exit 1
+fi
+git clone --depth 1 https://code.videolan.org/videolan/dav1d.git
+cd dav1d
+# TODO(vigneshv): 6afabf8 is the earliest version that contains the crossfiles
+# necessary for Android NDK builds. Replace this with git clone at 1.2.0 (or
+# higher) when dav1d.cmd is updated.
+git checkout 6afabf8
+mkdir build
+cd build
+
+# This only works on linux.
+android_bin="${1}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+
+ABI_LIST=("armeabi-v7a" "arm64-v8a" "x86" "x86_64")
+ARCH_LIST=("arm" "aarch64" "x86" "x86_64")
+for i in "${!ABI_LIST[@]}"; do
+  abi="${ABI_LIST[i]}"
+  mkdir "${abi}"
+  cd "${abi}"
+  PATH=$PATH:${android_bin} meson --default-library=static --buildtype release \
+    --cross-file="../../package/crossfiles/${ARCH_LIST[i]}-android.meson" \
+    -Denable_tools=false -Denable_tests=false ../..
+  PATH=$PATH:${android_bin} ninja
+  cd ..
+done
+
+cd ../..


### PR DESCRIPTION
This allows for the JNI bindings to be compiled with dav1d using the Android NDK. The codec choice can be specified at build time by toggling the variables in jni/CMakeLists.txt.

Fixes issue #1360