### PR TITLE
Add StreamReadBits() and StreamWriteBits()

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -453,6 +453,12 @@ typedef struct avifROStream
     // Index of the next byte in the raw stream.
     size_t offset;
 
+    // Index of the currently selected partial byte. Must be lower than offset.
+    // Only meaningful if numUsedBitsInPartialByte is not zero.
+    size_t offsetOfPartialByte;
+    // Number of bits already used in the currently selected partial byte.
+    size_t numUsedBitsInPartialByte;
+
     // Error information, if any.
     avifDiagnostics * diag;
     const char * diagContext;
@@ -478,6 +484,9 @@ avifBool avifROStreamReadBoxHeader(avifROStream * stream, avifBoxHeader * header
 avifBool avifROStreamReadBoxHeaderPartial(avifROStream * stream, avifBoxHeader * header); // This doesn't require that the full box can fit in the stream
 avifBool avifROStreamReadVersionAndFlags(avifROStream * stream, uint8_t * version, uint32_t * flags); // version and flags ptrs are both optional
 avifBool avifROStreamReadAndEnforceVersion(avifROStream * stream, uint8_t enforcedVersion); // currently discards flags
+avifBool avifROStreamReadBits8(avifROStream * stream, uint8_t * v, size_t bitCount);
+avifBool avifROStreamReadBits(avifROStream * stream, uint32_t * v, size_t bitCount);
+avifBool avifROStreamReadVarInt(avifROStream * stream, uint32_t * v);
 
 typedef struct avifRWStream
 {
@@ -485,6 +494,12 @@ typedef struct avifRWStream
 
     // Index of the next byte in the raw stream.
     size_t offset;
+
+    // Index of the currently selected partial byte. Must be lower than offset.
+    // Only meaningful if numUsedBitsInPartialByte is not zero.
+    size_t offsetOfPartialByte;
+    // Number of bits already used in the currently selected partial byte.
+    size_t numUsedBitsInPartialByte;
 } avifRWStream;
 
 void avifRWStreamStart(avifRWStream * stream, avifRWData * raw);
@@ -502,6 +517,8 @@ void avifRWStreamWriteU16(avifRWStream * stream, uint16_t v);
 void avifRWStreamWriteU32(avifRWStream * stream, uint32_t v);
 void avifRWStreamWriteU64(avifRWStream * stream, uint64_t v);
 void avifRWStreamWriteZeros(avifRWStream * stream, size_t byteCount);
+void avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCount);
+void avifRWStreamWriteVarInt(avifRWStream * stream, uint32_t v);
 
 // This is to make it clear that the box size is currently unknown, and will be determined later (with a call to avifRWStreamFinishBox)
 #define AVIF_BOX_SIZE_TBD 0

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -453,10 +453,9 @@ typedef struct avifROStream
     // Index of the next byte in the raw stream.
     size_t offset;
 
-    // Index of the currently selected partial byte. Must be lower than offset.
-    // Only meaningful if numUsedBitsInPartialByte is not zero.
-    size_t offsetOfPartialByte;
-    // Number of bits already used in the currently selected partial byte.
+    // If 0, byte-aligned functions can be used (avifROStreamRead() etc.).
+    // Otherwise, it represents the number of bits already used in the last byte
+    // (located at offset-1).
     size_t numUsedBitsInPartialByte;
 
     // Error information, if any.
@@ -471,6 +470,7 @@ void avifROStreamSetOffset(avifROStream * stream, size_t offset);
 
 avifBool avifROStreamHasBytesLeft(const avifROStream * stream, size_t byteCount);
 size_t avifROStreamRemainingBytes(const avifROStream * stream);
+// The following functions require byte alignment.
 avifBool avifROStreamSkip(avifROStream * stream, size_t byteCount);
 avifBool avifROStreamRead(avifROStream * stream, uint8_t * data, size_t size);
 avifBool avifROStreamReadU16(avifROStream * stream, uint16_t * v);
