### PR TITLE
Treat SYSTEM include directories as such

### DIFF
--- a/contrib/gdk-pixbuf/CMakeLists.txt
+++ b/contrib/gdk-pixbuf/CMakeLists.txt
@@ -12,7 +12,7 @@ if(AVIF_BUILD_GDK_PIXBUF)
 
             target_link_libraries(pixbufloader-avif PUBLIC ${GDK_PIXBUF_LIBRARIES} avif)
             target_link_directories(pixbufloader-avif PUBLIC ${GDK_PIXBUF_LIBRARY_DIRS})
-            target_include_directories(pixbufloader-avif PUBLIC ${GDK_PIXBUF_INCLUDE_DIRS})
+            target_include_directories(pixbufloader-avif SYSTEM PUBLIC ${GDK_PIXBUF_INCLUDE_DIRS})
 
             pkg_get_variable(GDK_PIXBUF_MODULEDIR gdk-pixbuf-2.0 gdk_pixbuf_moduledir)
             string(REPLACE ${GDK_PIXBUF_PREFIX} ${CMAKE_INSTALL_PREFIX} GDK_PIXBUF_MODULEDIR ${GDK_PIXBUF_MODULEDIR})


### PR DESCRIPTION
Include system directories with corresponding keyword. This effectively lowers their lookup priority relative to project include directories and prevents the build picking libavif includes from system installed version instead of repository version.