### PR TITLE
Add SVT-AV1 to ci-unix-static-av2

### DIFF
--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -56,6 +56,10 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash rav1e.cmd
+    - name: Build SVT-AV1
+      if: steps.cache-ext.outputs.cache-hit != 'true'
+      working-directory: ./ext
+      run: bash svt.cmd
     - name: Build libyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
@@ -79,6 +83,7 @@ jobs:
         -DAVIF_CODEC_AVM=ON -DAVIF_LOCAL_AVM=ON
         -DAVIF_CODEC_DAV1D=${{ runner.also-enable-av1-codecs }} -DAVIF_LOCAL_DAV1D=ON
         -DAVIF_CODEC_RAV1E=${{ runner.also-enable-av1-codecs }} -DAVIF_LOCAL_RAV1E=ON
+        -DAVIF_CODEC_SVT=${{ runner.also-enable-av1-codecs }} -DAVIF_LOCAL_SVT=ON
         -DAVIF_LOCAL_LIBYUV=ON
         -DAVIF_LOCAL_LIBSHARPYUV=ON
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON

--- a/ext/svt.cmd
+++ b/ext/svt.cmd
@@ -11,6 +11,9 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #    "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
+: # Starting with SVT-AV1 v1.5.0, it can be used alongside avm as a dependency of libavif.
+: # See https://github.com/AOMediaCodec/libavif/pull/1361#discussion_r1183100879.
+
 git clone -b v1.5.0 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 
 cd SVT-AV1


### PR DESCRIPTION
`svt.cmd` was modified to clear the CI cache. The CI cache can also be cleared manually.