@@ -484,6 +484,7 @@ avifBool avifROStreamReadBoxHeader(avifROStream * stream, avifBoxHeader * header
 avifBool avifROStreamReadBoxHeaderPartial(avifROStream * stream, avifBoxHeader * header); // This doesn't require that the full box can fit in the stream
 avifBool avifROStreamReadVersionAndFlags(avifROStream * stream, uint8_t * version, uint32_t * flags); // version and flags ptrs are both optional
 avifBool avifROStreamReadAndEnforceVersion(avifROStream * stream, uint8_t enforcedVersion); // currently discards flags
+// The following functions can write non-aligned bits.
 avifBool avifROStreamReadBits8(avifROStream * stream, uint8_t * v, size_t bitCount);
 avifBool avifROStreamReadBits(avifROStream * stream, uint32_t * v, size_t bitCount);
 avifBool avifROStreamReadVarInt(avifROStream * stream, uint32_t * v);
@@ -495,10 +496,9 @@ typedef struct avifRWStream
     // Index of the next byte in the raw stream.
     size_t offset;
 
-    // Index of the currently selected partial byte. Must be lower than offset.
-    // Only meaningful if numUsedBitsInPartialByte is not zero.
-    size_t offsetOfPartialByte;
-    // Number of bits already used in the currently selected partial byte.
+    // If 0, byte-aligned functions can be used (avifRWStreamWrite() etc.).
+    // Otherwise, it represents the number of bits already used in the last byte
+    // (located at offset-1).
     size_t numUsedBitsInPartialByte;
 } avifRWStream;
 
@@ -507,6 +507,7 @@ size_t avifRWStreamOffset(const avifRWStream * stream);
 void avifRWStreamSetOffset(avifRWStream * stream, size_t offset);
 
 void avifRWStreamFinishWrite(avifRWStream * stream);
+// The following functions require byte alignment.
 void avifRWStreamWrite(avifRWStream * stream, const void * data, size_t size);
 void avifRWStreamWriteChars(avifRWStream * stream, const char * chars, size_t size);
 avifBoxMarker avifRWStreamWriteBox(avifRWStream * stream, const char * type, size_t contentSize);
@@ -517,6 +518,7 @@ void avifRWStreamWriteU16(avifRWStream * stream, uint16_t v);
 void avifRWStreamWriteU32(avifRWStream * stream, uint32_t v);
 void avifRWStreamWriteU64(avifRWStream * stream, uint64_t v);
 void avifRWStreamWriteZeros(avifRWStream * stream, size_t byteCount);
