### PR TITLE
Remove static for TestUtils.Image in android_jni

### DIFF
--- a/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/AnimatedImageTest.java
+++ b/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/AnimatedImageTest.java
@@ -1,7 +1,6 @@
 package org.aomedia.avif.android;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.aomedia.avif.android.TestUtils.Image;
 
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
@@ -9,6 +8,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import org.aomedia.avif.android.TestUtils.Image;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/StillImageTest.java
+++ b/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/StillImageTest.java
@@ -1,7 +1,6 @@
 package org.aomedia.avif.android;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.aomedia.avif.android.TestUtils.Image;
 
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
@@ -10,6 +9,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import org.aomedia.avif.android.AvifDecoder.Info;
+import org.aomedia.avif.android.TestUtils.Image;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;


### PR DESCRIPTION
See https://google.github.io/styleguide/javaguide.html#s3.3.4-import-class-not-static