### PR TITLE
Add avifclaptest.cc for testing 'clap' properties

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,11 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifchangesettingtest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifchangesettingtest COMMAND avifchangesettingtest)
 
+    add_executable(avifclaptest gtest/avifclaptest.cc)
+    target_link_libraries(avifclaptest avif ${GTEST_BOTH_LIBRARIES})
+    target_include_directories(avifclaptest PRIVATE ${GTEST_INCLUDE_DIRS})
+    add_test(NAME avifclaptest COMMAND avifclaptest)
+
     add_executable(avifcllitest gtest/avifcllitest.cc)
     target_link_libraries(avifcllitest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
     target_include_directories(avifcllitest PRIVATE ${GTEST_INCLUDE_DIRS})

--- a/tests/gtest/avifclaptest.cc
+++ b/tests/gtest/avifclaptest.cc
@@ -1,0 +1,181 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+struct AVIFClapPropertyParam {
+  uint32_t width;
+  uint32_t height;
+  avifPixelFormat yuv_format;
+  avifCleanApertureBox clap;
+
+  bool expected_result;
+  avifCropRect expected_crop_rect;  // Ignored if expected_result is false.
+};
+
+AVIFClapPropertyParam kAVIFClapPropertyTestParams[] = {
+    //////////////////////////////////////////////////
+    // Negative tests:
+
+    // Zero or negative denominators.
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 0, 132, 1, 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, static_cast<uint32_t>(-1), 132, 1, 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, 132, 0, 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, 132, static_cast<uint32_t>(-1), 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, 132, 1, 0, 0, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, 132, 1, 0, static_cast<uint32_t>(-1), 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, 132, 1, 0, 1, 0, 0},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, 132, 1, 0, 1, 0, static_cast<uint32_t>(-1)},
+     false,
+     {0, 0, 0, 0}},
+    // Zero or negative clean aperture width or height.
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {static_cast<uint32_t>(-96), 1, 132, 1, 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {0, 1, 132, 1, 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, static_cast<uint32_t>(-132), 1, 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, 0, 1, 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    // Clean aperture width or height is not an integer.
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 5, 132, 1, 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, 132, 5, 0, 1, 0, 1},
+     false,
+     {0, 0, 0, 0}},
+    // pcX = 103 + (722 - 1)/2 = 463.5
+    // pcY = -308 + (1024 - 1)/2 = 203.5
+    // leftmost = 463.5 - (385 - 1)/2 = 271.5 (not an integer)
+    // topmost = 203.5 - (330 - 1)/2 = 39
+    {722,
+     1024,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {385, 1, 330, 1, 103, 1, static_cast<uint32_t>(-308), 1},
+     false,
+     {0, 0, 0, 0}},
+    // pcX = -308 + (1024 - 1)/2 = 203.5
+    // pcY = 103 + (722 - 1)/2 = 463.5
+    // leftmost = 203.5 - (330 - 1)/2 = 39
+    // topmost = 463.5 - (385 - 1)/2 = 271.5 (not an integer)
+    {1024,
+     722,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {330, 1, 385, 1, static_cast<uint32_t>(-308), 1, 103, 1},
+     false,
+     {0, 0, 0, 0}},
+
+    //////////////////////////////////////////////////
+    // Positive tests:
+
+    // pcX = 0 + (120 - 1)/2 = 59.5
+    // pcY = 0 + (160 - 1)/2 = 79.5
+    // leftmost = 59.5 - (96 - 1)/2 = 12
+    // topmost = 79.5 - (132 - 1)/2 = 14
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {96, 1, 132, 1, 0, 1, 0, 1},
+     true,
+     {12, 14, 96, 132}},
+    // pcX = -30 + (120 - 1)/2 = 29.5
+    // pcY = -40 + (160 - 1)/2 = 39.5
+    // leftmost = 29.5 - (60 - 1)/2 = 0
+    // topmost = 39.5 - (80 - 1)/2 = 0
+    {120,
+     160,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {60, 1, 80, 1, static_cast<uint32_t>(-30), 1, static_cast<uint32_t>(-40),
+      1},
+     true,
+     {0, 0, 60, 80}},
+};
+
+using AVIFClapPropertyTest = ::testing::TestWithParam<AVIFClapPropertyParam>;
+
+INSTANTIATE_TEST_SUITE_P(Parameterized, AVIFClapPropertyTest,
+                         ::testing::ValuesIn(kAVIFClapPropertyTestParams));
+
+// Test the avifCropRectConvertCleanApertureBox() function.
+TEST_P(AVIFClapPropertyTest, ValidateClapProperty) {
+  const AVIFClapPropertyParam& param = GetParam();
+  avifCropRect crop_rect;
+  avifDiagnostics diag;
+  EXPECT_EQ(avifCropRectConvertCleanApertureBox(&crop_rect, &param.clap,
+                                                param.width, param.height,
+                                                param.yuv_format, &diag),
+            param.expected_result);
+  if (param.expected_result) {
+    EXPECT_EQ(crop_rect.x, param.expected_crop_rect.x);
+    EXPECT_EQ(crop_rect.y, param.expected_crop_rect.y);
+    EXPECT_EQ(crop_rect.width, param.expected_crop_rect.width);
+    EXPECT_EQ(crop_rect.height, param.expected_crop_rect.height);
+  }
+}
+
+}  // namespace
+}  // namespace libavif

