### PR TITLE
Add "setup" to the "meson" commands

### DIFF
--- a/ext/dav1d.cmd
+++ b/ext/dav1d.cmd
@@ -18,6 +18,6 @@ cd build
 : # macOS might require: -Dc_args=-fno-stack-check
 : # Build with asan: -Db_sanitize=address
 : # Build with ubsan: -Db_sanitize=undefined
-meson --default-library=static --buildtype release ..
+meson setup --default-library=static --buildtype release ..
 ninja
 cd ../..

--- a/ext/dav1d_android.sh
+++ b/ext/dav1d_android.sh
@@ -27,7 +27,7 @@ for i in "${!ABI_LIST[@]}"; do
   abi="${ABI_LIST[i]}"
   mkdir "${abi}"
   cd "${abi}"
-  PATH=$PATH:${android_bin} meson --default-library=static --buildtype release \
+  PATH=$PATH:${android_bin} meson setup --default-library=static --buildtype release \
     --cross-file="../../package/crossfiles/${ARCH_LIST[i]}-android.meson" \
     -Denable_tools=false -Denable_tests=false ../..
   PATH=$PATH:${android_bin} ninja

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -39,7 +39,7 @@ git clone -b 1.2.0 --depth 1 https://code.videolan.org/videolan/dav1d.git
 cd dav1d
 mkdir build
 cd build
-meson --prefix=/usr --buildtype release ..
+meson setup --prefix=/usr --buildtype release ..
 ninja install
 
 # libgav1


### PR DESCRIPTION
Fix the following meson warning:
  WARNING: Running the setup command as `meson [options]` instead of
  `meson setup [options]` is ambiguous and deprecated.