### PR TITLE
Use fuzztest targets for oss-fuzz.

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,12 @@
 name: CI Fuzz
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'include/**'
+      - 'src/**'
+      - 'tests/oss-fuzz/**'
+    types:
+      - closed
 
 permissions:
   contents: read
@@ -11,6 +18,7 @@ concurrency:
 
 jobs:
   fuzz:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Build Fuzzers

--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -37,12 +37,6 @@
 #     --sanitizer address
 
 ln -s $SRC/fuzztest $SRC/libavif/ext/fuzztest
-mkdir $SRC/libavif/ext/fuzztest/build.libavif
-cd $SRC/libavif/ext/fuzztest/build.libavif
-cmake -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
-ninja
-cd ../../../
-
 
 # build dependencies
 cd ext && bash aom.cmd && bash dav1d.cmd && bash googletest.cmd && bash libjpeg.cmd && \
@@ -56,7 +50,7 @@ cmake -G Ninja -DBUILD_SHARED_LIBS=OFF -DAVIF_CODEC_AOM=ON -DAVIF_CODEC_DAV1D=ON
       -DAVIF_LOCAL_AOM=ON -DAVIF_LOCAL_DAV1D=ON -DAVIF_LOCAL_FUZZTEST=ON \
       -DAVIF_LOCAL_GTEST=ON -DAVIF_LOCAL_JPEG=ON -DAVIF_LOCAL_LIBSHARPYUV=ON \
       -DAVIF_LOCAL_LIBYUV=ON \-DAVIF_LOCAL_ZLIBPNG=ON \
-      -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_ENABLE_FUZZTEST=ON ..
+      -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=OFF -DAVIF_ENABLE_FUZZTEST=ON ..
 
 ninja
 

--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -45,7 +45,8 @@ cd ../../../
 
 
 # build dependencies
-cd ext && bash aom.cmd && bash dav1d.cmd && bash googletest.cmd && bash libjpeg.cmd && bash libyuv && bash zlibpng.cmd && cd ..
+cd ext && bash aom.cmd && bash dav1d.cmd && bash googletest.cmd && bash libjpeg.cmd && \
+      bash libsharpyuv.cmd && bash libyuv.cmd && bash zlibpng.cmd && cd ..
 
 # build libavif
 mkdir build
@@ -53,7 +54,8 @@ cd build
 cmake -G Ninja -DBUILD_SHARED_LIBS=OFF -DAVIF_CODEC_AOM=ON -DAVIF_CODEC_DAV1D=ON \
       -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DAVIF_ENABLE_WERROR=OFF \
       -DAVIF_LOCAL_AOM=ON -DAVIF_LOCAL_DAV1D=ON -DAVIF_LOCAL_FUZZTEST=ON \
-      -DAVIF_LOCAL_GTEST=ON -DAVIF_LOCAL_JPEG=ON -DAVIF_LOCAL_LIBYUV=ON -DAVIF_LOCAL_ZLIBPNG=ON \
+      -DAVIF_LOCAL_GTEST=ON -DAVIF_LOCAL_JPEG=ON -DAVIF_LOCAL_LIBSHARPYUV=ON \
+      -DAVIF_LOCAL_LIBYUV=ON \-DAVIF_LOCAL_ZLIBPNG=ON \
       -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_ENABLE_FUZZTEST=ON ..
 
 ninja
@@ -71,7 +73,6 @@ $CXX $CXXFLAGS -std=c++11 -I../include \
 # The scripts will be named:
 # {binary_name}@{fuzztest_entrypoint}
 FUZZ_TEST_BINARIES_OUT_PATHS=`ls ./tests/avif_fuzztest_*`
-#cp ./bin/opencv_fuzz_* $OUT/
 echo "Fuzz binaries: $FUZZ_TEST_BINARIES_OUT_PATHS"
 for fuzz_main_file in $FUZZ_TEST_BINARIES_OUT_PATHS; do
   FUZZ_TESTS=$($fuzz_main_file --list_fuzz_tests | cut -d ' ' -f 4)


### PR DESCRIPTION
To test locally, follow the instructions at the beginning of the file.

Also: Limit CIFuzz to when a PR is merged
This can be revisited at some point but first:
- let's make sure new oss-fuzz targets are built and created
on the site
- let's make sure we fix all fuzzer bugs if any
- let's see how long the job really takes