### PR TITLE
read.c: Remove diagnostic message

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -4986,7 +4986,6 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
                                         decoder->imageSizeLimit,
                                         decoder->imageDimensionLimit,
                                         &decoder->diag) != AVIF_RESULT_OK) {
-                avifDiagnosticsPrintf(&decoder->diag, "avifImageScaleWithLimit() failed");
                 return avifGetErrorForItemCategory(tile->input->itemCategory);
             }
         }


### PR DESCRIPTION
`avifImageScaleWithLimit` already updates the diagnostic message on failure. So there is no need to over-write it with a less informative message in the caller.