### PR TITLE
Don't add ldflags to aom library

### DIFF
--- a/cmake/Modules/Findaom.cmake
+++ b/cmake/Modules/Findaom.cmake
@@ -26,7 +26,7 @@ find_path(AOM_INCLUDE_DIR NAMES aom/aom.h PATHS ${_AOM_INCLUDEDIR})
 
 find_library(AOM_LIBRARY NAMES aom PATHS ${_AOM_LIBDIR})
 
-set(AOM_LIBRARIES ${AOM_LIBRARIES} ${AOM_LIBRARY} ${_AOM_LDFLAGS})
+set(AOM_LIBRARIES ${AOM_LIBRARIES} ${AOM_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(


### PR DESCRIPTION
To link with aom, only AOM_LIBRARY is needed. Don't append LDFLAGS from pkgconfig, which contain (duplicate) flags to link the very same library, also in error-prone -L/-l form.

Link with aom before: `/usr/local/lib/libaom.so  -L/usr/local/lib -laom`
Link with aom after: `/usr/local/lib/libaom.so`