### PR TITLE
Ignore gain maps by default.

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1142,7 +1142,14 @@ typedef struct avifDecoder
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     // This is true when avifDecoderParse() detects a gain map.
     avifBool gainMapPresent;
-    // TODO(maryla): add flags to ignore the main image, or ignore the gain map if desired.
+    // Do not decode the gain map image or gain map metadata if present (defaults to AVIF_TRUE).
+    // Set this to AVIF_FALSE if you DO want to decode gain map pixels and metadata.
+    // gainMapPresent is still set if the presence of a gain map is detected, regardless
+    // of this setting.
+    avifBool ignoreGainMap;
+    // Do not decode the color/alpha planes of the main image.
+    // Can be useful to decode the gain map only.
+    avifBool ignoreColorAndAlpha;
 #endif
 } avifDecoder;
 

--- a/src/read.c
+++ b/src/read.c
@@ -4661,7 +4661,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         if (decoder->ignoreGainMap) {
             // When ignoring the gain map, we still report whether one is present or not,
             // but do not fail if there was any error with the gain map.
-            decoder->gainMapPresent = (findGainMapResult == AVIF_RESULT_OK) && gainMapItem != NULL;
+            decoder->gainMapPresent = (findGainMapResult == AVIF_RESULT_OK) && (gainMapItem != NULL);
             // We also ignore the actual item and don't decode it.
             gainMapItem = NULL;
         } else {

--- a/src/read.c
+++ b/src/read.c
@@ -3786,6 +3786,9 @@ avifDecoder * avifDecoderCreate(void)
     decoder->imageDimensionLimit = AVIF_DEFAULT_IMAGE_DIMENSION_LIMIT;
     decoder->imageCountLimit = AVIF_DEFAULT_IMAGE_COUNT_LIMIT;
     decoder->strictFlags = AVIF_STRICT_ENABLED;
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+    decoder->ignoreGainMap = AVIF_TRUE;
+#endif
     return decoder;
 }
 
