### PR TITLE
Remove abort() on avifAlloc() failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix SVT-AV1 codec interface which was not setting video range at encoding.
 * Any item ID being 0 in an "iref" box with version 0 or 1 is now treated as an
   error instead of being ignored.
+* API calls now return AVIF_RESULT_OUT_OF_MEMORY instead of aborting on memory
+  allocation failure.
 
 ## [1.0.1] - 2023-08-29
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -132,9 +132,7 @@ AVIF_API unsigned int avifLibYUVVersion(void); // returns 0 if libavif wasn't co
 // ---------------------------------------------------------------------------
 // Memory management
 
-// NOTE: On memory allocation failure, the current implementation of avifAlloc() calls abort(),
-// but in a future release it may return NULL. To be future-proof, callers should check for a NULL
-// return value.
+// Returns NULL on memory allocation failure.
 AVIF_API void * avifAlloc(size_t size);
 AVIF_API void avifFree(void * p);
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -3,10 +3,12 @@
 
 #include "avif/avif.h"
 
+#include <assert.h>
 #include <stdlib.h>
 
 void * avifAlloc(size_t size)
 {
+    assert(size != 0); // Implementation-defined. See https://en.cppreference.com/w/cpp/memory/c/malloc
     return malloc(size);
 }
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -7,12 +7,7 @@
 
 void * avifAlloc(size_t size)
 {
-    void * out = malloc(size);
-    if (out == NULL) {
-        // TODO(issue #820): Remove once all calling sites propagate the error as AVIF_RESULT_OUT_OF_MEMORY.
-        abort();
-    }
-    return out;
+    return malloc(size);
 }
 
 void avifFree(void * p)

--- a/tests/gtest/avifallocationtest.cc
+++ b/tests/gtest/avifallocationtest.cc
@@ -189,10 +189,6 @@ TEST(EncodingTest, MaximumInvalidDimensions) {
 }
 
 TEST(AvifAllocTest, Extremes) {
-  void* p0 = avifAlloc(0);
-  EXPECT_NE(p0, nullptr);
-  avifFree(p0);
-
   void* p1 = avifAlloc(1);
   EXPECT_NE(p1, nullptr);
   avifFree(p1);

--- a/tests/gtest/avifallocationtest.cc
+++ b/tests/gtest/avifallocationtest.cc
@@ -188,5 +188,17 @@ TEST(EncodingTest, MaximumInvalidDimensions) {
                AVIF_RESULT_UNSUPPORTED_DEPTH);
 }
 
+TEST(AvifAllocTest, Extremes) {
+  void* p0 = avifAlloc(0);
+  EXPECT_NE(p0, nullptr);
+  avifFree(p0);
+
+  void* p1 = avifAlloc(1);
+  EXPECT_NE(p1, nullptr);
+  avifFree(p1);
+
+  EXPECT_EQ(avifAlloc(std::numeric_limits<size_t>::max()), nullptr);
+}
+
 }  // namespace
 }  // namespace libavif


### PR DESCRIPTION
See #820.