### PR TITLE
Link with ntdll.lib if rav1e is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,7 +397,7 @@ if(AVIF_CODEC_RAV1E)
 
     # Unfortunately, rav1e requires a few more libraries
     if(WIN32)
-        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ws2_32.lib bcrypt.lib userenv.lib)
+        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ws2_32.lib bcrypt.lib userenv.lib ntdll.lib)
     elseif(UNIX AND NOT APPLE)
         set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${CMAKE_DL_LIBS}) # for backtrace
     endif()


### PR DESCRIPTION
Fix the following linker errors in the windows-latest os image:

rav1e.lib(rav1e-6457e1f48599bb43.std-391022a4250a8b9a.std.feb3b897-cgu.0.rcgu.o.rcgu.o) : error LNK2019: unresolved external symbol __imp_NtWriteFile referenced in function _ZN3std3sys7windows5stdio5write17h3c0a0f8c7c3063c9E.llvm.15018492211956286748
rav1e.lib(rav1e-6457e1f48599bb43.std-391022a4250a8b9a.std.feb3b897-cgu.0.rcgu.o.rcgu.o) : error LNK2019: unresolved external symbol __imp_RtlNtStatusToDosError referenced in function _ZN3std3sys7windows5stdio5write17h3c0a0f8c7c3063c9E.llvm.15018492211956286748