### PR TITLE
Experimental reduced HEIF header

### DIFF
--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -98,6 +98,7 @@ jobs:
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON
         -DAVIF_ENABLE_EXPERIMENTAL_YCGCO_R=ON
         -DAVIF_ENABLE_EXPERIMENTAL_GAIN_MAP=ON
+        -DAVIF_ENABLE_EXPERIMENTAL_AVIR=ON
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -112,6 +112,7 @@ jobs:
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON
         -DAVIF_ENABLE_EXPERIMENTAL_YCGCO_R=ON
         -DAVIF_ENABLE_EXPERIMENTAL_GAIN_MAP=ON
+        -DAVIF_ENABLE_EXPERIMENTAL_AVIR=ON
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+List of incompatible ABI changes in this release:
+
+* The headerFormat member was added to avifEncoder.
+
 ### Added
 * Add experimental API for reading and writing gain maps in AVIF files.
   If enabled at compile time, add `gainMap` field to `avifImage`,
@@ -17,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the future. Files created now might not decode in a future version.
   This feature is off by default and must be enabled with the
   AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP compilation flag.
+* Add the headerFormat member of new type avifHeaderFormat to avifEncoder.
+* Add experimental API for reading and writing "avir"-branded AVIF files
+  behind the compilation flag AVIF_ENABLE_EXPERIMENTAL_AVIR.
 
 ### Changed
 * Update svt.cmd/svt.sh: v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-List of incompatible ABI changes in this release:
