### PR TITLE
Update a stale comment for avifItemCategory

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -227,7 +227,7 @@ avifBool avifImageScale(avifImage * image,
                         avifDiagnostics * diag);
 
 // ---------------------------------------------------------------------------
-// AVIF item type
+// AVIF item category
 
 typedef enum avifItemCategory
 {


### PR DESCRIPTION
avifItemCategory was originally named avifItemType in https://github.com/AOMediaCodec/libavif/pull/1499.