### PR TITLE
Lower min_psnr for PlainAnySubsampling8b to 45

### DIFF
--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -542,7 +542,7 @@ INSTANTIATE_TEST_SUITE_P(
         /*add_noise=*/Values(false),
         /*rgb_step=*/Values(17),
         /*max_abs_average_diff=*/Values(0.02),  // The color drift is centered.
-        /*min_psnr=*/Values(49.)  // RGB>YUV>RGB distortion is barely
+        /*min_psnr=*/Values(45.)  // RGB>YUV>RGB distortion is barely
                                   // noticeable.
         ));
 


### PR DESCRIPTION
The chroma subsampling code for Arm in libyuv uses a different algorithm, which has a higher distortion than the algorithm used by the code for x86. Lower the min_psnr parameter for the PlainAnySubsampling8b test suite from 49 to 45, which should be nearly identical visually.

Fix https://github.com/AOMediaCodec/libavif/issues/1407.