### PR TITLE
Always use AUTO, AOM and DAV1D as codec choices in fuzzers.

### DIFF
--- a/tests/gtest/avif_fuzztest_dec.cc
+++ b/tests/gtest/avif_fuzztest_dec.cc
@@ -37,7 +37,7 @@ void Decode(const std::string& arbitrary_bytes, AvifDecoderPtr decoder) {
 
 FUZZ_TEST(DecodeAvifTest, Decode)
     .WithDomains(ArbitraryImageWithSeeds({AVIF_APP_FILE_FORMAT_AVIF}),
-                 ArbitraryAvifDecoder({AVIF_CODEC_CHOICE_AUTO}));
+                 ArbitraryAvifDecoder());
 
 //------------------------------------------------------------------------------
 

--- a/tests/gtest/avif_fuzztest_enc_dec.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec.cc
@@ -51,8 +51,7 @@ void EncodeDecodeValid(AvifImagePtr image, AvifEncoderPtr encoder,
 
 FUZZ_TEST(EncodeDecodeAvifFuzzTest, EncodeDecodeValid)
     .WithDomains(ArbitraryAvifImage(), ArbitraryAvifEncoder(),
-                 ArbitraryAvifDecoder({AVIF_CODEC_CHOICE_AUTO,
-                                       AVIF_CODEC_CHOICE_DAV1D}));
+                 ArbitraryAvifDecoder());
 
 }  // namespace
 }  // namespace testutil

--- a/tests/gtest/avif_fuzztest_enc_dec_anim.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_anim.cc
@@ -95,9 +95,7 @@ FUZZ_TEST(EncodeDecodeAvifFuzzTest, EncodeDecodeAnimation)
                     {AVIF_ADD_IMAGE_FLAG_FORCE_KEYFRAME})))
             .WithMinSize(1)
             .WithMaxSize(kMaxFrames),
-        ArbitraryAvifEncoder(),
-        ArbitraryAvifDecoder({AVIF_CODEC_CHOICE_AUTO,
-                              AVIF_CODEC_CHOICE_DAV1D}));
+        ArbitraryAvifEncoder(), ArbitraryAvifDecoder());
 
 }  // namespace
 }  // namespace testutil

--- a/tests/gtest/avif_fuzztest_enc_dec_experimental.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_experimental.cc
@@ -116,8 +116,7 @@ inline auto ArbitraryAvifImageWithGainMap() {
 FUZZ_TEST(EncodeDecodeAvifFuzzTest, EncodeDecodeValid)
     .WithDomains(fuzztest::OneOf(ArbitraryAvifImage(),
                                  ArbitraryAvifImageWithGainMap()),
-                 ArbitraryAvifEncoder(),
-                 ArbitraryAvifDecoder({AVIF_CODEC_CHOICE_AUTO}));
+                 ArbitraryAvifEncoder(), ArbitraryAvifDecoder());
 
 }  // namespace
 }  // namespace testutil

--- a/tests/gtest/avif_fuzztest_enc_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_incr.cc
@@ -69,7 +69,7 @@ void EncodeDecodeGridValid(AvifImagePtr image, AvifEncoderPtr encoder,
 
 FUZZ_TEST(EncodeDecodeAvifFuzzTest, EncodeDecodeGridValid)
     .WithDomains(ArbitraryAvifImage(), ArbitraryAvifEncoder(),
-                 ArbitraryAvifDecoder({AVIF_CODEC_CHOICE_AUTO}),
+                 ArbitraryAvifDecoder(),
                  /*grid_cols=*/InRange<uint32_t>(1, 32),
                  /*grid_rows=*/InRange<uint32_t>(1, 32),
                  /*is_encoded_data_persistent=*/Arbitrary<bool>(),

--- a/tests/gtest/avif_fuzztest_enc_dec_incr_experimental.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_incr_experimental.cc
@@ -116,8 +116,7 @@ inline auto ArbitraryAvifImageWithGainMap() {
 FUZZ_TEST(EncodeDecodeAvifFuzzTest, EncodeDecodeGridValid)
     .WithDomains(fuzztest::OneOf(ArbitraryAvifImage(),
                                  ArbitraryAvifImageWithGainMap()),
-                 ArbitraryAvifEncoder(),
-                 ArbitraryAvifDecoder({AVIF_CODEC_CHOICE_AUTO}),
+                 ArbitraryAvifEncoder(), ArbitraryAvifDecoder(),
                  /*grid_cols=*/InRange<uint32_t>(1, 32),
                  /*grid_rows=*/InRange<uint32_t>(1, 32),
                  /*is_encoded_data_persistent=*/Arbitrary<bool>(),

--- a/tests/gtest/avif_fuzztest_helpers.h
+++ b/tests/gtest/avif_fuzztest_helpers.h
@@ -134,13 +134,15 @@ inline auto ArbitraryAvifEncoder() {
 
 // Generator for an arbitrary AvifEncoderPtr with base options fuzzed (i.e.
 // without "experimental" options hidden behind compile flags).
-inline auto ArbitraryBaseAvifDecoder(
-    const std::vector<avifCodecChoice>& codec_choices) {
-  const auto codec_choice = fuzztest::ElementOf<avifCodecChoice>(codec_choices);
+inline auto ArbitraryBaseAvifDecoder() {
   // MAX_NUM_THREADS from libaom/aom_util/aom_thread.h
   const auto max_threads = fuzztest::InRange(0, 64);
   return fuzztest::Map(
-      CreateAvifDecoder, codec_choice, max_threads,
+      CreateAvifDecoder,
+      fuzztest::ElementOf<avifCodecChoice>({AVIF_CODEC_CHOICE_AUTO,
+                                            AVIF_CODEC_CHOICE_AOM,
+                                            AVIF_CODEC_CHOICE_DAV1D}),
+      max_threads,
       /*requested_source=*/
       fuzztest::ElementOf(
           {AVIF_DECODER_SOURCE_AUTO, AVIF_DECODER_SOURCE_PRIMARY_ITEM}),
@@ -161,18 +163,16 @@ inline auto ArbitraryBaseAvifDecoder(
 // Generator for an arbitrary AvifEncoderPtr with base options and gain map
 // options fuzzed, with the exception of 'ignoreColorAndAlpha' (because it would
 // break most tests' assumptions).
-inline auto ArbitraryAvifDecoderWithGainMapOptions(
-    const std::vector<avifCodecChoice>& codec_choices) {
+inline auto ArbitraryAvifDecoderWithGainMapOptions() {
   return fuzztest::Map(
-      AddGainMapOptionsToDecoder, ArbitraryBaseAvifDecoder(codec_choices),
+      AddGainMapOptionsToDecoder, ArbitraryBaseAvifDecoder(),
       /*enable_parsing_gain_map_metadata=*/fuzztest::Arbitrary<bool>(),
       /*enable_decoding_gain_map=*/fuzztest::Arbitrary<bool>());
 }
 
 // Generator for an arbitrary AvifDecoderPtr.
-inline auto ArbitraryAvifDecoder(
-    const std::vector<avifCodecChoice>& codec_choices) {
-  return ArbitraryAvifDecoderWithGainMapOptions(codec_choices);
+inline auto ArbitraryAvifDecoder() {
+  return ArbitraryAvifDecoderWithGainMapOptions();
 }
 #else
 // Generator for an arbitrary AvifDecoderPtr.


### PR DESCRIPTION
AUTO defaults to DAV1D if available, so adding AOM explicitly allows the libaom decoder to be exercised as well.