@@ -4249,11 +4252,11 @@ static avifResult avifDecoderDataFindAlphaItem(avifDecoderData * data,
 // Finds a 'tmap' (tone mapped image item) box associated with the given 'colorItem'.
 // If found, fills 'toneMappedImageItem' and  sets 'gainMapItemID' to the id of the gain map
 // item associated with the box. Otherwise, sets 'toneMappedImageItem' to NULL.
-// Returns AVIF_RESULT_OK on success (whether or not a tmap box was found).
+// Returns AVIF_RESULT_OK if no errors were encountered (whether or not a tmap box was found).
 // Assumes that there is a single tmap item, and not, e.g., a grid of tmap items.
 // TODO(maryla): add support for files with multiple tmap items if it gets allowed by the spec.
-static avifResult avifDecoderDataFindToneMappedImageItem(avifDecoderData * data,
-                                                         avifDecoderItem * colorItem,
+static avifResult avifDecoderDataFindToneMappedImageItem(const avifDecoderData * data,
+                                                         const avifDecoderItem * colorItem,
                                                          avifDecoderItem ** toneMappedImageItem,
                                                          uint32_t * gainMapItemID)
 {
@@ -4293,6 +4296,99 @@ static avifResult avifDecoderDataFindToneMappedImageItem(avifDecoderData * data,
     }
     *toneMappedImageItem = NULL;
     *gainMapItemID = 0;
+    return AVIF_RESULT_OK;
+}
+
+// Finds a 'tmap' (tone mapped image item) box associated with the given 'colorItem',
+// then finds the associated gain map image.
+// If found, fills 'gainMapItem' and  'gainMapCodecType'. Otherwise, sets 'gainMapItem' to NULL.
+// Returns AVIF_RESULT_OK if no errors were encountered (whether or not a gain map was found).
+// Assumes that there is a single tmap item, and not, e.g., a grid of tmap items.
+static avifResult avifDecoderFindGainMapItem(const avifDecoder * decoder,
+                                             const avifDecoderItem * colorItem,
+                                             avifDecoderItem ** gainMapItem,
+                                             avifCodecType * gainMapCodecType)
+{
+    *gainMapItem = NULL;
+    *gainMapCodecType = AVIF_CODEC_TYPE_UNKNOWN;
+
+    avifDecoderData * data = decoder->data;
+
+    avifDecoderItem * toneMappedImageItem;
+    uint32_t gainMapItemID;
+    AVIF_CHECKRES(avifDecoderDataFindToneMappedImageItem(data, colorItem, &toneMappedImageItem, &gainMapItemID));
+    if (!toneMappedImageItem) {
+        return AVIF_RESULT_OK;
+    }
+
+    if (!decoder->ignoreGainMap) {
+        // Read the gain map's metadata.
+        avifROData tmapData;
+        AVIF_CHECKRES(avifDecoderItemRead(toneMappedImageItem, decoder->io, &tmapData, 0, 0, data->diag));
+
+        AVIF_CHECKERR(avifParseToneMappedImageBox(&decoder->image->gainMap.metadata, tmapData.data, tmapData.size, data->diag),
+                      AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE);
+    }
+
+    avifDecoderItem * gainMapItemTmp = avifMetaFindItem(data->meta, gainMapItemID);
+    if (!gainMapItemTmp) {
+        avifDiagnosticsPrintf(data->diag, "Box[tmap] gain map item ID %d not found", gainMapItemID);
+        return AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE;
+    }
+    if (avifDecoderItemShouldBeSkipped(gainMapItemTmp)) {
+        avifDiagnosticsPrintf(data->diag, "Box[tmap] gain map item %d is not a supported image type", gainMapItemID);
+        return AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE;
+    }
+
+    if (!memcmp(gainMapItemTmp->type, "grid", 4)) {
+        avifROData gainMapGridData;
+        AVIF_CHECKRES(avifDecoderItemRead(gainMapItemTmp, decoder->io, &gainMapGridData, 0, 0, data->diag));
+        AVIF_CHECKERR(avifParseImageGridBox(&data->gainMap.grid,
+                                            gainMapGridData.data,
+                                            gainMapGridData.size,
+                                            decoder->imageSizeLimit,
+                                            decoder->imageDimensionLimit,
+                                            data->diag),
+                      AVIF_RESULT_INVALID_IMAGE_GRID);
+        *gainMapCodecType = avifDecoderItemGetGridCodecType(gainMapItemTmp);
+        if (*gainMapCodecType == AVIF_CODEC_TYPE_UNKNOWN) {
+            return AVIF_RESULT_INVALID_IMAGE_GRID;
+        }
+    } else {
+        *gainMapCodecType = avifGetCodecType(gainMapItemTmp->type);
+        assert(*gainMapCodecType != AVIF_CODEC_TYPE_UNKNOWN);
+    }
+
+    if (!decoder->ignoreGainMap) {
+        decoder->image->gainMap.image = avifImageCreateEmpty();
+
+        // Look for a colr nclx box. Other colr box types (e.g. ICC) are not supported.
+        for (uint32_t propertyIndex = 0; propertyIndex < gainMapItemTmp->properties.count; ++propertyIndex) {
+            avifProperty * prop = &gainMapItemTmp->properties.prop[propertyIndex];
+            if (!memcmp(prop->type, "colr", 4) && prop->u.colr.hasNCLX) {
+                decoder->image->gainMap.image->colorPrimaries = prop->u.colr.colorPrimaries;
+                decoder->image->gainMap.image->transferCharacteristics = prop->u.colr.transferCharacteristics;
+                decoder->image->gainMap.image->matrixCoefficients = prop->u.colr.matrixCoefficients;
+                decoder->image->gainMap.image->yuvRange = prop->u.colr.range;
+                break;
+            }
+        }
+
+        // If the base image is not HDR, then the tone mapped image is.
+        // Copy HDR properties associated with the tmap box to the gain map image.
+        // Technically, the gain map is not an HDR image, but in the API, this is the most convenient
+        // place to put this data.
+        if (!decoder->image->gainMap.metadata.baseRenditionIsHDR) {
+            // TODO(maryla): add other HDR boxes: mdcv, cclv, etc.
+            const avifProperty * clliProp = avifPropertyArrayFind(&toneMappedImageItem->properties, "clli");
+            if (clliProp) {
+                decoder->image->gainMap.image->clli = clliProp->u.clli;
+            }
+        }
+    }
+
+    // Only set the output parameter after everything has been validated.
+    *gainMapItem = gainMapItemTmp;
     return AVIF_RESULT_OK;
 }
 #endif // AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP
@@ -4559,71 +4655,17 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         }
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-        avifDecoderItem * gainMapItem = NULL;
-        avifDecoderItem * toneMappedImageItem;
-        uint32_t gainMapItemID;
-        AVIF_CHECKRES(avifDecoderDataFindToneMappedImageItem(data, colorItem, &toneMappedImageItem, &gainMapItemID));
-        avifCodecType gainMapCodecType = AVIF_CODEC_TYPE_UNKNOWN;
-        if (toneMappedImageItem) {
-            avifROData tmapData;
-            AVIF_CHECKRES(avifDecoderItemRead(toneMappedImageItem, decoder->io, &tmapData, 0, 0, data->diag));
-            AVIF_CHECKERR(avifParseToneMappedImageBox(&decoder->image->gainMap.metadata, tmapData.data, tmapData.size, data->diag),
-                          AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE);
-
-            gainMapItem = avifMetaFindItem(data->meta, gainMapItemID);
-            if (!gainMapItem) {
-                avifDiagnosticsPrintf(data->diag, "Box[tmap] gain map item ID %d not found", gainMapItemID);
-                return AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE;
-            }
-            if (avifDecoderItemShouldBeSkipped(gainMapItem)) {
-                avifDiagnosticsPrintf(data->diag, "Box[tmap] gain map item %d is not a supported image type", gainMapItemID);
-                return AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE;
-            }
-
-            if (!memcmp(gainMapItem->type, "grid", 4)) {
-                avifROData gainMapGridData;
-                AVIF_CHECKRES(avifDecoderItemRead(gainMapItem, decoder->io, &gainMapGridData, 0, 0, data->diag));
-                AVIF_CHECKERR(avifParseImageGridBox(&data->gainMap.grid,
-                                                    gainMapGridData.data,
-                                                    gainMapGridData.size,
-                                                    decoder->imageSizeLimit,
-                                                    decoder->imageDimensionLimit,
-                                                    data->diag),
-                              AVIF_RESULT_INVALID_IMAGE_GRID);
-                gainMapCodecType = avifDecoderItemGetGridCodecType(gainMapItem);
-                if (gainMapCodecType == AVIF_CODEC_TYPE_UNKNOWN) {
-                    return AVIF_RESULT_INVALID_IMAGE_GRID;
-                }
-            } else {
-                gainMapCodecType = avifGetCodecType(gainMapItem->type);
-                assert(gainMapCodecType != AVIF_CODEC_TYPE_UNKNOWN);
-            }
-
-            decoder->image->gainMap.image = avifImageCreateEmpty();
-
-            // Look for a colr nclx box. Other colr box types (e.g. ICC) are not supported.
-            for (uint32_t propertyIndex = 0; propertyIndex < gainMapItem->properties.count; ++propertyIndex) {
-                avifProperty * prop = &gainMapItem->properties.prop[propertyIndex];
-                if (!memcmp(prop->type, "colr", 4) && prop->u.colr.hasNCLX) {
-                    decoder->image->gainMap.image->colorPrimaries = prop->u.colr.colorPrimaries;
-                    decoder->image->gainMap.image->transferCharacteristics = prop->u.colr.transferCharacteristics;
-                    decoder->image->gainMap.image->matrixCoefficients = prop->u.colr.matrixCoefficients;
-                    decoder->image->gainMap.image->yuvRange = prop->u.colr.range;
-                    break;
-                }
-            }
-
-            // If the base image is not HDR, then the tone mapped image is.
-            // Copy HDR properties associated with the tmap box to the gain map image.
-            // Technically, the gain map is not an HDR image, but in the API, this is the most convenient
-            // place to put this data.
-            if (!decoder->image->gainMap.metadata.baseRenditionIsHDR) {
-                // TODO(maryla): add other HDR boxes: mdcv, cclv, etc.
-                const avifProperty * clliProp = avifPropertyArrayFind(&toneMappedImageItem->properties, "clli");
-                if (clliProp) {
-                    decoder->image->gainMap.image->clli = clliProp->u.clli;
-                }
-            }
+        avifDecoderItem * gainMapItem;
+        avifCodecType gainMapCodecType;
+        avifResult findGainMapResult = avifDecoderFindGainMapItem(decoder, colorItem, &gainMapItem, &gainMapCodecType);
+        if (decoder->ignoreGainMap) {
+            // When ignoring the gain map, we still report whether one is present or not,
+            // but do not fail if there was any error with the gain map.
+            decoder->gainMapPresent = (findGainMapResult == AVIF_RESULT_OK) && gainMapItem != NULL;
+            // We also ignore the actual item and don't decode it.
+            gainMapItem = NULL;
+        } else {
+            AVIF_CHECKRES(findGainMapResult);
         }
 #endif // AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP
 
@@ -4642,26 +4684,33 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         decoder->duration = 1;
         decoder->durationInTimescales = 1;
 
-        AVIF_CHECKRES(avifDecoderGenerateImageTiles(decoder, &data->color, colorItem, AVIF_ITEM_COLOR));
-        if ((data->color.grid.rows == 0) || (data->color.grid.columns == 0)) {
-            if (colorItem->progressive) {
-                decoder->progressiveState = AVIF_PROGRESSIVE_STATE_AVAILABLE;
-                const avifTile * colorTile = &data->tiles.tile[0];
-                if (colorTile->input->samples.count > 1) {
-                    decoder->progressiveState = AVIF_PROGRESSIVE_STATE_ACTIVE;
-                    decoder->imageCount = (int)colorTile->input->samples.count;
+        avifBool shouldDecodeColorAndAlpha = AVIF_TRUE;
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+        shouldDecodeColorAndAlpha = !decoder->ignoreColorAndAlpha;
+#endif
+
+        if (shouldDecodeColorAndAlpha) {
+            AVIF_CHECKRES(avifDecoderGenerateImageTiles(decoder, &data->color, colorItem, AVIF_ITEM_COLOR));
+            if ((data->color.grid.rows == 0) || (data->color.grid.columns == 0)) {
+                if (colorItem->progressive) {
+                    decoder->progressiveState = AVIF_PROGRESSIVE_STATE_AVAILABLE;
+                    const avifTile * colorTile = &data->tiles.tile[0];
+                    if (colorTile->input->samples.count > 1) {
+                        decoder->progressiveState = AVIF_PROGRESSIVE_STATE_ACTIVE;
+                        decoder->imageCount = (int)colorTile->input->samples.count;
+                    }
                 }
             }
-        }
 
-        if (alphaItem) {
-            if (!alphaItem->width && !alphaItem->height) {
-                // NON-STANDARD: Alpha subimage does not have an ispe property; adopt width/height from color item
-                assert(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED));
-                alphaItem->width = colorItem->width;
-                alphaItem->height = colorItem->height;
+            if (alphaItem) {
+                if (!alphaItem->width && !alphaItem->height) {
+                    // NON-STANDARD: Alpha subimage does not have an ispe property; adopt width/height from color item
+                    assert(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED));
+                    alphaItem->width = colorItem->width;
+                    alphaItem->height = colorItem->height;
+                }
+                AVIF_CHECKRES(avifDecoderGenerateImageTiles(decoder, &data->alpha, alphaItem, AVIF_ITEM_ALPHA));
             }
-            AVIF_CHECKRES(avifDecoderGenerateImageTiles(decoder, &data->alpha, alphaItem, AVIF_ITEM_ALPHA));
         }
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -89,6 +89,7 @@ TEST(GainMapTest, EncodeDecodeBaseImageSdr) {
   ASSERT_NE(decoded, nullptr);
   testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
   ASSERT_NE(decoder, nullptr);
+  decoder->ignoreGainMap = AVIF_FALSE;
   result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
                                  encoded.size);
   ASSERT_EQ(result, AVIF_RESULT_OK)
@@ -107,8 +108,8 @@ TEST(GainMapTest, EncodeDecodeBaseImageSdr) {
             image->gainMap.image->clli.maxCLL);
   EXPECT_EQ(decoded->gainMap.image->clli.maxPALL,
             image->gainMap.image->clli.maxPALL);
-  CheckGainMapMetadataMatches(image->gainMap.metadata,
-                              decoded->gainMap.metadata);
+  CheckGainMapMetadataMatches(decoded->gainMap.metadata,
+                              image->gainMap.metadata);
 
   // Uncomment the following to save the encoded image as an AVIF file.
   //  std::ofstream("/tmp/avifgainmaptest_basesdr.avif", std::ios::binary)
@@ -146,6 +147,7 @@ TEST(GainMapTest, EncodeDecodeBaseImageHdr) {
   testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
   ASSERT_NE(decoded, nullptr);
   testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  decoder->ignoreGainMap = AVIF_FALSE;
   ASSERT_NE(decoder, nullptr);
   result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
                                  encoded.size);
@@ -161,8 +163,8 @@ TEST(GainMapTest, EncodeDecodeBaseImageHdr) {
             40.0);
   EXPECT_EQ(decoded->clli.maxCLL, image->clli.maxCLL);
   EXPECT_EQ(decoded->clli.maxPALL, image->clli.maxPALL);
-  CheckGainMapMetadataMatches(image->gainMap.metadata,
-                              decoded->gainMap.metadata);
+  CheckGainMapMetadataMatches(decoded->gainMap.metadata,
+                              image->gainMap.metadata);
 
   // Uncomment the following to save the encoded image as an AVIF file.
   //  std::ofstream("/tmp/avifgainmaptest_basehdr.avif", std::ios::binary)
@@ -218,6 +220,7 @@ TEST(GainMapTest, EncodeDecodeGrid) {
   ASSERT_NE(decoded, nullptr);
   testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
   ASSERT_NE(decoder, nullptr);
+  decoder->ignoreGainMap = AVIF_FALSE;
   result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
                                  encoded.size);
   ASSERT_EQ(result, AVIF_RESULT_OK)
@@ -244,7 +247,7 @@ TEST(GainMapTest, EncodeDecodeGrid) {
   EXPECT_TRUE(decoder->gainMapPresent);
   ASSERT_NE(decoded->gainMap.image, nullptr);
   ASSERT_GT(testutil::GetPsnr(*merged_gain_map, *decoded->gainMap.image), 40.0);
-  CheckGainMapMetadataMatches(gain_map_metadata, decoded->gainMap.metadata);
+  CheckGainMapMetadataMatches(decoded->gainMap.metadata, gain_map_metadata);
 
   // Uncomment the following to save the encoded image as an AVIF file.
   //  std::ofstream("/tmp/avifgainmaptest_grid.avif", std::ios::binary)
@@ -349,6 +352,114 @@ TEST(GainMapTest, SequenceNotSupported) {
   // Image sequences with gain maps are not supported.
   ASSERT_EQ(result, AVIF_RESULT_NOT_IMPLEMENTED)
       << avifResultToString(result) << " " << encoder->diag.error;
+}
+
+TEST(GainMapTest, IgnoreGainMapOrColor) {
+  // Create image with gain map.
+  testutil::AvifImagePtr image =
+      testutil::CreateImage(/*width=*/12, /*height=*/34, /*depth=*/10,
+                            AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_ALL);
+  ASSERT_NE(image, nullptr);
+  image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
+  testutil::FillImageGradient(image.get());
+  testutil::AvifImagePtr gain_map =
+      testutil::CreateImage(/*width=*/6, /*height=*/17, /*depth=*/8,
+                            AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_YUV);
+  ASSERT_NE(gain_map, nullptr);
+  testutil::FillImageGradient(gain_map.get());
+  image->gainMap.image = gain_map.release();  // 'image' now owns the gain map.
+  image->gainMap.metadata =
+      GetTestGainMapMetadata(/*base_rendition_is_hdr=*/false);
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  testutil::AvifRwData encoded;
+  avifResult result = avifEncoderWrite(encoder.get(), image.get(), &encoded);
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << " " << encoder->diag.error;
+
+  // Decode image, with ignoreGainMap true by default.
+  testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
+                                 encoded.size);
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << " " << decoder->diag.error;
+
+  // Verify that the input and decoded images are close.
+  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 40.0);
+  // Verify that the gain map was detected...
+  EXPECT_TRUE(decoder->gainMapPresent);
+  // ... but not decoded because ignoreGainMap is true by default.
+  EXPECT_EQ(decoded->gainMap.image, nullptr);
+  // Check that the gain map metadata was not populated either.
+  CheckGainMapMetadataMatches(decoded->gainMap.metadata, avifGainMapMetadata());
+
+  // Decode again, just the gain map this time.
+  decoder->ignoreGainMap = AVIF_FALSE;
+  decoder->ignoreColorAndAlpha = AVIF_TRUE;
+  result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
+                                 encoded.size);
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << " " << decoder->diag.error;
+  // Main image metadata is available.
+  EXPECT_EQ(decoder->image->width, 12u);
+  EXPECT_EQ(decoder->image->height, 34u);
+  // But pixels are not.
+  EXPECT_EQ(decoder->image->yuvRowBytes[0], 0u);
+  EXPECT_EQ(decoder->image->yuvRowBytes[1], 0u);
+  EXPECT_EQ(decoder->image->yuvRowBytes[2], 0u);
+  EXPECT_EQ(decoder->image->alphaRowBytes, 0u);
+  // The gain map was decoded.
+  EXPECT_TRUE(decoder->gainMapPresent);
+  ASSERT_NE(decoded->gainMap.image, nullptr);
+  EXPECT_GT(testutil::GetPsnr(*image->gainMap.image, *decoded->gainMap.image),
+            40.0);
+  CheckGainMapMetadataMatches(decoded->gainMap.metadata,
+                              image->gainMap.metadata);
+
+  // Decode again, disabling both the gain map and the main image...
+  decoder->ignoreGainMap = AVIF_TRUE;
+  decoder->ignoreColorAndAlpha = AVIF_TRUE;
+  result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
+                                 encoded.size);
+  // ... which should give an error.
+  ASSERT_EQ(result, AVIF_RESULT_NO_CONTENT);
+}
+
+TEST(GainMapTest, NoGainMap) {
+  // Create a simple image without a gain map.
+  testutil::AvifImagePtr image =
+      testutil::CreateImage(/*width=*/12, /*height=*/34, /*depth=*/10,
+                            AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_ALL);
+  ASSERT_NE(image, nullptr);
+  image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
+  testutil::FillImageGradient(image.get());
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  testutil::AvifRwData encoded;
+  avifResult result = avifEncoderWrite(encoder.get(), image.get(), &encoded);
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << " " << encoder->diag.error;
+
+  testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  // Enable gain map decoding.
+  decoder->ignoreGainMap = AVIF_FALSE;
+  result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
+                                 encoded.size);
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << " " << decoder->diag.error;
+
+  // Verify that the input and decoded images are close.
+  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 40.0);
+  // Verify that no gain map was found.
+  EXPECT_FALSE(decoder->gainMapPresent);
+  EXPECT_EQ(decoded->gainMap.image, nullptr);
+  CheckGainMapMetadataMatches(decoded->gainMap.metadata, avifGainMapMetadata());
 }
 
 }  // namespace

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -55,28 +55,44 @@ avifGainMapMetadata GetTestGainMapMetadata(bool base_rendition_is_hdr) {
   return metadata;
 }
 
