### PR TITLE
Give meaningful names to CI workflows.

### DIFF
--- a/.github/workflows/ci-android-emulator-tests.yml
+++ b/.github/workflows/ci-android-emulator-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Android Emulator Tests
 on:
   push:
     paths:

--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Android JNI
 on: [push, pull_request]
 
 permissions:

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -1,10 +1,10 @@
-# This is a copy of ci.yml with gtest disabled. It differs from ci.yml as follows:
+# This is a copy of ci-unix-static.yml with gtest disabled. It differs from ci-unix-static.yml as follows:
 #
 #   * The os matrix consists of ubuntu-latest only.
 #   * Does not build libgav1. (Building libgav1 would enable CXX in CMakeLists.txt.)
 #   * Disables gtest.
 
-name: CI
+name: CI Disable GTest
 on: [push, pull_request]
 
 permissions:

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -1,7 +1,7 @@
 # This is a copy of ci-unix-shared-local.yml for building shared libraries
 # with an additional build configuration (using installed deps and dav1d).
 
-name: CI
+name: CI Unix Shared Installed
 on: [push, pull_request]
 
 permissions:

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -1,9 +1,9 @@
-# This is a copy of ci.yml for building shared libraries. It differs from ci.yml as follows:
+# This is a copy of ci-unix-static.yml for building shared libraries. It differs from ci-unix-static.yml as follows:
 #
 #   * The os matrix consists of ubuntu-latest only.
 #   * Does not build rav1e, SVT-AV1 nor libgav1.
 
-name: CI
+name: CI Unix Shared Local
 on: [push, pull_request]
 
 permissions:

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Unix Static AV2
 on: [push, pull_request]
 
 permissions:

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Unix Static
 on: [push, pull_request]
 
 permissions:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,4 +1,4 @@
-# This is a copy of ci.yml for Windows. It differs from ci.yml as follows:
+# This is a copy of ci-unix-static.yml for Windows. It differs from ci-unix-static.yml as follows:
 #
 #   * The os matrix consists of windows-latest only.
 #   * Installs Visual Studio in the os image.
@@ -10,7 +10,7 @@
 #   * Builds with local libjpeg (-DAVIF_LOCAL_JPEG=ON).
 #   * Builds with local zlib and libpng (-DAVIF_LOCAL_ZLIBPNG=ON).
 
-name: CI
+name: CI Windows
 on: [push, pull_request]
 
 permissions:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Fuzz
 on: [pull_request]
 
 permissions:

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Format Check
 on: [push]
 
 permissions:


### PR DESCRIPTION
A meaningful workflow name is useful on the Actions page for example: https://github.com/AOMediaCodec/libavif/actions
On some other pages, when the job name is displayed as well, it can be redundant, but that is a minor issue.