### PR TITLE
Cancel previous CI workflows when pushing new changes, except on main.

### DIFF
--- a/.github/workflows/ci-android-emulator-tests.yml
+++ b/.github/workflows/ci-android-emulator-tests.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-and-run-android-jni-tests:
     runs-on: macos-latest

--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -4,6 +4,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-android-jni:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -10,6 +10,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-disable-gtest:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -8,6 +8,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-shared-run-golden-tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -7,6 +7,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-shared-installed:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -9,6 +9,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-shared-local:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -4,6 +4,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-static-av2:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -4,6 +4,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-static:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -16,6 +16,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-static:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -4,6 +4,11 @@ on: [pull_request]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -4,6 +4,11 @@ on: [push]
 permissions:
   contents: read
 
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   clang-format-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As suggested by @kmilos in https://github.com/AOMediaCodec/libavif/pull/1530#issuecomment-1697404965
This avoids wasting resources.

The only drawback is that Github sends an email notification for each cancelled job, see https://github.com/orgs/community/discussions/13015
Gmail users can create a filter to ignore those emails.
