### PR TITLE
Set video range when encoding with SVT-AV1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update zlibpng.cmd: zlib 1.3 and libpng 1.6.40
 * AVIF sequences encoded by libavif will now also have the "avio" brand when
   there is at least one track made only of AV1 keyframes.
+* Fix SVT-AV1 codec interface which was not setting video range at encoding.
 
 ## [1.0.1] - 2023-08-29
 

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -80,12 +80,12 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
     EbErrorType res = EB_ErrorNone;
 
     int y_shift = 0;
-    // EbColorRange svt_range;
+    EbColorRange svt_range;
     if (alpha) {
-        // svt_range = EB_CR_FULL_RANGE;
+        svt_range = EB_CR_FULL_RANGE;
         y_shift = 1;
     } else {
-        // svt_range = (image->yuvRange == AVIF_RANGE_FULL) ? EB_CR_FULL_RANGE : EB_CR_STUDIO_RANGE;
+        svt_range = (image->yuvRange == AVIF_RANGE_FULL) ? EB_CR_FULL_RANGE : EB_CR_STUDIO_RANGE;
         switch (image->yuvFormat) {
             case AVIF_PIXEL_FORMAT_YUV444:
                 color_format = EB_YUV444;
@@ -117,6 +117,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
         }
         svt_config->encoder_color_format = color_format;
         svt_config->encoder_bit_depth = (uint8_t)image->depth;
+        svt_config->color_range = svt_range;
 #if !SVT_AV1_CHECK_VERSION(0, 9, 0)
         svt_config->is_16bit_pipeline = image->depth > 8;
 #endif


### PR DESCRIPTION
[Section 2.3.4](https://aomediacodec.github.io/av1-isobmff/v1.2.0.html#av1codecconfigurationbox-semantics) of AV1-ISOBMFF spec says:
> the full_range_flag in the colr box shall match the color_range flag in the Sequence Header OBU.