### PR TITLE
Unbreak -DAVIF_BUILD_GDK_PIXBUF=ON build

### DIFF
--- a/contrib/gdk-pixbuf/CMakeLists.txt
+++ b/contrib/gdk-pixbuf/CMakeLists.txt
@@ -11,6 +11,7 @@ if(AVIF_BUILD_GDK_PIXBUF)
             add_library(pixbufloader-avif MODULE ${GDK_PIXBUF_SRCS})
 
             target_link_libraries(pixbufloader-avif PUBLIC ${GDK_PIXBUF_LIBRARIES} avif)
+            target_link_directories(pixbufloader-avif PUBLIC ${GDK_PIXBUF_LIBRARY_DIRS})
             target_include_directories(pixbufloader-avif PUBLIC ${GDK_PIXBUF_INCLUDE_DIRS})
 
             pkg_get_variable(GDK_PIXBUF_MODULEDIR gdk-pixbuf-2.0 gdk_pixbuf_moduledir)

--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -209,7 +209,7 @@ static gboolean avif_context_try_load(struct avif_context * context, GError ** e
     if (image->transformFlags & AVIF_TRANSFORM_IMIR) {
         GdkPixbuf *output_mirrored = NULL;
 
-        switch (image->imir.mode) {
+        switch (image->imir.axis) {
         case 0:
             output_mirrored = gdk_pixbuf_flip(output, FALSE);
             break;


### PR DESCRIPTION
Fix #1509 regression and apply part of #296 still required on BSDs.