### PR TITLE
Introduce avifDecoderData::tileCategories

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -253,11 +253,12 @@ avifBool avifImageScale(avifImage * image,
 
 typedef enum avifItemCategory
 {
-    AVIF_ITEM_COLOR = 0,
-    AVIF_ITEM_ALPHA = 1,
+    AVIF_ITEM_COLOR,
+    AVIF_ITEM_ALPHA,
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-    AVIF_ITEM_GAIN_MAP = 2
+    AVIF_ITEM_GAIN_MAP,
 #endif
+    AVIF_ITEM_CATEGORY_COUNT
 } avifItemCategory;
 
 // ---------------------------------------------------------------------------

--- a/src/read.c
+++ b/src/read.c
@@ -4065,8 +4065,7 @@ static avifResult avifCodecCreateInternal(avifCodecChoice choice, const avifTile
 
 static avifBool avifTilesCanBeDecodedWithSameCodecInstance(avifDecoderData * data)
 {
-    int32_t numImageBuffers = 0;
-    avifBool numStolenImageBuffers = AVIF_FALSE;
+    int32_t numImageBuffers = 0, numStolenImageBuffers = 0;
     for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
         if (data->tileInfos[c].tileCount > 0) {
             ++numImageBuffers;


### PR DESCRIPTION
Replaces `color`, `alpha` and `gainMap` members.
Removes `AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP` preprocessor condition in some places.

Regroup some lines into `avifDecoderItemReadAndParse()`.

Refactor `avifDecoderDataFindColorItem()` and `avifDecoderDataFindAlphaItem()` into `avifMetaFindColorItem()` and `avifMetaFindAlphaItem()`, respectively.

Also prepares read.c for https://github.com/AOMediaCodec/libavif/pull/1572.