### PR TITLE
Refactor FuzztestStackLimitEnvironment()

### DIFF
--- a/tests/gtest/avif_fuzztest_dec.cc
+++ b/tests/gtest/avif_fuzztest_dec.cc
@@ -16,9 +16,7 @@ namespace libavif {
 namespace testutil {
 namespace {
 
-::testing::Environment* const stack_limit_env =
-    ::testing::AddGlobalTestEnvironment(
-        new FuzztestStackLimitEnvironment("524288"));  // 512 * 1024
+::testing::Environment* const kStackLimitEnv = SetStackLimitTo512x1024Bytes();
 
 //------------------------------------------------------------------------------
 

--- a/tests/gtest/avif_fuzztest_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_dec_incr.cc
@@ -18,9 +18,7 @@ namespace libavif {
 namespace testutil {
 namespace {
 
-::testing::Environment* const stack_limit_env =
-    ::testing::AddGlobalTestEnvironment(
-        new FuzztestStackLimitEnvironment("524288"));  // 512 * 1024
+::testing::Environment* const kStackLimitEnv = SetStackLimitTo512x1024Bytes();
 
 //------------------------------------------------------------------------------
 

--- a/tests/gtest/avif_fuzztest_enc_dec.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec.cc
@@ -13,9 +13,7 @@ namespace libavif {
 namespace testutil {
 namespace {
 
-::testing::Environment* const stack_limit_env =
-    ::testing::AddGlobalTestEnvironment(
-        new FuzztestStackLimitEnvironment("524288"));  // 512 * 1024
+::testing::Environment* const kStackLimitEnv = SetStackLimitTo512x1024Bytes();
 
 void EncodeDecodeValid(AvifImagePtr image, AvifEncoderPtr encoder,
                        AvifDecoderPtr decoder) {

--- a/tests/gtest/avif_fuzztest_enc_dec_anim.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_anim.cc
@@ -14,9 +14,7 @@ namespace libavif {
 namespace testutil {
 namespace {
 
-::testing::Environment* const stack_limit_env =
-    ::testing::AddGlobalTestEnvironment(
-        new FuzztestStackLimitEnvironment("524288"));  // 512 * 1024
+::testing::Environment* const kStackLimitEnv = SetStackLimitTo512x1024Bytes();
 
 struct FrameOptions {
   uint64_t duration;

--- a/tests/gtest/avif_fuzztest_enc_dec_experimental.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_experimental.cc
@@ -17,9 +17,7 @@ namespace libavif {
 namespace testutil {
 namespace {
 
-::testing::Environment* const stack_limit_env =
-    ::testing::AddGlobalTestEnvironment(
-        new FuzztestStackLimitEnvironment("524288"));  // 512 * 1024
+::testing::Environment* const kStackLimitEnv = SetStackLimitTo512x1024Bytes();
 
 void CheckGainMapMetadataMatches(const avifGainMapMetadata& actual,
                                  const avifGainMapMetadata& expected) {

--- a/tests/gtest/avif_fuzztest_enc_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_incr.cc
@@ -21,9 +21,7 @@ namespace libavif {
 namespace testutil {
 namespace {
 
-::testing::Environment* const stack_limit_env =
-    ::testing::AddGlobalTestEnvironment(
-        new FuzztestStackLimitEnvironment("524288"));  // 512 * 1024
+::testing::Environment* const kStackLimitEnv = SetStackLimitTo512x1024Bytes();
 
 // Encodes an image into an AVIF grid then decodes it.
 void EncodeDecodeGridValid(AvifImagePtr image, AvifEncoderPtr encoder,

--- a/tests/gtest/avif_fuzztest_enc_dec_incr_experimental.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_incr_experimental.cc
@@ -21,9 +21,7 @@ namespace libavif {
 namespace testutil {
 namespace {
 
-::testing::Environment* const stack_limit_env =
-    ::testing::AddGlobalTestEnvironment(
-        new FuzztestStackLimitEnvironment("524288"));  // 512 * 1024
+::testing::Environment* const kStackLimitEnv = SetStackLimitTo512x1024Bytes();
 
 // Encodes an image into an AVIF grid then decodes it.
 void EncodeDecodeGridValid(AvifImagePtr image, AvifEncoderPtr encoder,

--- a/tests/gtest/avif_fuzztest_helpers.cc
+++ b/tests/gtest/avif_fuzztest_helpers.cc
@@ -14,6 +14,7 @@
 #include "avif/avif.h"
 #include "avifutil.h"
 #include "fuzztest/fuzztest.h"
+#include "gtest/gtest.h"
 
 namespace libavif {
 namespace testutil {
@@ -191,6 +192,23 @@ std::vector<uint8_t> GetWhiteSinglePixelAvif() {
       0x0,  0x1f, 0x6d, 0x64, 0x61, 0x74, 0x12, 0x0,  0xa,  0x7,  0x38, 0x0,
       0x6,  0x10, 0x10, 0xd0, 0x69, 0x32, 0xa,  0x1f, 0xf0, 0x3f, 0xff, 0xff,
       0xc4, 0x0,  0x0,  0xaf, 0x70};
+}
+
+//------------------------------------------------------------------------------
+// Environment setup
+
+namespace {
+class Environment : public ::testing::Environment {
+ public:
+  Environment(const char* key, const char* value) : key_(key), value_(value) {}
+  void SetUp() override { setenv(key_, value_, 1); }
+  const char* key_;
+  const char* value_;
+};
+}  // namespace
+
+::testing::Environment* SetEnv(const char* key, const char* value) {
+  return ::testing::AddGlobalTestEnvironment(new Environment(key, value));
 }
 
 //------------------------------------------------------------------------------

--- a/tests/gtest/avif_fuzztest_helpers.h
+++ b/tests/gtest/avif_fuzztest_helpers.h
@@ -4,8 +4,8 @@
 #ifndef LIBAVIF_TESTS_OSS_FUZZ_AVIF_FUZZTEST_HELPERS_H_
 #define LIBAVIF_TESTS_OSS_FUZZ_AVIF_FUZZTEST_HELPERS_H_
 
+#include <cstdint>
 #include <cstdlib>
-#include <memory>
 #include <vector>
 
 #include "avif/avif.h"
@@ -184,19 +184,16 @@ inline auto ArbitraryAvifDecoder() { return ArbitraryBaseAvifDecoder(); }
 // Returns a white pixel compressed with AVIF.
 std::vector<uint8_t> GetWhiteSinglePixelAvif();
 
-// Sets the FUZZTEST_STACK_LIMIT environment variable to the value passed to
-// the constructor.
-class FuzztestStackLimitEnvironment : public ::testing::Environment {
- public:
-  FuzztestStackLimitEnvironment(const char* stack_limit)
-      : stack_limit_(stack_limit) {}
-  ~FuzztestStackLimitEnvironment() override {}
+//------------------------------------------------------------------------------
+// Environment setup
 
-  void SetUp() override { setenv("FUZZTEST_STACK_LIMIT", stack_limit_, 1); }
+// Sets the environment variable 'key' to the 'value'.
+::testing::Environment* SetEnv(const char* key, const char* value);
 
- private:
-  const char* stack_limit_;
-};
+// Sets the FUZZTEST_STACK_LIMIT environment variable to 524288.
+inline ::testing::Environment* SetStackLimitTo512x1024Bytes() {
+  return SetEnv("FUZZTEST_STACK_LIMIT", "524288");
+}
 
 //------------------------------------------------------------------------------
 

--- a/tests/gtest/avif_fuzztest_read_image.cc
+++ b/tests/gtest/avif_fuzztest_read_image.cc
@@ -22,9 +22,7 @@ namespace libavif {
 namespace testutil {
 namespace {
 
-::testing::Environment* const stack_limit_env =
-    ::testing::AddGlobalTestEnvironment(
-        new FuzztestStackLimitEnvironment("524288"));  // 512 * 1024
+::testing::Environment* const kStackLimitEnv = SetStackLimitTo512x1024Bytes();
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
into SetStackLimitTo512x1024Bytes().