### PR TITLE
Don't call avifAlloc,avifFree in apps and examples

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -687,11 +687,11 @@ static avifBool readEntireFile(const char * filename, avifRWData * raw)
     return AVIF_TRUE;
 }
 
-// Returns NULL if a memory allocation failed.
+// Returns NULL if a memory allocation failed. The return value should be freed with free().
 static char * avifStrdup(const char * str)
 {
     size_t len = strlen(str);
-    char * dup = avifAlloc(len + 1);
+    char * dup = malloc(len + 1);
     if (!dup) {
         return NULL;
     }

--- a/examples/avif_example_decode_streaming.c
+++ b/examples/avif_example_decode_streaming.c
@@ -6,7 +6,6 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 // This example intends to show how a custom avifIO implementation can be used to decode
 // partially-downloaded AVIFs. Read either the avif_example_decode_file or
@@ -91,16 +90,15 @@ static avifResult avifIOStreamingReaderRead(struct avifIO * io, uint32_t readFla
 
 static void avifIOStreamingReaderDestroy(struct avifIO * io)
 {
-    avifFree(io);
+    free(io);
 }
 
 // Returns null in case of memory allocation failure.
 static avifIOStreamingReader * avifIOCreateStreamingReader(const uint8_t * data, size_t size)
 {
-    avifIOStreamingReader * reader = avifAlloc(sizeof(avifIOStreamingReader));
+    avifIOStreamingReader * reader = calloc(1, sizeof(avifIOStreamingReader));
     if (!reader)
         return NULL;
-    memset(reader, 0, sizeof(avifIOStreamingReader));
 
     // It is legal for io.destroy to be NULL, in which you are responsible for cleaning up
     // your own reader. This allows for a pre-existing, on-the-stack, or member variable to be


### PR DESCRIPTION
They can call malloc(), calloc(), realloc(), and free().