### PR TITLE
avifpng.c: Validate RGB row bytes in avifPNGRead()

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -372,6 +372,11 @@ avifBool avifPNGRead(const char * inputFilename,
         fprintf(stderr, "Conversion to YUV failed: %s (out of memory)\n", inputFilename);
         goto cleanup;
     }
+    size_t rowBytes = png_get_rowbytes(png, info);
+    if (rgb.rowBytes != rowBytes) {
+        fprintf(stderr, "avifPNGRead internal error: rowBytes mismatch libavif %u vs libpng %" AVIF_FMT_ZU "\n", rgb.rowBytes, rowBytes);
+        goto cleanup;
+    }
     rowPointers = (png_bytep *)malloc(sizeof(png_bytep) * rgb.height);
     for (uint32_t y = 0; y < rgb.height; ++y) {
         rowPointers[y] = &rgb.pixels[y * rgb.rowBytes];

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -372,7 +372,10 @@ avifBool avifPNGRead(const char * inputFilename,
         fprintf(stderr, "Conversion to YUV failed: %s (out of memory)\n", inputFilename);
         goto cleanup;
     }
-    size_t rowBytes = png_get_rowbytes(png, info);
+    // png_read_image() receives the row pointers but not the row buffer size. Verify the row
+    // buffer size is exactly what libpng expects. If they are different, we have a bug and should
+    // not proceed.
+    const size_t rowBytes = png_get_rowbytes(png, info);
     if (rgb.rowBytes != rowBytes) {
         fprintf(stderr, "avifPNGRead internal error: rowBytes mismatch libavif %u vs libpng %" AVIF_FMT_ZU "\n", rgb.rowBytes, rowBytes);
         goto cleanup;


### PR DESCRIPTION
If libavif and libpng disagree on the value of RGB row bytes, this is a bug and we should not proceed.