### PR TITLE
Print gain map info in avifenc/avifdec.

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -328,7 +328,11 @@ int main(int argc, char * argv[])
 
     printf("Image decoded: %s\n", inputFilename);
     printf("Image details:\n");
-    avifImageDump(decoder->image, 0, 0, decoder->progressiveState);
+    avifBool gainMapPresent = AVIF_FALSE;
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+    gainMapPresent = decoder->gainMapPresent;
+#endif
+    avifImageDump(decoder->image, 0, 0, gainMapPresent, decoder->progressiveState);
 
     if (ignoreICC && (decoder->image->icc.size > 0)) {
         printf("[--ignore-icc] Discarding ICC profile.\n");

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -2472,9 +2472,14 @@ int main(int argc, char * argv[])
     }
     printf("AVIF to be written:%s\n", lossyHint);
     const avifImage * avif = gridCells ? gridCells[0] : image;
+    avifBool gainMapPresent = AVIF_FALSE;
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+    gainMapPresent = (avif->gainMap.image != NULL);
+#endif
     avifImageDump(avif,
                   settings.gridDims[0],
                   settings.gridDims[1],
+                  gainMapPresent,
                   settings.layers > 1 ? AVIF_PROGRESSIVE_STATE_AVAILABLE : AVIF_PROGRESSIVE_STATE_UNAVAILABLE);
 
     avifIOStats ioStats = { 0, 0 };

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -28,7 +28,7 @@ extern "C" {
 #define AVIF_FMT_ZU "zu"
 #endif
 
-void avifImageDump(const avifImage * avif, uint32_t gridCols, uint32_t gridRows, avifProgressiveState progressiveState);
+void avifImageDump(const avifImage * avif, uint32_t gridCols, uint32_t gridRows, avifBool gainMapPresent, avifProgressiveState progressiveState);
 void avifContainerDump(const avifDecoder * decoder);
 void avifPrintVersions(void);
 void avifDumpDiagnostics(const avifDiagnostics * diag);


### PR DESCRIPTION
In avifenc, the gain map's detailed info like pixel size, yuv format etc. are printed.
In avifdec, only the presence/absence of a gain map in the AVIF file is printed. The full info is not available because enableDecodingGainMap is disabled by default, and it doesn't make sense to enable it since the gain map won't be savec anyway (saving to jpeg+gainmap is not implemented).