-
-* The headerFormat member was added to avifEncoder.
-
 ### Added
 * Add experimental API for reading and writing gain maps in AVIF files.
   If enabled at compile time, add `gainMap` field to `avifImage`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(AVIF_ENABLE_EXPERIMENTAL_YCGCO_R "Enable experimental YCgCo-R matrix code
 option(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP
        "Enable experimental gain map code (for HDR images that look good both on HDR and SDR displays)" OFF
 )
+option(AVIF_ENABLE_EXPERIMENTAL_AVIR "Enable experimental reduced header" OFF)
 
 option(AVIF_CODEC_AOM "Use the AOM codec for encoding/decoding (see AVIF_CODEC_AOM_DECODE/AVIF_CODEC_AOM_ENCODE)" OFF)
 option(AVIF_CODEC_DAV1D "Use the dav1d codec for decoding" OFF)
@@ -267,6 +268,10 @@ endif()
 
 if(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     add_compile_definitions(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+endif()
+
+if(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+    add_compile_definitions(AVIF_ENABLE_EXPERIMENTAL_AVIR)
 endif()
 
 set(AVIF_SRCS

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -672,7 +672,7 @@ typedef struct
     avifBool autoTiling;
     avifBool progressive;
     int speed;
-    avifEncoderHeaderFormat headerFormat;
+    avifHeaderFormat headerFormat;
 
     int paspCount;
     uint32_t paspValues[8]; // only the first two are used
@@ -1112,7 +1112,7 @@ int main(int argc, char * argv[])
     settings.autoTiling = AVIF_FALSE;
     settings.progressive = AVIF_FALSE;
     settings.speed = 6;
-    settings.headerFormat = AVIF_ENCODER_FULL_HEADER;
+    settings.headerFormat = AVIF_HEADER_FULL;
     settings.repetitionCount = AVIF_REPETITION_COUNT_INFINITE;
     settings.keyframeInterval = 0;
     settings.ignoreExif = AVIF_FALSE;
@@ -1185,7 +1185,7 @@ int main(int argc, char * argv[])
             outputFilename = arg;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
         } else if (!strcmp(arg, "--avir")) {
-            settings.headerFormat = AVIF_ENCODER_REDUCED_HEADER;
+            settings.headerFormat = AVIF_HEADER_REDUCED;
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
         } else if (!strcmp(arg, "-d") || !strcmp(arg, "--depth")) {
             NEXTARG();

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -1185,7 +1185,7 @@ int main(int argc, char * argv[])
             outputFilename = arg;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
         } else if (!strcmp(arg, "--avir")) {
-            settings.headerStrategy = AVIF_ENCODER_MINIMIZE_HEADER;
+            settings.headerStrategy = AVIF_ENCODER_REDUCE_HEADER;
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
         } else if (!strcmp(arg, "-d") || !strcmp(arg, "--depth")) {
             NEXTARG();

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -1185,7 +1185,7 @@ int main(int argc, char * argv[])
             outputFilename = arg;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
         } else if (!strcmp(arg, "--avir")) {
-            settings.headerStrategy = AVIF_ENCODER_REDUCE_HEADER;
+            settings.headerStrategy = AVIF_ENCODER_REDUCED_HEADER;
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
         } else if (!strcmp(arg, "-d") || !strcmp(arg, "--depth")) {
             NEXTARG();

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -672,7 +672,7 @@ typedef struct
     avifBool autoTiling;
     avifBool progressive;
     int speed;
-    avifEncoderHeaderStrategy headerStrategy;
+    avifEncoderHeaderFormat headerFormat;
 
     int paspCount;
     uint32_t paspValues[8]; // only the first two are used
@@ -892,7 +892,7 @@ static avifBool avifEncodeImagesFixedQuality(const avifSettings * settings,
     encoder->autoTiling = settings->autoTiling;
     encoder->codecChoice = settings->codecChoice;
     encoder->speed = settings->speed;
-    encoder->headerStrategy = settings->headerStrategy;
+    encoder->headerFormat = settings->headerFormat;
     encoder->timescale = settings->outputTiming.timescale;
     encoder->keyframeInterval = settings->keyframeInterval;
     encoder->repetitionCount = settings->repetitionCount;
@@ -1112,7 +1112,7 @@ int main(int argc, char * argv[])
     settings.autoTiling = AVIF_FALSE;
     settings.progressive = AVIF_FALSE;
     settings.speed = 6;
-    settings.headerStrategy = AVIF_ENCODER_FULL_HEADER;
+    settings.headerFormat = AVIF_ENCODER_FULL_HEADER;
     settings.repetitionCount = AVIF_REPETITION_COUNT_INFINITE;
     settings.keyframeInterval = 0;
     settings.ignoreExif = AVIF_FALSE;
@@ -1185,7 +1185,7 @@ int main(int argc, char * argv[])
             outputFilename = arg;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
         } else if (!strcmp(arg, "--avir")) {
-            settings.headerStrategy = AVIF_ENCODER_REDUCED_HEADER;
+            settings.headerFormat = AVIF_ENCODER_REDUCED_HEADER;
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
         } else if (!strcmp(arg, "-d") || !strcmp(arg, "--depth")) {
             NEXTARG();

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -98,7 +98,7 @@ static void syntaxLong(void)
     printf("    --no-overwrite                    : Never overwrite existing output file\n");
     printf("    -o,--output FILENAME              : Instead of using the last filename given as output, use this filename\n");
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
-    printf("    --avir                            : Minimize header if possible\n");
+    printf("    --avir                            : Use reduced header if possible\n");
 #endif
     printf("    -l,--lossless                     : Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it\n");
     printf("    -d,--depth D                      : Output depth [8,10,12]. (JPEG/PNG only; For y4m or stdin, depth is retained)\n");

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -97,6 +97,9 @@ static void syntaxLong(void)
     printf("    -j,--jobs J                       : Number of jobs (worker threads, default: 1. Use \"all\" to use all available cores)\n");
     printf("    --no-overwrite                    : Never overwrite existing output file\n");
     printf("    -o,--output FILENAME              : Instead of using the last filename given as output, use this filename\n");
+#if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+    printf("    --avir                            : Minimize header if possible\n");
+#endif
     printf("    -l,--lossless                     : Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it\n");
     printf("    -d,--depth D                      : Output depth [8,10,12]. (JPEG/PNG only; For y4m or stdin, depth is retained)\n");
     printf("    -y,--yuv FORMAT                   : Output format [default=auto, 444, 422, 420, 400]. Ignored for y4m or stdin (y4m format is retained)\n");
@@ -669,6 +672,7 @@ typedef struct
     avifBool autoTiling;
     avifBool progressive;
     int speed;
+    avifEncoderHeaderStrategy headerStrategy;
 
     int paspCount;
     uint32_t paspValues[8]; // only the first two are used
@@ -888,6 +892,7 @@ static avifBool avifEncodeImagesFixedQuality(const avifSettings * settings,
     encoder->autoTiling = settings->autoTiling;
     encoder->codecChoice = settings->codecChoice;
     encoder->speed = settings->speed;
+    encoder->headerStrategy = settings->headerStrategy;
     encoder->timescale = settings->outputTiming.timescale;
     encoder->keyframeInterval = settings->keyframeInterval;
     encoder->repetitionCount = settings->repetitionCount;
@@ -1107,6 +1112,7 @@ int main(int argc, char * argv[])
     settings.autoTiling = AVIF_FALSE;
     settings.progressive = AVIF_FALSE;
     settings.speed = 6;
+    settings.headerStrategy = AVIF_ENCODER_FULL_HEADER;
     settings.repetitionCount = AVIF_REPETITION_COUNT_INFINITE;
     settings.keyframeInterval = 0;
     settings.ignoreExif = AVIF_FALSE;
@@ -1177,6 +1183,10 @@ int main(int argc, char * argv[])
         } else if (!strcmp(arg, "-o") || !strcmp(arg, "--output")) {
             NEXTARG();
             outputFilename = arg;
+#if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+        } else if (!strcmp(arg, "--avir")) {
+            settings.headerStrategy = AVIF_ENCODER_MINIMIZE_HEADER;
+#endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
         } else if (!strcmp(arg, "-d") || !strcmp(arg, "--depth")) {
             NEXTARG();
             input.requestedDepth = atoi(arg);

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1272,9 +1272,6 @@ typedef struct avifScalingMode
 //   call to avifEncoderAddImage().
 typedef struct avifEncoder
 {
-    // Defaults to AVIF_ENCODER_FULL_HEADER
-    avifEncoderHeaderStrategy headerStrategy;
-
     // Defaults to AVIF_CODEC_CHOICE_AUTO: Preference determined by order in availableCodecs table (avif.c)
     avifCodecChoice codecChoice;
 
@@ -1313,6 +1310,9 @@ typedef struct avifEncoder
     struct avifCodecSpecificOptions * csOptions;
 
     // Version 1.0.0 ends here. Add any new members after this line.
+
+    // Defaults to AVIF_ENCODER_FULL_HEADER
+    avifEncoderHeaderStrategy headerStrategy;
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     int qualityGainMap; // changeable encoder setting

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -185,6 +185,20 @@ typedef enum avifResult
 AVIF_API const char * avifResultToString(avifResult result);
 
 // ---------------------------------------------------------------------------
+// avifEncoderHeaderStrategy
+
+typedef enum avifEncoderHeaderStrategy
+{
+    // Encodes as "avif" brand with a MetaBox and all its required boxes for maximum compatibility.
+    AVIF_ENCODER_FULL_HEADER,
+#if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+    // Encodes as "avir" brand with a CondensedImageBox to reduce the encoded file size.
+    // WARNING: Experimental feature. Produces files that are incompatible with older decoders.
+    AVIF_ENCODER_MINIMIZE_HEADER,
+#endif
+} avifEncoderHeaderStrategy;
+
+// ---------------------------------------------------------------------------
 // avifROData/avifRWData: Generic raw memory storage
 
 typedef struct avifROData
@@ -1258,6 +1272,9 @@ typedef struct avifScalingMode
 //   call to avifEncoderAddImage().
 typedef struct avifEncoder
 {
+    // Defaults to AVIF_ENCODER_FULL_HEADER
+    avifEncoderHeaderStrategy headerStrategy;
+
     // Defaults to AVIF_CODEC_CHOICE_AUTO: Preference determined by order in availableCodecs table (avif.c)
     avifCodecChoice codecChoice;
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -194,7 +194,7 @@ typedef enum avifEncoderHeaderStrategy
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
     // Encodes as "avir" brand with a CondensedImageBox to reduce the encoded file size.
     // WARNING: Experimental feature. Produces files that are incompatible with older decoders.
-    AVIF_ENCODER_MINIMIZE_HEADER,
+    AVIF_ENCODER_REDUCE_HEADER,
 #endif
 } avifEncoderHeaderStrategy;
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -185,9 +185,9 @@ typedef enum avifResult
 AVIF_API const char * avifResultToString(avifResult result);
 
 // ---------------------------------------------------------------------------
-// avifEncoderHeaderStrategy
+// avifEncoderHeaderFormat
 
-typedef enum avifEncoderHeaderStrategy
+typedef enum avifEncoderHeaderFormat
 {
     // Encodes as "avif" brand with a MetaBox and all its required boxes for maximum compatibility.
     AVIF_ENCODER_FULL_HEADER,
@@ -197,7 +197,7 @@ typedef enum avifEncoderHeaderStrategy
     // WARNING: Experimental feature. Produces files that are incompatible with older decoders.
     AVIF_ENCODER_REDUCED_HEADER,
 #endif
-} avifEncoderHeaderStrategy;
+} avifEncoderHeaderFormat;
 
 // ---------------------------------------------------------------------------
 // avifROData/avifRWData: Generic raw memory storage
@@ -1313,7 +1313,7 @@ typedef struct avifEncoder
     // Version 1.0.0 ends here. Add any new members after this line.
 
     // Defaults to AVIF_ENCODER_FULL_HEADER
-    avifEncoderHeaderStrategy headerStrategy;
+    avifEncoderHeaderFormat headerFormat;
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     int qualityGainMap; // changeable encoder setting

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -193,6 +193,7 @@ typedef enum avifEncoderHeaderStrategy
     AVIF_ENCODER_FULL_HEADER,
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
     // Encodes as "avir" brand with a CondensedImageBox to reduce the encoded file size.
+    // This is based on the m64572 "Condensed image item" MPEG proposal for HEIF.
     // WARNING: Experimental feature. Produces files that are incompatible with older decoders.
     AVIF_ENCODER_REDUCE_HEADER,
 #endif

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -185,19 +185,19 @@ typedef enum avifResult
 AVIF_API const char * avifResultToString(avifResult result);
 
 // ---------------------------------------------------------------------------
-// avifEncoderHeaderFormat
+// avifHeaderFormat
 
-typedef enum avifEncoderHeaderFormat
+typedef enum avifHeaderFormat
 {
-    // Encodes as "avif" brand with a MetaBox and all its required boxes for maximum compatibility.
-    AVIF_ENCODER_FULL_HEADER,
+    // AVIF file with an "avif" brand, a MetaBox and all its required boxes for maximum compatibility.
+    AVIF_HEADER_FULL,
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
-    // Encodes as "avir" brand with a CondensedImageBox to reduce the encoded file size.
+    // AVIF file with an "avir" brand and a CondensedImageBox to reduce the encoded file size.
     // This is based on the m64572 "Condensed image item" MPEG proposal for HEIF.
     // WARNING: Experimental feature. Produces files that are incompatible with older decoders.
-    AVIF_ENCODER_REDUCED_HEADER,
+    AVIF_HEADER_REDUCED,
 #endif
-} avifEncoderHeaderFormat;
+} avifHeaderFormat;
 
 // ---------------------------------------------------------------------------
 // avifROData/avifRWData: Generic raw memory storage
@@ -1312,8 +1312,8 @@ typedef struct avifEncoder
 
     // Version 1.0.0 ends here. Add any new members after this line.
 
-    // Defaults to AVIF_ENCODER_FULL_HEADER
-    avifEncoderHeaderFormat headerFormat;
+    // Defaults to AVIF_HEADER_FULL
+    avifHeaderFormat headerFormat;
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     int qualityGainMap; // changeable encoder setting

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -195,7 +195,7 @@ typedef enum avifEncoderHeaderStrategy
     // Encodes as "avir" brand with a CondensedImageBox to reduce the encoded file size.
     // This is based on the m64572 "Condensed image item" MPEG proposal for HEIF.
     // WARNING: Experimental feature. Produces files that are incompatible with older decoders.
-    AVIF_ENCODER_REDUCE_HEADER,
+    AVIF_ENCODER_REDUCED_HEADER,
 #endif
 } avifEncoderHeaderStrategy;
 

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -239,9 +239,9 @@ typedef enum avifItemCategory
 } avifItemCategory;
 
 // ---------------------------------------------------------------------------
-// AVIF color_type field meaning in CondensendImageBox
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+// AVIF color_type field meaning in CondensedImageBox
 typedef enum avifConiColorType
 {
     AVIF_CONI_COLOR_TYPE_SRGB = 0,

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -239,6 +239,19 @@ typedef enum avifItemCategory
 } avifItemCategory;
 
 // ---------------------------------------------------------------------------
+// AVIF color_type field meaning in CondensendImageBox
+
+#if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+typedef enum avifConiColorType
+{
+    AVIF_CONI_COLOR_TYPE_SRGB = 0,
+    AVIF_CONI_COLOR_TYPE_NCLX_5BIT = 1,
+    AVIF_CONI_COLOR_TYPE_NCLX_8BIT = 2,
+    AVIF_CONI_COLOR_TYPE_ICC = 3
+} avifConiColorType;
+#endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
+
+// ---------------------------------------------------------------------------
 // Grid AVIF images
 
 // Returns false if the tiles in a grid image violate any standards.

--- a/src/read.c
+++ b/src/read.c
@@ -739,8 +739,8 @@ typedef struct avifMeta
     uint32_t primaryItemID;
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
-    // If true, the fields above were extracted from a CondensedImageBox. It implies some
-    // constraints to its optional extendedMeta field, such as forbidden item IDs, properties etc.
+    // If true, the fields above were extracted from a CondensedImageBox. It imposes some
+    // constraints on its optional extendedMeta field, such as forbidden item IDs, properties etc.
     avifBool fromConi;
 #endif
 } avifMeta;
@@ -1616,10 +1616,10 @@ static avifResult avifDecoderFindMetadata(avifDecoder * decoder, avifMeta * meta
             // Advance past Annex A.2.1's header
             BEGIN_STREAM(exifBoxStream, exifContents.data, exifContents.size, &decoder->diag, "Exif header");
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+            // The CondensedImageBox does not signal the exifTiffHeaderOffset.
             if (!meta->fromConi)
 #endif
             {
-                // The CondensedImageBox does not signal the exifTiffHeaderOffset.
                 uint32_t exifTiffHeaderOffset;
                 AVIF_CHECKERR(avifROStreamReadU32(&exifBoxStream, &exifTiffHeaderOffset),
                               AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) exif_tiff_header_offset;

--- a/src/read.c
+++ b/src/read.c
@@ -3677,7 +3677,7 @@ static avifResult avifParse(avifDecoder * decoder)
 
         if (ftypSeen && !needsConi && coniSeen) {
             // The 'coni' box should be ignored if there is no 'avir' brand, but libavif allows reading them in any order.
-            return AVIF_RESULT_NOT_IMPLEMENTED;
+            return AVIF_RESULT_NOT_IMPLEMENTED; // TODO(yguyon): Implement
         }
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
 

--- a/src/read.c
+++ b/src/read.c
@@ -3302,20 +3302,20 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
     uint32_t transferCharacteristics;
     uint32_t matrixCoefficients;
     uint32_t iccDataSize;
-    if (colorType == 3) {
+    if (colorType == AVIF_CONI_COLOR_TYPE_ICC) {
         colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
         transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
         AVIF_CHECKERR(avifROStreamReadBits(&s, &matrixCoefficients, 8), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(8) matrix_coefficients;
         AVIF_CHECKERR(avifROStreamReadVarInt(&s, &iccDataSize), AVIF_RESULT_BMFF_PARSE_FAILED); // varint(32) icc_data_size;
         ++iccDataSize;
-    } else if (colorType == 0) {
+    } else if (colorType == AVIF_CONI_COLOR_TYPE_SRGB) {
         // sRGB
         colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
         transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
         matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
         iccDataSize = 0;
     } else {
-        const uint32_t numBitsPerComponent = (colorType == 1) ? 5 : 8;
+        const uint32_t numBitsPerComponent = (colorType == AVIF_CONI_COLOR_TYPE_NCLX_5BIT) ? 5 : 8;
         AVIF_CHECKERR(avifROStreamReadBits(&s, &colorPrimaries, numBitsPerComponent),
                       AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(5/8) color_primaries;
         AVIF_CHECKERR(avifROStreamReadBits(&s, &transferCharacteristics, numBitsPerComponent),

--- a/src/read.c
+++ b/src/read.c
@@ -3270,6 +3270,7 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
     meta->fromConi = AVIF_TRUE;
 
     // Read the bit fields.
+    // TODO(yguyon): Implement or return an appropriate error in cases where AVIF_RESULT_NOT_IMPLEMENTED is returned.
 
     uint32_t version;
     AVIF_CHECKERR(avifROStreamReadBits(&s, &version, 2), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(2) version;

--- a/src/write.c
+++ b/src/write.c
@@ -429,7 +429,7 @@ avifEncoder * avifEncoderCreate(void)
         return NULL;
     }
     memset(encoder, 0, sizeof(avifEncoder));
-    encoder->headerStrategy = AVIF_ENCODER_FULL_HEADER;
+    encoder->headerFormat = AVIF_ENCODER_FULL_HEADER;
     encoder->codecChoice = AVIF_CODEC_CHOICE_AUTO;
     encoder->maxThreads = 1;
     encoder->speed = AVIF_SPEED_DEFAULT;
@@ -2154,7 +2154,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     // Decide whether to go for a CondensedImageBox or a full regular MetaBox.
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
-    if ((encoder->headerStrategy == AVIF_ENCODER_REDUCED_HEADER) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
+    if ((encoder->headerFormat == AVIF_ENCODER_REDUCED_HEADER) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
         AVIF_CHECKRES(avifEncoderWriteFileTypeBoxAndCondensedImageBox(encoder, output));
         return AVIF_RESULT_OK;
     }

--- a/src/write.c
+++ b/src/write.c
@@ -1842,7 +1842,7 @@ static avifResult avifImageWriteExtendedMeta(const avifImage * imageMetadata, av
         AVIF_CHECKRES(avifRWStreamWriteBox(stream, "ipco", AVIF_BOX_SIZE_TBD, &ipco));
         {
             // No need for dedup because there is only one property of each type and for a single item.
-            avifEncoderWriteExtendedColorProperties(stream, stream, imageMetadata, /*ipma=*/NULL, /*dedup=*/NULL);
+            AVIF_CHECKRES(avifEncoderWriteExtendedColorProperties(stream, stream, imageMetadata, /*ipma=*/NULL, /*dedup=*/NULL));
         }
         avifRWStreamFinishBox(stream, ipco);
 

--- a/src/write.c
+++ b/src/write.c
@@ -1968,6 +1968,7 @@ static avifResult avifEncoderWriteFileTypeBoxAndCondensedImageBox(avifEncoder * 
         }
     }
 
+    assert(colorItem);
     const avifRWData * colorData = &colorItem->encodeOutput->samples.sample[0].data;
     const avifRWData * alphaData = alphaItem ? &alphaItem->encodeOutput->samples.sample[0].data : NULL;
 

--- a/src/write.c
+++ b/src/write.c
@@ -1842,6 +1842,7 @@ static avifResult avifImageWriteExtendedMeta(const avifImage * imageMetadata, av
         AVIF_CHECKRES(avifRWStreamWriteBox(stream, "ipco", AVIF_BOX_SIZE_TBD, &ipco));
         {
             // No need for dedup because there is only one property of each type and for a single item.
+            AVIF_CHECKRES(avifEncoderWriteHDRProperties(stream, stream, imageMetadata, /*ipma=*/NULL, /*dedup=*/NULL));
             AVIF_CHECKRES(avifEncoderWriteExtendedColorProperties(stream, stream, imageMetadata, /*ipma=*/NULL, /*dedup=*/NULL));
         }
         avifRWStreamFinishBox(stream, ipco);

--- a/src/write.c
+++ b/src/write.c
@@ -450,11 +450,11 @@ avifEncoder * avifEncoderCreate(void)
     encoder->scalingMode = noScaling;
     encoder->data = avifEncoderDataCreate();
     encoder->csOptions = avifCodecSpecificOptionsCreate();
-    encoder->headerFormat = AVIF_HEADER_FULL;
     if (!encoder->data || !encoder->csOptions) {
         avifEncoderDestroy(encoder);
         return NULL;
     }
+    encoder->headerFormat = AVIF_HEADER_FULL;
     return encoder;
 }
 
@@ -2146,14 +2146,6 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     // -----------------------------------------------------------------------
     // Begin write stream
 
-    const avifImage * imageMetadata = encoder->data->imageMetadata;
-    // The epoch for creation_time and modification_time is midnight, Jan. 1,
-    // 1904, in UTC time. Add the number of seconds between that epoch and the
-    // Unix epoch.
-    uint64_t now = (uint64_t)time(NULL) + 2082844800;
-
-    // -----------------------------------------------------------------------
-
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
     // Decide whether to go for a CondensedImageBox or a full regular MetaBox.
     if ((encoder->headerFormat == AVIF_HEADER_REDUCED) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
@@ -2161,6 +2153,12 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
         return AVIF_RESULT_OK;
     }
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
+
+    const avifImage * imageMetadata = encoder->data->imageMetadata;
+    // The epoch for creation_time and modification_time is midnight, Jan. 1,
+    // 1904, in UTC time. Add the number of seconds between that epoch and the
+    // Unix epoch.
+    uint64_t now = (uint64_t)time(NULL) + 2082844800;
 
     avifRWStream s;
     avifRWStreamStart(&s, output);

--- a/src/write.c
+++ b/src/write.c
@@ -2154,7 +2154,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     // Decide whether to go for a CondensedImageBox or a full regular MetaBox.
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
-    if ((encoder->headerStrategy == AVIF_ENCODER_REDUCE_HEADER) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
+    if ((encoder->headerStrategy == AVIF_ENCODER_REDUCED_HEADER) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
         AVIF_CHECKRES(avifEncoderWriteFileTypeBoxAndCondensedImageBox(encoder, output));
         return AVIF_RESULT_OK;
     }

--- a/src/write.c
+++ b/src/write.c
@@ -1927,7 +1927,7 @@ static avifBool avifEncoderIsCondensedImageBoxCompatible(const avifEncoder * enc
         // Items besides the colorItem, the alphaItem and Exif/XMP/ICC
         // metadata are not directly supported by the CondensedImageBox.
         // Store them in its inner extendedMeta field instead.
-        // TODO(yguyon): Implement comment above instead of fallbacking to regular AVIF
+        // TODO(yguyon): Implement comment above instead of falling back to regular AVIF
         //               (or drop the comment above if there is no other item type).
         return AVIF_FALSE;
     }

--- a/src/write.c
+++ b/src/write.c
@@ -429,7 +429,7 @@ avifEncoder * avifEncoderCreate(void)
         return NULL;
     }
     memset(encoder, 0, sizeof(avifEncoder));
-    encoder->headerFormat = AVIF_ENCODER_FULL_HEADER;
+    encoder->headerFormat = AVIF_HEADER_FULL;
     encoder->codecChoice = AVIF_CODEC_CHOICE_AUTO;
     encoder->maxThreads = 1;
     encoder->speed = AVIF_SPEED_DEFAULT;
@@ -2154,7 +2154,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     // Decide whether to go for a CondensedImageBox or a full regular MetaBox.
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
-    if ((encoder->headerFormat == AVIF_ENCODER_REDUCED_HEADER) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
+    if ((encoder->headerFormat == AVIF_HEADER_REDUCED) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
         AVIF_CHECKRES(avifEncoderWriteFileTypeBoxAndCondensedImageBox(encoder, output));
         return AVIF_RESULT_OK;
     }

--- a/src/write.c
+++ b/src/write.c
@@ -579,7 +579,8 @@ static avifResult avifEncoderWriteNclxProperty(avifRWStream * dedupStream,
 }
 
 // Subset of avifEncoderWriteColorProperties() for the properties clli, pasp, clap, irot, imir.
-// Also used by the extendedMeta field of the CondensedImageBox.
+// Also used by the extendedMeta field of the CondensedImageBox if AVIF_ENABLE_EXPERIMENTAL_AVIR is
+// defined.
 static avifResult avifEncoderWriteExtendedColorProperties(avifRWStream * dedupStream,
                                                           avifRWStream * outputStream,
                                                           const avifImage * imageMetadata,
@@ -2152,9 +2153,9 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     uint64_t now = (uint64_t)time(NULL) + 2082844800;
 
     // -----------------------------------------------------------------------
-    // Decide whether to go for a CondensedImageBox or a full regular MetaBox.
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+    // Decide whether to go for a CondensedImageBox or a full regular MetaBox.
     if ((encoder->headerFormat == AVIF_HEADER_REDUCED) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
         AVIF_CHECKRES(avifEncoderWriteFileTypeBoxAndCondensedImageBox(encoder, output));
         return AVIF_RESULT_OK;

--- a/src/write.c
+++ b/src/write.c
@@ -429,7 +429,6 @@ avifEncoder * avifEncoderCreate(void)
         return NULL;
     }
     memset(encoder, 0, sizeof(avifEncoder));
-    encoder->headerFormat = AVIF_HEADER_FULL;
     encoder->codecChoice = AVIF_CODEC_CHOICE_AUTO;
     encoder->maxThreads = 1;
     encoder->speed = AVIF_SPEED_DEFAULT;
@@ -451,6 +450,7 @@ avifEncoder * avifEncoderCreate(void)
     encoder->scalingMode = noScaling;
     encoder->data = avifEncoderDataCreate();
     encoder->csOptions = avifCodecSpecificOptionsCreate();
+    encoder->headerFormat = AVIF_HEADER_FULL;
     if (!encoder->data || !encoder->csOptions) {
         avifEncoderDestroy(encoder);
         return NULL;

--- a/src/write.c
+++ b/src/write.c
@@ -2154,7 +2154,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     // Decide whether to go for a CondensedImageBox or a full regular MetaBox.
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_AVIR)
-    if ((encoder->headerStrategy == AVIF_ENCODER_MINIMIZE_HEADER) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
+    if ((encoder->headerStrategy == AVIF_ENCODER_REDUCE_HEADER) && avifEncoderIsCondensedImageBoxCompatible(encoder)) {
         AVIF_CHECKRES(avifEncoderWriteFileTypeBoxAndCondensedImageBox(encoder, output));
         return AVIF_RESULT_OK;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,13 @@ if(AVIF_ENABLE_GTEST)
     target_include_directories(avifcodectest PRIVATE ${GTEST_INCLUDE_DIRS})
     add_test(NAME avifcodectest COMMAND avifcodectest)
 
+    if(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+        add_executable(avifconitest gtest/avifconitest.cc)
+        target_link_libraries(avifconitest aviftest_helpers ${GTEST_BOTH_LIBRARIES})
+        target_include_directories(avifconitest PRIVATE ${GTEST_INCLUDE_DIRS})
+        add_test(NAME avifconitest COMMAND avifconitest)
+    endif()
+
     add_executable(avifdecodetest gtest/avifdecodetest.cc)
     target_link_libraries(avifdecodetest aviftest_helpers ${GTEST_LIBRARIES})
     target_include_directories(avifdecodetest PRIVATE ${GTEST_INCLUDE_DIRS})
@@ -307,6 +314,9 @@ if(AVIF_CODEC_AVM)
                 avifmetadatatest avifprogressivetest avify4mtest PROPERTIES DISABLED True
             )
 
+            if(AVIF_ENABLE_EXPERIMENTAL_AVIR)
+                set_tests_properties(avifconitest PROPERTIES DISABLED True)
+            endif()
             if(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
                 set_tests_properties(avifgainmaptest PROPERTIES DISABLED True)
             endif()

--- a/tests/gtest/avifconitest.cc
+++ b/tests/gtest/avifconitest.cc
@@ -83,7 +83,7 @@ TEST_P(AvifCondensedImageBoxTest, SimpleOpaque) {
   testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
   ASSERT_NE(encoder, nullptr);
   encoder->speed = AVIF_SPEED_FASTEST;
-  encoder->headerStrategy = AVIF_ENCODER_MINIMIZE_HEADER;
+  encoder->headerStrategy = AVIF_ENCODER_REDUCE_HEADER;
   ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encoded_coni),
             AVIF_RESULT_OK);
 

--- a/tests/gtest/avifconitest.cc
+++ b/tests/gtest/avifconitest.cc
@@ -83,7 +83,7 @@ TEST_P(AvifCondensedImageBoxTest, SimpleOpaque) {
   testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
   ASSERT_NE(encoder, nullptr);
   encoder->speed = AVIF_SPEED_FASTEST;
-  encoder->headerFormat = AVIF_ENCODER_REDUCED_HEADER;
+  encoder->headerFormat = AVIF_HEADER_REDUCED;
   ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encoded_coni),
             AVIF_RESULT_OK);
 

--- a/tests/gtest/avifconitest.cc
+++ b/tests/gtest/avifconitest.cc
@@ -67,9 +67,10 @@ TEST_P(AvifCondensedImageBoxTest, SimpleOpaque) {
     const avifCropRect rect{image->width / 4, image->height / 4,
                             std::min(1u, image->width / 2),
                             std::min(1u, image->height / 2)};
-    ASSERT_TRUE(avifCleanApertureBoxConvertCropRect(
-        &image->clap, &rect, image->width, image->height, image->yuvFormat,
-        /*diag=*/nullptr));
+    avifDiagnostics diag;
+    ASSERT_TRUE(avifCleanApertureBoxConvertCropRect(&image->clap, &rect,
+                                                    image->width, image->height,
+                                                    image->yuvFormat, &diag));
   }
   if (create_transform_flags & AVIF_TRANSFORM_IROT) {
     image->irot.angle = 2;

--- a/tests/gtest/avifconitest.cc
+++ b/tests/gtest/avifconitest.cc
@@ -83,7 +83,7 @@ TEST_P(AvifCondensedImageBoxTest, SimpleOpaque) {
   testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
   ASSERT_NE(encoder, nullptr);
   encoder->speed = AVIF_SPEED_FASTEST;
-  encoder->headerStrategy = AVIF_ENCODER_REDUCE_HEADER;
+  encoder->headerStrategy = AVIF_ENCODER_REDUCED_HEADER;
   ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encoded_coni),
             AVIF_RESULT_OK);
 

--- a/tests/gtest/avifconitest.cc
+++ b/tests/gtest/avifconitest.cc
@@ -83,7 +83,7 @@ TEST_P(AvifCondensedImageBoxTest, SimpleOpaque) {
   testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
   ASSERT_NE(encoder, nullptr);
   encoder->speed = AVIF_SPEED_FASTEST;
-  encoder->headerStrategy = AVIF_ENCODER_REDUCED_HEADER;
+  encoder->headerFormat = AVIF_ENCODER_REDUCED_HEADER;
   ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encoded_coni),
             AVIF_RESULT_OK);
 

--- a/tests/gtest/avifconitest.cc
+++ b/tests/gtest/avifconitest.cc
@@ -1,0 +1,159 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "avif/avif.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+using ::testing::Combine;
+using ::testing::Values;
+
+namespace libavif {
+namespace {
+
+//------------------------------------------------------------------------------
+
+class AvifCondensedImageBoxTest
+    : public testing::TestWithParam<std::tuple<
+          /*width=*/int, /*height=*/int, /*depth=*/int, avifPixelFormat,
+          avifPlanesFlags, avifRange, /*create_icc=*/bool, /*create_exif=*/bool,
+          /*create_xmp=*/bool, /*create_clli=*/bool, avifTransformFlags>> {};
+
+TEST_P(AvifCondensedImageBoxTest, SimpleOpaque) {
+  const int width = std::get<0>(GetParam());
+  const int height = std::get<1>(GetParam());
+  const int depth = std::get<2>(GetParam());
+  const avifPixelFormat format = std::get<3>(GetParam());
+  const avifPlanesFlags planes = std::get<4>(GetParam());
+  const avifRange range = std::get<5>(GetParam());
+  const bool create_icc = std::get<6>(GetParam());
+  const bool create_exif = std::get<7>(GetParam());
+  const bool create_xmp = std::get<8>(GetParam());
+  const bool create_clli = std::get<9>(GetParam());
+  const avifTransformFlags create_transform_flags = std::get<10>(GetParam());
+
+  testutil::AvifImagePtr image =
+      testutil::CreateImage(width, height, depth, format, planes, range);
+  ASSERT_NE(image, nullptr);
+  testutil::FillImageGradient(image.get());  // The pixels do not matter.
+  if (create_icc) {
+    avifImageSetProfileICC(image.get(), testutil::kSampleIcc.data(),
+                           testutil::kSampleIcc.size());
+  }
+  if (create_exif) {
+    size_t exif_tiff_header_offset;  // Must be 0 for 'avir' brand.
+    ASSERT_EQ(avifGetExifTiffHeaderOffset(testutil::kSampleExif.data(),
+                                          testutil::kSampleExif.size(),
+                                          &exif_tiff_header_offset),
+              AVIF_RESULT_OK);
+    avifImageSetMetadataExif(
+        image.get(), testutil::kSampleExif.data() + exif_tiff_header_offset,
+        testutil::kSampleExif.size() - exif_tiff_header_offset);
+  }
+  if (create_xmp) {
+    avifImageSetMetadataXMP(image.get(), testutil::kSampleXmp.data(),
+                            testutil::kSampleXmp.size());
+  }
+  if (create_clli) {
+    image->clli.maxCLL = 1;
+    image->clli.maxPALL = 2;
+  }
+  image->transformFlags = create_transform_flags;
+  if (create_transform_flags & AVIF_TRANSFORM_PASP) {
+    image->pasp.hSpacing = 1;
+    image->pasp.vSpacing = 2;
+  }
+  if (create_transform_flags & AVIF_TRANSFORM_CLAP) {
+    const avifCropRect rect{image->width / 4, image->height / 4,
+                            std::min(1u, image->width / 2),
+                            std::min(1u, image->height / 2)};
+    ASSERT_TRUE(avifCleanApertureBoxConvertCropRect(
+        &image->clap, &rect, image->width, image->height, image->yuvFormat,
+        /*diag=*/nullptr));
+  }
+  if (create_transform_flags & AVIF_TRANSFORM_IROT) {
+    image->irot.angle = 2;
+  }
+  if (create_transform_flags & AVIF_TRANSFORM_IMIR) {
+    image->imir.axis = 1;
+  }
+
+  // Encode.
+  testutil::AvifRwData encoded_coni;
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->headerStrategy = AVIF_ENCODER_MINIMIZE_HEADER;
+  ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encoded_coni),
+            AVIF_RESULT_OK);
+
+  // Decode.
+  const testutil::AvifImagePtr decoded_coni =
+      testutil::Decode(encoded_coni.data, encoded_coni.size);
+  ASSERT_NE(decoded_coni, nullptr);
+
+  // Compare.
+  testutil::AvifRwData encoded_meta =
+      testutil::Encode(image.get(), encoder->speed);
+  ASSERT_NE(encoded_meta.data, nullptr);
+  // At least 200 bytes should be saved.
+  EXPECT_LT(encoded_coni.size, encoded_meta.size - 200);
+
+  const testutil::AvifImagePtr decoded_meta =
+      testutil::Decode(encoded_meta.data, encoded_meta.size);
+  ASSERT_NE(decoded_meta, nullptr);
+
+  // Only the container changed. The pixels, features and metadata should be
+  // identical.
+  EXPECT_TRUE(
+      testutil::AreImagesEqual(*decoded_meta.get(), *decoded_coni.get()));
+}
+
+INSTANTIATE_TEST_SUITE_P(OnePixel, AvifCondensedImageBoxTest,
+                         Combine(/*width=*/Values(1), /*height=*/Values(1),
+                                 /*depth=*/Values(8),
+                                 Values(AVIF_PIXEL_FORMAT_YUV444),
+                                 Values(AVIF_PLANES_YUV, AVIF_PLANES_ALL),
+                                 Values(AVIF_RANGE_LIMITED, AVIF_RANGE_FULL),
+                                 /*create_icc=*/Values(false, true),
+                                 /*create_exif=*/Values(false, true),
+                                 /*create_xmp=*/Values(false, true),
+                                 /*create_clli=*/Values(false),
+                                 Values(AVIF_TRANSFORM_NONE)));
+
+INSTANTIATE_TEST_SUITE_P(
+    DepthsSubsamplings, AvifCondensedImageBoxTest,
+    Combine(/*width=*/Values(12), /*height=*/Values(34),
+            /*depth=*/Values(8, 10, 12),
+            Values(AVIF_PIXEL_FORMAT_YUV444, AVIF_PIXEL_FORMAT_YUV420,
+                   AVIF_PIXEL_FORMAT_YUV400),
+            Values(AVIF_PLANES_ALL), Values(AVIF_RANGE_FULL),
+            /*create_icc=*/Values(false), /*create_exif=*/Values(false),
+            /*create_xmp=*/Values(false), /*create_clli=*/Values(false),
+            Values(AVIF_TRANSFORM_NONE)));
+
+INSTANTIATE_TEST_SUITE_P(
+    Dimensions, AvifCondensedImageBoxTest,
+    Combine(/*width=*/Values(127), /*height=*/Values(200), /*depth=*/Values(8),
+            Values(AVIF_PIXEL_FORMAT_YUV444), Values(AVIF_PLANES_ALL),
+            Values(AVIF_RANGE_FULL), /*create_icc=*/Values(true),
+            /*create_exif=*/Values(true), /*create_xmp=*/Values(true),
+            /*create_clli=*/Values(false), Values(AVIF_TRANSFORM_NONE)));
+
+// Use CLLI and transform properties that are not supported by a plain
+// CondensedImageBox to force the use of an ExtendedMetaBox.
+INSTANTIATE_TEST_SUITE_P(
+    ExtendedMetaBox, AvifCondensedImageBoxTest,
+    Combine(/*width=*/Values(16), /*height=*/Values(24), /*depth=*/Values(8),
+            Values(AVIF_PIXEL_FORMAT_YUV444), Values(AVIF_PLANES_ALL),
+            Values(AVIF_RANGE_FULL), /*create_icc=*/Values(true),
+            /*create_exif=*/Values(true), /*create_xmp=*/Values(true),
+            /*create_clli=*/Values(true),
+            Values(AVIF_TRANSFORM_NONE,
+                   AVIF_TRANSFORM_PASP | AVIF_TRANSFORM_CLAP |
+                       AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR)));
+
+//------------------------------------------------------------------------------
+
+}  // namespace
+}  // namespace libavif


### PR DESCRIPTION
Remove a few hundred bytes of container boilerplate for simple images. This prototype uses a small box that expands in meaning to a full meta box with all defined items and properties.

Warning: This feature is experimental and forbidden by the current AVIF specification.