### PR TITLE
Do not build fuzztest in ext

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,7 +731,7 @@ option(
     OFF
 )
 
-if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND AVIF_ENABLE_GTEST))
+if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST)))
     if(NOT AVIF_LOCAL_ZLIBPNG)
         find_package(ZLIB REQUIRED)
         find_package(PNG 1.6.32 REQUIRED) # 1.6.32 or above for png_get_eXIf_1()/png_set_eXIf_1() and iTXt (for XMP).

--- a/ext/fuzztest.cmd
+++ b/ext/fuzztest.cmd
@@ -12,8 +12,5 @@ cd fuzztest
 : # There is no tagged release as of 2023/09/18. Pick the last commit.
 git checkout b5500afbac873c884e1e021ea019ad943434df7d
 
-mkdir build.libavif
-cd build.libavif
-cmake -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
-ninja
-cd ../..
+: # fuzztest is built by the main CMake project through add_subdirectory as recommended at:
+: # https://github.com/google/fuzztest/blob/main/doc/quickstart-cmake.md

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,7 @@ foreach(AVIFYUV_MODE limited rgb) # Modes drift and premultiply take more than 2
     add_test(NAME avifyuv_${AVIFYUV_MODE} COMMAND avifyuv -m ${AVIFYUV_MODE})
 endforeach()
 
-if(AVIF_ENABLE_GTEST OR AVIF_BUILD_APPS)
+if(AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST OR AVIF_BUILD_APPS)
     enable_language(CXX)
     set(CMAKE_CXX_STANDARD 14)
     add_library(aviftest_helpers OBJECT gtest/aviftest_helpers.cc)
@@ -97,6 +97,10 @@ if(AVIF_ENABLE_GTEST OR AVIF_ENABLE_FUZZTEST)
     else()
         find_package(GTest REQUIRED)
     endif()
+
+    add_library(avifincrtest_helpers OBJECT gtest/avifincrtest_helpers.cc)
+    target_link_libraries(avifincrtest_helpers avif ${AVIF_PLATFORM_LIBRARIES} ${GTEST_LIBRARIES})
+    target_include_directories(avifincrtest_helpers PUBLIC ${GTEST_INCLUDE_DIRS})
 endif()
 
 if(AVIF_ENABLE_GTEST)
@@ -126,10 +130,6 @@ if(AVIF_ENABLE_GTEST)
 
     add_avif_gtest(avifgridapitest)
     add_avif_gtest(avifimagetest)
-
-    add_library(avifincrtest_helpers OBJECT gtest/avifincrtest_helpers.cc)
-    target_link_libraries(avifincrtest_helpers avif ${AVIF_PLATFORM_LIBRARIES} ${GTEST_LIBRARIES})
-    target_include_directories(avifincrtest_helpers PUBLIC ${GTEST_INCLUDE_DIRS})
 
     add_executable(avifincrtest gtest/avifincrtest.cc)
     target_link_libraries(avifincrtest aviftest_helpers avifincrtest_helpers)


### PR DESCRIPTION
This is handled by add_subdirectory any way.
Also fix some dependencies to not builg gtest tests at the same time.