### PR TITLE
Add support for more transfer functions when calling libsharpyuv.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ List of incompatible ABI changes in this release:
 * Add experimental support for AV2 behind the compilation flag AVIF_CODEC_AVM.
   AVIF_CODEC_CHOICE_AVM is now part of avifCodecChoice.
 * Add avifenc --no-overwrite flag to avoid overwriting output file.
+* Add support for all transfer functions when using libsharpyuv.
 
 ### Changed
 * Exif and XMP metadata is exported to PNG and JPEG files by default,
@@ -61,6 +62,7 @@ List of incompatible ABI changes in this release:
   instances.
 * Update aom.cmd: v3.6.1
 * Update dav1d.cmd: 1.2.0
+* Update libsharpyuv: 0.4.0
 * Update rav1e.cmd: v0.6.6
 * Update svt.cmd/svt.sh: v1.6.0
 * Update zlibpng.cmd: zlib 1.2.13 and libpng 1.6.39

--- a/ext/libsharpyuv.cmd
+++ b/ext/libsharpyuv.cmd
@@ -12,7 +12,7 @@
 git clone --single-branch https://chromium.googlesource.com/webm/libwebp
 
 cd libwebp
-git checkout 15a91ab
+git checkout 048cfc
 
 mkdir build
 cd build

