### PR TITLE
fix: unused parameter error in third_party libyuv with release build 

### DIFF
--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -21,6 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        libyuv: [ON, OFF]
+
+    name: build-shared-local (${{ matrix.os }}, libyuv ${{ matrix.libyuv }})
 
     steps:
     - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
@@ -89,7 +92,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
         -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON
         -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON
-        -DAVIF_LOCAL_LIBYUV=ON
+        -DAVIF_LOCAL_LIBYUV=${{ matrix.libyuv }}
         -DAVIF_LOCAL_LIBSHARPYUV=ON
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON

--- a/third_party/libyuv/source/scale.c
+++ b/third_party/libyuv/source/scale.c
@@ -465,6 +465,7 @@ static void ScalePlaneUp2_Linear(int src_width,
   int y;
   int dy;
 
+  (void)src_width;
   // This function can only scale up by 2 times horizontally.
   assert(src_width == ((dst_width + 1) / 2));
 
@@ -499,6 +500,7 @@ static void ScalePlaneUp2_Bilinear(int src_width,
       ScaleRowUp2_Bilinear_Any_C;
   int x;
 
+  (void)src_width;
   // This function can only scale up by 2 times.
   assert(src_width == ((dst_width + 1) / 2));
   assert(src_height == ((dst_height + 1) / 2));
@@ -536,6 +538,7 @@ static void ScalePlaneUp2_12_Linear(int src_width,
   int y;
   int dy;
 
+  (void)src_width;
   // This function can only scale up by 2 times horizontally.
   assert(src_width == ((dst_width + 1) / 2));
 
@@ -571,6 +574,7 @@ static void ScalePlaneUp2_12_Bilinear(int src_width,
       ScaleRowUp2_Bilinear_16_Any_C;
   int x;
 
+  (void)src_width;
   // This function can only scale up by 2 times.
   assert(src_width == ((dst_width + 1) / 2));
   assert(src_height == ((dst_height + 1) / 2));
@@ -601,6 +605,7 @@ static void ScalePlaneUp2_16_Linear(int src_width,
   int y;
   int dy;
 
+  (void)src_width;
   // This function can only scale up by 2 times horizontally.
   assert(src_width == ((dst_width + 1) / 2));
 
@@ -631,6 +636,7 @@ static void ScalePlaneUp2_16_Bilinear(int src_width,
       ScaleRowUp2_Bilinear_16_Any_C;
   int x;
 
+  (void)src_width;
   // This function can only scale up by 2 times.
   assert(src_width == ((dst_width + 1) / 2));
   assert(src_height == ((dst_height + 1) / 2));


### PR DESCRIPTION
In several functions in libyuv's scale.c, the only reference to the parameter `src_width` is an `assert` statement. When `NDEBUG` is defined (as it is on some platforms when compiling with `CMAKE_BUILD_TYPE=Release`) the assert condition is removed from the source and an unused-parameter warning/error is raised.

There were not any tests that compiled the third_party/libyuv source files. I added such a test in a separate commit to demonstrate the issue. Without the fix, [the new job fails](https://github.com/fdintino/libavif/actions/runs/6354750162/job/17261762381); with it the [job succeeds](https://github.com/fdintino/libavif/actions/runs/6354904451/job/17262117947).