### PR TITLE
workflows: invoke bash with -e

### DIFF
--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -53,27 +53,27 @@ jobs:
     - name: Build aom
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash aom.cmd
+      run: bash -e aom.cmd
     - name: Build dav1d
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash dav1d.cmd
+      run: bash -e dav1d.cmd
     - name: Build rav1e
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash rav1e.cmd
+      run: bash -e rav1e.cmd
     - name: Build SVT-AV1
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash svt.cmd
+      run: bash -e svt.cmd
     - name: Build libyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash libyuv.cmd
+      run: bash -e libyuv.cmd
     - name: Build libsharpyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash libsharpyuv.cmd
+      run: bash -e libsharpyuv.cmd
 
     - name: Prepare libavif (cmake)
       run: >

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Build GoogleTest
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash googletest.cmd
+      run: bash -e googletest.cmd
 
     - name: Prepare libavif (cmake)
       run: >

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -58,23 +58,23 @@ jobs:
     - name: Build aom
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash aom.cmd
+      run: bash -e aom.cmd
     - name: Build dav1d
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash dav1d.cmd
+      run: bash -e dav1d.cmd
     - name: Build libyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash libyuv.cmd
+      run: bash -e libyuv.cmd
     - name: Build libsharpyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash libsharpyuv.cmd
+      run: bash -e libsharpyuv.cmd
     - name: Build GoogleTest
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash googletest.cmd
+      run: bash -e googletest.cmd
 
     - name: Prepare libavif (cmake)
       run: >

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -47,32 +47,32 @@ jobs:
     - name: Build avm
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash avm.cmd
+      run: bash -e avm.cmd
     - name: Build dav1d
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash dav1d.cmd
+      run: bash -e dav1d.cmd
     - name: Build rav1e
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash rav1e.cmd
+      run: bash -e rav1e.cmd
     - name: Build SVT-AV1
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash svt.cmd
+      run: bash -e svt.cmd
     - name: Build libyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash libyuv.cmd
+      run: bash -e libyuv.cmd
     - name: Build libsharpyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash libsharpyuv.cmd
+      run: bash -e libsharpyuv.cmd
     - name: Build GoogleTest
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       # Note: "apt install googletest" is sometimes insufficient for find_package(GTest) so build in ext/ instead.
-      run: bash googletest.cmd
+      run: bash -e googletest.cmd
 
     - name: Prepare libavif (cmake)
       run: >

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -50,36 +50,36 @@ jobs:
     - name: Build aom
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash aom.cmd
+      run: bash -e aom.cmd
     - name: Build dav1d
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash dav1d.cmd
+      run: bash -e dav1d.cmd
     - name: Build rav1e
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash rav1e.cmd
+      run: bash -e rav1e.cmd
     - name: Build SVT-AV1
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash svt.cmd
+      run: bash -e svt.cmd
     - name: Build libgav1
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash libgav1.cmd
+      run: bash -e libgav1.cmd
     - name: Build libyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash libyuv.cmd
+      run: bash -e libyuv.cmd
     - name: Build libsharpyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
-      run: bash libsharpyuv.cmd
+      run: bash -e libsharpyuv.cmd
     - name: Build GoogleTest
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       # Note: "apt install googletest" is sometimes insufficient for find_package(GTest) so build in ext/ instead.
-      run: bash googletest.cmd
+      run: bash -e googletest.cmd
 
     - name: Prepare libavif (cmake)
       run: >

--- a/ext/dav1d_android.sh
+++ b/ext/dav1d_android.sh
@@ -9,6 +9,8 @@
 # The git tag below is known to work, and will occasionally be updated. Feel
 # free to use a more recent commit.
 
+set -e
+
 if [ $# -ne 1 ]; then
   echo "Usage: ${0} <path_to_android_ndk>"
   exit 1

--- a/ext/libgav1_android.sh
+++ b/ext/libgav1_android.sh
@@ -9,6 +9,8 @@
 # The git tag below is known to work, and will occasionally be updated. Feel
 # free to use a more recent commit.
 
+set -e
+
 if [ $# -ne 1 ]; then
   echo "Usage: ${0} <path_to_android_ndk>"
   exit 1

--- a/ext/svt.sh
+++ b/ext/svt.sh
@@ -2,6 +2,8 @@
 # then enable CMake's AVIF_CODEC_SVT and AVIF_LOCAL_SVT options.
 # cmake and ninja must be in your PATH.
 
+set -e
+
 git clone -b v1.6.0 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 
 cd SVT-AV1


### PR DESCRIPTION
This will cause failures of simple commands to exit immediately. This
would have detected the use of an incorrect hash in libsharpyuv.cmd
which was fixed in:
29dfb12 libsharpyuv.cmd: fix commit hash (#1472)
