### PR TITLE
Allow providing a custom decoder to testutil::DecodeIncrementally.

### DIFF
--- a/tests/gtest/avifincrtest.cc
+++ b/tests/gtest/avifincrtest.cc
@@ -55,10 +55,11 @@ TEST(IncrementalTest, Decode) {
 
   // Cell height is hardcoded because there is no API to extract it from an
   // encoded payload.
-  testutil::DecodeIncrementally(
-      encoded_avif, /*is_persistent=*/true, /*give_size_hint=*/true,
-      /*use_nth_image_api=*/false, *reference, /*cell_height=*/154,
-      /*enable_fine_incremental_check=*/true);
+  testutil::DecodeIncrementally(encoded_avif, decoder.get(),
+                                /*is_persistent=*/true, /*give_size_hint=*/true,
+                                /*use_nth_image_api=*/false, *reference,
+                                /*cell_height=*/154,
+                                /*enable_fine_incremental_check=*/true);
 }
 
 //------------------------------------------------------------------------------
@@ -98,8 +99,9 @@ TEST_P(IncrementalTest, EncodeDecode) {
   testutil::EncodeRectAsIncremental(*image, width, height, create_alpha,
                                     flat_cells, &encoded_avif, &cell_width,
                                     &cell_height);
+
   testutil::DecodeNonIncrementallyAndIncrementally(
-      encoded_avif, encoded_avif_is_persistent, give_size_hint,
+      encoded_avif, decoder.get(), encoded_avif_is_persistent, give_size_hint,
       use_nth_image_api, cell_height, /*enable_fine_incremental_check=*/true);
 }
 

--- a/tests/gtest/avifincrtest_helpers.h
+++ b/tests/gtest/avifincrtest_helpers.h
@@ -4,6 +4,8 @@
 #ifndef LIBAVIF_TESTS_AVIFINCRTEST_HELPERS_H_
 #define LIBAVIF_TESTS_AVIFINCRTEST_HELPERS_H_
 
+#include <cstdint>
+
 #include "avif/avif.h"
 
 namespace libavif {
@@ -24,16 +26,17 @@ void EncodeRectAsIncremental(const avifImage& image, uint32_t width,
 // incremental granularity. enable_fine_incremental_check checks that sample
 // rows are gradually output when feeding more and more input bytes to the
 // decoder.
-void DecodeIncrementally(const avifRWData& encoded_avif, bool is_persistent,
-                         bool give_size_hint, bool use_nth_image_api,
-                         const avifImage& reference, uint32_t cell_height,
+void DecodeIncrementally(const avifRWData& encoded_avif, avifDecoder* decoder,
+                         bool is_persistent, bool give_size_hint,
+                         bool use_nth_image_api, const avifImage& reference,
+                         uint32_t cell_height,
                          bool enable_fine_incremental_check = false);
 
 // Calls DecodeIncrementally() with the reference being a regular decoding of
 // encoded_avif.
 void DecodeNonIncrementallyAndIncrementally(
-    const avifRWData& encoded_avif, bool is_persistent, bool give_size_hint,
-    bool use_nth_image_api, uint32_t cell_height,
+    const avifRWData& encoded_avif, avifDecoder* decoder, bool is_persistent,
+    bool give_size_hint, bool use_nth_image_api, uint32_t cell_height,
     bool enable_fine_incremental_check = false);
 
 }  // namespace testutil


### PR DESCRIPTION
This allows testing decoders with different settings.