### PR TITLE
Skip 'stss' box if all samples are sync

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -2822,6 +2822,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             for (uint32_t sampleIndex = 0; sampleIndex < item->encodeOutput->samples.count; ++sampleIndex) {
                 if (!item->encodeOutput->samples.sample[sampleIndex].sync) {
                     hasNonSyncSample = AVIF_TRUE;
+                    break;
                 }
             }
             // ISO/IEC 14496-12, Section 8.6.2.1:


### PR DESCRIPTION
See https://github.com/gpac/ComplianceWarden/issues/68.