### PR TITLE
avifenc.c: Fix error msg on avifReadImage failure

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -411,7 +411,7 @@ static avifBool avifInputReadImage(avifInput * input,
                                                             dstSourceTiming,
                                                             &input->frameIter);
         if (inputFormat == AVIF_APP_FILE_FORMAT_UNKNOWN) {
-            fprintf(stderr, "Cannot determine input file format: %s\n", input->files[input->fileIndex].filename);
+            fprintf(stderr, "Cannot read input file: %s\n", input->files[input->fileIndex].filename);
             return AVIF_FALSE;
         }
         if (dstSourceIsRGB) {


### PR DESCRIPTION
avifReadImage() returns AVIF_APP_FILE_FORMAT_UNKNOWN on failure. But the reason for failure is not necessarily an unknown file format, so the error message "Cannot determine input file format" is confusing. Change it to "Cannot read input file".