### PR TITLE
Use dav1d by default for Android builds

### DIFF
--- a/.github/workflows/ci-android-emulator-tests.yml
+++ b/.github/workflows/ci-android-emulator-tests.yml
@@ -31,11 +31,18 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@187efd9581ed20ee4e03c0dfb9ac2cd5896c4835 # v1.14.1
         with:
-          # This is the minimum cmake version needed to build libgav1.
-          cmake-version: '3.7.x'
-      - name: Build libgav1 with the Android NDK
+          cmake-version: "3.19.x"
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Setup meson
+        run: pip install meson
+      - name: Setup nasm
+        uses: ilammy/setup-nasm@v1
+      - name: Build dav1d with the Android NDK
         working-directory: ext
-        run: bash libgav1_android.sh ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: bash dav1d_android.sh ${{ steps.setup-ndk.outputs.ndk-path }}
       - name: Build libyuv with the Android NDK
         working-directory: ext
         run: bash libyuv_android.sh ${{ steps.setup-ndk.outputs.ndk-path }}

--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -25,11 +25,18 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@187efd9581ed20ee4e03c0dfb9ac2cd5896c4835 # v1.14.1
         with:
-          # This is the minimum cmake version needed to build libgav1.
-          cmake-version: "3.7.x"
-      - name: Build libgav1 with the Android NDK
+          cmake-version: "3.19.x"
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Setup meson
+        run: pip install meson
+      - name: Setup nasm
+        uses: ilammy/setup-nasm@v1
+      - name: Build dav1d with the Android NDK
         working-directory: ext
-        run: bash libgav1_android.sh ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: bash dav1d_android.sh ${{ steps.setup-ndk.outputs.ndk-path }}
       - name: Build libyuv with the Android NDK
         working-directory: ext
         run: bash libyuv_android.sh ${{ steps.setup-ndk.outputs.ndk-path }}

