### PR TITLE
Force keyframe for alpha if color is a keyframe

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -357,7 +357,9 @@ typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec,
 // avifCodecEncodeImageFunc is responsible for automatic tiling if encoder->autoTiling is set to
 // AVIF_TRUE. The actual tiling values are passed to avifCodecEncodeImageFunc as parameters.
 // Similarly, avifCodecEncodeImageFunc should use the quantizer parameter instead of
-// encoder->quality and encoder->qualityAlpha.
+// encoder->quality and encoder->qualityAlpha. If disableLaggedOutput is AVIF_TRUE, then the encoder will emit the output frame
+// without any lag (if supported). Note that disableLaggedOutput is only used by the first call to this function (which
+// initializes the encoder) and is ignored by the subsequent calls.
 //
 // Note: The caller of avifCodecEncodeImageFunc always passes encoder->data->tileRowsLog2 and
 // encoder->data->tileColsLog2 as the tileRowsLog2 and tileColsLog2 arguments. Because
@@ -372,6 +374,7 @@ typedef avifResult (*avifCodecEncodeImageFunc)(struct avifCodec * codec,
                                                int tileColsLog2,
                                                int quantizer,
                                                avifEncoderChanges encoderChanges,
+                                               avifBool disableLaggedOutput,
                                                avifAddImageFlags addImageFlags,
                                                avifCodecEncodeOutput * output);
 typedef avifBool (*avifCodecEncodeFinishFunc)(struct avifCodec * codec, avifCodecEncodeOutput * output);

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -545,6 +545,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
                                       int tileColsLog2,
                                       int quantizer,
                                       avifEncoderChanges encoderChanges,
+                                      avifBool disableLaggedOutput,
                                       avifAddImageFlags addImageFlags,
                                       avifCodecEncodeOutput * output)
 {
@@ -714,6 +715,9 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             cfg->g_limit = encoder->extraLayerCount + 1;
             // For layered image, disable lagged encoding to always get output
             // frame for each input frame.
+            cfg->g_lag_in_frames = 0;
+        }
+        if (disableLaggedOutput) {
             cfg->g_lag_in_frames = 0;
         }
         if (encoder->maxThreads > 1) {

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -535,6 +535,7 @@ static avifResult avmCodecEncodeImage(avifCodec * codec,
                                       int tileColsLog2,
                                       int quantizer,
                                       avifEncoderChanges encoderChanges,
+                                      avifBool disableLaggedOutput,
                                       avifAddImageFlags addImageFlags,
                                       avifCodecEncodeOutput * output)
 {
@@ -634,6 +635,9 @@ static avifResult avmCodecEncodeImage(avifCodec * codec,
             cfg->g_limit = encoder->extraLayerCount + 1;
             // For layered image, disable lagged encoding to always get output
             // frame for each input frame.
+            cfg->g_lag_in_frames = 0;
+        }
+        if (disableLaggedOutput) {
             cfg->g_lag_in_frames = 0;
         }
         if (encoder->maxThreads > 1) {

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -57,6 +57,7 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
                                         int tileColsLog2,
                                         int quantizer,
                                         avifEncoderChanges encoderChanges,
+                                        avifBool disableLaggedOutput,
                                         uint32_t addImageFlags,
                                         avifCodecEncodeOutput * output)
 {
@@ -77,6 +78,9 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
     if (encoder->extraLayerCount > 0) {
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
+
+    // rav1e does not support disabling lagged output. See https://github.com/xiph/rav1e/issues/2267. Ignore this setting.
+    (void)disableLaggedOutput;
 
     avifResult result = AVIF_RESULT_UNKNOWN_ERROR;
 

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -50,6 +50,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
                                       int tileColsLog2,
                                       int quantizer,
                                       avifEncoderChanges encoderChanges,
+                                      avifBool disableLaggedOutput,
                                       uint32_t addImageFlags,
                                       avifCodecEncodeOutput * output)
 {
@@ -69,6 +70,9 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
     if (encoder->extraLayerCount > 0) {
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
+
+    // SVT-AV1 does not support disabling lagged output. Ignore this setting.
+    (void)disableLaggedOutput;
 
     avifResult result = AVIF_RESULT_UNKNOWN_ERROR;
     EbColorFormat color_format = EB_YUV420;


### PR DESCRIPTION
When the encoder supports it (as of now only libaom does), disable lagged output when encoding animated images with alpha channel. When the utput of the color planes is a keyframe, force a keyframe on the alpha channel as well.

While the spec does not enforce this, and the libavif decoder can handle files without this requirement just fine, this change is still an enhancement because most decoders look at whether or not the color frame is a keyframe to determine seek points.

Fixes: Issue #841