### PR TITLE
avifenc.c: Remove the --longhelp option

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -70,15 +70,14 @@ static void syntaxShort(void)
     printf("Syntax: avifenc [options] -q quality input.[jpg|jpeg|png|y4m] output.avif\n");
     printf("where quality is between %d (worst quality) and %d (lossless).\n", AVIF_QUALITY_WORST, AVIF_QUALITY_LOSSLESS);
     printf("Typical value is 60-80.\n\n");
-    printf("Try --longhelp for an exhaustive list of advanced options.\n");
+    printf("Try -h for an exhaustive list of options.\n");
 }
 
 static void syntaxLong(void)
 {
     printf("Syntax: avifenc [options] input.[jpg|jpeg|png|y4m] output.avif\n");
     printf("Standard options:\n");
-    printf("    -h,--help                         : Show short syntax help\n");
-    printf("    --longhelp                        : Show long syntax help (this page)\n");
+    printf("    -h,--help                         : Show syntax help (this page)\n");
     printf("    -V,--version                      : Show the version number\n");
     printf("\n");
     printf("Basic options:\n");
@@ -1137,9 +1136,6 @@ int main(int argc, char * argv[])
             }
             break;
         } else if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
-            syntaxShort();
-            goto cleanup;
-        } else if (!strcmp(arg, "--longhelp")) {
             syntaxLong();
             goto cleanup;
         } else if (!strcmp(arg, "-V") || !strcmp(arg, "--version")) {


### PR DESCRIPTION
Go back to using the -h or --help option to request the full syntax help. The short syntax help is only used as the error message for certain kinds of command-line errors.

This follows the design of libwebp2/examples/cwp2.cc.

The rationale is that when users type the -h or --help option, they are most likely interested in the full syntax help, so it doesn't make sense to require an intermediate step to get there.

We can revisit this design if we add a "basic" syntax help message that is more informative than the current short syntax help message.

Bug: b/275100954