### PR TITLE
ci-windows.yml: Do not build rav1e

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -32,11 +32,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
 
     - name: Cache external dependencies
       id: cache-ext
@@ -59,10 +54,6 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./dav1d.cmd
-    - name: Build rav1e
-      if: steps.cache-ext.outputs.cache-hit != 'true'
-      working-directory: ./ext
-      run: ./rav1e.cmd
     - name: Build SVT-AV1
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
@@ -100,7 +91,6 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON
         -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON
-        -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=ON
         -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON
         -DAVIF_CODEC_LIBGAV1=ON -DAVIF_LOCAL_LIBGAV1=ON
         -DAVIF_LOCAL_LIBYUV=ON -DAVIF_LOCAL_JPEG=ON


### PR DESCRIPTION
Work around the following linker errors that started to appear today:

rav1e.lib(rav1e-6457e1f48599bb43.std-391022a4250a8b9a.std.feb3b897-cgu.0.rcgu.o.rcgu.o) : error LNK2019: unresolved external symbol __imp_NtWriteFile referenced in function _ZN3std3sys7windows5stdio5write17h3c0a0f8c7c3063c9E.llvm.15018492211956286748
rav1e.lib(rav1e-6457e1f48599bb43.std-391022a4250a8b9a.std.feb3b897-cgu.0.rcgu.o.rcgu.o) : error LNK2019: unresolved external symbol __imp_RtlNtStatusToDosError referenced in function _ZN3std3sys7windows5stdio5write17h3c0a0f8c7c3063c9E.llvm.15018492211956286748