### PR TITLE
Fix ArbitraryAvifDecoder() without EXP_GAIN_MAP

### DIFF
--- a/tests/gtest/avif_fuzztest_helpers.h
+++ b/tests/gtest/avif_fuzztest_helpers.h
@@ -176,10 +176,7 @@ inline auto ArbitraryAvifDecoder() {
 }
 #else
 // Generator for an arbitrary AvifDecoderPtr.
-inline auto ArbitraryAvifDecoder(
-    const std::vector<avifCodecChoice>& codec_choices) {
-  return ArbitraryBaseAvifDecoder(codec_choices);
-}
+inline auto ArbitraryAvifDecoder() { return ArbitraryBaseAvifDecoder(); }
 #endif  // AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
The API changed in https://github.com/AOMediaCodec/libavif/pull/1644.