### PR TITLE
zlibpng.cmd: Revert the update to libpng 1.6.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ List of incompatible ABI changes in this release:
 * Update dav1d.cmd: 1.2.0
 * Update rav1e.cmd: v0.6.3
 * Update svt.cmd/svt.sh: v1.5.0
-* Update zlibpng.cmd: zlib 1.2.13 and libpng 1.6.39
+* Update zlibpng.cmd: zlib 1.2.13
 * avifImageCreate(), avifImageCreateEmpty(), avifEncoderCreate() and other
   internal functions now return NULL if a memory allocation failed.
 * avifEncoderSetCodecSpecificOption() now returns avifResult instead of void to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,10 +90,10 @@ endif()
 option(AVIF_LOCAL_ZLIBPNG "Build zlib and libpng by providing your own copy inside the ext subdir." OFF)
 if(AVIF_LOCAL_ZLIBPNG)
     add_subdirectory(ext/zlib)
-    # Put the value of ZLIB_INCLUDE_DIRS in the cache. This works around cmake behavior that has been updated by
+    # Put the value of ZLIB_INCLUDE_DIR in the cache. This works around cmake behavior that has been updated by
     # cmake policy CMP0102 in cmake 3.17. Remove the CACHE workaround when we require cmake 3.17 or later. See
     # https://gitlab.kitware.com/cmake/cmake/-/issues/21343.
-    set(ZLIB_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib" CACHE PATH "zlib include dir")
+    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib" CACHE PATH "zlib include dir")
     include_directories("${CMAKE_CURRENT_BINARY_DIR}/ext/zlib")
     set(CMAKE_DEBUG_POSTFIX "")
 

--- a/ext/zlibpng.cmd
+++ b/ext/zlibpng.cmd
@@ -5,4 +5,4 @@
 : # The odd choice of comment style in this file is to try to share this script between *nix and win32.
 
 git clone -b v1.2.13 --depth 1 https://github.com/madler/zlib.git
-git clone -b v1.6.39 --depth 1 https://github.com/glennrp/libpng.git
+git clone -b v1.6.37 --depth 1 https://github.com/glennrp/libpng.git


### PR DESCRIPTION
It broke the AppVeyor build.