+// The following functions can write non-aligned bits.
 void avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCount);
 void avifRWStreamWriteVarInt(avifRWStream * stream, uint32_t v);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -21,6 +21,8 @@ void avifROStreamStart(avifROStream * stream, avifROData * raw, avifDiagnostics 
 {
     stream->raw = raw;
     stream->offset = 0;
+    stream->offsetOfPartialByte = 0;
+    stream->numUsedBitsInPartialByte = 0;
     stream->diag = diag;
     stream->diagContext = diagContext;
 
@@ -45,6 +47,7 @@ size_t avifROStreamOffset(const avifROStream * stream)
 
 void avifROStreamSetOffset(avifROStream * stream, size_t offset)
 {
+    assert(stream->numUsedBitsInPartialByte == 0);
     stream->offset = offset;
     if (stream->offset > stream->raw->size) {
         stream->offset = stream->raw->size;
@@ -134,6 +137,78 @@ avifBool avifROStreamReadU64(avifROStream * stream, uint64_t * v)
 {
     AVIF_CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint64_t)));
     *v = avifNTOH64(*v);
+    return AVIF_TRUE;
+}
+
+// Override of avifROStreamReadBits() for convenient uint8_t output.
+avifBool avifROStreamReadBits8(avifROStream * stream, uint8_t * v, size_t bitCount)
+{
+    assert(bitCount <= sizeof(*v) * 8);
+    uint32_t v32;
+    if (!avifROStreamReadBits(stream, &v32, bitCount)) {
+        return AVIF_FALSE;
+    }
+    *v = (uint8_t)v32;
+    return AVIF_TRUE;
+}
+
+avifBool avifROStreamReadBits(avifROStream * stream, uint32_t * v, size_t bitCount)
+{
+    assert(bitCount <= sizeof(*v) * 8);
+    *v = 0;
+    while (bitCount) {
+        if (stream->numUsedBitsInPartialByte == 0) {
+            stream->offsetOfPartialByte = stream->offset;
+            AVIF_CHECK(avifROStreamSkip(stream, sizeof(uint8_t))); // Book a new partial byte in the stream.
+        }
+        const uint8_t * packedBits = stream->raw->data + stream->offsetOfPartialByte;
+
+        const size_t numBits = AVIF_MIN(bitCount, 8 - stream->numUsedBitsInPartialByte);
+        stream->numUsedBitsInPartialByte += numBits;
+        bitCount -= numBits;
+        // The stream bits are packed starting with the most significant bit of the first input byte.
+        // This way, packed bits can be found in the same order in the bit stream.
+        const uint32_t bits = (*packedBits >> (8 - stream->numUsedBitsInPartialByte)) & ((1 << numBits) - 1);
+        // The value bits are ordered from the most significant bit to the least significant bit.
+        // In the case where avifROStreamReadBits() is used to parse the unsigned integer value *v
+        // over multiple aligned bytes, this order corresponds to big endianness.
+        *v |= bits << bitCount;
+
+        if (stream->numUsedBitsInPartialByte == 8) {
+            // Start a new partial byte the next time a bit is needed.
+            stream->numUsedBitsInPartialByte = 0;
+        }
+    }
+    return AVIF_TRUE;
+}
+
+// Based on https://sqlite.org/src4/doc/trunk/www/varint.wiki.
+avifBool avifROStreamReadVarInt(avifROStream * stream, uint32_t * v)
+{
+    uint32_t a[5];
+    AVIF_CHECK(avifROStreamReadBits(stream, &a[0], 8));
+    if (a[0] <= 240) {
+        *v = a[0];
+    } else {
+        AVIF_CHECK(avifROStreamReadBits(stream, &a[1], 8));
+        if (a[0] <= 248) {
+            *v = 240 + 256 * (a[0] - 241) + a[1];
+        } else {
+            AVIF_CHECK(avifROStreamReadBits(stream, &a[2], 8));
+            if (a[0] == 249) {
+                *v = 2288 + 256 * a[1] + a[2];
+            } else {
+                AVIF_CHECK(avifROStreamReadBits(stream, &a[3], 8));
+                if (a[0] == 250) {
+                    *v = (a[3] << 16) | (a[2] << 8) | a[1];
+                } else {
+                    // TODO(yguyon): Use values of a[0] in range [252-255] (avoid pessimization).
+                    AVIF_CHECK(avifROStreamReadBits(stream, &a[4], 8));
+                    *v = (a[4] << 24) | (a[3] << 16) | (a[2] << 8) | a[1];
+                }
+            }
+        }
+    }
     return AVIF_TRUE;
 }
 
@@ -250,6 +325,8 @@ void avifRWStreamStart(avifRWStream * stream, avifRWData * raw)
 {
     stream->raw = raw;
     stream->offset = 0;
+    stream->offsetOfPartialByte = 0;
+    stream->numUsedBitsInPartialByte = 0;
 }
 
 size_t avifRWStreamOffset(const avifRWStream * stream)
@@ -371,4 +448,60 @@ void avifRWStreamWriteZeros(avifRWStream * stream, size_t byteCount)
         ++p;
     }
     stream->offset += byteCount;
