### PR TITLE
Revert "Guard diag in avifDiagnosticsClearError()"

### DIFF
--- a/src/diag.c
+++ b/src/diag.c
@@ -9,9 +9,7 @@
 
 void avifDiagnosticsClearError(avifDiagnostics * diag)
 {
-    if (diag) {
-        *diag->error = '\0';
-    }
+    *diag->error = '\0';
 }
 
 #ifdef __clang__
@@ -20,6 +18,7 @@ __attribute__((__format__(__printf__, 2, 3)))
 void avifDiagnosticsPrintf(avifDiagnostics * diag, const char * format, ...)
 {
     if (!diag) {
+        // It is possible this is NULL (e.g. calls to avifPeekCompatibleFileType())
         return;
     }
     if (*diag->error) {


### PR DESCRIPTION
This reverts commit 173961dac588d5b7cf0d6749d1aada9050b6197a in the 1.0.0 release, to give us more time to re-evaluate https://github.com/AOMediaCodec/libavif/pull/1496.