### PR TITLE
gdk-pixbuf: Fix build failure after imir.mode -> imir.axis rename

### DIFF
--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -209,7 +209,7 @@ static gboolean avif_context_try_load(struct avif_context * context, GError ** e
     if (image->transformFlags & AVIF_TRANSFORM_IMIR) {
         GdkPixbuf *output_mirrored = NULL;
 
-        switch (image->imir.mode) {
+        switch (image->imir.axis) {
         case 0:
             output_mirrored = gdk_pixbuf_flip(output, FALSE);
             break;


### PR DESCRIPTION
Fixes #1526.