### PR TITLE
test_cmd_icc_profile.sh: Move --cicp tests earlier

### DIFF
--- a/tests/test_cmd_icc_profile.sh
+++ b/tests/test_cmd_icc_profile.sh
@@ -61,6 +61,12 @@ cleanup() {
 trap cleanup EXIT
 
 pushd ${TMP_DIR}
+  # Check --cicp flag works
+  "${AVIFENC}" --cicp 9/12/8 -s 8 "${INPUT_COLOR_PNG}" -o "${ENCODED_FILE}"
+  "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}" | grep "Color Primaries.* 9$"
+  "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}" | grep "Transfer Char.* 12$"
+  "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}" | grep "Matrix Coeffs.* 8$"
+
   # We use third-party tool (ImageMagick) to independently check
   # our generated ICC profile is valid and correct.
   if command -v magick &> /dev/null
@@ -74,6 +80,7 @@ pushd ${TMP_DIR}
     touch "${ENCODED_FILE}"
     touch "${DECODED_FILE}"
     touch "${CORRECTED_FILE}"
+    popd
     exit 0
   fi
 
@@ -90,12 +97,6 @@ pushd ${TMP_DIR}
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}"
   "${IMAGEMAGICK}" "${DECODED_FILE}" -profile "${SRGB_ICC}" "${CORRECTED_FILE}"
   "${ARE_IMAGES_EQUAL}" "${REFERENCE_GRAY_PNG}" "${CORRECTED_FILE}" 0 45
-
-  # Check --cicp flag works
-  "${AVIFENC}" --cicp 9/12/8 -s 8 "${INPUT_COLOR_PNG}" -o "${ENCODED_FILE}"
-  "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}" | grep "Color Primaries.* 9$"
-  "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}" | grep "Transfer Char.* 12$"
-  "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}" | grep "Matrix Coeffs.* 8$"
 popd
 
 exit 0


### PR DESCRIPTION
The --cicp tests do not use ImageMagick, so run those tests before checking for the presence of ImageMagick.

Also run popd before exiting with 0 if ImageMagick is not present.

A follow-up to the pull request
https://github.com/AOMediaCodec/libavif/pull/1463.