### PR TITLE
codec_dav1d.c: Add comment about stealing planes

### DIFF
--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -178,6 +178,7 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
         image->transferCharacteristics = (avifTransferCharacteristics)dav1dImage->seq_hdr->trc;
         image->matrixCoefficients = (avifMatrixCoefficients)dav1dImage->seq_hdr->mtrx;
 
+        // Steal the pointers from the decoder's image directly
         avifImageFreePlanes(image, AVIF_PLANES_YUV);
         int yuvPlaneCount = (yuvFormat == AVIF_PIXEL_FORMAT_YUV400) ? 1 : 3;
         for (int yuvPlane = 0; yuvPlane < yuvPlaneCount; ++yuvPlane) {


### PR DESCRIPTION
Since we steal the planes without using the avifImageStealPlanes() function, a comment helps identify this location when we need to inspect the code that steal planes. All the other codec_xxx.c files (for decoders) have this comment.