--- a/tests/gtest/avifclaptest.cc
+++ b/tests/gtest/avifclaptest.cc
@@ -7,107 +7,49 @@
 namespace libavif {
 namespace {
 
-struct AVIFClapPropertyParam {
+struct InvalidClapPropertyParam {
   uint32_t width;
   uint32_t height;
   avifPixelFormat yuv_format;
   avifCleanApertureBox clap;
-
-  bool expected_result;
-  avifCropRect expected_crop_rect;  // Ignored if expected_result is false.
 };
 
-AVIFClapPropertyParam kAVIFClapPropertyTestParams[] = {
-    //////////////////////////////////////////////////
-    // Negative tests:
-
+InvalidClapPropertyParam kInvalidClapPropertyTestParams[] = {
     // Zero or negative denominators.
+    {120, 160, AVIF_PIXEL_FORMAT_YUV420, {96, 0, 132, 1, 0, 1, 0, 1}},
     {120,
      160,
      AVIF_PIXEL_FORMAT_YUV420,
-     {96, 0, 132, 1, 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
+     {96, static_cast<uint32_t>(-1), 132, 1, 0, 1, 0, 1}},
+    {120, 160, AVIF_PIXEL_FORMAT_YUV420, {96, 1, 132, 0, 0, 1, 0, 1}},
     {120,
      160,
      AVIF_PIXEL_FORMAT_YUV420,
-     {96, static_cast<uint32_t>(-1), 132, 1, 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
+     {96, 1, 132, static_cast<uint32_t>(-1), 0, 1, 0, 1}},
+    {120, 160, AVIF_PIXEL_FORMAT_YUV420, {96, 1, 132, 1, 0, 0, 0, 1}},
     {120,
      160,
      AVIF_PIXEL_FORMAT_YUV420,
-     {96, 1, 132, 0, 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
+     {96, 1, 132, 1, 0, static_cast<uint32_t>(-1), 0, 1}},
+    {120, 160, AVIF_PIXEL_FORMAT_YUV420, {96, 1, 132, 1, 0, 1, 0, 0}},
     {120,
      160,
      AVIF_PIXEL_FORMAT_YUV420,
-     {96, 1, 132, static_cast<uint32_t>(-1), 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
-    {120,
-     160,
-     AVIF_PIXEL_FORMAT_YUV420,
-     {96, 1, 132, 1, 0, 0, 0, 1},
-     false,
-     {0, 0, 0, 0}},
-    {120,
-     160,
-     AVIF_PIXEL_FORMAT_YUV420,
-     {96, 1, 132, 1, 0, static_cast<uint32_t>(-1), 0, 1},
-     false,
-     {0, 0, 0, 0}},
-    {120,
-     160,
-     AVIF_PIXEL_FORMAT_YUV420,
-     {96, 1, 132, 1, 0, 1, 0, 0},
-     false,
-     {0, 0, 0, 0}},
-    {120,
-     160,
-     AVIF_PIXEL_FORMAT_YUV420,
-     {96, 1, 132, 1, 0, 1, 0, static_cast<uint32_t>(-1)},
-     false,
-     {0, 0, 0, 0}},
+     {96, 1, 132, 1, 0, 1, 0, static_cast<uint32_t>(-1)}},
     // Zero or negative clean aperture width or height.
     {120,
      160,
      AVIF_PIXEL_FORMAT_YUV420,
-     {static_cast<uint32_t>(-96), 1, 132, 1, 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
+     {static_cast<uint32_t>(-96), 1, 132, 1, 0, 1, 0, 1}},
+    {120, 160, AVIF_PIXEL_FORMAT_YUV420, {0, 1, 132, 1, 0, 1, 0, 1}},
     {120,
      160,
      AVIF_PIXEL_FORMAT_YUV420,
-     {0, 1, 132, 1, 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
-    {120,
-     160,
-     AVIF_PIXEL_FORMAT_YUV420,
-     {96, 1, static_cast<uint32_t>(-132), 1, 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
-    {120,
-     160,
-     AVIF_PIXEL_FORMAT_YUV420,
-     {96, 1, 0, 1, 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
+     {96, 1, static_cast<uint32_t>(-132), 1, 0, 1, 0, 1}},
+    {120, 160, AVIF_PIXEL_FORMAT_YUV420, {96, 1, 0, 1, 0, 1, 0, 1}},
     // Clean aperture width or height is not an integer.
-    {120,
-     160,
-     AVIF_PIXEL_FORMAT_YUV420,
-     {96, 5, 132, 1, 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
-    {120,
-     160,
-     AVIF_PIXEL_FORMAT_YUV420,
-     {96, 1, 132, 5, 0, 1, 0, 1},
-     false,
-     {0, 0, 0, 0}},
+    {120, 160, AVIF_PIXEL_FORMAT_YUV420, {96, 5, 132, 1, 0, 1, 0, 1}},
+    {120, 160, AVIF_PIXEL_FORMAT_YUV420, {96, 1, 132, 5, 0, 1, 0, 1}},
     // pcX = 103 + (722 - 1)/2 = 463.5
     // pcY = -308 + (1024 - 1)/2 = 203.5
     // leftmost = 463.5 - (385 - 1)/2 = 271.5 (not an integer)
@@ -115,9 +57,7 @@ AVIFClapPropertyParam kAVIFClapPropertyTestParams[] = {
     {722,
      1024,
      AVIF_PIXEL_FORMAT_YUV420,
-     {385, 1, 330, 1, 103, 1, static_cast<uint32_t>(-308), 1},
-     false,
-     {0, 0, 0, 0}},
+     {385, 1, 330, 1, 103, 1, static_cast<uint32_t>(-308), 1}},
     // pcX = -308 + (1024 - 1)/2 = 203.5
     // pcY = 103 + (722 - 1)/2 = 463.5
     // leftmost = 203.5 - (330 - 1)/2 = 39
@@ -125,13 +65,35 @@ AVIFClapPropertyParam kAVIFClapPropertyTestParams[] = {
     {1024,
      722,
      AVIF_PIXEL_FORMAT_YUV420,
-     {330, 1, 385, 1, static_cast<uint32_t>(-308), 1, 103, 1},
-     false,
-     {0, 0, 0, 0}},
+     {330, 1, 385, 1, static_cast<uint32_t>(-308), 1, 103, 1}},
+};
 
-    //////////////////////////////////////////////////
-    // Positive tests:
+using InvalidClapPropertyTest =
+    ::testing::TestWithParam<InvalidClapPropertyParam>;
 
+INSTANTIATE_TEST_SUITE_P(Parameterized, InvalidClapPropertyTest,
+                         ::testing::ValuesIn(kInvalidClapPropertyTestParams));
+
+// Negative tests for the avifCropRectConvertCleanApertureBox() function.
+TEST_P(InvalidClapPropertyTest, ValidateClapProperty) {
+  const InvalidClapPropertyParam& param = GetParam();
+  avifCropRect crop_rect;
+  avifDiagnostics diag;
+  EXPECT_FALSE(avifCropRectConvertCleanApertureBox(&crop_rect, &param.clap,
+                                                   param.width, param.height,
+                                                   param.yuv_format, &diag));
+}
+
+struct ValidClapPropertyParam {
+  uint32_t width;
+  uint32_t height;
+  avifPixelFormat yuv_format;
+  avifCleanApertureBox clap;
+
+  avifCropRect expected_crop_rect;
+};
+
+ValidClapPropertyParam kValidClapPropertyTestParams[] = {
     // pcX = 0 + (120 - 1)/2 = 59.5
     // pcY = 0 + (160 - 1)/2 = 79.5
     // leftmost = 59.5 - (96 - 1)/2 = 12
@@ -140,7 +102,6 @@ AVIFClapPropertyParam kAVIFClapPropertyTestParams[] = {
      160,
      AVIF_PIXEL_FORMAT_YUV420,
      {96, 1, 132, 1, 0, 1, 0, 1},
-     true,
      {12, 14, 96, 132}},
     // pcX = -30 + (120 - 1)/2 = 29.5
     // pcY = -40 + (160 - 1)/2 = 39.5
@@ -151,30 +112,26 @@ AVIFClapPropertyParam kAVIFClapPropertyTestParams[] = {
      AVIF_PIXEL_FORMAT_YUV420,
      {60, 1, 80, 1, static_cast<uint32_t>(-30), 1, static_cast<uint32_t>(-40),
       1},
-     true,
      {0, 0, 60, 80}},
 };
 
-using AVIFClapPropertyTest = ::testing::TestWithParam<AVIFClapPropertyParam>;
+using ValidClapPropertyTest = ::testing::TestWithParam<ValidClapPropertyParam>;
 
-INSTANTIATE_TEST_SUITE_P(Parameterized, AVIFClapPropertyTest,
-                         ::testing::ValuesIn(kAVIFClapPropertyTestParams));
+INSTANTIATE_TEST_SUITE_P(Parameterized, ValidClapPropertyTest,
+                         ::testing::ValuesIn(kValidClapPropertyTestParams));
 
-// Test the avifCropRectConvertCleanApertureBox() function.
-TEST_P(AVIFClapPropertyTest, ValidateClapProperty) {
-  const AVIFClapPropertyParam& param = GetParam();
+// Positive tests for the avifCropRectConvertCleanApertureBox() function.
+TEST_P(ValidClapPropertyTest, ValidateClapProperty) {
+  const ValidClapPropertyParam& param = GetParam();
   avifCropRect crop_rect;
   avifDiagnostics diag;
-  EXPECT_EQ(avifCropRectConvertCleanApertureBox(&crop_rect, &param.clap,
-                                                param.width, param.height,
-                                                param.yuv_format, &diag),
-            param.expected_result);
-  if (param.expected_result) {
-    EXPECT_EQ(crop_rect.x, param.expected_crop_rect.x);
-    EXPECT_EQ(crop_rect.y, param.expected_crop_rect.y);
-    EXPECT_EQ(crop_rect.width, param.expected_crop_rect.width);
-    EXPECT_EQ(crop_rect.height, param.expected_crop_rect.height);
-  }
+  EXPECT_TRUE(avifCropRectConvertCleanApertureBox(&crop_rect, &param.clap,
+                                                  param.width, param.height,
+                                                  param.yuv_format, &diag));
+  EXPECT_EQ(crop_rect.x, param.expected_crop_rect.x);
+  EXPECT_EQ(crop_rect.y, param.expected_crop_rect.y);
+  EXPECT_EQ(crop_rect.width, param.expected_crop_rect.width);
+  EXPECT_EQ(crop_rect.height, param.expected_crop_rect.height);
 }
 
 }  // namespace


### PR DESCRIPTION
This file has a test for the avifCropRectConvertCleanApertureBox() function. The test was ported from the test deleted in patchset 9 of https://chromium-review.googlesource.com/c/chromium/src/+/4585301/8..9. I wrote that test originally.

More tests related to the 'clap' (clean aperture) image properties can be added to this file in the future.