### PR TITLE
Check avifAlloc() result in avifArrayPush*()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * AVIF sequences encoded by libavif will now also have the "avio" brand when
   there is at least one track made only of AV1 keyframes.
 * Fix SVT-AV1 codec interface which was not setting video range at encoding.
+* Any item ID being 0 in an "iref" box with version 0 or 1 is now treated as an
+  error instead of being ignored.
 
 ## [1.0.1] - 2023-08-29
 

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -102,9 +102,7 @@ avifTransferFunction avifTransferCharacteristicsGetLinearToGammaFunction(avifTra
         uint32_t capacity;                                 \
     } TYPENAME
 avifBool avifArrayCreate(void * arrayStruct, uint32_t elementSize, uint32_t initialCapacity);
-uint32_t avifArrayPushIndex(void * arrayStruct);
-void * avifArrayPushPtr(void * arrayStruct);
-void avifArrayPush(void * arrayStruct, void * element);
+void * avifArrayPush(void * arrayStruct);
 void avifArrayPop(void * arrayStruct);
 void avifArrayDestroy(void * arrayStruct);
 

--- a/src/avif.c
+++ b/src/avif.c
@@ -975,7 +975,7 @@ avifResult avifCodecSpecificOptionsSet(avifCodecSpecificOptions * csOptions, con
 
     if (value) {
         // Add a new key
-        avifCodecSpecificOption * entry = (avifCodecSpecificOption *)avifArrayPushPtr(csOptions);
+        avifCodecSpecificOption * entry = (avifCodecSpecificOption *)avifArrayPush(csOptions);
         AVIF_CHECKERR(entry, AVIF_RESULT_OUT_OF_MEMORY);
         entry->key = avifStrdup(key);
         AVIF_CHECKERR(entry->key, AVIF_RESULT_OUT_OF_MEMORY);

--- a/src/utils.c
+++ b/src/utils.c
@@ -99,34 +99,23 @@ avifBool avifArrayCreate(void * arrayStruct, uint32_t elementSize, uint32_t init
     return AVIF_TRUE;
 }
 
-uint32_t avifArrayPushIndex(void * arrayStruct)
+void * avifArrayPush(void * arrayStruct)
 {
     avifArrayInternal * arr = (avifArrayInternal *)arrayStruct;
     if (arr->count == arr->capacity) {
         uint8_t * oldPtr = arr->ptr;
         size_t oldByteCount = (size_t)arr->elementSize * arr->capacity;
         arr->ptr = (uint8_t *)avifAlloc(oldByteCount * 2);
+        if (arr->ptr == NULL) {
+            return NULL;
+        }
         memset(arr->ptr + oldByteCount, 0, oldByteCount);
         memcpy(arr->ptr, oldPtr, oldByteCount);
         arr->capacity *= 2;
         avifFree(oldPtr);
     }
     ++arr->count;
-    return arr->count - 1;
-}
-
-void * avifArrayPushPtr(void * arrayStruct)
-{
-    uint32_t index = avifArrayPushIndex(arrayStruct);
-    avifArrayInternal * arr = (avifArrayInternal *)arrayStruct;
-    return &arr->ptr[index * (size_t)arr->elementSize];
-}
-
-void avifArrayPush(void * arrayStruct, void * element)
-{
-    avifArrayInternal * arr = (avifArrayInternal *)arrayStruct;
-    void * newElement = avifArrayPushPtr(arr);
-    memcpy(newElement, element, arr->elementSize);
+    return &arr->ptr[(arr->count - 1) * (size_t)arr->elementSize];
 }
 
 void avifArrayPop(void * arrayStruct)


### PR DESCRIPTION
Propagate `avifResult` to call sites.
Remove unused `avifArrayPushIndex()` and `avifArrayPush()`.
Rename `avifArrayPushPtr()` to `avifArrayPush()`.
Rename `avifMetaFindItem()` to `avifMetaFindOrCreateItem()`.
Fix `iref` checking item ID != 0 too late.
Add entry to `CHANGELOG.md`.

See https://github.com/AOMediaCodec/libavif/issues/820.