--- a/android_jni/README.md
+++ b/android_jni/README.md
@@ -6,7 +6,7 @@ This subdirectory contains Android JNI bindings that will enable use of the liba
 ## Prerequisites
 
 * [Android SDK](https://developer.android.com/studio#downloads) - For building the JNI bindings. SDK has to be downloaded and set up for Android API target 30.
-* [Android NDK](https://developer.android.com/ndk/downloads) - For building the decoder (in the examples, we use libgav1).
+* [Android NDK](https://developer.android.com/ndk/downloads) - For building the decoder (in the examples, we use dav1d).
 * [Gradle](https://gradle.org/).
 * CMake.
 * Ninja.
@@ -15,7 +15,7 @@ This subdirectory contains Android JNI bindings that will enable use of the liba
 
 The following steps will generate the AAR package that contains libavif and the JNI wrapper. It can then be used as a dependency for Android apps.
 
-> Note: The instructions in this section will use libgav1 as the AV1 decoder. Any other decoder can be used but the `avifandroidjni/src/main/jni/CMakeLists.txt` file has to be updated accordingly.
+> Note: The instructions in this section will use dav1d as the AV1 decoder. Any other decoder can be used but the `avifandroidjni/src/main/jni/CMakeLists.txt` file has to be updated accordingly.
 
 Step 1 - Checkout libavif
 
@@ -31,15 +31,7 @@ $ export ANDROID_SDK_ROOT="/path/to/android/sdk"
 $ export ANDROID_NDK_HOME="/path/to/android/ndk"
 ```
 
-Step 3 - Checkout and build libgav1 or dav1d
-
-```
-$ cd ext
-$ ./libgav1_android.sh "${ANDROID_NDK_HOME}"
-$ cd ..
-```
-
-If you want to use dav1d instead:
+Step 3 - Checkout and build dav1d (or libgav1)
 
 ```
 $ cd ext
@@ -47,9 +39,17 @@ $ ./dav1d_android.sh "${ANDROID_NDK_HOME}"
 $ cd ..
 ```
 
+If you want to use libgav1 instead:
+
+```
+$ cd ext
+$ ./libgav1_android.sh "${ANDROID_NDK_HOME}"
+$ cd ..
+```
+
 Update [CMakeLists.txt](avifandroidjni/src/main/jni/CMakeLists.txt) as follows:
- * Set `AVIF_LOCAL_LIBGAV1` and `AVIF_CODEC_LIBGAV1` to `OFF`.
- * Set `AVIF_LOCAL_DAV1D` and `AVIF_CODEC_DAV1D` to `ON`.
+ * Set `AVIF_LOCAL_DAV1D` and `AVIF_CODEC_DAV1D` to `OFF`.
+ * Set `AVIF_LOCAL_LIBGAV1` and `AVIF_CODEC_LIBGAV1` to `ON`.
 
 Step 4 - Checkout and build libyuv
 

--- a/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/AvifDecoderTest.java
+++ b/android_jni/avifandroidjni/src/androidTest/java/org/aomedia/avif/android/AvifDecoderTest.java
@@ -213,5 +213,7 @@ public class AvifDecoderTest {
     assertThat(AvifDecoder.versionString()).startsWith("libavif");
     // Ensure that the version string contains "libyuv".
     assertThat(AvifDecoder.versionString()).contains("libyuv");
+    // Ensure that the version string contains "dav1d".
+    assertThat(AvifDecoder.versionString()).contains("dav1d");
   }
 }

--- a/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
+++ b/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
@@ -16,16 +16,16 @@ project(avif_android_jni)
 # https://stackoverflow.com/questions/3766740/overriding-a-default-option-value-in-cmake-from-a-parent-cmakelists-txt
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
 
-# To disable libgav1, change the following two variables to OFF.
-set(AVIF_LOCAL_LIBGAV1 ON CACHE BOOL "" FORCE)
-set(AVIF_CODEC_LIBGAV1 ON CACHE BOOL "" FORCE)
-
-# To disable dav1d, change the following two variables to ON.
-set(AVIF_LOCAL_DAV1D OFF CACHE BOOL "" FORCE)
-set(AVIF_CODEC_DAV1D OFF CACHE BOOL "" FORCE)
+# To disable dav1d, change the following two variables to OFF.
+set(AVIF_CODEC_DAV1D ON CACHE BOOL "" FORCE)
+set(AVIF_LOCAL_DAV1D ON CACHE BOOL "" FORCE)
 
 # To disable libyuv, change this variable to OFF.
 set(AVIF_LOCAL_LIBYUV ON CACHE BOOL "" FORCE)
+
+# To enable libgav1, change the following two variables to ON.
+set(AVIF_CODEC_LIBGAV1 OFF CACHE BOOL "" FORCE)
+set(AVIF_LOCAL_LIBGAV1 OFF CACHE BOOL "" FORCE)
 
 # The current CMake file lives in:
 # $LIBAVIF_ROOT/android_jni/avifandroidjni/src/main/jni.

--- a/ext/dav1d_android.sh
+++ b/ext/dav1d_android.sh
@@ -20,8 +20,13 @@ cd dav1d
 mkdir build
 cd build
 
-# This only works on linux.
-android_bin="${1}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+# This only works on linux and mac.
+if [ "$(uname)" == "Darwin" ]; then
+  HOST_TAG="darwin"
+else
+  HOST_TAG="linux"
+fi
+android_bin="${1}/toolchains/llvm/prebuilt/${HOST_TAG}-x86_64/bin"
 
 ABI_LIST=("armeabi-v7a" "arm64-v8a" "x86" "x86_64")
 ARCH_LIST=("arm" "aarch64" "x86" "x86_64")


### PR DESCRIPTION
Replace the instructions to place dav1d as the decoder of choice. This is what we distribute in maven. Also update the CI workflows to use dav1d instead of libgav1.