+}
+
+void avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCount)
+{
+    assert(((uint64_t)v >> bitCount) == 0); // (uint32_t >> 32 is undefined behavior)
+    while (bitCount) {
+        if (stream->numUsedBitsInPartialByte == 0) {
+            makeRoom(stream, 1); // Book a new partial byte in the stream.
+            stream->offsetOfPartialByte = stream->offset;
+            stream->raw->data[stream->offsetOfPartialByte] = 0;
+            stream->offset += 1;
+        }
+        uint8_t * packedBits = stream->raw->data + stream->offsetOfPartialByte;
+
+        const size_t numBits = AVIF_MIN(bitCount, 8 - stream->numUsedBitsInPartialByte);
+        stream->numUsedBitsInPartialByte += numBits;
+        bitCount -= numBits;
+        // Order the input bits from the most significant bit to the least significant bit.
+        // In the case where avifRWStreamWriteBits() is used to write the unsigned integer value v
+        // over multiple aligned bytes, this order corresponds to big endianness.
+        const uint32_t bits = (v >> bitCount) & ((1 << numBits) - 1);
+        // Pack bits starting with the most significant bit of the first output byte.
+        // This way, packed bits can be found in the same order in the bit stream.
+        *packedBits |= bits << (8 - stream->numUsedBitsInPartialByte);
+
+        if (stream->numUsedBitsInPartialByte == 8) {
+            // Start a new partial byte the next time a bit is needed.
+            stream->numUsedBitsInPartialByte = 0;
+        }
+    }
+}
+
+// Based on https://sqlite.org/src4/doc/trunk/www/varint.wiki.
+void avifRWStreamWriteVarInt(avifRWStream * stream, uint32_t v)
+{
+    if (v <= 240) {
+        avifRWStreamWriteBits(stream, v, 8);
+    } else if (v <= 2287) {
+        avifRWStreamWriteBits(stream, (v - 240) / 256 + 241, 8);
+        avifRWStreamWriteBits(stream, (v - 240) % 256, 8);
+    } else if (v <= 67823) {
+        avifRWStreamWriteBits(stream, 249, 8);
+        avifRWStreamWriteBits(stream, (v - 2288) / 256, 8);
+        avifRWStreamWriteBits(stream, (v - 2288) % 256, 8);
+    } else if (v <= 16777215) {
+        avifRWStreamWriteBits(stream, 250, 8);
+        avifRWStreamWriteBits(stream, (v >> 0) & 0xff, 8);
+        avifRWStreamWriteBits(stream, (v >> 8) & 0xff, 8);
+        avifRWStreamWriteBits(stream, (v >> 16) & 0xff, 8);
+    } else {
+        avifRWStreamWriteBits(stream, 251, 8);
+        avifRWStreamWriteBits(stream, (v >> 0) & 0xff, 8);
+        avifRWStreamWriteBits(stream, (v >> 8) & 0xff, 8);
+        avifRWStreamWriteBits(stream, (v >> 16) & 0xff, 8);
+        avifRWStreamWriteBits(stream, (v >> 24) & 0xff, 8);
+    }
 }

