### PR TITLE
Remove yuvRange assertion in avifImageCopySamples

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -197,7 +197,9 @@ void avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avif
 {
     assert(srcImage->depth == dstImage->depth);
     if (planes & AVIF_PLANES_YUV) {
-        assert((srcImage->yuvFormat == dstImage->yuvFormat) && (srcImage->yuvRange == dstImage->yuvRange));
+        assert(srcImage->yuvFormat == dstImage->yuvFormat);
+        // Note that there may be a mismatch between srcImage->yuvRange and dstImage->yuvRange
+        // because libavif allows for 'colr' and AV1 OBU video range values to differ.
     }
     const size_t bytesPerPixel = avifImageUsesU16(srcImage) ? 2 : 1;
 

--- a/src/read.c
+++ b/src/read.c
@@ -1484,6 +1484,7 @@ static avifResult avifDecoderDataAllocateGridImagePlanes(avifDecoderData * data,
         dstImage->yuvFormat = tile->image->yuvFormat;
         // Keep dstImage->yuvRange which is already set to its correct value
         // (extracted from the 'colr' box if parsed or from a Sequence Header OBU otherwise).
+
         if (!data->cicpSet) {
             data->cicpSet = AVIF_TRUE;
             dstImage->colorPrimaries = tile->image->colorPrimaries;

--- a/src/read.c
+++ b/src/read.c
@@ -1482,7 +1482,8 @@ static avifResult avifDecoderDataAllocateGridImagePlanes(avifDecoderData * data,
         dstImage->height = grid->outputHeight;
         dstImage->depth = tile->image->depth;
         dstImage->yuvFormat = tile->image->yuvFormat;
-        dstImage->yuvRange = tile->image->yuvRange;
+        // Keep dstImage->yuvRange which is already set to its correct value
+        // (extracted from the 'colr' box if parsed or from a Sequence Header OBU otherwise).
         if (!data->cicpSet) {
             data->cicpSet = AVIF_TRUE;
             dstImage->colorPrimaries = tile->image->colorPrimaries;
@@ -4983,6 +4984,25 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
             avifDiagnosticsPrintf(&decoder->diag, "tile->codec->getNextImage() failed");
             return avifGetErrorForItemCategory(tile->input->itemCategory);
         }
+
+        // Section 2.3.4 of AV1 Codec ISO Media File Format Binding v1.2.0 says:
+        //   the full_range_flag in the colr box shall match the color_range
+        //   flag in the Sequence Header OBU.
+        // See https://aomediacodec.github.io/av1-isobmff/v1.2.0.html#av1codecconfigurationbox-semantics.
+        // If a 'colr' box of colour_type 'nclx' was parsed, a mismatch between
+        // the 'colr' decoder->image->yuvRange and the AV1 OBU
+        // tile->image->yuvRange should be treated as an error.
+        // However codec_svt.c was not encoding the color_range field for
+        // multiple years, so there probably are files in the wild that will
+        // fail decoding if this is enforced. Thus this pattern is allowed.
+        // Section 12.1.5.1 of ISO 14496-12 (ISOBMFF) says:
+        //   If colour information is supplied in both this [colr] box, and also
+        //   in the video bitstream, this box takes precedence, and over-rides
+        //   the information in the bitstream.
+        // So decoder->image->yuvRange is kept because it was either the 'colr'
+        // value set when the 'colr' box was parsed, or it was the AV1 OBU value
+        // extracted from the sequence header OBU of the first tile of the first
+        // frame (if no 'colr' box of colour_type 'nclx' was found).
 
         // Alpha plane with limited range is not allowed by the latest revision
         // of the specification. However, it was allowed in version 1.0.0 of the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,7 @@ if(AVIF_ENABLE_GTEST)
     add_avif_gtest(avifopaquetest)
     add_avif_gtest_with_data(avifpng16bittest)
     add_avif_gtest(avifprogressivetest)
+    add_avif_gtest(avifrangetest)
     add_avif_gtest_with_data(avifreadimagetest)
     add_avif_gtest(avifrgbtest)
     add_avif_gtest(avifrgbtoyuvtest)
@@ -315,7 +316,7 @@ if(AVIF_CODEC_AVM)
         if(AVIF_ENABLE_GTEST)
             set_tests_properties(
                 avifallocationtest avifbasictest avifchangesettingtest avifcllitest avifgridapitest avifincrtest avifiostatstest
-                avifmetadatatest avifprogressivetest avify4mtest PROPERTIES DISABLED True
+                avifmetadatatest avifprogressivetest avifrangetest avify4mtest PROPERTIES DISABLED True
             )
 
             if(AVIF_ENABLE_EXPERIMENTAL_AVIR)

--- a/tests/gtest/avifrangetest.cc
+++ b/tests/gtest/avifrangetest.cc
@@ -1,0 +1,135 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <algorithm>
+#include <cstring>
+#include <tuple>
+
+#include "avif/internal.h"
+#include "aviftest_helpers.h"
+#include "gtest/gtest.h"
+
+namespace libavif {
+namespace {
+
+enum class InputType { kStillImage, kGrid, kAnimation };
+
+// Generates a valid AVIF stream with the video range flag set to the same value
+// in the "colr" box and in the AV1 OBU payload (in the "mdat" box).
+avifResult GenerateEncodedData(avifRange range, InputType input_type,
+                               testutil::AvifRwData* encoded) {
+  testutil::AvifImagePtr image =
+      testutil::CreateImage(/*width=*/64, /*height=*/64, /*depth=*/8,
+                            AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_ALL, range);
+  AVIF_CHECKERR(image != nullptr, AVIF_RESULT_OUT_OF_MEMORY);
+  testutil::FillImageGradient(image.get());  // Pixel values do not matter.
+
+  testutil::AvifEncoderPtr encoder(avifEncoderCreate(), avifEncoderDestroy);
+  AVIF_CHECKERR(encoder != nullptr, AVIF_RESULT_OUT_OF_MEMORY);
+  if (input_type == InputType::kStillImage) {
+    AVIF_CHECKRES(avifEncoderWrite(encoder.get(), image.get(), encoded));
+  } else if (input_type == InputType::kGrid) {
+    const avifImage* cellImages[2] = {image.get(), image.get()};
+    AVIF_CHECKRES(avifEncoderAddImageGrid(encoder.get(), /*gridCols=*/2,
+                                          /*gridRows=*/1, cellImages,
+                                          AVIF_ADD_IMAGE_FLAG_SINGLE));
+    AVIF_CHECKRES(avifEncoderFinish(encoder.get(), encoded));
+  } else {
+    assert(input_type == InputType::kAnimation);
+    AVIF_CHECKRES(avifEncoderAddImage(encoder.get(), image.get(),
+                                      /*durationInTimescales=*/1,
+                                      AVIF_ADD_IMAGE_FLAG_NONE));
+    AVIF_CHECKRES(avifEncoderAddImage(encoder.get(), image.get(),
+                                      /*durationInTimescales=*/1,
+                                      AVIF_ADD_IMAGE_FLAG_NONE));
+    AVIF_CHECKRES(avifEncoderFinish(encoder.get(), encoded));
+  }
+  return AVIF_RESULT_OK;
+}
+
+class RangeTest
+    : public testing::TestWithParam<std::tuple<avifRange, InputType>> {};
+
+TEST_P(RangeTest, DifferentVideoRangeInColrAndMdat) {
+  const avifRange obu_range = std::get<0>(GetParam());
+  const InputType input_type = std::get<1>(GetParam());
+  testutil::AvifRwData encoded;
+  ASSERT_EQ(GenerateEncodedData(obu_range, input_type, &encoded),
+            AVIF_RESULT_OK);
+
+  // Set full_range_flag in the "colr" box to a different value.
+  // This creates an invalid bitstream according to AV1-ISOBMFF v1.2.0 but
+  // libavif still allows it.
+  const avifRange colr_range =
+      (obu_range == AVIF_RANGE_LIMITED) ? AVIF_RANGE_FULL : AVIF_RANGE_LIMITED;
+  const uint8_t kColrBoxTag[] = "colr";
+  uint8_t* colr_box = std::search(encoded.data, encoded.data + encoded.size,
+                                  kColrBoxTag, kColrBoxTag + 4);
+  do {
+    ASSERT_GT(colr_box, encoded.data + 4);
+    ASSERT_LT(colr_box, encoded.data + encoded.size);
+    const uint32_t colr_box_size = (colr_box[-4] << 24) | (colr_box[-3] << 16) |
+                                   (colr_box[-2] << 8) | colr_box[-1];
+    ASSERT_EQ(colr_box_size, 19u);
+    ASSERT_LT(colr_box + colr_box_size - 4, encoded.data + encoded.size);
+    ASSERT_TRUE(std::equal(colr_box + 4, colr_box + 8,
+                           reinterpret_cast<const uint8_t*>("nclx")));
+    // full_range_flag(1bit)=colr_range, reserved(7bits)=0
+    colr_box[colr_box_size - 5] = static_cast<uint8_t>(colr_range << 7);
+    colr_box = std::search(colr_box + 4, encoded.data + encoded.size,
+                           kColrBoxTag, kColrBoxTag + 4);
+  } while (colr_box != encoded.data + encoded.size);
+
+  // Section 12.1.5.1 of ISO 14496-12 (ISOBMFF) says:
+  //   If colour information is supplied in both this [colr] box, and also in
+  //   the video bitstream, this box takes precedence, and over-rides the
+  //   information in the bitstream.
+  testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
+                                  encoded.size),
+            AVIF_RESULT_OK);
+  ASSERT_EQ(decoded->yuvRange, colr_range);
+}
+
+TEST_P(RangeTest, MissingColr) {
+  const avifRange obu_range = std::get<0>(GetParam());
+  const InputType input_type = std::get<1>(GetParam());
+  testutil::AvifRwData encoded;
+  ASSERT_EQ(GenerateEncodedData(obu_range, input_type, &encoded),
+            AVIF_RESULT_OK);
+
+  // Remove the "colr" box (by replacing it with a placeholder).
+  // This creates an invalid bitstream according to AV1-ISOBMFF v1.2.0 but
+  // libavif still allows it.
+  const uint8_t kColrBoxTag[] = "colr";
+  uint8_t* colr_box = std::search(encoded.data, encoded.data + encoded.size,
+                                  kColrBoxTag, kColrBoxTag + 4);
+  do {
+    ASSERT_LT(colr_box + 4, encoded.data + encoded.size);
+    std::memcpy(colr_box, "free", 4);
+    colr_box = std::search(colr_box + 4, encoded.data + encoded.size,
+                           kColrBoxTag, kColrBoxTag + 4);
+  } while (colr_box != encoded.data + encoded.size);
+
+  // Make sure the AV1 OBU range is kept.
+  testutil::AvifImagePtr decoded(avifImageCreateEmpty(), avifImageDestroy);
+  ASSERT_NE(decoded, nullptr);
+  testutil::AvifDecoderPtr decoder(avifDecoderCreate(), avifDecoderDestroy);
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
+                                  encoded.size),
+            AVIF_RESULT_OK);
+  ASSERT_EQ(decoded->yuvRange, obu_range);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    All, RangeTest,
+    testing::Combine(testing::Values(AVIF_RANGE_LIMITED, AVIF_RANGE_FULL),
+                     testing::Values(InputType::kStillImage, InputType::kGrid,
+                                     InputType::kAnimation)));
+
+}  // namespace
+}  // namespace libavif


### PR DESCRIPTION
Add explanation in avifDecoderDecodeTiles().
Add avifrangetest.cc.

This issue of mismatched `colr`/OBU video range values was caught by avif_fuzztest_dec.cc which triggered the following failed assertion:

https://github.com/AOMediaCodec/libavif/blob/7a07e7206bd7012de8c26249f8e49b7880897ad3/src/avif.c#L200

Related to https://github.com/AOMediaCodec/libavif/pull/1687.