### PR TITLE
Write primaries and transfer characteritics info in decoded png.

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -535,7 +535,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
             // simple gamma value. Most transfer characteristics cannot be
             // represented this way. Viewers that support the cICP chunk can use
             // that instead, but older viewers might show incorrect colors.
-            if (avifTransferCharacteristicsGamma(avif->transferCharacteristics, &gamma)) {
+            if (avifTransferCharacteristicsGetGamma(avif->transferCharacteristics, &gamma) == AVIF_RESULT_OK) {
                 png_set_gAMA(png, info, 1.0f / gamma);
             }
         }
@@ -578,7 +578,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
     png_write_info(png, info);
 
     // Custom chunk writing, must appear after png_write_info.
-    // With AVIF, an ICC profile takes priority over ICC, but with PNG files, CICP takes priority over ICC.
+    // With AVIF, an ICC profile takes priority over CICP, but with PNG files, CICP takes priority over ICC.
     // Therefore CICP should only be written if there is no ICC profile.
     if (!hasIcc) {
         const png_byte cicp[5] = "cICP";

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -503,8 +503,40 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
     }
 
     png_set_IHDR(png, info, avif->width, avif->height, rgbDepth, colorType, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-    if (avif->icc.data && (avif->icc.size > 0)) {
+
+    const avifColorPrimaries primaries = avif->colorPrimaries;
+    const avifTransferCharacteristics transfer = avif->transferCharacteristics;
+    const avifBool hasIcc = avif->icc.data && (avif->icc.size > 0);
+    const avifBool hasNonSrgbPrimaries = (primaries != AVIF_COLOR_PRIMARIES_UNKNOWN &&
+                                          primaries != AVIF_COLOR_PRIMARIES_UNSPECIFIED && primaries != AVIF_COLOR_PRIMARIES_BT709);
+    const avifBool hasNonSrgbTransfer =
+        (transfer != AVIF_TRANSFER_CHARACTERISTICS_UNKNOWN && transfer != AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED &&
+         transfer != AVIF_TRANSFER_CHARACTERISTICS_SRGB);
+
+    avifBool writeCicp = AVIF_FALSE;
+    if (hasIcc) {
         png_set_iCCP(png, info, "libavif", 0, avif->icc.data, (png_uint_32)avif->icc.size);
+    } else if (hasNonSrgbPrimaries || hasNonSrgbTransfer) {
+        float primariesCoords[8];
+        avifColorPrimariesGetValues(avif->colorPrimaries, primariesCoords);
+        png_set_cHRM(png,
+                     info,
+                     primariesCoords[6],
+                     primariesCoords[7],
+                     primariesCoords[0],
+                     primariesCoords[1],
+                     primariesCoords[2],
+                     primariesCoords[3],
+                     primariesCoords[4],
+                     primariesCoords[5]);
+        float gamma;
+        if (avifTransferCharacteristicsGamma(avif->transferCharacteristics, &gamma)) {
+            png_set_gAMA(png, info, 1.0f / gamma);
+        } else {
+            // The transfer characteristics cannot be represented with a simple gAma chunk.
+            // A cICP chunk is needed, but might not be understood by all viewers since it's new.
+            writeCicp = AVIF_TRUE;
+        }
     }
 
     png_text texts[2];
@@ -542,6 +574,16 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
     }
 
     png_write_info(png, info);
+
+    // Custom chunk writing, must appear after png_write_info.
+    if (writeCicp) {
+        const png_byte cicp[5] = "cICP";
+        const png_byte cicpData[4] = { (png_byte)avif->colorPrimaries,
+                                       (png_byte)avif->transferCharacteristics,
+                                       AVIF_MATRIX_COEFFICIENTS_IDENTITY,
+                                       1 /*full range*/ };
+        png_write_chunk(png, cicp, cicpData, 4);
+    }
 
     rowPointers = (png_bytep *)malloc(sizeof(png_bytep) * avif->height);
     if (monochrome8bit) {

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -320,8 +320,8 @@ enum
 typedef uint16_t avifTransferCharacteristics; // AVIF_TRANSFER_CHARACTERISTICS_*
 
 // If the given transfer characteristics can be expressed with a simple gamma value, sets 'gamma'
-// to that value and returns AVIF_TRUE. Returns AVIF_FALSE otherwise.
-AVIF_API avifBool avifTransferCharacteristicsGamma(avifTransferCharacteristics atc, float * gamma);
+// to that value and returns AVIF_RESULT_OK. Returns an error otherwise.
+AVIF_API avifResult avifTransferCharacteristicsGetGamma(avifTransferCharacteristics atc, float * gamma);
 
 enum
 {

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -319,6 +319,10 @@ enum
 };
 typedef uint16_t avifTransferCharacteristics; // AVIF_TRANSFER_CHARACTERISTICS_*
 
+// If the given transfer characteristics can be expressed with a simple gamma value, sets 'gamma'
+// to that value and returns AVIF_TRUE. Returns AVIF_FALSE otherwise.
+AVIF_API avifBool avifTransferCharacteristicsGamma(avifTransferCharacteristics atc, float * gamma);
+
 enum
 {
     AVIF_MATRIX_COEFFICIENTS_IDENTITY = 0,

--- a/src/colr.c
+++ b/src/colr.c
@@ -69,6 +69,23 @@ avifColorPrimaries avifColorPrimariesFind(const float inPrimaries[8], const char
     return AVIF_COLOR_PRIMARIES_UNKNOWN;
 }
 
+avifBool avifTransferCharacteristicsGamma(avifTransferCharacteristics atc, float * gamma)
+{
+    switch (atc) {
+        case AVIF_TRANSFER_CHARACTERISTICS_BT470M:
+            *gamma = 2.2f;
+            return AVIF_TRUE;
+        case AVIF_TRANSFER_CHARACTERISTICS_BT470BG:
+            *gamma = 2.8f;
+            return AVIF_TRUE;
+        case AVIF_TRANSFER_CHARACTERISTICS_LINEAR:
+            *gamma = 1.0f;
+            return AVIF_TRUE;
+        default:
+            return AVIF_FALSE;
+    }
+}
+
 struct avifMatrixCoefficientsTable
 {
     avifMatrixCoefficients matrixCoefficientsEnum;

--- a/src/colr.c
+++ b/src/colr.c
@@ -69,20 +69,20 @@ avifColorPrimaries avifColorPrimariesFind(const float inPrimaries[8], const char
     return AVIF_COLOR_PRIMARIES_UNKNOWN;
 }
 
-avifBool avifTransferCharacteristicsGamma(avifTransferCharacteristics atc, float * gamma)
+avifResult avifTransferCharacteristicsGetGamma(avifTransferCharacteristics atc, float * gamma)
 {
     switch (atc) {
         case AVIF_TRANSFER_CHARACTERISTICS_BT470M:
             *gamma = 2.2f;
-            return AVIF_TRUE;
+            return AVIF_RESULT_OK;
         case AVIF_TRANSFER_CHARACTERISTICS_BT470BG:
             *gamma = 2.8f;
-            return AVIF_TRUE;
+            return AVIF_RESULT_OK;
         case AVIF_TRANSFER_CHARACTERISTICS_LINEAR:
             *gamma = 1.0f;
-            return AVIF_TRUE;
+            return AVIF_RESULT_OK;
         default:
-            return AVIF_FALSE;
+            return AVIF_RESULT_INVALID_ARGUMENT;
     }
 }
 


### PR DESCRIPTION
If there is no ICC but the cicp values are different from sRGB, they are added to the png file using the cHRM, gAMA and cICP chunks.

The cHRM and gAMA chunks are preferred since they are older and more widely understood (although some viewers may ignore them). The new cICP chunk is added if gAMA is not enough to specify the transfer characteristics.

Fixes #1421  for png.