### PR TITLE
android_jni: Add braces to single line statement

### DIFF
--- a/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/AvifDecoderTest.java
+++ b/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/AvifDecoderTest.java
@@ -141,7 +141,9 @@ public class AvifDecoderTest {
   // can be decoded this way.
   @Test
   public void testDecodeUtilityClass() throws IOException {
-    if (image.isAnimated) return;
+    if (image.isAnimated) {
+      return;
+    }
     ByteBuffer buffer = image.getBuffer();
     assertThat(buffer).isNotNull();
     assertThat(AvifDecoder.isAvifImage(buffer)).isTrue();


### PR DESCRIPTION
Unlike C/C++, the Java style guide seems to disallow this.

https://google.github.io/styleguide/javaguide.html#s4.1.1-braces-always-used