### PR TITLE
Add AVIF_ENABLE_COMPLIANCE_WARDEN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /obj*
 /ext/aom
 /ext/avm
+/ext/ComplianceWarden
 /ext/dav1d
 /ext/fuzztest
 /ext/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,16 @@ option(AVIF_LOCAL_AVM "Build the AVM (AV2) codec by providing your own copy of t
        OFF
 )
 
+option(
+    AVIF_ENABLE_COMPLIANCE_WARDEN
+    "Check all avifEncoderFinish() output for AVIF specification compliance. Depends on gpac/ComplianceWarden which can be added with ext/compliance_warden.sh"
+    OFF
+)
+
+set(AVIF_USE_CXX OFF)
+
 if(AVIF_LOCAL_LIBGAV1)
-    enable_language(CXX)
+    set(AVIF_USE_CXX ON)
 endif()
 
 if(APPLE)
@@ -340,6 +348,45 @@ if(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     list(APPEND AVIF_SRCS src/gainmap.c)
 endif()
 
+if(AVIF_ENABLE_COMPLIANCE_WARDEN)
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ext/ComplianceWarden")
+        message(FATAL_ERROR "AVIF_ENABLE_COMPLIANCE_WARDEN: ext/ComplianceWarden is missing, bailing out")
+    endif()
+
+    set(AVIF_USE_CXX ON)
+    add_compile_definitions(AVIF_ENABLE_COMPLIANCE_WARDEN)
+
+    list(
+        APPEND
+        AVIF_SRCS
+            src/compliance.cc
+        ext/ComplianceWarden/src/app/cw.cpp
+        ext/ComplianceWarden/src/app/options.cpp
+        ext/ComplianceWarden/src/app/report_std.cpp
+        ext/ComplianceWarden/src/app/report_json.cpp
+        ext/ComplianceWarden/src/utils/common_boxes.cpp
+        ext/ComplianceWarden/src/utils/tools.cpp
+        ext/ComplianceWarden/src/utils/av1_utils.cpp
+        ext/ComplianceWarden/src/utils/isobmff_utils.cpp
+        ext/ComplianceWarden/src/utils/isobmff_derivations.cpp
+        ext/ComplianceWarden/src/utils/spec_utils.cpp
+        ext/ComplianceWarden/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
+        ext/ComplianceWarden/src/specs/avif/avif.cpp
+        ext/ComplianceWarden/src/specs/avif/profiles.cpp
+        ext/ComplianceWarden/src/specs/avif/utils.cpp
+        ext/ComplianceWarden/src/specs/isobmff/isobmff.cpp
+        ext/ComplianceWarden/src/specs/heif/heif.cpp
+        ext/ComplianceWarden/src/specs/miaf/miaf.cpp
+        ext/ComplianceWarden/src/specs/miaf/audio.cpp
+        ext/ComplianceWarden/src/specs/miaf/brands.cpp
+        ext/ComplianceWarden/src/specs/miaf/derivations.cpp
+        ext/ComplianceWarden/src/specs/miaf/colours.cpp
+        ext/ComplianceWarden/src/specs/miaf/num_pixels.cpp
+        ext/ComplianceWarden/src/specs/miaf/profiles.cpp
+        ext/ComplianceWarden/src/cw_version.cpp
+    )
+endif()
+
 # Only applicable to macOS. In GitHub CI's macos-latest os image, this prevents using the libpng
 # and libjpeg headers from /Library/Frameworks/Mono.framework/Headers instead of
 # /usr/local/include.
@@ -594,11 +641,14 @@ target_include_directories(avif SYSTEM PRIVATE ${AVIF_PLATFORM_SYSTEM_INCLUDES} 
 if(NOT libyuv_FOUND)
     target_include_directories(avif PRIVATE ${libavif_SOURCE_DIR}/third_party/libyuv/include/)
 endif()
+if(AVIF_ENABLE_COMPLIANCE_WARDEN)
+    target_include_directories(avif PRIVATE ${libavif_SOURCE_DIR}/ext/ComplianceWarden/src/utils/)
+endif()
 set(AVIF_PKG_CONFIG_EXTRA_CFLAGS "")
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(avif PUBLIC AVIF_DLL PRIVATE AVIF_BUILDING_SHARED_LIBS)
     set(AVIF_PKG_CONFIG_EXTRA_CFLAGS " -DAVIF_DLL")
-    if(AVIF_LOCAL_LIBGAV1)
+    if(AVIF_USE_CXX)
         set_target_properties(avif PROPERTIES LINKER_LANGUAGE "CXX")
     endif()
 endif()
@@ -626,7 +676,7 @@ if(AVIF_BUILD_EXAMPLES)
 
     foreach(EXAMPLE ${AVIF_EXAMPLES})
         add_executable(${EXAMPLE} examples/${EXAMPLE}.c)
-        if(AVIF_LOCAL_LIBGAV1)
+        if(AVIF_USE_CXX)
             set_target_properties(${EXAMPLE} PROPERTIES LINKER_LANGUAGE "CXX")
         endif()
         target_link_libraries(${EXAMPLE} avif ${AVIF_PLATFORM_LIBRARIES})
@@ -642,6 +692,11 @@ if(NOT SKIP_INSTALL_ALL)
 endif()
 
 if(AVIF_CODEC_LIBRARIES MATCHES vmaf)
+    # vmaf only impacts the avifenc and avifdec targets below, not the library avif target above.
+    set(AVIF_USE_CXX ON)
+endif()
+
+if(AVIF_USE_CXX)
     enable_language(CXX)
 endif()
 
@@ -697,12 +752,12 @@ endif()
 
 if(AVIF_BUILD_APPS)
     add_executable(avifenc apps/avifenc.c)
-    if(AVIF_LOCAL_LIBGAV1 OR AVIF_CODEC_LIBRARIES MATCHES vmaf)
+    if(AVIF_USE_CXX)
         set_target_properties(avifenc PROPERTIES LINKER_LANGUAGE "CXX")
     endif()
     target_link_libraries(avifenc avif_apps)
     add_executable(avifdec apps/avifdec.c)
-    if(AVIF_LOCAL_LIBGAV1 OR AVIF_CODEC_LIBRARIES MATCHES vmaf)
+    if(AVIF_USE_CXX)
         set_target_properties(avifdec PROPERTIES LINKER_LANGUAGE "CXX")
     endif()
     target_link_libraries(avifdec avif_apps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,7 +359,7 @@ if(AVIF_ENABLE_COMPLIANCE_WARDEN)
     list(
         APPEND
         AVIF_SRCS
-            src/compliance.cc
+        src/compliance.cc
         ext/ComplianceWarden/src/app/cw.cpp
         ext/ComplianceWarden/src/app/options.cpp
         ext/ComplianceWarden/src/app/report_std.cpp

--- a/ext/compliance_warden.sh
+++ b/ext/compliance_warden.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Local clone of ComplianceWarden (part of the gpac organization) for tests.
+# Used when AVIF_ENABLE_COMPLIANCE_WARDEN is ON.
+
+set -e
+
+git clone -b v33 --depth 1 https://github.com/gpac/ComplianceWarden.git
+# The provided Makefile only builds bin/cw.exe and objects.
+# We are interested in the library, so the files are directly used instead of building with make -j.
+ComplianceWarden/scripts/version.sh > ComplianceWarden/src/cw_version.cpp
+
+# registerSpec() does not seem to be called in the static 'registered' local variables,
+# for example in avif.cpp. Use the following hack to access the static SpecDescs.
+# Feel free to replace by a prettier solution.
+echo "extern const SpecDesc *const globalSpecAvif = &specAvif;\n" >> ComplianceWarden/src/specs/avif/avif.cpp
+echo "extern const SpecDesc *const globalSpecAv1Hdr10plus = &specAv1Hdr10plus;\n" >> ComplianceWarden/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
+echo "extern const SpecDesc *const globalSpecHeif = &specHeif;\n" >> ComplianceWarden/src/specs/heif/heif.cpp
+echo "extern const SpecDesc *const globalSpecIsobmff = &specIsobmff;\n" >> ComplianceWarden/src/specs/isobmff/isobmff.cpp
+echo "extern const SpecDesc *const globalSpecMiaf = &specMiaf;\n" >> ComplianceWarden/src/specs/miaf/miaf.cpp

--- a/ext/compliance_warden.sh
+++ b/ext/compliance_warden.sh
@@ -13,8 +13,8 @@ ComplianceWarden/scripts/version.sh > ComplianceWarden/src/cw_version.cpp
 # registerSpec() does not seem to be called in the static 'registered' local variables,
 # for example in avif.cpp. Use the following hack to access the static SpecDescs.
 # Feel free to replace by a prettier solution.
-echo "extern const SpecDesc *const globalSpecAvif = &specAvif;\n" >> ComplianceWarden/src/specs/avif/avif.cpp
-echo "extern const SpecDesc *const globalSpecAv1Hdr10plus = &specAv1Hdr10plus;\n" >> ComplianceWarden/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
-echo "extern const SpecDesc *const globalSpecHeif = &specHeif;\n" >> ComplianceWarden/src/specs/heif/heif.cpp
-echo "extern const SpecDesc *const globalSpecIsobmff = &specIsobmff;\n" >> ComplianceWarden/src/specs/isobmff/isobmff.cpp
-echo "extern const SpecDesc *const globalSpecMiaf = &specMiaf;\n" >> ComplianceWarden/src/specs/miaf/miaf.cpp
+printf "extern const SpecDesc *const globalSpecAvif = &specAvif;\n" >> ComplianceWarden/src/specs/avif/avif.cpp
+printf "extern const SpecDesc *const globalSpecAv1Hdr10plus = &specAv1Hdr10plus;\n" >> ComplianceWarden/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
+printf "extern const SpecDesc *const globalSpecHeif = &specHeif;\n" >> ComplianceWarden/src/specs/heif/heif.cpp
+printf "extern const SpecDesc *const globalSpecIsobmff = &specIsobmff;\n" >> ComplianceWarden/src/specs/isobmff/isobmff.cpp
+printf "extern const SpecDesc *const globalSpecMiaf = &specMiaf;\n" >> ComplianceWarden/src/specs/miaf/miaf.cpp

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -471,6 +471,10 @@ __attribute__((__format__(__printf__, 2, 3)))
 #endif
 void avifDiagnosticsPrintf(avifDiagnostics * diag, const char * format, ...);
 
+#if defined(AVIF_ENABLE_COMPLIANCE_WARDEN)
+avifResult avifIsCompliant(uint8_t * data, size_t size);
+#endif
+
 // ---------------------------------------------------------------------------
 // avifStream
 //

--- a/src/compliance.cc
+++ b/src/compliance.cc
@@ -6,6 +6,8 @@
 #include <limits>
 
 #include "avif/internal.h"
+
+// From ../ext/ComplianceWarden/src/utils/
 #include "box_reader_impl.h"
 #include "spec.h"
 
@@ -30,7 +32,7 @@ avifResult avifIsCompliant(uint8_t * data, size_t size)
         registerSpec(globalSpecMiaf);
     }
 
-    // Inspired from ComplianceWarden/src/app/cw.cpp
+    // Inspired from ext/ComplianceWarden/src/app/cw.cpp
     BoxReader topReader;
     for (char sym : { 'f', 'i', 'l', 'e', '.', 'a', 'v', 'i', 'f' }) {
         // Setting made-up file name (letter by letter).
@@ -46,6 +48,7 @@ avifResult avifIsCompliant(uint8_t * data, size_t size)
     AVIF_CHECKERR(topReader.specs[0] != nullptr, AVIF_RESULT_UNKNOWN_ERROR);
     auto parseFunc = getParseFunction(topReader.myBox.fourcc);
     parseFunc(&topReader);
+    // gpac/ComplianceWarden will print the formatted result page to stdout, warnings and errors inclusive.
     AVIF_CHECKERR(!checkComplianceStd(topReader.myBox, topReader.specs[0]), AVIF_RESULT_BMFF_PARSE_FAILED);
     return AVIF_RESULT_OK;
 }

--- a/src/compliance.cc
+++ b/src/compliance.cc
@@ -1,0 +1,55 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#if defined(AVIF_ENABLE_COMPLIANCE_WARDEN)
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include "avif/internal.h"
+#include "box_reader_impl.h"
+#include "spec.h"
+
+bool checkComplianceStd(Box const & file, SpecDesc const * spec);
+
+SpecDesc const * specFind(const char * name);
+std::vector<SpecDesc const *> & g_allSpecs();
+extern const SpecDesc * const globalSpecAvif;
+extern const SpecDesc * const globalSpecAv1Hdr10plus;
+extern const SpecDesc * const globalSpecHeif;
+extern const SpecDesc * const globalSpecIsobmff;
+extern const SpecDesc * const globalSpecMiaf;
+
+avifResult avifIsCompliant(uint8_t * data, size_t size)
+{
+    // See compliance_warden.sh.
+    if (g_allSpecs().empty()) {
+        registerSpec(globalSpecAvif);
+        registerSpec(globalSpecAv1Hdr10plus);
+        registerSpec(globalSpecHeif);
+        registerSpec(globalSpecIsobmff);
+        registerSpec(globalSpecMiaf);
+    }
+
+    // Inspired from ComplianceWarden/src/app/cw.cpp
+    BoxReader topReader;
+    for (char sym : { 'f', 'i', 'l', 'e', '.', 'a', 'v', 'i', 'f' }) {
+        // Setting made-up file name (letter by letter).
+        topReader.myBox.syms.push_back({ "filename", static_cast<int64_t>(sym), 8 });
+    }
+    AVIF_CHECKERR(size <= std::numeric_limits<int>::max(), AVIF_RESULT_INVALID_ARGUMENT);
+    topReader.br = { data, static_cast<int>(size) };
+    topReader.myBox.original = data;
+    topReader.myBox.position = 0;
+    topReader.myBox.size = size;
+    topReader.myBox.fourcc = FOURCC("root");
+    topReader.specs = { specFind("avif") };
+    AVIF_CHECKERR(topReader.specs[0] != nullptr, AVIF_RESULT_UNKNOWN_ERROR);
+    auto parseFunc = getParseFunction(topReader.myBox.fourcc);
+    parseFunc(&topReader);
+    AVIF_CHECKERR(!checkComplianceStd(topReader.myBox, topReader.specs[0]), AVIF_RESULT_BMFF_PARSE_FAILED);
+    return AVIF_RESULT_OK;
+}
+
+#endif // AVIF_ENABLE_COMPLIANCE_WARDEN

--- a/src/compliance.cc
+++ b/src/compliance.cc
@@ -1,8 +1,6 @@
 // Copyright 2023 Google LLC
 // SPDX-License-Identifier: BSD-2-Clause
 
-#if defined(AVIF_ENABLE_COMPLIANCE_WARDEN)
-
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -51,5 +49,3 @@ avifResult avifIsCompliant(uint8_t * data, size_t size)
     AVIF_CHECKERR(!checkComplianceStd(topReader.myBox, topReader.specs[0]), AVIF_RESULT_BMFF_PARSE_FAILED);
     return AVIF_RESULT_OK;
 }
-
-#endif // AVIF_ENABLE_COMPLIANCE_WARDEN

--- a/src/write.c
+++ b/src/write.c
@@ -2866,6 +2866,10 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
 
     avifRWStreamFinishWrite(&s);
 
+#if defined(AVIF_ENABLE_COMPLIANCE_WARDEN)
+    AVIF_CHECKRES(avifIsCompliant(output->data, output->size));
+#endif
+
     return AVIF_RESULT_OK;
 }
 


### PR DESCRIPTION
Use github.com/gpac/ComplianceWarden as a dependency to check all AVIF bitstreams output by avifEncoderFinish().

Introduce `AVIF_USE_CXX` in CMakeLists.txt to regroup the use cases requiring C++.

`AVIF_ENABLE_COMPLIANCE_WARDEN` is OFF in GitHub CI because many tests fail.  
For example, the following build instructions
```
cmake .. -DAVIF_BUILD_APPS=ON  -DAVIF_BUILD_EXAMPLES=ON  -DAVIF_BUILD_TESTS=ON  -DAVIF_ENABLE_GTEST=ON  -DAVIF_ENABLE_COMPLIANCE_WARDEN=ON  -DAVIF_CODEC_AOM=ON  -DAVIF_LOCAL_AOM=ON  -DAVIF_LOCAL_LIBYUV=ON  -DAVIF_LOCAL_LIBSHARPYUV=ON  -DAVIF_LOCAL_GTEST=ON  -DAVIF_ENABLE_WERROR=OFF -DCMAKE_BUILD_TYPE=Release  -DBUILD_SHARED_LIBS=OFF  -DCMAKE_C_COMPILER=clang  -DCMAKE_CXX_COMPILER=clang++ && make -j 7 && ctest . -j 7
```
gives
```
The following tests FAILED:
avifchangesettingtest, avifclaptest, avifgridapitest, avifincrtest, avifiostatstest, aviflosslesstest, avifmetadatatest, avifprogressivetest, avifstreamtest, aviftilingtest, avifutilstest, test_cmd_animation, test_cmd_grid, test_cmd_lossless, test_cmd_metadata, test_cmd_progressive, test_cmd_targetsize
```
Some are due to warnings but there are also errors, such as for `avifmetadatatest.cc` > `ExifButDefaultIrotImir`:
```
[miaf][Rule #26] Error: Found 1 (ItemIds={1}) 'pixi' associated for 3 displayable (not hidden) images (ItemIds={1,2,3})
```
These should be investigated and ComplianceWarden or libavif should be fixed when relevant.

The [LICENSE](https://github.com/gpac/ComplianceWarden/blob/master/LICENSE) is fine because there is no "Redistributions of source code", "Redistributions in binary form" and "Neither the name of the copyright holder nor the names of its contributors" are used.

`compliance_warden.sh` is a bit hacky but it can be improved later on.