-TEST(GainMapTest, EncodeDecodeBaseImageSdr) {
+testutil::AvifImagePtr CreateTestImageWithGainMap(bool base_rendition_is_hdr) {
   testutil::AvifImagePtr image =
       testutil::CreateImage(/*width=*/12, /*height=*/34, /*depth=*/10,
                             AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_ALL);
-  ASSERT_NE(image, nullptr);
-  image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
+  if (image == nullptr) {
+    return {nullptr, nullptr};
+  }
+  image->transferCharacteristics =
+      (avifTransferCharacteristics)(base_rendition_is_hdr
+                                        ? AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084
+                                        : AVIF_TRANSFER_CHARACTERISTICS_SRGB);
   testutil::FillImageGradient(image.get());
-
   testutil::AvifImagePtr gain_map =
       testutil::CreateImage(/*width=*/6, /*height=*/17, /*depth=*/8,
                             AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_YUV);
-  ASSERT_NE(gain_map, nullptr);
+  if (gain_map == nullptr) {
+    return {nullptr, nullptr};
+  }
   testutil::FillImageGradient(gain_map.get());
-  gain_map->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_FCC;
-  // Even though this is attached to the gain map, it represents the clli
-  // information of the tone mapped image.
-  gain_map->clli.maxCLL = 10;
-  gain_map->clli.maxPALL = 5;
-
   image->gainMap.image = gain_map.release();  // 'image' now owns the gain map.
-  image->gainMap.metadata =
-      GetTestGainMapMetadata(/*base_rendition_is_hdr=*/false);
+  image->gainMap.metadata = GetTestGainMapMetadata(base_rendition_is_hdr);
+
+  if (base_rendition_is_hdr) {
+    image->clli.maxCLL = 10;
+    image->clli.maxPALL = 5;
+  } else {
+    // Even though this is attached to the gain map, it represents the clli
+    // information of the tone mapped image.
+    image->gainMap.image->clli.maxCLL = 10;
+    image->gainMap.image->clli.maxPALL = 5;
+  }
+
+  return image;
+}
+
+TEST(GainMapTest, EncodeDecodeBaseImageSdr) {
+  testutil::AvifImagePtr image =
+      CreateTestImageWithGainMap(/*base_rendition_is_hdr=*/false);
 
   testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
   ASSERT_NE(encoder, nullptr);
@@ -118,24 +134,7 @@ TEST(GainMapTest, EncodeDecodeBaseImageSdr) {
 
 TEST(GainMapTest, EncodeDecodeBaseImageHdr) {
   testutil::AvifImagePtr image =
-      testutil::CreateImage(/*width=*/12, /*height=*/34, /*depth=*/10,
-                            AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_ALL);
-  ASSERT_NE(image, nullptr);
-  image->transferCharacteristics =
-      AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084;  // PQ
-  image->clli.maxCLL = 10;
-  image->clli.maxPALL = 5;
-  testutil::FillImageGradient(image.get());
-
-  testutil::AvifImagePtr gain_map =
-      testutil::CreateImage(/*width=*/6, /*height=*/17, /*depth=*/8,
-                            AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_YUV);
-  ASSERT_NE(gain_map, nullptr);
-  testutil::FillImageGradient(gain_map.get());
-
-  image->gainMap.image = gain_map.release();  // 'image' now owns the gain map.
-  image->gainMap.metadata =
-      GetTestGainMapMetadata(/*base_rendition_is_hdr=*/true);
+      CreateTestImageWithGainMap(/*base_rendition_is_hdr=*/true);
 
   testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
   ASSERT_NE(encoder, nullptr);
@@ -354,22 +353,11 @@ TEST(GainMapTest, SequenceNotSupported) {
       << avifResultToString(result) << " " << encoder->diag.error;
 }
 
-TEST(GainMapTest, IgnoreGainMapOrColor) {
-  // Create image with gain map.
+TEST(GainMapTest, IgnoreGainMap) {
   testutil::AvifImagePtr image =
-      testutil::CreateImage(/*width=*/12, /*height=*/34, /*depth=*/10,
-                            AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_ALL);
+      CreateTestImageWithGainMap(/*base_rendition_is_hdr=*/false);
   ASSERT_NE(image, nullptr);
-  image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
-  testutil::FillImageGradient(image.get());
-  testutil::AvifImagePtr gain_map =
-      testutil::CreateImage(/*width=*/6, /*height=*/17, /*depth=*/8,
-                            AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_YUV);
-  ASSERT_NE(gain_map, nullptr);
-  testutil::FillImageGradient(gain_map.get());
-  image->gainMap.image = gain_map.release();  // 'image' now owns the gain map.
-  image->gainMap.metadata =
-      GetTestGainMapMetadata(/*base_rendition_is_hdr=*/false);
+
   testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
   ASSERT_NE(encoder, nullptr);
   testutil::AvifRwData encoded;
@@ -395,14 +383,32 @@ TEST(GainMapTest, IgnoreGainMapOrColor) {
   EXPECT_EQ(decoded->gainMap.image, nullptr);
   // Check that the gain map metadata was not populated either.
   CheckGainMapMetadataMatches(decoded->gainMap.metadata, avifGainMapMetadata());
+}
 
-  // Decode again, just the gain map this time.
-  decoder->ignoreGainMap = AVIF_FALSE;
+TEST(GainMapTest, IgnoreColorAndAlpha) {
+  testutil::AvifImagePtr image =
+      CreateTestImageWithGainMap(/*base_rendition_is_hdr=*/false);
+  ASSERT_NE(image, nullptr);
+
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  testutil::AvifRwData encoded;
+  avifResult result = avifEncoderWrite(encoder.get(), image.get(), &encoded);
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << " " << encoder->diag.error;
+
+  testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  // Decode just the gain map.
   decoder->ignoreColorAndAlpha = AVIF_TRUE;
+  decoder->ignoreGainMap = AVIF_FALSE;
   result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
                                  encoded.size);
   ASSERT_EQ(result, AVIF_RESULT_OK)
       << avifResultToString(result) << " " << decoder->diag.error;
+
   // Main image metadata is available.
   EXPECT_EQ(decoder->image->width, 12u);
   EXPECT_EQ(decoder->image->height, 34u);
@@ -418,10 +424,27 @@ TEST(GainMapTest, IgnoreGainMapOrColor) {
             40.0);
   CheckGainMapMetadataMatches(decoded->gainMap.metadata,
                               image->gainMap.metadata);
+}
 
-  // Decode again, disabling both the gain map and the main image...
-  decoder->ignoreGainMap = AVIF_TRUE;
+TEST(GainMapTest, IgnoreAll) {
+  testutil::AvifImagePtr image =
+      CreateTestImageWithGainMap(/*base_rendition_is_hdr=*/false);
+  ASSERT_NE(image, nullptr);
+
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  ASSERT_NE(encoder, nullptr);
+  testutil::AvifRwData encoded;
+  avifResult result = avifEncoderWrite(encoder.get(), image.get(), &encoded);
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << " " << encoder->diag.error;
+
+  testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  // Ignore both the main image and the gain map.
   decoder->ignoreColorAndAlpha = AVIF_TRUE;
+  decoder->ignoreGainMap = AVIF_TRUE;
   result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
                                  encoded.size);
   // ... which should give an error.


### PR DESCRIPTION
When AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP is enabled, add two decoder options: ignoreGainMap (true by default) and ignoreColorAndAlpha (to allow decoding the gain map only).

The names were chosen to mimic ignoreExif and ignoreXMP. But maybe for gain maps, it would be better to have something that is false by default? Like 'enableGainMaps', 'decodeGainMap', etc.?