--- a/src/reformat_libsharpyuv.c
+++ b/src/reformat_libsharpyuv.c
@@ -16,50 +16,50 @@ avifResult avifImageRGBToYUVLibSharpYUV(avifImage * image, const avifRGBImage * 
     SharpYuvConversionMatrix matrix;
     // Fills in 'matrix' for the given YUVColorSpace.
     SharpYuvComputeConversionMatrix(&color_space, &matrix);
-#if SHARPYUV_VERSION >= SHARPYUV_MAKE_VERSION(0, 3, 0)
+#if SHARPYUV_VERSION >= SHARPYUV_MAKE_VERSION(0, 4, 0)
     SharpYuvOptions options;
-    options.yuv_matrix = &matrix;
+    SharpYuvOptionsInit(&matrix, &options);
     if (image->transferCharacteristics == AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED) {
-        // Set to SRGB for backward compatibility.
+        // Set to sRGB for backward compatibility.
         options.transfer_type = kSharpYuvTransferFunctionSrgb;
     } else {
         options.transfer_type = (SharpYuvTransferFunctionType)image->transferCharacteristics;
     }
-    if (!SharpYuvConvertWithOptions(&rgb->pixels[state->rgbOffsetBytesR],
-                                    &rgb->pixels[state->rgbOffsetBytesG],
-                                    &rgb->pixels[state->rgbOffsetBytesB],
-                                    state->rgbPixelBytes,
-                                    rgb->rowBytes,
-                                    rgb->depth,
-                                    image->yuvPlanes[AVIF_CHAN_Y],
-                                    image->yuvRowBytes[AVIF_CHAN_Y],
-                                    image->yuvPlanes[AVIF_CHAN_U],
-                                    image->yuvRowBytes[AVIF_CHAN_U],
-                                    image->yuvPlanes[AVIF_CHAN_V],
-                                    image->yuvRowBytes[AVIF_CHAN_V],
-                                    image->depth,
-                                    rgb->width,
-                                    rgb->height,
-                                    &options))
+    const int sharpyuvRes = SharpYuvConvertWithOptions(&rgb->pixels[state->rgbOffsetBytesR],
+                                                       &rgb->pixels[state->rgbOffsetBytesG],
+                                                       &rgb->pixels[state->rgbOffsetBytesB],
+                                                       state->rgbPixelBytes,
+                                                       rgb->rowBytes,
+                                                       rgb->depth,
+                                                       image->yuvPlanes[AVIF_CHAN_Y],
+                                                       image->yuvRowBytes[AVIF_CHAN_Y],
+                                                       image->yuvPlanes[AVIF_CHAN_U],
+                                                       image->yuvRowBytes[AVIF_CHAN_U],
+                                                       image->yuvPlanes[AVIF_CHAN_V],
+                                                       image->yuvRowBytes[AVIF_CHAN_V],
+                                                       image->depth,
+                                                       rgb->width,
+                                                       rgb->height,
+                                                       &options);
 #else
-    if (!SharpYuvConvert(&rgb->pixels[state->rgbOffsetBytesR],
-                         &rgb->pixels[state->rgbOffsetBytesG],
-                         &rgb->pixels[state->rgbOffsetBytesB],
-                         state->rgbPixelBytes,
-                         rgb->rowBytes,
-                         rgb->depth,
-                         image->yuvPlanes[AVIF_CHAN_Y],
-                         image->yuvRowBytes[AVIF_CHAN_Y],
-                         image->yuvPlanes[AVIF_CHAN_U],
-                         image->yuvRowBytes[AVIF_CHAN_U],
-                         image->yuvPlanes[AVIF_CHAN_V],
-                         image->yuvRowBytes[AVIF_CHAN_V],
-                         image->depth,
-                         rgb->width,
-                         rgb->height,
-                         &matrix))
+    const int sharpyuvRes = SharpYuvConvert(&rgb->pixels[state->rgbOffsetBytesR],
+                                            &rgb->pixels[state->rgbOffsetBytesG],
+                                            &rgb->pixels[state->rgbOffsetBytesB],
+                                            state->rgbPixelBytes,
+                                            rgb->rowBytes,
+                                            rgb->depth,
+                                            image->yuvPlanes[AVIF_CHAN_Y],
+                                            image->yuvRowBytes[AVIF_CHAN_Y],
+                                            image->yuvPlanes[AVIF_CHAN_U],
+                                            image->yuvRowBytes[AVIF_CHAN_U],
+                                            image->yuvPlanes[AVIF_CHAN_V],
+                                            image->yuvRowBytes[AVIF_CHAN_V],
+                                            image->depth,
+                                            rgb->width,
+                                            rgb->height,
+                                            &matrix);
 #endif
-    {
+    if (!sharpyuvRes) {
         return AVIF_RESULT_REFORMAT_FAILED;
     }
 

--- a/src/reformat_libsharpyuv.c
+++ b/src/reformat_libsharpyuv.c
@@ -9,13 +9,13 @@
 
 avifResult avifImageRGBToYUVLibSharpYUV(avifImage * image, const avifRGBImage * rgb, const avifReformatState * state)
 {
-    const SharpYuvColorSpace color_space = {
+    const SharpYuvColorSpace colorSpace = {
         state->kr, state->kb, image->depth, (state->yuvRange == AVIF_RANGE_LIMITED) ? kSharpYuvRangeLimited : kSharpYuvRangeFull
     };
 
     SharpYuvConversionMatrix matrix;
     // Fills in 'matrix' for the given YUVColorSpace.
-    SharpYuvComputeConversionMatrix(&color_space, &matrix);
+    SharpYuvComputeConversionMatrix(&colorSpace, &matrix);
 #if SHARPYUV_VERSION >= SHARPYUV_MAKE_VERSION(0, 4, 0)
     SharpYuvOptions options;
     SharpYuvOptionsInit(&matrix, &options);
@@ -58,7 +58,7 @@ avifResult avifImageRGBToYUVLibSharpYUV(avifImage * image, const avifRGBImage * 
                                             rgb->width,
                                             rgb->height,
                                             &matrix);
-#endif
+#endif // SHARPYUV_VERSION >= SHARPYUV_MAKE_VERSION(0, 4, 0)
     if (!sharpyuvRes) {
         return AVIF_RESULT_REFORMAT_FAILED;
     }
@@ -75,4 +75,4 @@ avifResult avifImageRGBToYUVLibSharpYUV(avifImage * image, const avifRGBImage * 
     (void)state;
     return AVIF_RESULT_NOT_IMPLEMENTED;
 }
-#endif
+#endif // defined(AVIF_LIBSHARPYUV_ENABLED)

--- a/src/reformat_libsharpyuv.c
+++ b/src/reformat_libsharpyuv.c
@@ -16,6 +16,32 @@ avifResult avifImageRGBToYUVLibSharpYUV(avifImage * image, const avifRGBImage * 
     SharpYuvConversionMatrix matrix;
     // Fills in 'matrix' for the given YUVColorSpace.
     SharpYuvComputeConversionMatrix(&color_space, &matrix);
+#if SHARPYUV_VERSION >= SHARPYUV_MAKE_VERSION(0, 3, 0)
+    SharpYuvOptions options;
+    options.yuv_matrix = &matrix;
+    if (image->transferCharacteristics == AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED) {
+        // Set to SRGB for backward compatibility.
+        options.transfer_type = kSharpYuvTransferFunctionSrgb;
+    } else {
+        options.transfer_type = (SharpYuvTransferFunctionType)image->transferCharacteristics;
+    }
+    if (!SharpYuvConvertWithOptions(&rgb->pixels[state->rgbOffsetBytesR],
+                                    &rgb->pixels[state->rgbOffsetBytesG],
+                                    &rgb->pixels[state->rgbOffsetBytesB],
+                                    state->rgbPixelBytes,
+                                    rgb->rowBytes,
+                                    rgb->depth,
+                                    image->yuvPlanes[AVIF_CHAN_Y],
+                                    image->yuvRowBytes[AVIF_CHAN_Y],
+                                    image->yuvPlanes[AVIF_CHAN_U],
+                                    image->yuvRowBytes[AVIF_CHAN_U],
+                                    image->yuvPlanes[AVIF_CHAN_V],
+                                    image->yuvRowBytes[AVIF_CHAN_V],
+                                    image->depth,
+                                    rgb->width,
+                                    rgb->height,
+                                    &options))
+#else
     if (!SharpYuvConvert(&rgb->pixels[state->rgbOffsetBytesR],
                          &rgb->pixels[state->rgbOffsetBytesG],
                          &rgb->pixels[state->rgbOffsetBytesB],
@@ -31,7 +57,9 @@ avifResult avifImageRGBToYUVLibSharpYUV(avifImage * image, const avifRGBImage * 
                          image->depth,
                          rgb->width,
                          rgb->height,
-                         &matrix)) {
+                         &matrix))
+#endif
+    {
         return AVIF_RESULT_REFORMAT_FAILED;
     }
 


### PR DESCRIPTION
This is a follow-up on https://github.com/AOMediaCodec/libavif/pull/444 with upstream libsharpyuv officially supporting all transfer functions since https://chromium.googlesource.com/webm/libwebp/+/25d94f473b10882b8bee9288d00539001b692042