### PR TITLE
appveyor.yml: No need to run git submodule update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,6 @@ skip_commits:
     - '*.md'
 
 install:
- # Get submodules
- - git submodule update --init --recursive
  # Prepare Visual Studio environment
  - call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
  # Install Nasm


### PR DESCRIPTION
We are no longer using git submodules.