### PR TITLE
Add "Version 1.0.0 ends here" comments

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -552,6 +552,8 @@ typedef struct avifImage
     // Metadata - set with avifImageSetMetadata*() before write, check .size>0 for existence after read
     avifRWData exif;
     avifRWData xmp;
+
+    // Version 1.0.0 ends here.
 } avifImage;
 
 // avifImageCreate() and avifImageCreateEmpty() return NULL if arguments are invalid or if a memory allocation failed.
@@ -1003,6 +1005,8 @@ typedef struct avifDecoder
 
     // Internals used by the decoder
     struct avifDecoderData * data;
+
+    // Version 1.0.0 ends here.
 } avifDecoder;
 
 AVIF_API avifDecoder * avifDecoderCreate(void);
@@ -1169,6 +1173,8 @@ typedef struct avifEncoder
     // Internals used by the encoder
     struct avifEncoderData * data;
     struct avifCodecSpecificOptions * csOptions;
+
+    // Version 1.0.0 ends here.
 } avifEncoder;
 
 // avifEncoderCreate() returns NULL if a memory allocation failed.

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -553,7 +553,7 @@ typedef struct avifImage
     avifRWData exif;
     avifRWData xmp;
 
-    // Version 1.0.0 ends here.
+    // Version 1.0.0 ends here. Add any new members after this line.
 } avifImage;
 
 // avifImageCreate() and avifImageCreateEmpty() return NULL if arguments are invalid or if a memory allocation failed.
@@ -1006,7 +1006,7 @@ typedef struct avifDecoder
     // Internals used by the decoder
     struct avifDecoderData * data;
 
-    // Version 1.0.0 ends here.
+    // Version 1.0.0 ends here. Add any new members after this line.
 } avifDecoder;
 
 AVIF_API avifDecoder * avifDecoderCreate(void);
@@ -1174,7 +1174,7 @@ typedef struct avifEncoder
     struct avifEncoderData * data;
     struct avifCodecSpecificOptions * csOptions;
 
-    // Version 1.0.0 ends here.
+    // Version 1.0.0 ends here. Add any new members after this line.
 } avifEncoder;
 
 // avifEncoderCreate() returns NULL if a memory allocation failed.


### PR DESCRIPTION
Add "Version 1.0.0 ends here" comments to the end of the avifImage, avifDecoder, and avifEncoder structs. New members in future libavif 1.x.y releases should be added to these structs after the "Version 1.0.0 ends here" comments, followed by "Version 1.x.y ends here" comments.