### PR TITLE
Remove define guard from gain map test.

### DIFF
--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -11,8 +11,6 @@
 namespace libavif {
 namespace {
 
-#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-
 void CheckGainMapMetadataMatches(const avifGainMapMetadata& lhs,
                                  const avifGainMapMetadata& rhs) {
   EXPECT_EQ(lhs.baseRenditionIsHDR, rhs.baseRenditionIsHDR);
@@ -352,8 +350,6 @@ TEST(GainMapTest, SequenceNotSupported) {
   ASSERT_EQ(result, AVIF_RESULT_NOT_IMPLEMENTED)
       << avifResultToString(result) << " " << encoder->diag.error;
 }
-
-#endif  // AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP
 
 }  // namespace
 }  // namespace libavif


### PR DESCRIPTION
The test is already excluded in CMakeLists if gain maps are disabled. Adding ifdef guards in the test might make it look like it's passing even when it's actually doing nothing.