### PR TITLE
Remove dot after specification section numbers

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -59,7 +59,7 @@ void avifGetPixelFormatInfo(avifPixelFormat format, avifPixelFormatInfo * info)
         case AVIF_PIXEL_FORMAT_YUV400:
             info->monochrome = AVIF_TRUE;
             // The nonexistent chroma is considered as subsampled in each dimension
-            // according to the AV1 specification. See sections 5.5.2. and 6.4.2.
+            // according to the AV1 specification. See sections 5.5.2 and 6.4.2.
             info->chromaShiftX = 1;
             info->chromaShiftY = 1;
             break;

--- a/tests/gtest/avifallocationtest.cc
+++ b/tests/gtest/avifallocationtest.cc
@@ -155,7 +155,7 @@ TEST(EncodingTest, ReasonableValidDimensions) {
 }
 
 // 65536 is the maximum AV1 frame dimension allowed by the AV1 specification.
-// See the section 5.5.1. General sequence header OBU syntax.
+// See the section 5.5.1 General sequence header OBU syntax.
 // However, this test is disabled because:
 // - Old versions of libaom are capped to 65535 (http://crbug.com/aomedia/3304).
 // - libaom may be compiled with CONFIG_SIZE_LIMIT defined, limiting the


### PR DESCRIPTION
[skip ci]

See https://github.com/AOMediaCodec/libavif/pull/1493#discussion_r1290780711