### PR TITLE
Split and document avifParseCodecConfiguration()

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1862,7 +1862,7 @@ static avifBool avifParseContentLightLevelInformationBox(avifProperty * prop, co
     return AVIF_TRUE;
 }
 
-// Implementation of section 2.3.3. of AV1 Codec ISO Media File Format Binding specification v1.2.0.
+// Implementation of section 2.3.3 of AV1 Codec ISO Media File Format Binding specification v1.2.0.
 // See https://aomediacodec.github.io/av1-isobmff/v1.2.0.html#av1codecconfigurationbox-syntax.
 static avifBool avifParseCodecConfiguration(avifROStream * s, avifCodecConfigurationBox * config, const char * configPropName, avifDiagnostics * diag)
 {
@@ -1898,12 +1898,12 @@ static avifBool avifParseCodecConfiguration(avifROStream * s, avifCodecConfigura
     // }
     AVIF_CHECK(avifROStreamSkip(s, 1));
 
-    // According to section 2.2.1. of AV1 Image File Format specification v1.1.0:
-    //   "- Sequence Header OBUs should not be present in the AV1CodecConfigurationBox."
-    //   "- If a Sequence Header OBU is present in the AV1CodecConfigurationBox,
-    //      it shall match the Sequence Header OBU in the AV1 Image Item Data."
-    //   "- Metadata OBUs, if present, shall match the values given in other item properties,
-    //      such as the PixelInformationProperty or ColourInformationBox."
+    // According to section 2.2.1 of AV1 Image File Format specification v1.1.0:
+    //   - Sequence Header OBUs should not be present in the AV1CodecConfigurationBox.
+    //   - If a Sequence Header OBU is present in the AV1CodecConfigurationBox,
+    //     it shall match the Sequence Header OBU in the AV1 Image Item Data.
+    //   - Metadata OBUs, if present, shall match the values given in other item properties,
+    //     such as the PixelInformationProperty or ColourInformationBox.
     // See https://aomediacodec.github.io/av1-avif/v1.1.0.html#av1-configuration-item-property.
     // For simplicity, the constraints above are not enforced.
     // The following is skipped by avifParseItemPropertyContainerBox().

--- a/src/read.c
+++ b/src/read.c
@@ -1917,7 +1917,7 @@ static avifBool avifParseCodecConfigurationBoxProperty(avifProperty * prop,
                                                        const char * configPropName,
                                                        avifDiagnostics * diag)
 {
-    char diagContext[] = "Box[....]";
+    char diagContext[10];
     snprintf(diagContext, sizeof(diagContext), "Box[%.4s]", configPropName); // "Box[av1C]" or "Box[av2C]"
     BEGIN_STREAM(s, raw, rawLen, diag, diagContext);
     return avifParseCodecConfiguration(&s, &prop->u.av1C, configPropName, diag);
@@ -2410,7 +2410,7 @@ static avifBool avifParseItemInfoEntry(avifMeta * meta, const uint8_t * raw, siz
 
     avifDecoderItem * item = avifMetaFindItem(meta, itemID);
     if (!item) {
-        avifDiagnosticsPrintf(diag, "%s: Box[infe] of type %.4s has an invalid item ID [%u]", s.diagContext, itemType, itemID);
+        avifDiagnosticsPrintf(diag, "%s: Box[infe] with item_type %.4s has an invalid item ID [%u]", s.diagContext, itemType, itemID);
         return AVIF_FALSE;
     }
 

--- a/src/write.c
+++ b/src/write.c
@@ -538,7 +538,8 @@ static avifBool avifEncoderDetectChanges(const avifEncoder * encoder, avifEncode
 }
 
 // Subset of avifEncoderWriteColorProperties() for the properties clli, pasp, clap, irot, imir.
-static void avifEncoderWriteExtendedColorProperties(avifRWStream * outputStream,
+static void avifEncoderWriteExtendedColorProperties(avifRWStream * dedupStream,
+                                                    avifRWStream * outputStream,
                                                     const avifImage * imageMetadata,
                                                     struct ipmaArray * ipma,
                                                     avifItemPropertyDedup * dedup);
@@ -597,24 +598,24 @@ static void avifEncoderWriteColorProperties(avifRWStream * outputStream,
         ipmaPush(ipma, avifItemPropertyDedupFinish(dedup, outputStream), AVIF_FALSE);
     }
 
-    avifEncoderWriteExtendedColorProperties(outputStream, imageMetadata, ipma, dedup);
+    avifEncoderWriteExtendedColorProperties(s, outputStream, imageMetadata, ipma, dedup);
 }
 
-static void avifEncoderWriteExtendedColorProperties(avifRWStream * outputStream,
+static void avifEncoderWriteExtendedColorProperties(avifRWStream * dedupStream,
+                                                    avifRWStream * outputStream,
                                                     const avifImage * imageMetadata,
                                                     struct ipmaArray * ipma,
                                                     avifItemPropertyDedup * dedup)
 {
-    avifRWStream * s = dedup ? &dedup->s : outputStream;
     // Write Content Light Level Information, if present
     if (imageMetadata->clli.maxCLL || imageMetadata->clli.maxPALL) {
         if (dedup) {
             avifItemPropertyDedupStart(dedup);
         }
-        avifBoxMarker clli = avifRWStreamWriteBox(s, "clli", AVIF_BOX_SIZE_TBD);
-        avifRWStreamWriteU16(s, imageMetadata->clli.maxCLL);  // unsigned int(16) max_content_light_level;
-        avifRWStreamWriteU16(s, imageMetadata->clli.maxPALL); // unsigned int(16) max_pic_average_light_level;
-        avifRWStreamFinishBox(s, clli);
+        avifBoxMarker clli = avifRWStreamWriteBox(dedupStream, "clli", AVIF_BOX_SIZE_TBD);
+        avifRWStreamWriteU16(dedupStream, imageMetadata->clli.maxCLL);  // unsigned int(16) max_content_light_level;
+        avifRWStreamWriteU16(dedupStream, imageMetadata->clli.maxPALL); // unsigned int(16) max_pic_average_light_level;
+        avifRWStreamFinishBox(dedupStream, clli);
         if (dedup) {
             ipmaPush(ipma, avifItemPropertyDedupFinish(dedup, outputStream), AVIF_FALSE);
         }
@@ -625,10 +626,10 @@ static void avifEncoderWriteExtendedColorProperties(avifRWStream * outputStream,
         if (dedup) {
             avifItemPropertyDedupStart(dedup);
         }
-        avifBoxMarker pasp = avifRWStreamWriteBox(s, "pasp", AVIF_BOX_SIZE_TBD);
-        avifRWStreamWriteU32(s, imageMetadata->pasp.hSpacing); // unsigned int(32) hSpacing;
-        avifRWStreamWriteU32(s, imageMetadata->pasp.vSpacing); // unsigned int(32) vSpacing;
-        avifRWStreamFinishBox(s, pasp);
+        avifBoxMarker pasp = avifRWStreamWriteBox(dedupStream, "pasp", AVIF_BOX_SIZE_TBD);
+        avifRWStreamWriteU32(dedupStream, imageMetadata->pasp.hSpacing); // unsigned int(32) hSpacing;
+        avifRWStreamWriteU32(dedupStream, imageMetadata->pasp.vSpacing); // unsigned int(32) vSpacing;
+        avifRWStreamFinishBox(dedupStream, pasp);
         if (dedup) {
             ipmaPush(ipma, avifItemPropertyDedupFinish(dedup, outputStream), AVIF_FALSE);
         }
@@ -637,16 +638,16 @@ static void avifEncoderWriteExtendedColorProperties(avifRWStream * outputStream,
         if (dedup) {
             avifItemPropertyDedupStart(dedup);
         }
-        avifBoxMarker clap = avifRWStreamWriteBox(s, "clap", AVIF_BOX_SIZE_TBD);
-        avifRWStreamWriteU32(s, imageMetadata->clap.widthN);    // unsigned int(32) cleanApertureWidthN;
-        avifRWStreamWriteU32(s, imageMetadata->clap.widthD);    // unsigned int(32) cleanApertureWidthD;
-        avifRWStreamWriteU32(s, imageMetadata->clap.heightN);   // unsigned int(32) cleanApertureHeightN;
-        avifRWStreamWriteU32(s, imageMetadata->clap.heightD);   // unsigned int(32) cleanApertureHeightD;
-        avifRWStreamWriteU32(s, imageMetadata->clap.horizOffN); // unsigned int(32) horizOffN;
-        avifRWStreamWriteU32(s, imageMetadata->clap.horizOffD); // unsigned int(32) horizOffD;
-        avifRWStreamWriteU32(s, imageMetadata->clap.vertOffN);  // unsigned int(32) vertOffN;
-        avifRWStreamWriteU32(s, imageMetadata->clap.vertOffD);  // unsigned int(32) vertOffD;
-        avifRWStreamFinishBox(s, clap);
+        avifBoxMarker clap = avifRWStreamWriteBox(dedupStream, "clap", AVIF_BOX_SIZE_TBD);
+        avifRWStreamWriteU32(dedupStream, imageMetadata->clap.widthN);    // unsigned int(32) cleanApertureWidthN;
+        avifRWStreamWriteU32(dedupStream, imageMetadata->clap.widthD);    // unsigned int(32) cleanApertureWidthD;
+        avifRWStreamWriteU32(dedupStream, imageMetadata->clap.heightN);   // unsigned int(32) cleanApertureHeightN;
+        avifRWStreamWriteU32(dedupStream, imageMetadata->clap.heightD);   // unsigned int(32) cleanApertureHeightD;
+        avifRWStreamWriteU32(dedupStream, imageMetadata->clap.horizOffN); // unsigned int(32) horizOffN;
+        avifRWStreamWriteU32(dedupStream, imageMetadata->clap.horizOffD); // unsigned int(32) horizOffD;
+        avifRWStreamWriteU32(dedupStream, imageMetadata->clap.vertOffN);  // unsigned int(32) vertOffN;
+        avifRWStreamWriteU32(dedupStream, imageMetadata->clap.vertOffD);  // unsigned int(32) vertOffD;
+        avifRWStreamFinishBox(dedupStream, clap);
         if (dedup) {
             ipmaPush(ipma, avifItemPropertyDedupFinish(dedup, outputStream), AVIF_TRUE);
         }
@@ -655,10 +656,10 @@ static void avifEncoderWriteExtendedColorProperties(avifRWStream * outputStream,
         if (dedup) {
             avifItemPropertyDedupStart(dedup);
         }
-        avifBoxMarker irot = avifRWStreamWriteBox(s, "irot", AVIF_BOX_SIZE_TBD);
+        avifBoxMarker irot = avifRWStreamWriteBox(dedupStream, "irot", AVIF_BOX_SIZE_TBD);
         uint8_t angle = imageMetadata->irot.angle & 0x3;
-        avifRWStreamWrite(s, &angle, 1); // unsigned int (6) reserved = 0; unsigned int (2) angle;
-        avifRWStreamFinishBox(s, irot);
+        avifRWStreamWrite(dedupStream, &angle, 1); // unsigned int (6) reserved = 0; unsigned int (2) angle;
+        avifRWStreamFinishBox(dedupStream, irot);
         if (dedup) {
             ipmaPush(ipma, avifItemPropertyDedupFinish(dedup, outputStream), AVIF_TRUE);
         }
@@ -667,10 +668,10 @@ static void avifEncoderWriteExtendedColorProperties(avifRWStream * outputStream,
         if (dedup) {
             avifItemPropertyDedupStart(dedup);
         }
-        avifBoxMarker imir = avifRWStreamWriteBox(s, "imir", AVIF_BOX_SIZE_TBD);
+        avifBoxMarker imir = avifRWStreamWriteBox(dedupStream, "imir", AVIF_BOX_SIZE_TBD);
         uint8_t mode = imageMetadata->imir.mode & 0x1;
-        avifRWStreamWrite(s, &mode, 1); // unsigned int (7) reserved = 0; unsigned int (1) mode;
-        avifRWStreamFinishBox(s, imir);
+        avifRWStreamWrite(dedupStream, &mode, 1); // unsigned int (7) reserved = 0; unsigned int (1) mode;
+        avifRWStreamFinishBox(dedupStream, imir);
         if (dedup) {
             ipmaPush(ipma, avifItemPropertyDedupFinish(dedup, outputStream), AVIF_TRUE);
         }

--- a/src/write.c
+++ b/src/write.c
@@ -2190,7 +2190,7 @@ avifResult avifEncoderWrite(avifEncoder * encoder, const avifImage * image, avif
     return avifEncoderFinish(encoder, output);
 }
 
-// Implementation of section 2.3.3. of AV1 Codec ISO Media File Format Binding specification v1.2.0.
+// Implementation of section 2.3.3 of AV1 Codec ISO Media File Format Binding specification v1.2.0.
 // See https://aomediacodec.github.io/av1-isobmff/v1.2.0.html#av1codecconfigurationbox-syntax.
 static void writeCodecConfig(avifRWStream * s, const avifCodecConfigurationBox * cfg)
 {
@@ -2221,7 +2221,7 @@ static void writeCodecConfig(avifRWStream * s, const avifCodecConfigurationBox *
     // }
     avifRWStreamWriteU8(s, 0);
 
-    // According to section 2.2.1. of AV1 Image File Format specification v1.1.0,
+    // According to section 2.2.1 of AV1 Image File Format specification v1.1.0,
     // there is no need to write any OBU here.
     // See https://aomediacodec.github.io/av1-avif/v1.1.0.html#av1-configuration-item-property.
     // unsigned int (8) configOBUs[];


### PR DESCRIPTION
Mirror the changes of read.c to write.c too.
Also nits.

This is partly to simplify #1432.