### PR TITLE
reformat_libyuv: Fix compile with libyuv < 1813

### DIFF
--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -116,6 +116,9 @@ unsigned int avifLibYUVVersion(void)
 #endif
 #if LIBYUV_VERSION < 1780
 #define I410ToARGBMatrix NULL
+#define I410AlphaToARGBMatrix NULL
+#define I210AlphaToARGBMatrix NULL
+#define I010AlphaToARGBMatrix NULL
 #endif
 #if LIBYUV_VERSION < 1771
 #define I422AlphaToARGBMatrix NULL


### PR DESCRIPTION
Alpha matrix NULL defines were not added in cf747ba03af0d6d8ff52

With libyuv 1766:

```
/home/yarrick/code/libavif/src/reformat_libyuv.c: In function ‘getLibYUVConversionFunction’:
/home/yarrick/code/libavif/src/reformat_libyuv.c:672:21: error: ‘I410AlphaToARGBMatrix’ undeclared (first use in this function); did you mean ‘I420AlphaToARGBMatrix’?
  672 |             { NULL, I410AlphaToARGBMatrix, I210AlphaToARGBMatrix, I010AlphaToARGBMatrix, NULL }, // RGBA
      |                     ^~~~~~~~~~~~~~~~~~~~~
      |                     I420AlphaToARGBMatrix
/home/yarrick/code/libavif/src/reformat_libyuv.c:672:21: note: each undeclared identifier is reported only once for each function it appears in
/home/yarrick/code/libavif/src/reformat_libyuv.c:672:44: error: ‘I210AlphaToARGBMatrix’ undeclared (first use in this function); did you mean ‘I420AlphaToARGBMatrix’?
  672 |             { NULL, I410AlphaToARGBMatrix, I210AlphaToARGBMatrix, I010AlphaToARGBMatrix, NULL }, // RGBA
      |                                            ^~~~~~~~~~~~~~~~~~~~~
      |                                            I420AlphaToARGBMatrix
/home/yarrick/code/libavif/src/reformat_libyuv.c:672:67: error: ‘I010AlphaToARGBMatrix’ undeclared (first use in this function); did you mean ‘I420AlphaToARGBMatrix’?
  672 |             { NULL, I410AlphaToARGBMatrix, I210AlphaToARGBMatrix, I010AlphaToARGBMatrix, NULL }, // RGBA
      |                                                                   ^~~~~~~~~~~~~~~~~~~~~
      |                                                                   I420AlphaToARGBMatrix
make[2]: *** [CMakeFiles/avif.dir/build.make:244: CMakeFiles/avif.dir/src/reformat_libyuv.c.o] Error 1
```