### PR TITLE
Add avifBreakOnError() to internal.h

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -15,13 +15,13 @@ extern "C" {
 #define AVIF_MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define AVIF_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
-// Used for debugging. Add ! to catch the earliest failure during encoding or decoding.
+// Used for debugging. Define AVIF_BREAK_ON_ERROR to catch the earliest failure during encoding or decoding.
 #if defined(AVIF_BREAK_ON_ERROR)
 static inline void avifBreakOnError()
 {
-    // Same mechanism as OpenCV's error() function.
-    static volatile int * p = 0;
-    *p = 0; // or replace by a breakpoint
+    // Same mechanism as OpenCV's error() function, or replace by a breakpoint.
+    int * p = NULL;
+    *p = 0;
 }
 #else
 #define avifBreakOnError()

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -19,7 +19,9 @@ extern "C" {
 #if defined(AVIF_BREAK_ON_ERROR)
 static inline void avifBreakOnError()
 {
-    abort(); // or replace by a breakpoint
+    // Same mechanisme as OpenCV's error() function.
+    static volatile int * p = 0;
+    *p = 0; // or replace by a breakpoint
 }
 #else
 #define avifBreakOnError()

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -15,6 +15,7 @@ extern "C" {
 #define AVIF_MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define AVIF_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
+// Used for debugging. Add ! to catch the earliest failure during encoding or decoding.
 #if defined(AVIF_BREAK_ON_ERROR)
 static inline void avifBreakOnError()
 {

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -19,7 +19,7 @@ extern "C" {
 #if defined(AVIF_BREAK_ON_ERROR)
 static inline void avifBreakOnError()
 {
-    // Same mechanisme as OpenCV's error() function.
+    // Same mechanism as OpenCV's error() function.
     static volatile int * p = 0;
     *p = 0; // or replace by a breakpoint
 }

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -15,26 +15,41 @@ extern "C" {
 #define AVIF_MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define AVIF_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
+#if defined(AVIF_BREAK_ON_ERROR)
+static inline void avifBreakOnError()
+{
+    abort(); // or replace by a breakpoint
+}
+#else
+#define avifBreakOnError()
+#endif
+
 // Used by stream related things.
-#define AVIF_CHECK(A)          \
-    do {                       \
-        if (!(A))              \
-            return AVIF_FALSE; \
+#define AVIF_CHECK(A)           \
+    do {                        \
+        if (!(A)) {             \
+            avifBreakOnError(); \
+            return AVIF_FALSE;  \
+        }                       \
     } while (0)
 
 // Used instead of CHECK if needing to return a specific error on failure, instead of AVIF_FALSE
-#define AVIF_CHECKERR(A, ERR) \
-    do {                      \
-        if (!(A))             \
-            return ERR;       \
+#define AVIF_CHECKERR(A, ERR)   \
+    do {                        \
+        if (!(A)) {             \
+            avifBreakOnError(); \
+            return ERR;         \
+        }                       \
     } while (0)
 
 // Forward any error to the caller now or continue execution.
-#define AVIF_CHECKRES(A)                 \
-    do {                                 \
-        const avifResult result__ = (A); \
-        if (result__ != AVIF_RESULT_OK)  \
-            return result__;             \
+#define AVIF_CHECKRES(A)                  \
+    do {                                  \
+        const avifResult result__ = (A);  \
+        if (result__ != AVIF_RESULT_OK) { \
+            avifBreakOnError();           \
+            return result__;              \
+        }                                 \
     } while (0)
 
 // ---------------------------------------------------------------------------

--- a/src/read.c
+++ b/src/read.c
@@ -3761,8 +3761,7 @@ avifBool avifPeekCompatibleFileType(const avifROData * input)
     BEGIN_STREAM(s, input->data, input->size, NULL, NULL);
 
     avifBoxHeader header;
-    AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
-    if (memcmp(header.type, "ftyp", 4)) {
+    if (!avifROStreamReadBoxHeader(&s, &header) || memcmp(header.type, "ftyp", 4)) {
         return AVIF_FALSE;
     }
 


### PR DESCRIPTION
To debug `AVIF_CHECK*()` failures by just adding `!` to
```c
#if defined(AVIF_BREAK_ON_ERROR)
```
I have used this debugging pattern multiple times now so I thought it would be handy to have it committed. Happy to hear opinions though.

Remove `AVIF_CHECK()` from `avifPeekCompatibleFileType()` because it is expected to often fail.