### PR TITLE
Apply clang-format-12

### DIFF
--- a/src/scale.c
+++ b/src/scale.c
@@ -11,7 +11,7 @@
 // in version 1813:
 // https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3183182
 // https://chromium-review.googlesource.com/c/libyuv/libyuv/+/3527834
-#pragma clang diagnostic ignored "-Wnewline-eof"       // "no newline at end of file"
+#pragma clang diagnostic ignored "-Wnewline-eof" // "no newline at end of file"
 #endif
 #include <libyuv.h>
 #if defined(__clang__)


### PR DESCRIPTION
Command used:

```
clang-format-12 -style=file -i   apps/*.c apps/shared/avifexif.*  apps/*.c apps/shared/avifjpeg.* apps/shared/avifpng.*   apps/shared/avifutil.* apps/shared/y4m.* examples/*.c   include/avif/*.h src/*.c tests/*.c tests/gtest/*.h tests/gtest/*.cc
```