### PR TITLE
feat: FindPkg.cmake fixes; .pc deps; option to bundle system static libs

### DIFF
--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -17,6 +17,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         build-type: [Release, Debug]
+        install-type: [local, system, system-merged]
+        include:
+          - install-type: system-merged
+            static-link-flags: "-lrav1e -lSvtAv1Enc -laom -lsharpyuv -lyuv -lgav1 -ldav1d"
 
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -37,7 +41,7 @@ jobs:
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       with:
         path: ext
-        key: ${{ runner.os }}-${{ runner.build-type }}-${{ hashFiles('ext/*.cmd') }}
+        key: ${{ runner.os }}-${{ matrix.build-type }}-${{ hashFiles('ext/*.cmd') }}
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@187efd9581ed20ee4e03c0dfb9ac2cd5896c4835 # v1.14.1
       with:
@@ -80,39 +84,72 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash -e libsharpyuv.cmd
+
+    - name: Install system libraries
+      if: matrix.install-type != 'local'
+      working-directory: ./ext
+      run: |
+        cat<<"EOF" | sudo -E env PATH="$PATH" bash
+        (cd aom/build.libavif && ninja install)
+        (cd dav1d/build && ninja install)
+        (cd libgav1/build && ninja install)
+        (cd libwebp/build && ninja install)
+        (cd libyuv/build && ninja install)
+        (cd SVT-AV1/Build/linux/Release && make install)
+        cp -rf rav1e/build.libavif/usr/* /usr/local/
+        EOF
+
     - name: Build GoogleTest
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       # Note: "apt install googletest" is sometimes insufficient for find_package(GTest) so build in ext/ instead.
       run: bash -e googletest.cmd
 
-    - name: Prepare libavif (cmake)
+    - name: Prepare libavif install (cmake)
+      env:
+        LOCAL: ${{ matrix.install-type == 'local' && 'ON' || 'OFF' }}
+        MERGE_SYSTEM_LIBS: ${{ matrix.install-type == 'system-merged' && 'ON' || 'OFF' }}
       run: >
         mkdir build && cd build
 
         cmake .. -G Ninja
-        -DCMAKE_BUILD_TYPE=${{ runner.build-type }} -DBUILD_SHARED_LIBS=OFF
-        -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON
-        -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON
-        -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=ON
-        -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=ON
-        -DAVIF_CODEC_LIBGAV1=ON -DAVIF_LOCAL_LIBGAV1=ON
-        -DAVIF_LOCAL_LIBYUV=ON
-        -DAVIF_LOCAL_LIBSHARPYUV=ON
+        -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DBUILD_SHARED_LIBS=OFF
+        -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=$LOCAL
+        -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=$LOCAL
+        -DAVIF_CODEC_RAV1E=ON -DAVIF_LOCAL_RAV1E=$LOCAL
+        -DAVIF_CODEC_SVT=ON -DAVIF_LOCAL_SVT=$LOCAL
+        -DAVIF_CODEC_LIBGAV1=ON -DAVIF_LOCAL_LIBGAV1=$LOCAL
+        -DAVIF_LOCAL_LIBYUV=$LOCAL
+        -DAVIF_LOCAL_LIBSHARPYUV=$LOCAL
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_LOCAL_GTEST=ON
         -DAVIF_ENABLE_EXPERIMENTAL_YCGCO_R=ON
         -DAVIF_ENABLE_EXPERIMENTAL_GAIN_MAP=ON
         -DAVIF_ENABLE_EXPERIMENTAL_AVIR=ON
+        -DAVIF_STATIC_SYSTEM_LIBRARY_MERGE=$MERGE_SYSTEM_LIBS
+
     - name: Build libavif (ninja)
       working-directory: ./build
-      run: ninja
+      run: ninja -v && sudo -E env PATH="$PATH" ninja install
     - name: Run AVIF Tests
       working-directory: ./build
       run: ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure
+    - name: Check .pc file contents
+      run: cat build/libavif.pc
+
     - name: Check static link bundling
       run: |
-        cc -o avifenc  -I./apps/shared -I./include apps/avifenc.c apps/shared/*.c \
-          build/libavif.a -lpng -ljpeg -lz -lm -ldl -lstdc++
+        cat <<EOF > test.c
+        #include "avif/avif.h"
+        #include <stdio.h>
 
-        ./avifenc --help
+        int main(int argc, char * argv[]) {
+            char codecVersions[256];
+            avifCodecVersions(codecVersions);
+            printf("Version: %s (%s)\n", avifVersion(), codecVersions);
+        }
+        EOF
+
+        cc -o test -I./include test.c build/libavif.a $(PKG_CONFIG_PATH=build pkg-config --libs --static libavif) -lstdc++
+
+        ./test

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -36,6 +36,13 @@ jobs:
             static-link-libraries: ws2_32.lib userenv.lib advapi32.lib bcrypt.lib ntdll.lib
 
     steps:
+    # Fixes an issue with the image where the wrong cmake is used
+    # See https://github.com/actions/runner-images/issues/8598
+    - name: Remove Strawberry Perl from PATH (Windows)
+      shell: pwsh
+      run: |
+        $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
+        "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
     - name: Setup Visual Studio shell
       if: runner.os == 'Windows'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -24,10 +24,16 @@ concurrency:
 jobs:
   build-static:
     runs-on: ${{ matrix.os }}
+    name: "build-static ${{ matrix.os }} AVIF_STATIC_SYSTEM_LIBRARY_MERGE=${{ matrix.system-lib-merge }}"
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest]
+        system-lib-merge: ["ON", "OFF"]
+        include:
+          - system-lib-merge: "OFF"
+            # See https://github.com/rust-lang/rust/blob/9e3f784eb2c7c847b6c3578b373c0e0bc9233ca3/library/std/src/sys/windows/c/windows_sys.rs#L625
+            static-link-libraries: ws2_32.lib userenv.lib advapi32.lib bcrypt.lib ntdll.lib
 
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -118,28 +124,35 @@ jobs:
         -DAVIF_ENABLE_EXPERIMENTAL_YCGCO_R=ON
         -DAVIF_ENABLE_EXPERIMENTAL_GAIN_MAP=ON
         -DAVIF_ENABLE_EXPERIMENTAL_AVIR=ON
+        -DAVIF_STATIC_SYSTEM_LIBRARY_MERGE=${{ matrix.system-lib-merge }}
     - name: Build libavif (ninja)
       working-directory: ./build
-      run: ninja
+      run: ninja -v
     - name: Run AVIF Tests
       working-directory: ./build
       run: ctest -j $Env:NUMBER_OF_PROCESSORS --output-on-failure
+    - name: Check .pc file contents
+      working-directory: ./build
+      shell: pwsh
+      run: cat libavif.pc
+    - name: Save source file for static link bundling test
+      shell: pwsh
+      run: |
+        @"
+        #include "avif/avif.h"
+        #include <stdio.h>
+
+        int main(int argc, char * argv[])
+        {
+            char codecVersions[256];
+            avifCodecVersions(codecVersions);
+            printf("Version: %s (%s)\n", avifVersion(), codecVersions);
+        }
+        "@ | Out-File test.c
     - name: Check static link bundling
       run: >
-        cl .\apps\avifenc.c .\apps\shared\*.c /nologo
-        /DWIN32 /D_WINDOWS /MD /O2 /Ob2
-        -I.\apps\shared -I.\include
-        -external:W0
-        -external:I.\ext\libpng
-        -external:I.\ext\libjpeg
-        -external:I.\ext\zlib
-        -external:I.\build\ext\libpng
-        -external:I.\build\ext\zlib
-        /link
-        build\ext\libjpeg\jpeg.lib
-        build\ext\libpng\libpng16_static.lib
-        build\ext\zlib\zlibstatic.lib
-        build\avif.lib
-        /out:avifenc.exe
+        cl .\test.c /nologo /DWIN32 /D_WINDOWS /MD /O2 /Ob2 -I.\include
+        /link ${{ matrix.static-link-libraries }} build\avif.lib
+        /out:test.exe
 
-        .\avifenc.exe --help
+        .\test.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,12 +160,13 @@ if(AVIF_LOCAL_ZLIBPNG)
     set(PNG_SHARED OFF CACHE BOOL "")
     set(PNG_TESTS OFF CACHE BOOL "")
     add_subdirectory(ext/libpng)
-    set(PNG_PNG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libpng")
+    set(PNG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libpng")
     set(PNG_LIBRARY png_static)
     include_directories("${CMAKE_CURRENT_BINARY_DIR}/ext/libpng")
     set(ANDROID ${PREV_ANDROID})
 
     set(ZLIB_LIBRARY zlibstatic)
+    set(PNG_LIBRARIES ${PNG_LIBRARY} ${ZLIB_LIBRARY})
 endif()
 
 if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST)))
@@ -843,14 +844,14 @@ if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE
         avif_apps STATIC apps/shared/avifexif.c apps/shared/avifjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c
                          apps/shared/iccjpeg.c apps/shared/iccmaker.c apps/shared/y4m.c
     )
-    target_link_libraries(avif_apps ${AVIF_LINK_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARIES})
-    target_link_directories(avif_apps PUBLIC ${AVIF_LINK_DIRS} ${JPEG_LIBRARY_DIRS})
+    target_link_libraries(avif_apps ${AVIF_LINK_LIBRARIES} ${PNG_LIBRARIES} ${ZLIB_LIBRARY} ${JPEG_LIBRARIES})
+    target_link_directories(avif_apps PUBLIC ${AVIF_LINK_DIRS} ${JPEG_LIBRARY_DIRS} ${PNG_LIBRARY_DIRS})
     # In GitHub CI's macos-latest os image, /usr/local/include has not only the headers of libpng
     # and libjpeg but also the headers of an older version of libavif. Put the avif include
-    # directory before ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR} to prevent picking up old libavif
+    # directory before ${PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR} to prevent picking up old libavif
     # headers from /usr/local/include.
     target_include_directories(avif_apps PRIVATE $<TARGET_PROPERTY:avif,INTERFACE_INCLUDE_DIRECTORIES>)
-    target_include_directories(avif_apps SYSTEM PRIVATE ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR})
+    target_include_directories(avif_apps SYSTEM PRIVATE ${PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR})
     target_include_directories(avif_apps INTERFACE apps/shared)
 
     if(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,15 @@ if(AVIF_LOCAL_ZLIBPNG)
     set(ZLIB_LIBRARY zlibstatic)
 endif()
 
+if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST)))
+    if(NOT AVIF_LOCAL_ZLIBPNG)
+        find_package_libavif(ZLIB REQUIRED)
+        find_package_libavif(PNG 1.6.32 REQUIRED) # 1.6.32 or above for png_get_eXIf_1()/png_set_eXIf_1() and iTXt (for XMP).
+    endif()
+    if(NOT AVIF_LOCAL_JPEG)
+        find_package_libavif(JPEG REQUIRED)
+    endif()
+endif()
 option(AVIF_LOCAL_JPEG "Build jpeg by providing your own copy inside the ext subdir." OFF)
 if(AVIF_LOCAL_JPEG)
     add_subdirectory(ext/libjpeg)
@@ -830,14 +839,6 @@ option(
 )
 
 if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST)))
-    if(NOT AVIF_LOCAL_ZLIBPNG)
-        find_package_libavif(ZLIB REQUIRED)
-        find_package_libavif(PNG 1.6.32 REQUIRED) # 1.6.32 or above for png_get_eXIf_1()/png_set_eXIf_1() and iTXt (for XMP).
-    endif()
-    if(NOT AVIF_LOCAL_JPEG)
-        find_package_libavif(JPEG REQUIRED)
-    endif()
-
     add_library(
         avif_apps STATIC apps/shared/avifexif.c apps/shared/avifjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c
                          apps/shared/iccjpeg.c apps/shared/iccmaker.c apps/shared/y4m.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,9 +81,11 @@ option(
     OFF
 )
 
+option(AVIF_STATIC_SYSTEM_LIBRARY_MERGE "If building static libraries, include system static libraries in the merged archive" OFF)
+
 set(AVIF_USE_CXX OFF)
 
-if(AVIF_LOCAL_LIBGAV1)
+if(AVIF_CODEC_LIBGAV1)
     set(AVIF_USE_CXX ON)
 endif()
 
@@ -105,6 +107,15 @@ set(AVIF_PLATFORM_DEFINITIONS)
 set(AVIF_PLATFORM_INCLUDES)
 set(AVIF_PLATFORM_SYSTEM_INCLUDES)
 set(AVIF_PLATFORM_LIBRARIES)
+# The libraries that apps, examples, and tests are linked against.
+# This includes avif for shared builds and avif_internal for static
+# builds, as well as any codec or platform libraries.
+set(AVIF_LINK_LIBRARIES)
+set(AVIF_LINK_DIRS)
+
+set(AVIF_PKG_CONFIG_LIBS)
+set(AVIF_PKG_CONFIG_LIBS_PRIVATE)
+set(AVIF_PKG_CONFIG_REQUIRES)
 
 # A macro that wraps find_package, preferring static libraries if this is a static build
 # Should only be used for libraries linked against avif, not for those only used
@@ -167,6 +178,7 @@ if(AVIF_LOCAL_JPEG)
         set(JPEG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libjpeg" PARENT_SCOPE)
         set(JPEG_LIBRARY jpeg PARENT_SCOPE)
     endif()
+    set(JPEG_LIBRARIES ${JPEG_LIBRARY})
 endif()
 
 option(AVIF_LOCAL_LIBYUV "Build libyuv by providing your own copy inside the ext subdir." OFF)
@@ -217,6 +229,14 @@ if(libyuv_FOUND)
     set(AVIF_PLATFORM_DEFINITIONS ${AVIF_PLATFORM_DEFINITIONS} -DAVIF_LIBYUV_ENABLED=1)
     set(AVIF_PLATFORM_SYSTEM_INCLUDES ${AVIF_PLATFORM_SYSTEM_INCLUDES} ${LIBYUV_INCLUDE_DIR})
     set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${LIBYUV_LIBRARY})
+    set(AVIF_LINK_DIRS ${AVIF_LINK_DIRS} ${LIBYUV_LIBRARY_DIRS})
+    if(NOT AVIF_LOCAL_LIBYUV)
+        if(BUILD_SHARED_LIBS)
+            list(APPEND AVIF_PKG_CONFIG_LIBS "-lyuv")
+        else()
+            list(APPEND AVIF_PKG_CONFIG_LIBS_PRIVATE "-lyuv")
+        endif()
+    endif()
 endif(libyuv_FOUND)
 
 option(AVIF_LOCAL_LIBSHARPYUV "Build libsharpyuv by providing your own copy inside the ext subdir." OFF)
@@ -245,6 +265,10 @@ if(libsharpyuv_FOUND)
         set(AVIF_PLATFORM_SYSTEM_INCLUDES ${AVIF_PLATFORM_SYSTEM_INCLUDES} ${LIBSHARPYUV_INCLUDE_DIR})
     endif()
     set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${LIBSHARPYUV_LIBRARY})
+    set(AVIF_LINK_DIRS ${AVIF_LINK_DIRS} ${LIBSHARPYUV_LIBRARY_DIRS})
+    if(NOT AVIF_LOCAL_LIBSHARPYUV)
+        list(APPEND AVIF_PKG_CONFIG_REQUIRES libsharpyuv)
+    endif()
 else(libsharpyuv_FOUND)
     message(STATUS "libavif: libsharpyuv not found")
 endif(libsharpyuv_FOUND)
@@ -266,9 +290,10 @@ if(AVIF_LOCAL_LIBXML2)
         set(LIBXML2_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/libxml2/install.libavif/include/libxml2" PARENT_SCOPE)
         set(LIBXML2_LIBRARY ${LIB_FILENAME} PARENT_SCOPE)
     endif()
+    set(LIBXML2_LIBRARIES ${LIBXML2_LIBRARY})
     set(LIBXML2_FOUND TRUE)
 else()
-    find_package(LibXml2 QUIET) # not required
+    find_package_libavif(LibXml2 QUIET) # not required
 endif()
 # ---------------------------------------------------------------------------------------
 
@@ -415,7 +440,11 @@ if(UNIX)
     # Find out if we have threading available
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads)
+    if(CMAKE_THREAD_LIBS_INIT)
+        list(APPEND AVIF_PKG_CONFIG_LIBS_PRIVATE "${CMAKE_THREAD_LIBS_INIT}")
+    endif()
     set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} m Threads::Threads)
+    list(APPEND AVIF_PKG_CONFIG_LIBS_PRIVATE "-lm")
 endif()
 
 set(AVIF_CODEC_DEFINITIONS)
@@ -472,8 +501,11 @@ if(AVIF_CODEC_DAV1D)
         if(NOT TARGET dav1d)
             find_package_libavif(dav1d REQUIRED)
             set(AVIF_CODEC_SYSTEM_INCLUDES ${AVIF_CODEC_SYSTEM_INCLUDES} ${DAV1D_INCLUDE_DIR})
+            set(AVIF_LINK_DIRS ${AVIF_LINK_DIRS} ${DAV1D_LIBRARY_DIRS})
         endif()
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${DAV1D_LIBRARY})
+
+        list(APPEND AVIF_PKG_CONFIG_REQUIRES dav1d)
     endif()
 
     if(UNIX AND NOT APPLE)
@@ -505,12 +537,32 @@ if(AVIF_CODEC_LIBGAV1)
         if(NOT TARGET libgav1)
             find_package_libavif(libgav1 REQUIRED)
             set(AVIF_CODEC_SYSTEM_INCLUDES ${AVIF_CODEC_SYSTEM_INCLUDES} ${LIBGAV1_INCLUDE_DIR})
+            set(AVIF_LINK_DIRS ${AVIF_LINK_DIRS} ${LIBGAV1_LIBRARY_DIRS})
         endif()
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIBGAV1_LIBRARY})
+        list(APPEND AVIF_PKG_CONFIG_REQUIRES libgav1)
     endif()
 
     message(STATUS "libavif: Codec enabled: libgav1 (decode)")
 endif()
+
+# Extract the library dependencies from the local rav1e pkg-config file from
+# Libs and Libs.private for shared and static builds, respectively.
+function(avif_parse_local_rav1e_pc_libs target)
+    if(BUILD_SHARED_LIBS)
+        set(RAV1E_PC_LIB_REGEX "Libs: -L\\$\\{libdir\\} -lrav1e ([^\n]+)\n")
+    else()
+        set(RAV1E_PC_LIB_REGEX "Libs\\.private: +(.+)\n")
+    endif()
+    set(RAV1E_PC "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/lib/pkgconfig/rav1e.pc")
+    file(READ ${RAV1E_PC} RAV1E_PC_CONTENTS)
+    string(REGEX MATCH "${RAV1E_PC_LIB_REGEX}" _ ${RAV1E_PC_CONTENTS})
+    if(CMAKE_MATCH_1)
+        string(STRIP ${CMAKE_MATCH_1} RAV1E_LIBS_PRIVATE)
+        string(REPLACE " " ";" RAV1E_LIBS_PRIVATE ${RAV1E_LIBS_PRIVATE})
+        set(${target} ${${target}} ${RAV1E_LIBS_PRIVATE} PARENT_SCOPE)
+    endif()
+endfunction()
 
 if(AVIF_CODEC_RAV1E)
     set(AVIF_CODEC_DEFINITIONS ${AVIF_CODEC_DEFINITIONS} -DAVIF_CODEC_RAV1E=1)
@@ -523,24 +575,47 @@ if(AVIF_CODEC_RAV1E)
         if(NOT EXISTS "${LIB_FILENAME}")
             message(FATAL_ERROR "libavif: compiled rav1e library is missing (in ext/rav1e/build.libavif/usr/lib), bailing out")
         endif()
-
-        set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/include/rav1e")
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${LIB_FILENAME})
+        set(RAV1E_LIBRARY ${LIB_FILENAME})
+        list(APPEND RAV1E_LIBRARIES ${RAV1E_LIBRARY})
+        set(RAV1E_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ext/rav1e/build.libavif/usr/include/rav1e")
+        avif_parse_local_rav1e_pc_libs(RAV1E_LIBRARIES)
     else()
         # Check to see if rav1e is independently being built by the outer CMake project
         if(NOT TARGET rav1e)
             find_package_libavif(rav1e REQUIRED)
             set(AVIF_CODEC_SYSTEM_INCLUDES ${AVIF_CODEC_SYSTEM_INCLUDES} ${RAV1E_INCLUDE_DIR})
+            set(AVIF_LINK_DIRS ${AVIF_LINK_DIRS} ${RAV1E_LIBRARY_DIRS})
         endif()
-        set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${RAV1E_LIBRARIES})
+
+        # Unfortunately, rav1e requires a few more libraries, which we add if rav1e was not found by pkg-config
+        if(NOT RAV1E_PC_FOUND)
+            if(WIN32)
+                set(RAV1E_LIBRARIES ${RAV1E_LIBRARIES} ntdll.lib userenv.lib ws2_32.lib bcrypt.lib)
+            elseif(UNIX AND NOT APPLE)
+                set(RAV1E_LIBRARIES ${RAV1E_LIBRARIES} ${CMAKE_DL_LIBS}) # for backtrace
+            endif()
+        endif()
+
+        list(APPEND AVIF_PKG_CONFIG_REQUIRES rav1e)
     endif()
 
-    # Unfortunately, rav1e requires a few more libraries
     if(WIN32)
-        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ntdll.lib userenv.lib ws2_32.lib bcrypt.lib)
-    elseif(UNIX AND NOT APPLE)
-        set(AVIF_PLATFORM_LIBRARIES ${AVIF_PLATFORM_LIBRARIES} ${CMAKE_DL_LIBS}) # for backtrace
+        # Remove msvcrt from RAV1E_LIBRARIES since it's linked by default
+        list(REMOVE_ITEM RAV1E_LIBRARIES "msvcrt.lib" "-lmsvcrt")
+
+        # If we have system libraries that include kernel32 but not ntdll, add it to address
+        # https://github.com/rust-lang/rust/issues/115813
+        if("kernel32.lib" IN_LIST RAV1E_LIBRARIES AND NOT "ntdll.lib" IN_LIST RAV1E_LIBRARIES)
+            list(APPEND RAV1E_LIBRARIES "ntdll.lib")
+        endif()
+        # cygwin and msys2 libraries are formatted with a -l prefix
+        if("-lkernel32" IN_LIST RAV1E_LIBRARIES AND NOT "-lntdll" IN_LIST RAV1E_LIBRARIES)
+            list(APPEND RAV1E_LIBRARIES "-lntdll")
+        endif()
     endif()
+
+    set(AVIF_CODEC_INCLUDES ${AVIF_CODEC_INCLUDES} ${RAV1E_INCLUDE_DIR})
+    set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${RAV1E_LIBRARIES})
 
     message(STATUS "libavif: Codec enabled: rav1e (encode)")
 endif()
@@ -564,8 +639,10 @@ if(AVIF_CODEC_SVT)
         if(NOT TARGET svt)
             find_package_libavif(svt REQUIRED)
             set(AVIF_CODEC_SYSTEM_INCLUDES ${AVIF_CODEC_SYSTEM_INCLUDES} ${SVT_INCLUDE_DIR})
+            set(AVIF_LINK_DIRS ${AVIF_LINK_DIRS} ${SVT_LIBRARY_DIRS})
         endif()
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${SVT_LIBRARY})
+        list(APPEND AVIF_PKG_CONFIG_REQUIRES SvtAv1Enc)
     endif()
 
     message(STATUS "libavif: Codec enabled: svt (encode)")
@@ -604,7 +681,9 @@ if(AVIF_CODEC_AOM)
         if(NOT TARGET aom)
             find_package_libavif(aom REQUIRED)
             set(AVIF_CODEC_SYSTEM_INCLUDES ${AVIF_CODEC_SYSTEM_INCLUDES} ${AOM_INCLUDE_DIR})
+            set(AVIF_LINK_DIRS ${AVIF_LINK_DIRS} ${AOM_LIBRARY_DIRS})
         endif()
+        list(APPEND AVIF_PKG_CONFIG_REQUIRES aom)
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${AOM_LIBRARIES})
     endif()
 
@@ -641,8 +720,10 @@ if(AVIF_CODEC_AVM)
         if(NOT TARGET avm)
             find_package_libavif(avm REQUIRED)
             set(AVIF_CODEC_SYSTEM_INCLUDES ${AVIF_CODEC_SYSTEM_INCLUDES} ${AVM_INCLUDE_DIR})
+            set(AVIF_LINK_DIRS ${AVIF_LINK_DIRS} ${AVM_LIBRARY_DIRS})
         endif()
         set(AVIF_CODEC_LIBRARIES ${AVIF_CODEC_LIBRARIES} ${AVM_LIBRARIES})
+        list(APPEND AVIF_PKG_CONFIG_REQUIRES avm)
     endif()
 
     message(STATUS "libavif: Codec enabled: avm (encode/decode)")
@@ -656,10 +737,33 @@ if(NOT AVIF_CODEC_AOM
     message(WARNING "libavif: No decoding library is enabled.")
 endif()
 
-add_library(avif ${AVIF_SRCS})
+# Give access to functions defined in internal.h when BUILD_SHARED_LIBS is ON, to tests for example.
+# The avif_internal target should not be used by external code.
+add_library(avif_internal STATIC ${AVIF_SRCS})
+# Copy or duplicate most properties from the public avif library target.
+target_compile_definitions(avif_internal PRIVATE "$<TARGET_PROPERTY:avif,COMPILE_DEFINITIONS>")
+target_link_libraries(avif_internal PRIVATE "$<TARGET_PROPERTY:avif,LINK_LIBRARIES>")
+target_include_directories(avif_internal PUBLIC ${libavif_SOURCE_DIR}/include)
+target_include_directories(avif_internal PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
+target_include_directories(avif_internal SYSTEM PRIVATE ${AVIF_PLATFORM_SYSTEM_INCLUDES} ${AVIF_CODEC_SYSTEM_INCLUDES})
+target_link_directories(avif_internal PRIVATE ${AVIF_LINK_DIRS})
+if(NOT libyuv_FOUND)
+    target_include_directories(avif_internal PRIVATE ${libavif_SOURCE_DIR}/third_party/libyuv/include/)
+endif()
+
+if(BUILD_SHARED_LIBS)
+    add_library(avif ${AVIF_SRCS})
+    list(APPEND AVIF_LINK_LIBRARIES avif ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
+else()
+    include(merge_static_libs)
+    merge_static_libs(avif avif_internal ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
+    list(APPEND AVIF_LINK_LIBRARIES avif_internal ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
+endif()
+
 set_target_properties(avif PROPERTIES VERSION ${LIBRARY_VERSION} SOVERSION ${LIBRARY_SOVERSION} C_VISIBILITY_PRESET hidden)
 target_compile_definitions(avif PRIVATE ${AVIF_PLATFORM_DEFINITIONS} ${AVIF_CODEC_DEFINITIONS})
 target_link_libraries(avif PRIVATE ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
+target_link_directories(avif PRIVATE ${AVIF_LINK_DIRS})
 target_include_directories(avif PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
 target_include_directories(avif PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
 target_include_directories(avif SYSTEM PRIVATE ${AVIF_PLATFORM_SYSTEM_INCLUDES} ${AVIF_CODEC_SYSTEM_INCLUDES})
@@ -678,25 +782,6 @@ if(BUILD_SHARED_LIBS)
     endif()
 endif()
 
-# Give access to functions defined in internal.h when BUILD_SHARED_LIBS is ON, to tests for example.
-# The avif_internal target should not be used by external code.
-if(BUILD_SHARED_LIBS)
-    add_library(avif_internal STATIC ${AVIF_SRCS})
-    # Copy or duplicate most properties from the public avif library target.
-    target_compile_definitions(avif_internal PRIVATE "$<TARGET_PROPERTY:avif,COMPILE_DEFINITIONS>")
-    target_link_libraries(avif_internal PRIVATE "$<TARGET_PROPERTY:avif,LINK_LIBRARIES>")
-    target_include_directories(avif_internal PUBLIC ${libavif_SOURCE_DIR}/include)
-    target_include_directories(avif_internal PRIVATE ${AVIF_PLATFORM_INCLUDES} ${AVIF_CODEC_INCLUDES})
-    target_include_directories(avif_internal SYSTEM PRIVATE ${AVIF_PLATFORM_SYSTEM_INCLUDES} ${AVIF_CODEC_SYSTEM_INCLUDES})
-    if(NOT libyuv_FOUND)
-        target_include_directories(avif_internal PRIVATE ${libavif_SOURCE_DIR}/third_party/libyuv/include/)
-    endif()
-else()
-    add_library(avif_internal ALIAS avif)
-    include(merge_static_libs)
-    merge_static_libs(avif ${AVIF_CODEC_LIBRARIES} ${AVIF_PLATFORM_LIBRARIES})
-endif()
-
 option(AVIF_BUILD_EXAMPLES "Build avif examples." OFF)
 if(AVIF_BUILD_EXAMPLES)
     set(AVIF_EXAMPLES avif_example_decode_memory avif_example_decode_file avif_example_decode_streaming avif_example_encode)
@@ -706,7 +791,8 @@ if(AVIF_BUILD_EXAMPLES)
         if(AVIF_USE_CXX)
             set_target_properties(${EXAMPLE} PROPERTIES LINKER_LANGUAGE "CXX")
         endif()
-        target_link_libraries(${EXAMPLE} avif ${AVIF_PLATFORM_LIBRARIES})
+        target_link_libraries(${EXAMPLE} ${AVIF_LINK_LIBRARIES})
+        target_link_directories(${EXAMPLE} PRIVATE ${AVIF_LINK_DIRS})
     endforeach()
 endif()
 
@@ -745,18 +831,19 @@ option(
 
 if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST)))
     if(NOT AVIF_LOCAL_ZLIBPNG)
-        find_package(ZLIB REQUIRED)
-        find_package(PNG 1.6.32 REQUIRED) # 1.6.32 or above for png_get_eXIf_1()/png_set_eXIf_1() and iTXt (for XMP).
+        find_package_libavif(ZLIB REQUIRED)
+        find_package_libavif(PNG 1.6.32 REQUIRED) # 1.6.32 or above for png_get_eXIf_1()/png_set_eXIf_1() and iTXt (for XMP).
     endif()
     if(NOT AVIF_LOCAL_JPEG)
-        find_package(JPEG REQUIRED)
+        find_package_libavif(JPEG REQUIRED)
     endif()
 
     add_library(
         avif_apps STATIC apps/shared/avifexif.c apps/shared/avifjpeg.c apps/shared/avifpng.c apps/shared/avifutil.c
                          apps/shared/iccjpeg.c apps/shared/iccmaker.c apps/shared/y4m.c
     )
-    target_link_libraries(avif_apps avif ${AVIF_PLATFORM_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARY})
+    target_link_libraries(avif_apps ${AVIF_LINK_LIBRARIES} ${PNG_LIBRARY} ${ZLIB_LIBRARY} ${JPEG_LIBRARIES})
+    target_link_directories(avif_apps PUBLIC ${AVIF_LINK_DIRS} ${JPEG_LIBRARY_DIRS})
     # In GitHub CI's macos-latest os image, /usr/local/include has not only the headers of libpng
     # and libjpeg but also the headers of an older version of libavif. Put the avif include
     # directory before ${PNG_PNG_INCLUDE_DIR} ${JPEG_INCLUDE_DIR} to prevent picking up old libavif
@@ -769,8 +856,9 @@ if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE
         if(LIBXML2_FOUND)
             set(AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION TRUE)
             add_compile_definitions(AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION)
-            target_link_libraries(avif_apps ${LIBXML2_LIBRARY})
+            target_link_libraries(avif_apps ${LIBXML2_LIBRARIES})
             target_include_directories(avif_apps SYSTEM PRIVATE ${LIBXML2_INCLUDE_DIR})
+            target_link_directories(avif_apps PRIVATE ${LIBXML2_LIBRARY_DIRS})
         else()
             message(STATUS "libavif: libxml2 not found; avifenc will ignore any gain map in jpeg files")
         endif()
@@ -833,6 +921,21 @@ if(AVIF_BUILD_MAN_PAGES)
     else()
         message(WARNING "libavif: No man pages are built (AVIF_BUILD_MAN_PAGES); AVIF_BUILD_APPS must be on.")
     endif()
+endif()
+
+# Convert pkg-config Requires, Libs, and Libs.private variables from lists to space-separated strings
+if(AVIF_PKG_CONFIG_REQUIRES)
+    string(REPLACE ";" " " AVIF_PKG_CONFIG_REQUIRES " ${AVIF_PKG_CONFIG_REQUIRES}")
+endif()
+if(AVIF_PKG_CONFIG_LIBS)
+    string(REPLACE ";" " " AVIF_PKG_CONFIG_LIBS " ${AVIF_PKG_CONFIG_LIBS}")
+endif()
+if(AVIF_PKG_CONFIG_LIBS_PRIVATE)
+    string(REPLACE ";" " " AVIF_PKG_CONFIG_LIBS_PRIVATE " ${AVIF_PKG_CONFIG_LIBS_PRIVATE}")
+endif()
+
+if(AVIF_STATIC_SYSTEM_LIBRARY_MERGE)
+    set(AVIF_PKG_CONFIG_REQUIRES "")
 endif()
 
 if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,11 @@ macro(find_package_libavif)
     set(CMAKE_FIND_LIBRARY_SUFFIXES, "${_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES}")
 endmacro()
 
+# Only applicable to macOS. In GitHub CI's macos-latest os image, this prevents using the libpng
+# and libjpeg headers from /Library/Frameworks/Mono.framework/Headers instead of
+# /usr/local/include.
+set(CMAKE_FIND_FRAMEWORK LAST)
+
 # ---------------------------------------------------------------------------------------
 # This insanity is for people embedding libavif or making fully static or Windows builds.
 # Any proper unix environment should ignore these entire following blocks.
@@ -440,11 +445,6 @@ if(AVIF_ENABLE_COMPLIANCE_WARDEN)
         ext/ComplianceWarden/src/cw_version.cpp
     )
 endif()
-
-# Only applicable to macOS. In GitHub CI's macos-latest os image, this prevents using the libpng
-# and libjpeg headers from /Library/Frameworks/Mono.framework/Headers instead of
-# /usr/local/include.
-set(CMAKE_FIND_FRAMEWORK LAST)
 
 if(UNIX)
     # Find out if we have threading available

--- a/cmake/Modules/FindJPEG.cmake
+++ b/cmake/Modules/FindJPEG.cmake
@@ -1,0 +1,55 @@
+# - Try to find libjpeg
+# Once done this will define
+#
+#  JPEG_FOUND - system has libjpeg
+#  JPEG_INCLUDE_DIR - the libjpeg include directory
+#  JPEG_LIBRARIES - Link these to use libjpeg
+#
+#=============================================================================
+#  Copyright (c) 2020 Google LLC
+#
+#  Distributed under the OSI-approved BSD License (the "License");
+#  see accompanying file Copyright.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even the
+#  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the License for more information.
+#=============================================================================
+#
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(_JPEG libjpeg)
+
+    if(_JPEG_FOUND)
+        if(BUILD_SHARED_LIBS)
+            set(_PC_TYPE)
+        else()
+            set(_PC_TYPE _STATIC)
+        endif()
+        set(JPEG_LIBRARY_DIRS ${_JPEG${_PC_TYPE}_LIBRARY_DIRS})
+        set(JPEG_LIBRARIES ${_JPEG${_PC_TYPE}_LIBRARIES})
+    endif()
+endif(PKG_CONFIG_FOUND)
+
+find_path(JPEG_INCLUDE_DIR NAMES jpeglib.h PATHS ${_JPEG_INCLUDE_DIRS})
+
+find_library(JPEG_LIBRARY NAMES jpeg PATHS ${_JPEG_LIBRARY_DIRS})
+
+# Remove -ljpeg since it will be replaced with full jpeg library path
+if(JPEG_LIBRARIES)
+    list(REMOVE_ITEM JPEG_LIBRARIES "jpeg")
+endif()
+set(JPEG_LIBRARIES ${JPEG_LIBRARY} ${JPEG_LIBRARIES})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    JPEG
+    FOUND_VAR JPEG_FOUND
+    REQUIRED_VARS JPEG_LIBRARY JPEG_LIBRARIES JPEG_INCLUDE_DIR
+    VERSION_VAR _JPEG_VERSION
+)
+
+# show the JPEG_INCLUDE_DIR, JPEG_LIBRARY and JPEG_LIBRARIES variables
+# only in the advanced view
+mark_as_advanced(JPEG_INCLUDE_DIR JPEG_LIBRARY JPEG_LIBRARIES)

--- a/cmake/Modules/FindLibXml2.cmake
+++ b/cmake/Modules/FindLibXml2.cmake
@@ -1,0 +1,79 @@
+# - Try to find libxml2
+# Once done this will define
+#
+#  LIBXML2_FOUND - system has libxml2
+#  LIBXML2_INCLUDE_DIR - the libxml2 include directory
+#  LIBXML2_LIBRARIES - Link these to use libxml2
+#
+#=============================================================================
+#  Copyright (c) 2022 Google LLC
+#
+#  Distributed under the OSI-approved BSD License (the "License");
+#  see accompanying file Copyright.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even the
+#  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the License for more information.
+#=============================================================================
+#
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(_LIBXML2 libxml-2.0)
+    if(_LIBXML2_FOUND)
+        if(BUILD_SHARED_LIBS)
+            set(_PC_TYPE)
+        else()
+            set(_PC_TYPE _STATIC)
+        endif()
+        set(LIBXML2_LIBRARY_DIRS ${_LIBXML2${_PC_TYPE}_LIBRARY_DIRS})
+        set(LIBXML2_LIBRARIES ${_LIBXML2${_PC_TYPE}_LIBRARIES})
+    endif()
+endif(PKG_CONFIG_FOUND)
+
+find_path(
+    LIBXML2_INCLUDE_DIR
+    NAMES libxml/xpath.h
+    HINTS ${_LIBXML_INCLUDEDIR} ${_LIBXML_INCLUDE_DIRS}
+    PATH_SUFFIXES libxml2
+)
+
+find_library(LIBXML2_LIBRARY NAMES xml2 libxml2 PATHS ${LIBXML2_LIBRARY_DIRS})
+
+# Remove the target lib as it will be replaced with full libxml2 library path,
+# but not if it is in the macOS SYSROOT.
+if(NOT BUILD_SHARED_LIBS
+   AND LIBXML2_LIBRARY
+   AND LIBXML2_LIBRARIES
+   AND CMAKE_OSX_SYSROOT
+)
+    list(POP_FRONT LIBXML2_LIBRARIES LIBXML2_PC_STATIC_LIBRARY)
+    string(FIND ${LIBXML2_LIBRARY} ${CMAKE_OSX_SYSROOT} MATCH_POS)
+    if(${MATCH_POS} EQUAL 0)
+        # list(POP_FRONT LIBXML2_LIBRARIES LIBXML2_LIBRARY)
+        set(LIBXML2_LIBRARY ${LIBXML2_PC_STATIC_LIBRARY})
+        # Check that the new LIBXML2_LIBRARY from the pkg-config static libraries
+        # is not also in the sysroot
+        string(FIND ${LIBXML2_LIBRARY} ${CMAKE_OSX_SYSROOT} MATCH_POS)
+        if(${MATCH_POS} EQUAL 0)
+            # Replace it with the first library from the shared pkg-config library type
+            list(GET _LIBXML2_LIBRARIES 0 LIBXML2_LIBRARY)
+        endif()
+    endif()
+    set(LIBXML2_LIBRARIES ${LIBXML2_LIBRARY} ${LIBXML2_LIBRARIES})
+else()
+    list(REMOVE_AT LIBXML2_LIBRARIES 0)
+    set(LIBXML2_LIBRARIES ${LIBXML2_LIBRARY} ${LIBXML2_LIBRARIES})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    LibXml2
+    FOUND_VAR LIBXML2_FOUND
+    REQUIRED_VARS LIBXML2_LIBRARY LIBXML2_LIBRARIES LIBXML2_INCLUDE_DIR
+    VERSION_VAR _LIBXML2_VERSION
+)
+
+# show the LIBXML2_INCLUDE_DIR, LIBXML2_LIBRARY and LIBXML2_LIBRARIES variables
+# only in the advanced view
+mark_as_advanced(LIBXML2_INCLUDE_DIR LIBXML2_LIBRARY LIBXML2_LIBRARIES)

--- a/cmake/Modules/FindLibXml2.cmake
+++ b/cmake/Modules/FindLibXml2.cmake
@@ -66,6 +66,10 @@ else()
     set(LIBXML2_LIBRARIES ${LIBXML2_LIBRARY} ${LIBXML2_LIBRARIES})
 endif()
 
+if(ZLIB_LIBRARY)
+    list(TRANSFORM LIBXML2_LIBRARIES REPLACE "^z$" ${ZLIB_LIBRARY})
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
     LibXml2

--- a/cmake/Modules/FindPNG.cmake
+++ b/cmake/Modules/FindPNG.cmake
@@ -1,0 +1,78 @@
+# - Try to find libpng
+# Once done this will define
+#
+#  PNG_FOUND - system has libpng
+#  PNG_INCLUDE_DIR - the libpng include directory
+#  PNG_LIBRARIES - Link these to use libpng
+#
+#=============================================================================
+#  Copyright (c) 2020 Andreas Schneider <asn@cryptomilk.org>
+#
+#  Distributed under the OSI-approved BSD License (the "License");
+#  see accompanying file Copyright.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even the
+#  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the License for more information.
+#=============================================================================
+#
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(_PNG libpng)
+    if(_PNG_FOUND)
+        if(BUILD_SHARED_LIBS)
+            set(_PC_TYPE)
+        else()
+            set(_PC_TYPE _STATIC)
+        endif()
+        set(PNG_INCLUDE_DIR ${_PNG_INCLUDE_DIR})
+        set(PNG_LIBRARY_DIRS ${_PNG${_PC_TYPE}_LIBRARY_DIRS})
+        set(PNG_LIBRARIES ${_PNG${_PC_TYPE}_LIBRARIES})
+        set(PNG_VERSION ${_PNG_VERSION})
+    endif()
+endif(PKG_CONFIG_FOUND)
+
+if(NOT PNG_INCLUDE_DIR)
+    find_path(PNG_INCLUDE_DIR NAMES png.h PATHS ${_PNG_INCLUDE_DIRS})
+endif()
+
+if(PNG_INCLUDE_DIR AND NOT PNG_VERSION)
+    set(PNG_PNG_H "${PNG_INCLUDE_DIR}/png.h")
+    if(EXISTS ${PNG_PNG_H})
+        message(STATUS "Reading: ${PNG_PNG_H}")
+        file(READ ${PNG_PNG_H} PNG_PNG_H_CONTENTS)
+        string(REGEX MATCH "#define PNG_LIBPNG_VER_STRING \"([0-9.]+)\"" _ ${PNG_PNG_H_CONTENTS})
+        set(PNG_VERSION ${CMAKE_MATCH_1})
+        message(STATUS "libpng version detected: ${PNG_VERSION}")
+    endif()
+    if(NOT PNG_VERSION)
+        message(STATUS "libpng version detection failed.")
+    endif()
+endif()
+
+if(NOT PNG_LIBRARY)
+    find_library(PNG_LIBRARY NAMES png png16 libpng libpng16 PATHS ${_PNG_LIBRARY_DIRS})
+endif()
+
+# Remove -lyuv since it will be replaced with full libpng library path
+if(PNG_LIBRARIES)
+    list(REMOVE_ITEM PNG_LIBRARIES png png12 png16 libpng libpng12 libpng16)
+endif()
+set(PNG_LIBRARIES ${PNG_LIBRARY} ${PNG_LIBRARIES})
+
+if(ZLIB_LIBRARY)
+    list(TRANSFORM LIBXML2_LIBRARIES REPLACE "^z$" ${ZLIB_LIBRARY})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    PNG
+    FOUND_VAR PNG_FOUND
+    REQUIRED_VARS PNG_LIBRARY PNG_LIBRARIES PNG_INCLUDE_DIR
+    VERSION_VAR _PNG_VERSION
+)
+
+# show the PNG_INCLUDE_DIR, PNG_LIBRARY and PNG_LIBRARIES variables only
+# in the advanced view
+mark_as_advanced(PNG_INCLUDE_DIR PNG_LIBRARY PNG_LIBRARIES)

--- a/cmake/Modules/Findaom.cmake
+++ b/cmake/Modules/Findaom.cmake
@@ -22,11 +22,25 @@ if(PKG_CONFIG_FOUND)
     pkg_check_modules(_AOM aom)
 endif(PKG_CONFIG_FOUND)
 
-find_path(AOM_INCLUDE_DIR NAMES aom/aom.h PATHS ${_AOM_INCLUDEDIR})
+if(_AOM_FOUND)
+    if(BUILD_SHARED_LIBS)
+        set(_PC_TYPE)
+    else()
+        set(_PC_TYPE _STATIC)
+    endif()
+    set(AOM_LIBRARY_DIRS ${_AOM${_PC_TYPE}_LIBRARY_DIRS})
+    set(AOM_LIBRARIES ${_AOM${_PC_TYPE}_LIBRARIES})
+endif()
 
-find_library(AOM_LIBRARY NAMES aom PATHS ${_AOM_LIBDIR})
+find_path(AOM_INCLUDE_DIR NAMES aom/aom.h PATHS ${_AOM_INCLUDE_DIRS})
 
-set(AOM_LIBRARIES ${AOM_LIBRARIES} ${AOM_LIBRARY})
+find_library(AOM_LIBRARY NAMES aom PATHS ${_AOM_LIBRARY_DIRS})
+
+# Remove -laom since it will be replaced with full libaom library path
+if(AOM_LIBRARIES)
+    list(REMOVE_ITEM AOM_LIBRARIES "aom")
+endif()
+set(AOM_LIBRARIES ${AOM_LIBRARY} ${AOM_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake/Modules/Finddav1d.cmake
+++ b/cmake/Modules/Finddav1d.cmake
@@ -20,15 +20,26 @@
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
     pkg_check_modules(_DAV1D dav1d)
+    if(_DAV1D_FOUND)
+        if(BUILD_SHARED_LIBS)
+            set(_PC_TYPE)
+        else()
+            set(_PC_TYPE _STATIC)
+        endif()
+        set(DAV1D_LIBRARY_DIRS ${_DAV1D${_PC_TYPE}_LIBRARY_DIRS})
+        set(DAV1D_LIBRARIES ${_DAV1D${_PC_TYPE}_LIBRARIES})
+    endif()
 endif(PKG_CONFIG_FOUND)
 
-find_path(DAV1D_INCLUDE_DIR NAMES dav1d/dav1d.h PATHS ${_DAV1D_INCLUDEDIR})
+find_path(DAV1D_INCLUDE_DIR NAMES dav1d/dav1d.h PATHS ${_DAV1D_INCLUDE_DIRS})
 
-find_library(DAV1D_LIBRARY NAMES dav1d PATHS ${_DAV1D_LIBDIR})
+find_library(DAV1D_LIBRARY NAMES dav1d PATHS ${_DAV1D_LIBRARY_DIRS})
 
-if(DAV1D_LIBRARY)
-    set(DAV1D_LIBRARIES ${DAV1D_LIBRARIES} ${DAV1D_LIBRARY})
-endif(DAV1D_LIBRARY)
+# Remove -ldav1d since it will be replaced with full dav1d library path
+if(DAV1D_LIBRARIES)
+    LIST(REMOVE_ITEM DAV1D_LIBRARIES "dav1d")
+endif()
+set(DAV1D_LIBRARIES ${DAV1D_LIBRARY} ${DAV1D_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake/Modules/Findlibgav1.cmake
+++ b/cmake/Modules/Findlibgav1.cmake
@@ -20,15 +20,27 @@
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
     pkg_check_modules(_LIBGAV1 libgav1)
+
+    if(_LIBGAV1_FOUND)
+        if(BUILD_SHARED_LIBS)
+            set(_PC_TYPE)
+        else()
+            set(_PC_TYPE _STATIC)
+        endif()
+        set(LIBGAV1_LIBRARY_DIRS ${_LIBGAV1${_PC_TYPE}_LIBRARY_DIRS})
+        set(LIBGAV1_LIBRARIES ${_LIBGAV1${_PC_TYPE}_LIBRARIES})
+    endif()
 endif(PKG_CONFIG_FOUND)
 
-find_path(LIBGAV1_INCLUDE_DIR NAMES gav1/decoder.h PATHS ${_LIBGAV1_INCLUDEDIR})
+find_path(LIBGAV1_INCLUDE_DIR NAMES gav1/decoder.h PATHS ${_LIBGAV1_INCLUDE_DIRS})
 
-find_library(LIBGAV1_LIBRARY NAMES gav1 PATHS ${_LIBGAV1_LIBDIR})
+find_library(LIBGAV1_LIBRARY NAMES gav1 PATHS ${_LIBGAV1_LIBRARY_DIRS})
 
-if(LIBGAV1_LIBRARY)
-    set(LIBGAV1_LIBRARIES ${LIBGAV1_LIBRARIES} ${LIBGAV1_LIBRARY})
-endif(LIBGAV1_LIBRARY)
+# Remove -lgav1 since it will be replaced with full libgav1 library path
+if(LIBGAV1_LIBRARIES)
+    list(REMOVE_ITEM LIBGAV1_LIBRARIES "gav1")
+endif()
+set(LIBGAV1_LIBRARIES ${LIBGAV1_LIBRARY} ${LIBGAV1_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake/Modules/Findlibsharpyuv.cmake
+++ b/cmake/Modules/Findlibsharpyuv.cmake
@@ -20,15 +20,26 @@
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
     pkg_check_modules(_LIBSHARPYUV libsharpyuv)
+    if(_LIBSHARPYUV_FOUND)
+        if(BUILD_SHARED_LIBS)
+            set(_PC_TYPE)
+        else()
+            set(_PC_TYPE _STATIC)
+        endif()
+        set(LIBSHARPYUV_LIBRARY_DIRS ${_LIBSHARPYUV${_PC_TYPE}_LIBRARY_DIRS})
+        set(LIBSHARPYUV_LIBRARIES ${_LIBSHARPYUV${_PC_TYPE}_LIBRARIES})
+    endif()
 endif(PKG_CONFIG_FOUND)
 
-find_path(LIBSHARPYUV_INCLUDE_DIR NAMES sharpyuv/sharpyuv.h PATHS ${_LIBSHARPYUV_INCLUDEDIR})
+find_path(LIBSHARPYUV_INCLUDE_DIR NAMES sharpyuv/sharpyuv.h PATHS ${_LIBSHARPYUV_INCLUDE_DIRS})
 
-find_library(LIBSHARPYUV_LIBRARY NAMES sharpyuv PATHS ${_LIBSHARPYUV_LIBDIR})
+find_library(LIBSHARPYUV_LIBRARY NAMES sharpyuv PATHS ${LIBSHARPYUV_LIBRARY_DIRS})
 
-if(LIBSHARPYUV_LIBRARY)
-    set(LIBSHARPYUV_LIBRARIES ${LIBSHARPYUV_LIBRARIES} ${LIBSHARPYUV_LIBRARY})
-endif(LIBSHARPYUV_LIBRARY)
+# Remove -lsharpyuv since it will be replaced with full libsharpyuv library path
+if(LIBSHARPYUV_LIBRARIES)
+    list(REMOVE_ITEM LIBSHARPYUV_LIBRARIES "sharpyuv")
+endif()
+set(LIBSHARPYUV_LIBRARIES ${LIBSHARPYUV_LIBRARY} ${LIBSHARPYUV_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake/Modules/Findlibyuv.cmake
+++ b/cmake/Modules/Findlibyuv.cmake
@@ -20,10 +20,19 @@
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
     pkg_check_modules(_LIBYUV libyuv)
+    if(_LIBYUV_FOUND)
+        if(BUILD_SHARED_LIBS)
+            set(_PC_TYPE)
+        else()
+            set(_PC_TYPE _STATIC)
+        endif()
+        set(LIBYUV_LIBRARY_DIRS ${_LIBYUV${_PC_TYPE}_LIBRARY_DIRS})
+        set(LIBYUV_LIBRARIES ${_LIBYUV${_PC_TYPE}_LIBRARIES})
+    endif()
 endif(PKG_CONFIG_FOUND)
 
 if(NOT LIBYUV_INCLUDE_DIR)
-    find_path(LIBYUV_INCLUDE_DIR NAMES libyuv.h PATHS ${_LIBYUV_INCLUDEDIR})
+    find_path(LIBYUV_INCLUDE_DIR NAMES libyuv.h PATHS ${_LIBYUV_INCLUDE_DIRS})
 endif()
 
 if(LIBYUV_INCLUDE_DIR AND NOT LIBYUV_VERSION)
@@ -41,12 +50,14 @@ if(LIBYUV_INCLUDE_DIR AND NOT LIBYUV_VERSION)
 endif()
 
 if(NOT LIBYUV_LIBRARY)
-    find_library(LIBYUV_LIBRARY NAMES yuv PATHS ${_LIBYUV_LIBDIR})
+    find_library(LIBYUV_LIBRARY NAMES yuv PATHS ${_LIBYUV_LIBRARY_DIRS})
 endif()
 
-if(LIBYUV_LIBRARY)
-    set(LIBYUV_LIBRARIES ${LIBYUV_LIBRARIES} ${LIBYUV_LIBRARY})
-endif(LIBYUV_LIBRARY)
+# Remove -lyuv since it will be replaced with full libyuv library path
+if(LIBYUV_LIBRARIES)
+    list(REMOVE_ITEM LIBYUV_LIBRARIES "yuv")
+endif()
+set(LIBYUV_LIBRARIES ${LIBYUV_LIBRARY} ${LIBYUV_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake/Modules/Findrav1e.cmake
+++ b/cmake/Modules/Findrav1e.cmake
@@ -19,32 +19,42 @@
 
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
-    pkg_check_modules(_RAV1E rav1e)
+    pkg_check_modules(RAV1E_PC rav1e)
+    if(RAV1E_PC_FOUND)
+        if(BUILD_SHARED_LIBS)
+            set(_PC_TYPE)
+        else()
+            set(_PC_TYPE _STATIC)
+        endif()
+        set(RAV1E_LIBRARY_DIRS ${RAV1E_PC${_PC_TYPE}_LIBRARY_DIRS})
+        set(RAV1E_LIBRARIES ${RAV1E_PC${_PC_TYPE}_LIBRARIES})
+    endif()
 endif(PKG_CONFIG_FOUND)
 
 if(NOT RAV1E_INCLUDE_DIR)
     find_path(
         RAV1E_INCLUDE_DIR
         NAMES rav1e.h
-        PATHS ${_RAV1E_INCLUDEDIR}
+        PATHS ${RAV1E_PC_INCLUDE_DIRS}
         PATH_SUFFIXES rav1e
     )
 endif()
 
-if(NOT RAV1E_LIBRARY)
-    find_library(RAV1E_LIBRARY NAMES rav1e PATHS ${_RAV1E_LIBDIR})
-endif()
+find_library(RAV1E_LIBRARY NAMES rav1e PATHS ${RAV1E_PC_LIBRARY_DIRS})
 
-set(RAV1E_LIBRARIES ${RAV1E_LIBRARIES} ${RAV1E_LIBRARY} ${_RAV1E_LDFLAGS})
+# Remove -lrav1e since it will be replaced with full librav1e library path
+if(RAV1E_LIBRARIES)
+    list(REMOVE_ITEM RAV1E_LIBRARIES "rav1e")
+endif()
+set(RAV1E_LIBRARIES ${RAV1E_LIBRARY} ${RAV1E_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
     rav1e
     FOUND_VAR RAV1E_FOUND
     REQUIRED_VARS RAV1E_LIBRARY RAV1E_LIBRARIES RAV1E_INCLUDE_DIR
-    VERSION_VAR _RAV1E_VERSION
+    VERSION_VAR RAV1E_PC_VERSION
 )
 
-# show the RAV1E_INCLUDE_DIR, RAV1E_LIBRARY and RAV1E_LIBRARIES variables only
-# in the advanced view
-mark_as_advanced(RAV1E_INCLUDE_DIR RAV1E_LIBRARY RAV1E_LIBRARIES)
+# show the RAV1E_INCLUDE_DIR, RAV1E_LIBRARY, RAV1E_LIBRARIES, and RAV1E_PC_FOUND variables only in the advanced view
+mark_as_advanced(RAV1E_INCLUDE_DIR RAV1E_LIBRARY RAV1E_LIBRARIES RAV1E_PC_FOUND)

--- a/cmake/Modules/Findsvt.cmake
+++ b/cmake/Modules/Findsvt.cmake
@@ -20,15 +20,26 @@
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
     pkg_check_modules(_SVT SvtAv1Enc)
+    if(_SVT_FOUND)
+        if(BUILD_SHARED_LIBS)
+            set(_PC_TYPE)
+        else()
+            set(_PC_TYPE _STATIC)
+        endif()
+        set(SVT_LIBRARY_DIRS ${_SVT${_PC_TYPE}_LIBRARY_DIRS})
+        set(SVT_LIBRARIES ${_SVT${_PC_TYPE}_LIBRARIES})
+    endif()
 endif(PKG_CONFIG_FOUND)
 
-find_path(SVT_INCLUDE_DIR NAMES svt-av1/EbSvtAv1Enc.h PATHS ${_SVT_INCLUDEDIR})
+find_path(SVT_INCLUDE_DIR NAMES svt-av1/EbSvtAv1Enc.h PATHS ${_SVT_INCLUDE_DIRS})
 
-find_library(SVT_LIBRARY NAMES SvtAv1Enc PATHS ${_SVT_LIBDIR})
+find_library(SVT_LIBRARY NAMES SvtAv1Enc PATHS ${_SVT_LIBRARY_DIRS})
 
-if(SVT_LIBRARY)
-    set(SVT_LIBRARIES ${SVT_LIBRARIES} ${SVT_LIBRARY})
-endif(SVT_LIBRARY)
+# Remove -lSvtAv1Enc since it will be replaced with full library path
+if(SVT_LIBRARIES)
+    list(REMOVE_ITEM SVT_LIBRARIES "SvtAv1Enc")
+endif()
+set(SVT_LIBRARIES ${SVT_LIBRARY} ${SVT_LIBRARIES})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/cmake/Modules/merge_static_libs.cmake
+++ b/cmake/Modules/merge_static_libs.cmake
@@ -1,65 +1,98 @@
-function(merge_static_libs target)
-  set(args ${ARGN})
-
-  foreach(lib ${args})
-    if("${lib}" MATCHES "(\\${CMAKE_STATIC_LIBRARY_SUFFIX}|dav1d\.a)$")
-      list(APPEND libs ${lib})
+# # Determine library name (lib) from file name (/path/liblib.a).
+function(avif_lib_filename_to_name lib_name lib_filename)
+    set(${lib_name} "" PARENT_SCOPE)
+    get_filename_component(lib_basename "${lib_filename}" NAME)
+    string(REGEX REPLACE "(.)" "\\\\\\1" lib_prefix_regex "${CMAKE_STATIC_LIBRARY_PREFIX}")
+    string(REGEX REPLACE "([.])" "\\\\\\1" lib_suffix_regex "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    set(lib_name_regex "^${CMAKE_STATIC_LIBRARY_PREFIX}([^.]+)${lib_suffix_regex}$")
+    if(${lib_basename} MATCHES "${lib_name_regex}")
+        set(${lib_name} "${CMAKE_MATCH_1}" PARENT_SCOPE)
     endif()
-  endforeach()
+endfunction()
 
-  if(APPLE)
-    add_custom_command(
-      TARGET ${target}
-      POST_BUILD
-      COMMENT "Merge static libraries with libtool"
-      COMMAND ${CMAKE_COMMAND} -E rename $<TARGET_FILE:${target}> $<TARGET_FILE:${target}>.tmp
-      COMMAND xcrun libtool -static -o $<TARGET_FILE:${target}> $<TARGET_FILE:${target}>.tmp ${libs}
-      COMMAND ${CMAKE_COMMAND} -E remove $<TARGET_FILE:${target}>.tmp
-    )
-  elseif(CMAKE_C_COMPILER_ID MATCHES "^(Clang|GNU|Intel|IntelLLVM)$")
-    add_custom_command(
-      TARGET ${target}
-      POST_BUILD
-      COMMENT "Merge static libraries with ar"
-      COMMAND ${CMAKE_COMMAND} -E rename $<TARGET_FILE:${target}> $<TARGET_FILE:${target}>.tmp
-      COMMAND ${CMAKE_COMMAND} -E echo CREATE $<TARGET_FILE:${target}> >script.ar
-      COMMAND ${CMAKE_COMMAND} -E echo ADDLIB $<TARGET_FILE:${target}>.tmp >>script.ar
-    )
+function(merge_static_libs target)
+    set(args ${ARGN})
 
-    foreach(lib ${libs})
-      add_custom_command(TARGET ${target} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E echo ADDLIB ${lib} >>script.ar
-      )
+    set(dependencies)
+
+    string(REGEX REPLACE "(.)" "\\\\\\1" src_dir_regex "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    foreach(lib ${args})
+        if(TARGET "${lib}")
+            get_target_property(target_type ${lib} TYPE)
+
+            if(${target_type} STREQUAL "STATIC_LIBRARY")
+                list(APPEND libs $<TARGET_FILE:${lib}>)
+                list(APPEND dependencies "${lib}")
+            endif()
+        elseif("${lib}" MATCHES "(\\${CMAKE_STATIC_LIBRARY_SUFFIX}|dav1d\.a)$")
+            if(AVIF_STATIC_SYSTEM_LIBRARY_MERGE OR "${lib}" MATCHES "^${src_dir_regex}[/\\\\]ext")
+                list(APPEND libs "${lib}")
+                avif_lib_filename_to_name(lib_name "${lib}")
+                list(REMOVE_ITEM AVIF_PKG_CONFIG_REQUIRES "${lib_name}" "lib${lib_name}")
+                list(REMOVE_ITEM AVIF_PKG_CONFIG_LIBS "${CMAKE_LINK_LIBRARY_FLAG}${lib_name}")
+            endif()
+
+            if(EXISTS "${lib}")
+                list(APPEND dependencies "${lib}")
+            endif()
+        endif()
     endforeach()
 
+    set(source_file ${CMAKE_CURRENT_BINARY_DIR}/${target}_depends.c)
+    add_library(${target} STATIC ${source_file})
+
     add_custom_command(
-      TARGET ${target}
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E echo SAVE >>script.ar
-      COMMAND ${CMAKE_COMMAND} -E echo END >>script.ar
-      COMMAND ${CMAKE_AR} -M <script.ar
-      COMMAND ${CMAKE_COMMAND} -E remove $<TARGET_FILE:${target}>.tmp script.ar
+        OUTPUT ${source_file} DEPENDS ${dependencies} COMMAND ${CMAKE_COMMAND} -E echo \"const int dummy = 0\;\" > ${source_file}
     )
-  elseif(MSVC)
-    if(CMAKE_LIBTOOL)
-      set(BUNDLE_TOOL ${CMAKE_LIBTOOL})
+
+    add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E remove $<TARGET_FILE:${target}>)
+
+    if(APPLE)
+        add_custom_command(
+            TARGET ${target}
+            POST_BUILD
+            COMMENT "Merge static libraries with libtool"
+            COMMAND xcrun libtool -static -o $<TARGET_FILE:${target}> -no_warning_for_no_symbols ${libs}
+        )
+    elseif(CMAKE_C_COMPILER_ID MATCHES "^(Clang|GNU|Intel|IntelLLVM)$")
+        add_custom_command(
+            TARGET ${target}
+            POST_BUILD
+            COMMENT "Merge static libraries with ar"
+            COMMAND ${CMAKE_COMMAND} -E echo CREATE $<TARGET_FILE:${target}> >script.ar
+        )
+
+        foreach(lib ${libs})
+            add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E echo ADDLIB ${lib} >>script.ar)
+        endforeach()
+
+        add_custom_command(
+            TARGET ${target}
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E echo SAVE >>script.ar
+            COMMAND ${CMAKE_COMMAND} -E echo END >>script.ar
+            COMMAND ${CMAKE_AR} -M <script.ar
+            COMMAND ${CMAKE_COMMAND} -E remove script.ar
+        )
+    elseif(MSVC)
+        if(CMAKE_LIBTOOL)
+            set(BUNDLE_TOOL ${CMAKE_LIBTOOL})
+        else()
+            find_program(BUNDLE_TOOL lib HINTS "${CMAKE_C_COMPILER}/..")
+
+            if(NOT BUNDLE_TOOL)
+                message(FATAL_ERROR "Cannot locate lib.exe to bundle libraries")
+            endif()
+        endif()
+
+        add_custom_command(
+            TARGET ${target}
+            POST_BUILD
+            COMMENT "Merge static libraries with lib.exe"
+            COMMAND ${BUNDLE_TOOL} /NOLOGO /OUT:$<TARGET_FILE:${target}> ${libs}
+        )
     else()
-      find_program(BUNDLE_TOOL lib HINTS "${CMAKE_C_COMPILER}/..")
-
-      if(NOT BUNDLE_TOOL)
-        message(FATAL_ERROR "Cannot locate lib.exe to bundle libraries")
-      endif()
+        message(FATAL_ERROR "Unsupported platform for static link merging")
     endif()
-
-    add_custom_command(
-      TARGET ${target}
-      POST_BUILD
-      COMMENT "Merge static libraries with lib.exe"
-      COMMAND ${CMAKE_COMMAND} -E rename $<TARGET_FILE:${target}> $<TARGET_FILE:${target}>.tmp
-      COMMAND ${BUNDLE_TOOL} /NOLOGO /OUT:$<TARGET_FILE:${target}> $<TARGET_FILE:${target}>.tmp ${libs}
-      COMMAND ${CMAKE_COMMAND} -E remove $<TARGET_FILE:${target}>.tmp
-    )
-  else()
-    message(FATAL_ERROR "Unsupported platform for static link merging")
-  endif()
 endfunction()

--- a/libavif.pc.cmake
+++ b/libavif.pc.cmake
@@ -6,5 +6,7 @@ includedir=@PC_INCLUDEDIR@
 Name: @PROJECT_NAME@
 Description: Library for encoding and decoding .avif files
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} -lavif
+Requires:@AVIF_PKG_CONFIG_REQUIRES@
+Libs: -L${libdir} -lavif@AVIF_PKG_CONFIG_LIBS@
+Libs.private:@AVIF_PKG_CONFIG_LIBS_PRIVATE@
 Cflags: -I${includedir}@AVIF_PKG_CONFIG_EXTRA_CFLAGS@

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,10 +9,11 @@ enable_testing()
 # C tests and tools
 
 add_executable(aviftest aviftest.c)
-if(AVIF_LOCAL_LIBGAV1)
+if(AVIF_USE_CXX)
     set_target_properties(aviftest PROPERTIES LINKER_LANGUAGE "CXX")
 endif()
-target_link_libraries(aviftest avif ${AVIF_PLATFORM_LIBRARIES})
+target_link_libraries(aviftest ${AVIF_LINK_LIBRARIES})
+target_link_directories(aviftest PUBLIC ${AVIF_LINK_DIRS})
 add_test(NAME aviftest COMMAND aviftest ${CMAKE_CURRENT_SOURCE_DIR}/data)
 
 if(AVIF_ENABLE_COVERAGE)
@@ -31,10 +32,11 @@ if(AVIF_ENABLE_COVERAGE)
 endif()
 
 add_executable(avifyuv avifyuv.c)
-if(AVIF_LOCAL_LIBGAV1)
+if(AVIF_USE_CXX)
     set_target_properties(avifyuv PROPERTIES LINKER_LANGUAGE "CXX")
 endif()
-target_link_libraries(avifyuv avif ${AVIF_PLATFORM_LIBRARIES})
+target_link_libraries(avifyuv ${AVIF_LINK_LIBRARIES})
+target_link_directories(avifyuv PUBLIC ${AVIF_LINK_DIRS})
 foreach(AVIFYUV_MODE limited rgb) # Modes drift and premultiply take more than 2 minutes each so they are disabled.
     add_test(NAME avifyuv_${AVIFYUV_MODE} COMMAND avifyuv -m ${AVIFYUV_MODE})
 endforeach()
@@ -48,10 +50,11 @@ endif()
 
 # Fuzz target without any fuzzing engine dependency. For easy reproduction of oss-fuzz issues.
 add_executable(repro_avif_decode_fuzzer oss-fuzz/avif_decode_fuzzer.cc oss-fuzz/repro_fuzz.cc)
-if(AVIF_LOCAL_LIBGAV1)
+if(AVIF_USE_CXX)
     set_target_properties(repro_avif_decode_fuzzer PROPERTIES LINKER_LANGUAGE "CXX")
 endif()
-target_link_libraries(repro_avif_decode_fuzzer avif ${AVIF_PLATFORM_LIBRARIES})
+target_link_libraries(repro_avif_decode_fuzzer ${AVIF_LINK_LIBRARIES})
+target_link_directories(repro_avif_decode_fuzzer PUBLIC ${AVIF_LINK_DIRS})
 # The test below exists for coverage and as a usage example: repro_avif_decode_fuzzer [reproducer file path]
 add_test(NAME repro_avif_decode_fuzzer COMMAND repro_avif_decode_fuzzer
                                                ${CMAKE_CURRENT_SOURCE_DIR}/data/color_grid_alpha_nogrid.avif
@@ -66,6 +69,7 @@ macro(add_avif_gtest TEST_NAME)
     add_executable(${TEST_NAME} gtest/${TEST_NAME}.cc)
     target_include_directories(${TEST_NAME} PRIVATE ${GTEST_INCLUDE_DIRS})
     target_link_libraries(${TEST_NAME} PRIVATE aviftest_helpers ${GTEST_BOTH_LIBRARIES} ${ARGN})
+
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 endmacro()
 macro(add_avif_gtest_with_data TEST_NAME)
@@ -99,7 +103,8 @@ if(AVIF_ENABLE_GTEST OR AVIF_ENABLE_FUZZTEST)
     endif()
 
     add_library(avifincrtest_helpers OBJECT gtest/avifincrtest_helpers.cc)
-    target_link_libraries(avifincrtest_helpers avif ${AVIF_PLATFORM_LIBRARIES} ${GTEST_LIBRARIES})
+    target_link_libraries(avifincrtest_helpers ${AVIF_LINK_LIBRARIES} ${GTEST_LIBRARIES})
+    target_link_directories(avifincrtest_helpers PUBLIC ${AVIF_LINK_DIRS})
     target_include_directories(avifincrtest_helpers PUBLIC ${GTEST_INCLUDE_DIRS})
 endif()
 


### PR DESCRIPTION
This pull request is meant to replace #1683.

Overall, the purpose of this pull request is to address issues that cause static builds to fail. Many of the issues are due to the `find_package` modules not returning the list of static dependencies. For instance, building with `-DBUILD_SHARED_LIBS=OFF -DAVIF_LOCAL_LIBXML2=OFF` fails because of undefined symbols from libicu and liblzma (absent any library archive merging). The local libxml2 build doesn't have this problem because it's built without those dependencies, but rhel, debian, and homebrew libxml2 distributions have them. I went through and updated the `find_package` modules to take advantage of pkg-config where it's available. There were a few other issues I encountered when trying to do a static build with non-local dependencies for which I've included fixes. An enumerated list of the changes (I think it's exhaustive but I may have missed something):

- Adds a cmake option, `AVIF_STATIC_SYSTEM_LIBRARY_MERGE`, which will include non-local static libraries in the merged static archive. By default only local libraries are bundled.
- Sets `Requires`, `Libs`, and `Libs.private` fields to their correct values in libavif.pc, omitting any libraries that are bundled in libavif.a / avif.lib from `Libs.private`.
  - The unix static test was updated to test that one can compile and link against static libavif using pkg-config ([see here](https://github.com/fdintino/libavif/blob/52732574e29af72f7f2c8c776125ab56956d72dc/.github/workflows/ci-unix-static.yml#L153))
    
- Makes fixes to the find_package modules
  - Add modules for libjpeg and libxml2
  - Fix typos in `FindPkgConfig` variable names
    - `PREFIX_INCLUDEDIR` should be `PREFIX_INCLUDE_DIRS`
    - `PREFIX_LIBDIRS` should be `PREFIX_LIBRARY_DIRS`
  - If `pkg-config` finds the package, use the `PREFIX_LIBRARIES` it returns
  - Use the `STATIC_` variants of the above variables when building a static library
  - Set link directories returned by pkg-config on relevant targets
- When building local rav1e, extracts shared/static library dependencies from the pc file's contents, which will have the correct rust system dependencies for the build platform, including any differences between msvc, cygwin, and msys2. The hard-coded list of rav1e link libraries is only set for system rav1e that wasn't found by `pkg-config`.
- Sets the `LINKER_LANGUAGE` property to "CXX" on any targets that link against libgav1. This was previously only being done if `AVIF_LOCAL_LIBGAV1` was true, but it needs to be done for non-local libgav1 packages as well, to prevent the `libstdc++` linker errors that the original conditional was intended to fix.
- Tracks dependencies in cmake for any local libraries, so that changes in the ext directory cause the merged static avif archive to be rebuilt.