### PR TITLE
Check avifAlloc() success in avifDecoderCreate()

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -228,6 +228,10 @@ int main(int argc, char * argv[])
         }
 
         avifDecoder * decoder = avifDecoderCreate();
+        if (!decoder) {
+            fprintf(stderr, "Memory allocation failure\n");
+            return 1;
+        }
         decoder->maxThreads = jobs;
         decoder->codecChoice = codecChoice;
         decoder->imageSizeLimit = imageSizeLimit;
@@ -298,6 +302,11 @@ int main(int argc, char * argv[])
 
     int returnCode = 0;
     avifDecoder * decoder = avifDecoderCreate();
+    if (!decoder) {
+        fprintf(stderr, "Memory allocation failure\n");
+        returnCode = 1;
+        goto cleanup;
+    }
     decoder->maxThreads = jobs;
     decoder->codecChoice = codecChoice;
     decoder->imageSizeLimit = imageSizeLimit;
@@ -370,6 +379,8 @@ cleanup:
     if (returnCode != 0) {
         avifDumpDiagnostics(&decoder->diag);
     }
-    avifDecoderDestroy(decoder);
+    if (decoder != NULL) {
+        avifDecoderDestroy(decoder);
+    }
     return returnCode;
 }

--- a/examples/avif_example_decode_file.c
+++ b/examples/avif_example_decode_file.c
@@ -20,6 +20,10 @@ int main(int argc, char * argv[])
     memset(&rgb, 0, sizeof(rgb));
 
     avifDecoder * decoder = avifDecoderCreate();
+    if (decoder == NULL) {
+        fprintf(stderr, "Memory allocation failure\n");
+        return 1;
+    }
     // Override decoder defaults here (codecChoice, requestedSource, ignoreExif, ignoreXMP, etc)
 
     avifResult result = avifDecoderSetIOFile(decoder, inputFilename);

--- a/examples/avif_example_decode_memory.c
+++ b/examples/avif_example_decode_memory.c
@@ -21,6 +21,10 @@ int main(int argc, char * argv[])
     memset(&rgb, 0, sizeof(rgb));
 
     avifDecoder * decoder = avifDecoderCreate();
+    if (decoder == NULL) {
+        fprintf(stderr, "Memory allocation failure\n");
+        return 1;
+    }
     // Override decoder defaults here (codecChoice, requestedSource, ignoreExif, ignoreXMP, etc)
 
     // Read entire file into fileBuffer

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1197,6 +1197,7 @@ typedef struct avifDecoder
     avifBool imageSequenceTrackPresent;
 } avifDecoder;
 
+// Returns NULL in case of memory allocation failure.
 AVIF_API avifDecoder * avifDecoderCreate(void);
 AVIF_API void avifDecoderDestroy(avifDecoder * decoder);
 

--- a/src/read.c
+++ b/src/read.c
@@ -3788,6 +3788,9 @@ avifBool avifPeekCompatibleFileType(const avifROData * input)
 avifDecoder * avifDecoderCreate(void)
 {
     avifDecoder * decoder = (avifDecoder *)avifAlloc(sizeof(avifDecoder));
+    if (decoder == NULL) {
+        return NULL;
+    }
     memset(decoder, 0, sizeof(avifDecoder));
     decoder->maxThreads = 1;
     decoder->imageSizeLimit = AVIF_DEFAULT_IMAGE_SIZE_LIMIT;

--- a/tests/aviftest.c
+++ b/tests/aviftest.c
@@ -217,6 +217,11 @@ static int runIOTests(const char * dataDir)
         fclose(f);
 
         avifDecoder * decoder = avifDecoderCreate();
+        if (decoder == NULL) {
+            printf("Memory allocation failure\n");
+            retCode = 1;
+            break;
+        }
         avifIOTestReader * io = avifIOCreateTestReader(fileBuffer.data, fileBuffer.size);
         avifDecoderSetIO(decoder, (avifIO *)io);
 

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -152,9 +152,9 @@ TEST(GainMapTest, EncodeDecodeBaseImageHdr) {
   testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
   ASSERT_NE(decoded, nullptr);
   testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
   decoder->enableDecodingGainMap = AVIF_TRUE;
   decoder->enableParsingGainMapMetadata = AVIF_TRUE;
-  ASSERT_NE(decoder, nullptr);
   result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
                                  encoded.size);
   ASSERT_EQ(result, AVIF_RESULT_OK)

--- a/tests/gtest/avifmetadatatest.cc
+++ b/tests/gtest/avifmetadatatest.cc
@@ -201,6 +201,7 @@ TEST(MetadataTest, Compare) {
 TEST(MetadataTest, DecoderParseICC) {
   std::string file_path = std::string(data_path) + "paris_icc_exif_xmp.avif";
   avifDecoder* decoder = avifDecoderCreate();
+  ASSERT_NE(decoder, nullptr);
   EXPECT_EQ(avifDecoderSetIOFile(decoder, file_path.c_str()), AVIF_RESULT_OK);
   EXPECT_EQ(avifDecoderParse(decoder), AVIF_RESULT_OK);
   // Check the first four bytes of the ICC profile.


### PR DESCRIPTION
The pointer is not checked in `avif_decode_fuzzer.cc` because it should be caught by sanitizers and there should be no memory allocation failure there anyway.

See https://github.com/AOMediaCodec/libavif/issues/820.

CHANGELOG.md is not modified because v1.0.0 has

https://github.com/AOMediaCodec/libavif/blob/1a6342e4b5a18cbf7e2222efe66b624236476fe2/CHANGELOG.md?plain=1#L69-L70