### PR TITLE
Update a comment in avifImageYUVAnyToRGBAnySlow()

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -763,7 +763,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
                     G = Y - ((2 * ((kr * (1 - kr) * Cr) + (kb * (1 - kb) * Cb))) / kg);
                 }
             } else {
-                // Monochrome: just populate all channels with luma (identity mode is irrelevant)
+                // Monochrome: just populate all channels with luma (state->mode is irrelevant)
                 R = Y;
                 G = Y;
                 B = Y;


### PR DESCRIPTION
The following comment in avifImageYUVAnyToRGBAnySlow()

  // Monochrome: ... (identity mode is irrelevant)

added in commit ca2c34dd, was written when avifReformatMode had only two values (the default mode and identity mode). Now avifReformatMode has 3 values (or 5 if AVIF_ENABLE_EXPERIMENTAL_YCGCO_R is defined). Instead of enumerating all the non-default modes in the comment, just change "identity mode" to "state->mode".