### PR TITLE
tests/oss-fuzz/build.sh: Minor cleanup

### DIFF
--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -19,7 +19,7 @@
 # https://github.com/google/oss-fuzz/blob/master/projects/libavif/build.sh
 # It builds the different fuzz targets.
 
-# build dav1d
+# build dependencies
 cd ext && bash dav1d.cmd && bash libyuv.cmd && cd ..
 
 # build libavif
@@ -33,7 +33,8 @@ ninja
 # build fuzzer
 $CXX $CXXFLAGS -std=c++11 -I../include \
     ../tests/oss-fuzz/avif_decode_fuzzer.cc -o $OUT/avif_decode_fuzzer \
-    $LIB_FUZZING_ENGINE libavif.a ../ext/dav1d/build/src/libdav1d.a
+    $LIB_FUZZING_ENGINE libavif.a ../ext/dav1d/build/src/libdav1d.a \
+    ../ext/libyuv/build/libyuv.a
 
 # copy seed corpus
 cp $SRC/avif_decode_seed_corpus.zip $OUT/


### PR DESCRIPTION
A follow-up to commit commit 60bbef7c47a8d564189df603ec12d4a9b67a71a5. Generalize a comment, and link with libyuv.a, which will be necessary when libavif.a is no longer a combined archive library.