### PR TITLE
Check avifAlloc() in avifIOCreateMemoryReader()

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -954,7 +954,9 @@ typedef struct avifIO
     void * data;
 } avifIO;
 
+// Returns NULL if the reader cannot be allocated.
 AVIF_API avifIO * avifIOCreateMemoryReader(const uint8_t * data, size_t size);
+// Returns NULL if the file cannot be opened or if the reader cannot be allocated.
 AVIF_API avifIO * avifIOCreateFileReader(const char * filename);
 AVIF_API void avifIODestroy(avifIO * io);
 

--- a/src/io.c
+++ b/src/io.c
@@ -57,6 +57,9 @@ static void avifIOMemoryReaderDestroy(struct avifIO * io)
 avifIO * avifIOCreateMemoryReader(const uint8_t * data, size_t size)
 {
     avifIOMemoryReader * reader = avifAlloc(sizeof(avifIOMemoryReader));
+    if (reader == NULL) {
+        return NULL;
+    }
     memset(reader, 0, sizeof(avifIOMemoryReader));
     reader->io.destroy = avifIOMemoryReaderDestroy;
     reader->io.read = avifIOMemoryReaderRead;

--- a/src/read.c
+++ b/src/read.c
@@ -3833,7 +3833,7 @@ void avifDecoderSetIO(avifDecoder * decoder, avifIO * io)
 avifResult avifDecoderSetIOMemory(avifDecoder * decoder, const uint8_t * data, size_t size)
 {
     avifIO * io = avifIOCreateMemoryReader(data, size);
-    assert(io);
+    AVIF_CHECKERR(io != NULL, AVIF_RESULT_OUT_OF_MEMORY);
     avifDecoderSetIO(decoder, io);
     return AVIF_RESULT_OK;
 }


### PR DESCRIPTION
The pointer is not checked in `avif_decode_fuzzer.cc` because it should be caught by sanitizers and there should be no memory allocation failure there anyway.

See https://github.com/AOMediaCodec/libavif/issues/820.

CHANGELOG.md is not modified because v1.0.0 has

https://github.com/AOMediaCodec/libavif/blob/1a6342e4b5a18cbf7e2222efe66b624236476fe2/CHANGELOG.md?plain=1#L69-L70