### PR TITLE
avifpng.c: two small changes to commit bd7e0cf

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -10,7 +10,6 @@
 
 #include <ctype.h>
 #include <limits.h>
-#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -298,11 +297,11 @@ avifBool avifPNGRead(const char * inputFilename,
         imgBitDepth = 16;
     }
 
-    png_read_update_info(png, info);
-
     if (outPNGDepth) {
         *outPNGDepth = imgBitDepth;
     }
+
+    png_read_update_info(png, info);
 
     avif->width = rawWidth;
     avif->height = rawHeight;


### PR DESCRIPTION
No need to include <math.h>. Was needed for fabs() in earleir versions of https://github.com/AOMediaCodec/libavif/pull/1448.

Move the png_read_update_info() call to its original location so as to not separate the code that sets up imgBitDepth.
---