--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -53,13 +53,6 @@ TEST(StreamTest, Roundtrip) {
   const uint32_t rw_someu32 = 0xABCD;
   avifRWStreamWriteU32(&rw_stream, rw_someu32);
 
-  const size_t rw_somebitcount = 6;
-  const uint32_t rw_somebits = (1 << rw_somebitcount) - 2;
-  avifRWStreamWriteBits(&rw_stream, rw_somebits, rw_somebitcount);
-  const size_t rw_maxbitcount = sizeof(uint32_t) * 8;
-  const uint32_t rw_maxbits = std::numeric_limits<uint32_t>::max();
-  avifRWStreamWriteBits(&rw_stream, rw_maxbits, rw_maxbitcount);
-
   size_t offset = avifRWStreamOffset(&rw_stream);
   const uint32_t rw_somevarint_1byte = 240;
   avifRWStreamWriteVarInt(&rw_stream, rw_somevarint_1byte);
@@ -73,6 +66,13 @@ TEST(StreamTest, Roundtrip) {
   const uint64_t rw_someu64 = 0xABCDEF01;
   avifRWStreamWriteU64(&rw_stream, rw_someu64);
 
+  const size_t rw_somebitcount = 6;
+  const uint32_t rw_somebits = (1 << rw_somebitcount) - 2;
+  avifRWStreamWriteBits(&rw_stream, rw_somebits, rw_somebitcount);
+  const size_t rw_maxbitcount = sizeof(uint32_t) * 8;
+  const uint32_t rw_maxbits = std::numeric_limits<uint32_t>::max();
+  avifRWStreamWriteBits(&rw_stream, rw_maxbits, rw_maxbitcount);
+
   offset = avifRWStreamOffset(&rw_stream);
   const uint32_t rw_somevarint_3bytes = 2288;
   avifRWStreamWriteVarInt(&rw_stream, rw_somevarint_3bytes);
@@ -81,6 +81,8 @@ TEST(StreamTest, Roundtrip) {
   EXPECT_EQ(avifRWStreamOffset(&rw_stream), offset + 3 + 4);
 
   const uint32_t rw_somebit = 1;
+  avifRWStreamWriteBits(&rw_stream, rw_somebit, /*bitCount=*/1);
+  // Pad till byte alignment.
   avifRWStreamWriteBits(&rw_stream, rw_somebit, /*bitCount=*/1);
 
   offset = avifRWStreamOffset(&rw_stream);
@@ -144,13 +146,6 @@ TEST(StreamTest, Roundtrip) {
   EXPECT_TRUE(avifROStreamReadU32(&ro_stream, &ro_someu32));
   EXPECT_EQ(rw_someu32, ro_someu32);
 
-  uint32_t ro_somebits;
-  EXPECT_TRUE(avifROStreamReadBits(&ro_stream, &ro_somebits, rw_somebitcount));
-  EXPECT_EQ(rw_somebits, ro_somebits);
-  uint32_t ro_maxbits;
-  EXPECT_TRUE(avifROStreamReadBits(&ro_stream, &ro_maxbits, rw_maxbitcount));
-  EXPECT_EQ(rw_maxbits, ro_maxbits);
-
   uint32_t ro_somevarint_1byte;
   EXPECT_TRUE(avifROStreamReadVarInt(&ro_stream, &ro_somevarint_1byte));
   EXPECT_EQ(rw_somevarint_1byte, ro_somevarint_1byte);
@@ -163,6 +158,13 @@ TEST(StreamTest, Roundtrip) {
   EXPECT_TRUE(avifROStreamReadU64(&ro_stream, &ro_someu64));
   EXPECT_EQ(rw_someu64, ro_someu64);
 
+  uint32_t ro_somebits;
+  EXPECT_TRUE(avifROStreamReadBits(&ro_stream, &ro_somebits, rw_somebitcount));
+  EXPECT_EQ(rw_somebits, ro_somebits);
+  uint32_t ro_maxbits;
+  EXPECT_TRUE(avifROStreamReadBits(&ro_stream, &ro_maxbits, rw_maxbitcount));
+  EXPECT_EQ(rw_maxbits, ro_maxbits);
+
   uint32_t ro_somevarint_3bytes;
   EXPECT_TRUE(avifROStreamReadVarInt(&ro_stream, &ro_somevarint_3bytes));
   EXPECT_EQ(rw_somevarint_3bytes, ro_somevarint_3bytes);
@@ -172,6 +174,8 @@ TEST(StreamTest, Roundtrip) {
   EXPECT_EQ(rw_somevarint_4bytes, ro_somevarint_4bytes);
 
   uint8_t ro_somebit;
+  EXPECT_TRUE(avifROStreamReadBits8(&ro_stream, &ro_somebit, /*bitCount=*/1));
+  EXPECT_EQ(rw_somebit, ro_somebit);
   EXPECT_TRUE(avifROStreamReadBits8(&ro_stream, &ro_somebit, /*bitCount=*/1));
   EXPECT_EQ(rw_somebit, ro_somebit);
 

--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 #include "avif/internal.h"
@@ -52,8 +53,40 @@ TEST(StreamTest, Roundtrip) {
   const uint32_t rw_someu32 = 0xABCD;
   avifRWStreamWriteU32(&rw_stream, rw_someu32);
 
+  const size_t rw_somebitcount = 6;
+  const uint32_t rw_somebits = (1 << rw_somebitcount) - 2;
+  avifRWStreamWriteBits(&rw_stream, rw_somebits, rw_somebitcount);
+  const size_t rw_maxbitcount = sizeof(uint32_t) * 8;
+  const uint32_t rw_maxbits = std::numeric_limits<uint32_t>::max();
+  avifRWStreamWriteBits(&rw_stream, rw_maxbits, rw_maxbitcount);
+
+  size_t offset = avifRWStreamOffset(&rw_stream);
+  const uint32_t rw_somevarint_1byte = 240;
+  avifRWStreamWriteVarInt(&rw_stream, rw_somevarint_1byte);
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), offset + 1);
+
+  offset = avifRWStreamOffset(&rw_stream);
+  const uint32_t rw_somevarint_2bytes = 241;
+  avifRWStreamWriteVarInt(&rw_stream, rw_somevarint_2bytes);
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), offset + 2);
+
   const uint64_t rw_someu64 = 0xABCDEF01;
   avifRWStreamWriteU64(&rw_stream, rw_someu64);
+
+  offset = avifRWStreamOffset(&rw_stream);
+  const uint32_t rw_somevarint_3bytes = 2288;
+  avifRWStreamWriteVarInt(&rw_stream, rw_somevarint_3bytes);
+  const uint32_t rw_somevarint_4bytes = 67824;
+  avifRWStreamWriteVarInt(&rw_stream, rw_somevarint_4bytes);
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), offset + 3 + 4);
+
+  const uint32_t rw_somebit = 1;
+  avifRWStreamWriteBits(&rw_stream, rw_somebit, /*bitCount=*/1);
+
+  offset = avifRWStreamOffset(&rw_stream);
+  const uint32_t rw_somevarint_5bytes = std::numeric_limits<uint32_t>::max();
+  avifRWStreamWriteVarInt(&rw_stream, rw_somevarint_5bytes);
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), offset + 5);
 
   const size_t num_zeros = 10000;
   avifRWStreamWriteZeros(&rw_stream, /*byteCount=*/num_zeros);
