### PR TITLE
CMakeLists.txt: Fix the AppVeyor build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,11 +90,11 @@ endif()
 option(AVIF_LOCAL_ZLIBPNG "Build zlib and libpng by providing your own copy inside the ext subdir." OFF)
 if(AVIF_LOCAL_ZLIBPNG)
     add_subdirectory(ext/zlib)
-    # Put the value of ZLIB_INCLUDE_DIRS in the cache. This works around cmake behavior that has been updated by
+    # Put the value of ZLIB_INCLUDE_DIR in the cache. This works around cmake behavior that has been updated by
     # cmake policy CMP0102 in cmake 3.17. Remove the CACHE workaround when we require cmake 3.17 or later. See
     # https://gitlab.kitware.com/cmake/cmake/-/issues/21343.
-    set(ZLIB_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib" CACHE PATH "zlib include dir")
-    include_directories("${CMAKE_CURRENT_BINARY_DIR}/ext/zlib")
+    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/zlib" CACHE PATH "zlib include dir")
+    include_directories(${ZLIB_INCLUDE_DIR} "${CMAKE_CURRENT_BINARY_DIR}/ext/zlib")
     set(CMAKE_DEBUG_POSTFIX "")
 
     # This is the only way I could avoid libpng going crazy if it found awk.exe, seems benign otherwise


### PR DESCRIPTION
If the system doesn't have the zlib package installed, for find_package(ZLIB REQUIRED) to succeed, we must set the ZLIB_INCLUDE_DIR variable. So change ZLIB_INCLUDE_DIRS back to ZLIB_INCLUDE_DIR.

Add ${ZLIB_INCLUDE_DIR} to the include directories so that zlib.h can be found. "${CMAKE_CURRENT_BINARY_DIR}/ext/zlib" only has zconf.h.