### PR TITLE
Print ImageMagick version on CI

### DIFF
--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -47,6 +47,8 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: brew install aom dav1d imagemagick
+    - name: Print ImageMagick version
+      run: convert --version
       # TODO(yguyon): Install libyuv (not available with brew).
 
       # `sudo apt-get install googletest libgtest-dev` leads to the following:

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -44,15 +44,8 @@ jobs:
         version: 2.15.05
     - uses: seanmiddleditch/gha-setup-ninja@v3
     - run: pip install meson
-    - name: Install ImageMagick for testing (Linux)
-      if: runner.os == 'Linux'
-      run: |
-        echo "deb http://azure.archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get update
-        sudo apt-get install imagemagick
-    - name: Install ImageMagick for testing (macOS)
-      if: runner.os == 'macOS'
-      run: brew install imagemagick
+    - name: Print ImageMagick version
+      run: convert --version
     - name: Set shared libs
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -45,15 +45,8 @@ jobs:
         version: 2.15.05
     - uses: seanmiddleditch/gha-setup-ninja@v3
     - run: pip install meson
-    - name: Install ImageMagick for testing (Linux)
-      if: runner.os == 'Linux'
-      run: |
-        echo "deb http://azure.archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get update
-        sudo apt-get install imagemagick
-    - name: Install ImageMagick for testing (macOS)
-      if: runner.os == 'macOS'
-      run: brew install imagemagick
+    - name: Print ImageMagick version
+      run: convert --version
     - name: Build aom
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -51,6 +51,8 @@ jobs:
         version: 2.15.05
     - uses: seanmiddleditch/gha-setup-ninja@v3
     - run: pip install meson
+    - name: Print ImageMagick version
+      run: magick --version
     - name: Build aom
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext


### PR DESCRIPTION
This is a follow up for #1448. Github CI has ImageMagick pre-installed, so instead of installing it again, print the version of already installed ImageMagick.