@@ -111,9 +144,40 @@ TEST(StreamTest, Roundtrip) {
   EXPECT_TRUE(avifROStreamReadU32(&ro_stream, &ro_someu32));
   EXPECT_EQ(rw_someu32, ro_someu32);
 
+  uint32_t ro_somebits;
+  EXPECT_TRUE(avifROStreamReadBits(&ro_stream, &ro_somebits, rw_somebitcount));
+  EXPECT_EQ(rw_somebits, ro_somebits);
+  uint32_t ro_maxbits;
+  EXPECT_TRUE(avifROStreamReadBits(&ro_stream, &ro_maxbits, rw_maxbitcount));
+  EXPECT_EQ(rw_maxbits, ro_maxbits);
+
+  uint32_t ro_somevarint_1byte;
+  EXPECT_TRUE(avifROStreamReadVarInt(&ro_stream, &ro_somevarint_1byte));
+  EXPECT_EQ(rw_somevarint_1byte, ro_somevarint_1byte);
+
+  uint32_t ro_somevarint_2bytes;
+  EXPECT_TRUE(avifROStreamReadVarInt(&ro_stream, &ro_somevarint_2bytes));
+  EXPECT_EQ(rw_somevarint_2bytes, ro_somevarint_2bytes);
+
   uint64_t ro_someu64;
   EXPECT_TRUE(avifROStreamReadU64(&ro_stream, &ro_someu64));
   EXPECT_EQ(rw_someu64, ro_someu64);
+
+  uint32_t ro_somevarint_3bytes;
+  EXPECT_TRUE(avifROStreamReadVarInt(&ro_stream, &ro_somevarint_3bytes));
+  EXPECT_EQ(rw_somevarint_3bytes, ro_somevarint_3bytes);
+
+  uint32_t ro_somevarint_4bytes;
+  EXPECT_TRUE(avifROStreamReadVarInt(&ro_stream, &ro_somevarint_4bytes));
+  EXPECT_EQ(rw_somevarint_4bytes, ro_somevarint_4bytes);
+
+  uint8_t ro_somebit;
+  EXPECT_TRUE(avifROStreamReadBits8(&ro_stream, &ro_somebit, /*bitCount=*/1));
+  EXPECT_EQ(rw_somebit, ro_somebit);
+
+  uint32_t ro_somevarint_5bytes;
+  EXPECT_TRUE(avifROStreamReadVarInt(&ro_stream, &ro_somevarint_5bytes));
+  EXPECT_EQ(rw_somevarint_5bytes, ro_somevarint_5bytes);
 
   EXPECT_TRUE(avifROStreamSkip(&ro_stream, /*byteCount=*/num_zeros));
   EXPECT_FALSE(avifROStreamSkip(&ro_stream, /*byteCount=*/1));


### PR DESCRIPTION
Simplify calling sites that were doing manual bit manipulation.
Also add VarInt versions.

https://github.com/AOMediaCodec/libavif/pull/1432 will be simplified when this PR is merged.