### PR TITLE
No need to set AV1E_SET_ROW_MT to 1

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -817,9 +817,6 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
         if (lossless) {
             aom_codec_control(&codec->internal->encoder, AV1E_SET_LOSSLESS, 1);
         }
-        if (encoder->maxThreads > 1) {
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_ROW_MT, 1);
-        }
         if (tileRowsLog2 != 0) {
             aom_codec_control(&codec->internal->encoder, AV1E_SET_TILE_ROWS, tileRowsLog2);
         }


### PR DESCRIPTION
The default value of AV1E_SET_ROW_MT was changed to 1 in https://aomedia-review.googlesource.com/c/aom/+/77983. The default value of AV1E_SET_ROW_MT is 1 in any libaom release that has AV1E_SET_ROW_MT, starting from v1.0.0-errata1-avif. So it is not necessary to set AV1E_SET_ROW_MT to 1.