### PR TITLE
Change "int depth" to "uint32_t depth"

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -716,10 +716,10 @@ AVIF_API avifResult avifRGBImageUnpremultiplyAlpha(avifRGBImage * rgb);
 // ---------------------------------------------------------------------------
 // YUV Utils
 
-AVIF_API int avifFullToLimitedY(int depth, int v);
-AVIF_API int avifFullToLimitedUV(int depth, int v);
-AVIF_API int avifLimitedToFullY(int depth, int v);
-AVIF_API int avifLimitedToFullUV(int depth, int v);
+AVIF_API int avifFullToLimitedY(uint32_t depth, int v);
+AVIF_API int avifFullToLimitedUV(uint32_t depth, int v);
+AVIF_API int avifLimitedToFullY(uint32_t depth, int v);
+AVIF_API int avifLimitedToFullUV(uint32_t depth, int v);
 
 // ---------------------------------------------------------------------------
 // Codec selection

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -481,7 +481,7 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
 
 // Allocates and fills look-up tables for going from YUV limited/full unorm -> full range RGB FP32.
 // Review this when implementing YCgCo limited range support.
-static avifBool avifCreateYUVToRGBLookUpTables(float ** unormFloatTableY, float ** unormFloatTableUV, int depth, const avifReformatState * state)
+static avifBool avifCreateYUVToRGBLookUpTables(float ** unormFloatTableY, float ** unormFloatTableUV, uint32_t depth, const avifReformatState * state)
 {
     const size_t cpCount = (size_t)1 << depth;
 
@@ -1625,7 +1625,7 @@ avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
     v = (((v * (MAXLIMITEDY - MINLIMITEDY)) + (FULLY / 2)) / FULLY) + MINLIMITEDY; \
     v = AVIF_CLAMP(v, MINLIMITEDY, MAXLIMITEDY)
 
-int avifLimitedToFullY(int depth, int v)
+int avifLimitedToFullY(uint32_t depth, int v)
 {
     switch (depth) {
         case 8:
@@ -1641,7 +1641,7 @@ int avifLimitedToFullY(int depth, int v)
     return v;
 }
 
-int avifLimitedToFullUV(int depth, int v)
+int avifLimitedToFullUV(uint32_t depth, int v)
 {
     switch (depth) {
         case 8:
@@ -1657,7 +1657,7 @@ int avifLimitedToFullUV(int depth, int v)
     return v;
 }
 
-int avifFullToLimitedY(int depth, int v)
+int avifFullToLimitedY(uint32_t depth, int v)
 {
     switch (depth) {
         case 8:
@@ -1673,7 +1673,7 @@ int avifFullToLimitedY(int depth, int v)
     return v;
 }
 
-int avifFullToLimitedUV(int depth, int v)
+int avifFullToLimitedUV(uint32_t depth, int v)
 {
     switch (depth) {
         case 8:

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -97,7 +97,7 @@ int main(int argc, char * argv[])
     if (mode == 0) {
         // Limited to full conversion roundtripping test
 
-        int depth = 8;
+        uint32_t depth = 8;
         int maxChannel = (1 << depth) - 1;
         for (int i = 0; i <= maxChannel; ++i) {
             int li = avifFullToLimitedY(depth, i);


### PR DESCRIPTION
This is for consistency. In avif.h `depth` is usually of the uint32_t type.