### PR TITLE
Change imir.mode back to imir.axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ List of incompatible ABI changes in this release:
   memory allocation failures.
 * avifReadImage(), avifJPEGRead() and avifPNGRead() now remove the trailing zero
   byte from read XMP chunks, if any. See avifImageFixXMP().
+* The 'mode' member of the avifImageMirror struct was renamed 'axis'.
 
 ## [0.11.1] - 2022-10-19
 

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -132,7 +132,7 @@ static void syntaxLong(void)
     printf("    --crop CROPX,CROPY,CROPW,CROPH    : Add clap property (clean aperture), but calculated from a crop rectangle\n");
     printf("    --clap WN,WD,HN,HD,HON,HOD,VON,VOD: Add clap property (clean aperture). Width, Height, HOffset, VOffset (in num/denom pairs)\n");
     printf("    --irot ANGLE                      : Add irot property (rotation). [0-3], makes (90 * ANGLE) degree rotation anti-clockwise\n");
-    printf("    --imir MODE                       : Add imir property (mirroring). 0=top-to-bottom, 1=left-to-right\n");
+    printf("    --imir AXIS                       : Add imir property (mirroring). 0=top-to-bottom, 1=left-to-right\n");
     printf("    --clli MaxCLL,MaxPALL             : Add clli property (content light level information).\n");
     printf("    --repetition-count N or infinite  : Number of times an animated image sequence will be repeated. Use 'infinite' for infinite repetitions (Default: infinite)\n");
     printf("    --min QP                          : Set min quantizer for color (%d-%d, where %d is lossless)\n",
@@ -1115,7 +1115,7 @@ int main(int argc, char * argv[])
 
     avifBool cropConversionRequired = AVIF_FALSE;
     uint8_t irotAngle = 0xff; // sentinel value indicating "unused"
-    uint8_t imirMode = 0xff;  // sentinel value indicating "unused"
+    uint8_t imirAxis = 0xff;  // sentinel value indicating "unused"
     avifRange requestedRange = AVIF_RANGE_FULL;
     avifBool lossless = AVIF_FALSE;
     avifImage * image = NULL;
@@ -1441,9 +1441,9 @@ int main(int argc, char * argv[])
             }
         } else if (!strcmp(arg, "--imir")) {
             NEXTARG();
-            imirMode = (uint8_t)atoi(arg);
-            if (imirMode > 1) {
-                fprintf(stderr, "ERROR: Invalid imir mode: %s\n", arg);
+            imirAxis = (uint8_t)atoi(arg);
+            if (imirAxis > 1) {
+                fprintf(stderr, "ERROR: Invalid imir axis: %s\n", arg);
                 returnCode = 1;
                 goto cleanup;
             }
@@ -1765,9 +1765,9 @@ int main(int argc, char * argv[])
         image->transformFlags |= AVIF_TRANSFORM_IROT;
         image->irot.angle = irotAngle;
     }
-    if (imirMode != 0xff) {
+    if (imirAxis != 0xff) {
         image->transformFlags |= AVIF_TRANSFORM_IMIR;
-        image->imir.mode = imirMode;
+        image->imir.axis = imirAxis;
     }
     if (settings.clliCount == 2) {
         image->clli.maxCLL = (uint16_t)settings.clliValues[0];

--- a/apps/shared/avifexif.c
+++ b/apps/shared/avifexif.c
@@ -8,7 +8,7 @@ uint8_t avifImageGetExifOrientationFromIrotImir(const avifImage * image)
 {
     if ((image->transformFlags & AVIF_TRANSFORM_IROT) && (image->irot.angle == 1)) {
         if (image->transformFlags & AVIF_TRANSFORM_IMIR) {
-            if (image->imir.mode) {
+            if (image->imir.axis) {
                 return 7; // 90 degrees anti-clockwise then swap left and right.
             }
             return 5; // 90 degrees anti-clockwise then swap top and bottom.
@@ -17,7 +17,7 @@ uint8_t avifImageGetExifOrientationFromIrotImir(const avifImage * image)
     }
     if ((image->transformFlags & AVIF_TRANSFORM_IROT) && (image->irot.angle == 2)) {
         if (image->transformFlags & AVIF_TRANSFORM_IMIR) {
-            if (image->imir.mode) {
+            if (image->imir.axis) {
                 return 4; // 180 degrees anti-clockwise then swap left and right.
             }
             return 2; // 180 degrees anti-clockwise then swap top and bottom.
@@ -26,7 +26,7 @@ uint8_t avifImageGetExifOrientationFromIrotImir(const avifImage * image)
     }
     if ((image->transformFlags & AVIF_TRANSFORM_IROT) && (image->irot.angle == 3)) {
         if (image->transformFlags & AVIF_TRANSFORM_IMIR) {
-            if (image->imir.mode) {
+            if (image->imir.axis) {
                 return 5; // 270 degrees anti-clockwise then swap left and right.
             }
             return 7; // 270 degrees anti-clockwise then swap top and bottom.
@@ -34,7 +34,7 @@ uint8_t avifImageGetExifOrientationFromIrotImir(const avifImage * image)
         return 8; // 270 degrees anti-clockwise.
     }
     if (image->transformFlags & AVIF_TRANSFORM_IMIR) {
-        if (image->imir.mode) {
+        if (image->imir.axis) {
             return 2; // Swap left and right.
         }
         return 4; // Swap top and bottom.

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -117,7 +117,7 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
             printf("    * irot (Rotation)      : %u\n", avif->irot.angle);
         }
         if (avif->transformFlags & AVIF_TRANSFORM_IMIR) {
-            printf("    * imir (Mirror)        : Mode %u (%s)\n", avif->imir.mode, (avif->imir.mode == 0) ? "top-to-bottom" : "left-to-right");
+            printf("    * imir (Mirror)        : %u (%s)\n", avif->imir.axis, (avif->imir.axis == 0) ? "top-to-bottom" : "left-to-right");
         }
     }
     printf(" * Progressive    : %s\n", avifProgressiveStateToString(progressiveState));

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -430,24 +430,19 @@ typedef struct avifImageRotation
 
 typedef struct avifImageMirror
 {
-    // 'imir' from ISO/IEC 23008-12:2017 6.5.12 (Draft Amendment 2):
+    // 'imir' from ISO/IEC 23008-12:2022 6.5.12:
     //
-    //     'mode' specifies how the mirroring is performed:
+    //     'axis' specifies how the mirroring is performed:
     //
     //     0 indicates that the top and bottom parts of the image are exchanged;
     //     1 specifies that the left and right parts are exchanged.
     //
     //     NOTE In Exif, orientation tag can be used to signal mirroring operations. Exif
-    //     orientation tag 4 corresponds to mode = 0 of ImageMirror, and Exif orientation tag 2
-    //     corresponds to mode = 1 accordingly.
+    //     orientation tag 4 corresponds to axis = 0 of ImageMirror, and Exif orientation tag 2
+    //     corresponds to axis = 1 accordingly.
     //
     // Legal values: [0, 1]
-    //
-    // NOTE: As of HEIF Draft Amendment 2, the name of this variable has changed from 'axis' to 'mode' as
-    //       the logic behind it has been *inverted*. Please use the wording above describing the legal
-    //       values for 'mode' and update any code that previously may have used `axis` to use
-    //       the *opposite* value (0 now means top-to-bottom, where it used to mean left-to-right).
-    uint8_t mode;
+    uint8_t axis;
 } avifImageMirror;
 
 // ---------------------------------------------------------------------------

--- a/src/exif.c
+++ b/src/exif.c
@@ -91,42 +91,42 @@ avifResult avifImageExtractExifOrientationToIrotImir(avifImage * image)
             case 1: // The 0th row is at the visual top of the image, and the 0th column is the visual left-hand side.
                 image->transformFlags = otherFlags;
                 image->irot.angle = 0; // ignored
-                image->imir.mode = 0;  // ignored
+                image->imir.axis = 0;  // ignored
                 return AVIF_RESULT_OK;
             case 2: // The 0th row is at the visual top of the image, and the 0th column is the visual right-hand side.
                 image->transformFlags = otherFlags | AVIF_TRANSFORM_IMIR;
                 image->irot.angle = 0; // ignored
-                image->imir.mode = 1;
+                image->imir.axis = 1;
                 return AVIF_RESULT_OK;
             case 3: // The 0th row is at the visual bottom of the image, and the 0th column is the visual right-hand side.
                 image->transformFlags = otherFlags | AVIF_TRANSFORM_IROT;
                 image->irot.angle = 2;
-                image->imir.mode = 0; // ignored
+                image->imir.axis = 0; // ignored
                 return AVIF_RESULT_OK;
             case 4: // The 0th row is at the visual bottom of the image, and the 0th column is the visual left-hand side.
                 image->transformFlags = otherFlags | AVIF_TRANSFORM_IMIR;
                 image->irot.angle = 0; // ignored
-                image->imir.mode = 0;
+                image->imir.axis = 0;
                 return AVIF_RESULT_OK;
             case 5: // The 0th row is the visual left-hand side of the image, and the 0th column is the visual top.
                 image->transformFlags = otherFlags | AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR;
                 image->irot.angle = 1; // applied before imir according to MIAF spec ISO/IEC 28002-12:2021 - section 7.3.6.7
-                image->imir.mode = 0;
+                image->imir.axis = 0;
                 return AVIF_RESULT_OK;
             case 6: // The 0th row is the visual right-hand side of the image, and the 0th column is the visual top.
                 image->transformFlags = otherFlags | AVIF_TRANSFORM_IROT;
                 image->irot.angle = 3;
-                image->imir.mode = 0; // ignored
+                image->imir.axis = 0; // ignored
                 return AVIF_RESULT_OK;
             case 7: // The 0th row is the visual right-hand side of the image, and the 0th column is the visual bottom.
                 image->transformFlags = otherFlags | AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR;
                 image->irot.angle = 3; // applied before imir according to MIAF spec ISO/IEC 28002-12:2021 - section 7.3.6.7
-                image->imir.mode = 0;
+                image->imir.axis = 0;
                 return AVIF_RESULT_OK;
             case 8: // The 0th row is the visual left-hand side of the image, and the 0th column is the visual bottom.
                 image->transformFlags = otherFlags | AVIF_TRANSFORM_IROT;
                 image->irot.angle = 1;
-                image->imir.mode = 0; // ignored
+                image->imir.axis = 0; // ignored
                 return AVIF_RESULT_OK;
             default: // reserved
                 break;
@@ -138,7 +138,7 @@ avifResult avifImageExtractExifOrientationToIrotImir(avifImage * image)
     //   The 0th row is at the visual top of the image, and the 0th column is the visual left-hand side.
     image->transformFlags = otherFlags;
     image->irot.angle = 0; // ignored
-    image->imir.mode = 0;  // ignored
+    image->imir.axis = 0;  // ignored
     return AVIF_RESULT_OK;
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -1968,12 +1968,12 @@ static avifBool avifParseImageMirrorProperty(avifProperty * prop, const uint8_t 
 
     avifImageMirror * imir = &prop->u.imir;
     uint8_t reserved;
-    AVIF_CHECK(avifROStreamReadBits8(&s, &reserved, /*bitCount=*/7)); // unsigned int (7) reserved = 0;
+    AVIF_CHECK(avifROStreamReadBits8(&s, &reserved, /*bitCount=*/7)); // unsigned int(7) reserved = 0;
     if (reserved) {
         avifDiagnosticsPrintf(diag, "Box[imir] contains nonzero reserved bits [%u]", reserved);
         return AVIF_FALSE;
     }
-    AVIF_CHECK(avifROStreamReadBits8(&s, &imir->mode, /*bitCount=*/1)); // unsigned int (1) mode;
+    AVIF_CHECK(avifROStreamReadBits8(&s, &imir->axis, /*bitCount=*/1)); // unsigned int(1) axis;
     return AVIF_TRUE;
 }
 

--- a/src/write.c
+++ b/src/write.c
@@ -683,8 +683,8 @@ static avifResult avifEncoderWriteExtendedColorProperties(avifRWStream * dedupSt
         }
         avifBoxMarker imir;
         AVIF_CHECKRES(avifRWStreamWriteBox(dedupStream, "imir", AVIF_BOX_SIZE_TBD, &imir));
-        AVIF_CHECKRES(avifRWStreamWriteBits(dedupStream, 0, /*bitCount=*/7)); // unsigned int (7) reserved = 0;
-        AVIF_CHECKRES(avifRWStreamWriteBits(dedupStream, imageMetadata->imir.mode ? 1 : 0, /*bitCount=*/1)); // unsigned int (1) mode;
+        AVIF_CHECKRES(avifRWStreamWriteBits(dedupStream, 0, /*bitCount=*/7)); // unsigned int(7) reserved = 0;
+        AVIF_CHECKRES(avifRWStreamWriteBits(dedupStream, imageMetadata->imir.axis ? 1 : 0, /*bitCount=*/1)); // unsigned int(1) axis;
         avifRWStreamFinishBox(dedupStream, imir);
         if (dedup) {
             AVIF_CHECKRES(avifItemPropertyDedupFinish(dedup, outputStream, ipma, AVIF_TRUE));

--- a/tests/gtest/avifmetadatatest.cc
+++ b/tests/gtest/avifmetadatatest.cc
@@ -49,7 +49,7 @@ TEST_P(AvifMetadataTest, EncodeDecode) {
   if (use_exif) {
     const avifTransformFlags old_transform_flags = image->transformFlags;
     const uint8_t old_irot_angle = image->irot.angle;
-    const uint8_t old_imir_mode = image->imir.mode;
+    const uint8_t old_imir_axis = image->imir.axis;
     ASSERT_EQ(
         avifImageSetMetadataExif(image.get(), testutil::kSampleExif.data(),
                                  testutil::kSampleExif.size()),
@@ -58,7 +58,7 @@ TEST_P(AvifMetadataTest, EncodeDecode) {
     // These fields should not be modified.
     EXPECT_EQ(image->transformFlags, old_transform_flags);
     EXPECT_EQ(image->irot.angle, old_irot_angle);
-    EXPECT_EQ(image->imir.mode, old_imir_mode);
+    EXPECT_EQ(image->imir.axis, old_imir_axis);
   }
   if (use_xmp) {
     ASSERT_EQ(avifImageSetMetadataXMP(image.get(), testutil::kSampleXmp.data(),
@@ -246,7 +246,7 @@ TEST(MetadataTest, ExifOrientation) {
   EXPECT_EQ(image->transformFlags & (AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR),
             avifTransformFlags{AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR});
   EXPECT_EQ(image->irot.angle, 1u);
-  EXPECT_EQ(image->imir.mode, 0u);
+  EXPECT_EQ(image->imir.axis, 0u);
 
   const testutil::AvifRwData encoded =
       testutil::Encode(image.get(), AVIF_SPEED_FASTEST);
@@ -260,7 +260,7 @@ TEST(MetadataTest, ExifOrientation) {
       decoded->transformFlags & (AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR),
       avifTransformFlags{AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR});
   EXPECT_EQ(decoded->irot.angle, 1u);
-  EXPECT_EQ(decoded->imir.mode, 0u);
+  EXPECT_EQ(decoded->imir.axis, 0u);
 
   // Exif orientation is kept in JPEG export.
   testutil::AvifImagePtr temp_image =
@@ -269,7 +269,7 @@ TEST(MetadataTest, ExifOrientation) {
   EXPECT_TRUE(testutil::AreByteSequencesEqual(image->exif, temp_image->exif));
   EXPECT_EQ(image->transformFlags, temp_image->transformFlags);
   EXPECT_EQ(image->irot.angle, temp_image->irot.angle);
-  EXPECT_EQ(image->imir.mode, temp_image->imir.mode);
+  EXPECT_EQ(image->imir.axis, temp_image->imir.axis);
   EXPECT_EQ(image->width, temp_image->width);  // Samples are left untouched.
 
   // Exif orientation in PNG export should be ignored or discarded.
@@ -292,7 +292,7 @@ TEST(MetadataTest, ExifOrientationAndForcedImir) {
   // This is not recommended but for testing only.
   EXPECT_GT(image->exif.size, 0u);
   image->transformFlags = AVIF_TRANSFORM_IMIR;
-  image->imir.mode = 1;
+  image->imir.axis = 1;
 
   const testutil::AvifRwData encoded =
       testutil::Encode(image.get(), AVIF_SPEED_FASTEST);
@@ -304,7 +304,7 @@ TEST(MetadataTest, ExifOrientationAndForcedImir) {
   EXPECT_TRUE(testutil::AreByteSequencesEqual(image->exif, decoded->exif));
   EXPECT_EQ(decoded->transformFlags, avifTransformFlags{AVIF_TRANSFORM_IMIR});
   EXPECT_EQ(decoded->irot.angle, 0u);
-  EXPECT_EQ(decoded->imir.mode, image->imir.mode);
+  EXPECT_EQ(decoded->imir.axis, image->imir.axis);
 
   // Exif orientation is set equivalent to irot/imir in JPEG export.
   // Existing Exif orientation is overwritten.
@@ -313,7 +313,7 @@ TEST(MetadataTest, ExifOrientationAndForcedImir) {
   ASSERT_NE(temp_image, nullptr);
   EXPECT_FALSE(testutil::AreByteSequencesEqual(image->exif, temp_image->exif));
   EXPECT_EQ(image->transformFlags, temp_image->transformFlags);
-  EXPECT_EQ(image->imir.mode, temp_image->imir.mode);
+  EXPECT_EQ(image->imir.axis, temp_image->imir.axis);
   EXPECT_EQ(image->width, temp_image->width);  // Samples are left untouched.
 }
 
@@ -327,7 +327,7 @@ TEST(MetadataTest, RotatedJpegBecauseOfIrotImir) {
   EXPECT_EQ(image->transformFlags & (AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR),
             avifTransformFlags{AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR});
   EXPECT_EQ(image->irot.angle, 1u);
-  EXPECT_EQ(image->imir.mode, 0u);
+  EXPECT_EQ(image->imir.axis, 0u);
 
   // No Exif metadata to store the orientation: the samples should be rotated.
   const testutil::AvifImagePtr temp_image =


### PR DESCRIPTION
Change imir.mode back to imir.axis for the libavif 1.0.0 release.

In ISO/IEC 23008-12:2017 Draft Amendment 2, the 'axis' field of the 'imir' property was renamed 'mode', so we changed imir.axis to imir.mode. But in ISO/IEC 23008-12:2022, the 'axis' field of the 'imir' property was not renamed.

In comments and messages, avoid using the words "vertical" and "horizontal" to describe how the mirroring is performed. Also avoid the word "axis" when possible.

Code that needs to support both old and new versions of libavif will need to test #if AVIF_VERSION_MAJOR >= 1.