### PR TITLE
Fix lossless codec check in avifenc

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -222,7 +222,7 @@ if(AVIF_BUILD_APPS)
     )
 
     if(NOT AVIF_CODEC_AOM OR NOT AVIF_CODEC_AOM_ENCODE)
-        # Only aom encoder supports lossless encoding.
+        # Only aom encoder supports AV1 lossless encoding.
         set_property(TEST test_cmd_animation PROPERTY DISABLED True)
         set_property(TEST test_cmd_lossless PROPERTY DISABLED True)
 
@@ -231,7 +231,7 @@ if(AVIF_BUILD_APPS)
             set_property(TEST test_cmd_metadata PROPERTY DISABLED True)
         endif()
 
-        # Only aom encoder supports progressive encoding.
+        # Only aom encoder supports AV1 progressive encoding.
         set_property(TEST test_cmd_progressive PROPERTY DISABLED True)
 
         message(STATUS "Some tests are disabled because aom is unavailable for encoding.")


### PR DESCRIPTION
Otherwise using `--lossless` without aom will fail with the misleading error status `AVIF_RESULT_NO_CODEC_AVAILABLE`.

Remove redundant aom lossless check below.

Also fix `avifCodecName()` usage in `avifEncodeImagesFixedQuality()` because it could lead to printing a null pointer as a string when there is no codec available.