### PR TITLE
Speed test_cmd_avm up

### DIFF
--- a/tests/test_cmd_avm.sh
+++ b/tests/test_cmd_avm.sh
@@ -46,12 +46,12 @@ ARE_IMAGES_EQUAL="${BINARY_DIR}/tests/are_images_equal"
 "${AVIFDEC}" --version
 
 # Input file paths.
-INPUT_Y4M="${TESTDATA_DIR}/kodim03_yuv420_8bpc.y4m"
+INPUT_PNG="${TESTDATA_DIR}/ArcTriomphe-cHRM-orig.png"
 # Output file names.
-ENCODED_FILE="avif_test_cmd_encoded.avif"
-ENCODED_FILE_WITH_DASH="-avif_test_cmd_encoded.avif"
-DECODED_FILE="avif_test_cmd_decoded.png"
-OUT_MSG="avif_test_cmd_out_msg.txt"
+ENCODED_FILE="avif_test_cmd_avm_encoded.avif"
+ENCODED_FILE_WITH_DASH="-avif_test_cmd_avm_encoded.avif"
+DECODED_FILE="avif_test_cmd_avm_decoded.png"
+OUT_MSG="avif_test_cmd_avm_out_msg.txt"
 
 # Cleanup
 cleanup() {
@@ -64,37 +64,37 @@ trap cleanup EXIT
 pushd ${TMP_DIR}
   # Lossy test. The decoded pixels should be different from the original image.
   echo "Testing basic lossy"
-  "${AVIFENC}" -c avm -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}"
+  "${AVIFENC}" -c avm -s 8 "${INPUT_PNG}" -o "${ENCODED_FILE}"
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}"
-  "${ARE_IMAGES_EQUAL}" "${INPUT_Y4M}" "${DECODED_FILE}" 0 && exit 1
+  "${ARE_IMAGES_EQUAL}" "${INPUT_PNG}" "${DECODED_FILE}" 0 && exit 1
 
   # Argument parsing test with filenames starting with a dash.
   echo "Testing arguments"
-  "${AVIFENC}" -c avm -s 10 "${INPUT_Y4M}" -- "${ENCODED_FILE_WITH_DASH}"
+  "${AVIFENC}" -c avm -s 10 "${INPUT_PNG}" -- "${ENCODED_FILE_WITH_DASH}"
   "${AVIFDEC}" --info  -- "${ENCODED_FILE_WITH_DASH}"
   # Passing a filename starting with a dash without using -- should fail.
-  "${AVIFENC}" -c avm -s 10 "${INPUT_Y4M}" "${ENCODED_FILE_WITH_DASH}" && exit 1
+  "${AVIFENC}" -c avm -s 10 "${INPUT_PNG}" "${ENCODED_FILE_WITH_DASH}" && exit 1
   "${AVIFDEC}" --info "${ENCODED_FILE_WITH_DASH}" && exit 1
 
   # --min and --max must be both specified.
-  "${AVIFENC}" -c avm -s 10 --min 24 "${INPUT_Y4M}" "${ENCODED_FILE}" && exit 1
-  "${AVIFENC}" -c avm -s 10 --max 26 "${INPUT_Y4M}" "${ENCODED_FILE}" && exit 1
+  "${AVIFENC}" -c avm -s 10 --min 24 "${INPUT_PNG}" "${ENCODED_FILE}" && exit 1
+  "${AVIFENC}" -c avm -s 10 --max 26 "${INPUT_PNG}" "${ENCODED_FILE}" && exit 1
   # --minalpha and --maxalpha must be both specified.
   "${AVIFENC}" -c avm -s 10 --minalpha 0 "${INPUT_PNG}" "${ENCODED_FILE}" && exit 1
   "${AVIFENC}" -c avm -s 10 --maxalpha 0 "${INPUT_PNG}" "${ENCODED_FILE}" && exit 1
 
   # The default quality is 60. The default alpha quality is 100 (lossless).
-  "${AVIFENC}" -c avm -s 10 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
+  "${AVIFENC}" -c avm -s 10 "${INPUT_PNG}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[60 " "${OUT_MSG}"
   grep " alpha quality \[100 " "${OUT_MSG}"
-  "${AVIFENC}" -c avm -s 10 -q 85 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
+  "${AVIFENC}" -c avm -s 10 -q 85 "${INPUT_PNG}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[85 " "${OUT_MSG}"
   grep " alpha quality \[100 " "${OUT_MSG}"
   # The average of 15 and 25 is 20. Quantizer 20 maps to quality 68.
-  "${AVIFENC}" -c avm -s 10 --min 15 --max 25 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
+  "${AVIFENC}" -c avm -s 10 --min 15 --max 25 "${INPUT_PNG}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[68 " "${OUT_MSG}"
   grep " alpha quality \[100 " "${OUT_MSG}"
-  "${AVIFENC}" -c avm -s 10 -q 65 --min 15 --max 25 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
+  "${AVIFENC}" -c avm -s 10 -q 65 --min 15 --max 25 "${INPUT_PNG}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[65 " "${OUT_MSG}"
   grep " alpha quality \[100 " "${OUT_MSG}"
 popd

--- a/tests/test_cmd_avm_lossless.sh
+++ b/tests/test_cmd_avm_lossless.sh
@@ -42,11 +42,11 @@ AVIFDEC="${BINARY_DIR}/avifdec"
 ARE_IMAGES_EQUAL="${BINARY_DIR}/tests/are_images_equal"
 
 # Input file paths.
-INPUT_PNG="${TESTDATA_DIR}/paris_icc_exif_xmp.png"
+INPUT_PNG="${TESTDATA_DIR}/ArcTriomphe-cHRM-orig.png"
 # Output file names.
-ENCODED_FILE="avif_test_cmd_lossless_encoded.avif"
-DECODED_FILE="avif_test_cmd_lossless_decoded.png"
-DECODED_FILE_LOSSLESS="avif_test_cmd_lossless_decoded_lossless.png"
+ENCODED_FILE="avif_test_cmd_avm_lossless_encoded.avif"
+DECODED_FILE="avif_test_cmd_avm_lossless_decoded.png"
+DECODED_FILE_LOSSLESS="avif_test_cmd_avm_lossless_decoded_lossless.png"
 
 # Cleanup
 cleanup() {


### PR DESCRIPTION
libavm became very slow even at minimum effort depending on the enabled features (`CONFIG_BLOCK_256` for example).
Use a tiny input image; the important is exercising the API anyway.

Also make test file names unique to the test.