### PR TITLE
Add missing 'useBaseColorSpace' field to avifGainMapMetadataDouble.

### DIFF
--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -607,6 +607,8 @@ static avifBool avifJPEGParseGainMapXMPProperties(const xmlNode * rootNode, avif
         metadataDouble.alternateOffset[i] = 1.0 / 64.0;
         metadataDouble.gainMapGamma[i] = 1.0;
     }
+    // Not in Adobe's spec but both color spaces should be the same so this value doesn't matter.
+    metadataDouble.useBaseColorSpace = AVIF_TRUE;
 
     AVIF_CHECK(avifJPEGFindGainMapPropertyDoubles(descNode, "HDRCapacityMin", &metadataDouble.baseHdrHeadroom, /*numDoubles=*/1));
     AVIF_CHECK(avifJPEGFindGainMapPropertyDoubles(descNode, "HDRCapacityMax", &metadataDouble.alternateHdrHeadroom, /*numDoubles=*/1));

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -651,6 +651,7 @@ typedef struct avifGainMapMetadataDouble
     double baseHdrHeadroom;
     double alternateHdrHeadroom;
     avifBool backwardDirection;
+    avifBool useBaseColorSpace;
 } avifGainMapMetadataDouble;
 
 // Converts a avifGainMapMetadataDouble to avifGainMapMetadata by converting double values

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -65,6 +65,7 @@ static void avifGainMapMetadataSetDefaults(avifGainMapMetadataDouble * metadata)
     }
     metadata->baseHdrHeadroom = 0.0;
     metadata->alternateHdrHeadroom = 1.0;
+    metadata->useBaseColorSpace = AVIF_TRUE;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -23,6 +23,7 @@ avifBool avifGainMapMetadataDoubleToFractions(avifGainMapMetadata * dst, const a
     AVIF_CHECK(avifDoubleToUnsignedFraction(src->baseHdrHeadroom, &dst->baseHdrHeadroomN, &dst->baseHdrHeadroomD));
     AVIF_CHECK(avifDoubleToUnsignedFraction(src->alternateHdrHeadroom, &dst->alternateHdrHeadroomN, &dst->alternateHdrHeadroomD));
     dst->backwardDirection = src->backwardDirection;
+    dst->useBaseColorSpace = src->useBaseColorSpace;
     return AVIF_TRUE;
 }
 
@@ -50,6 +51,7 @@ avifBool avifGainMapMetadataFractionsToDouble(avifGainMapMetadataDouble * dst, c
     dst->baseHdrHeadroom = (double)src->baseHdrHeadroomN / src->baseHdrHeadroomD;
     dst->alternateHdrHeadroom = (double)src->alternateHdrHeadroomN / src->alternateHdrHeadroomD;
     dst->backwardDirection = src->backwardDirection;
+    dst->useBaseColorSpace = src->useBaseColorSpace;
     return AVIF_TRUE;
 }
 

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -41,8 +41,9 @@ void CheckGainMapMetadataMatches(const avifGainMapMetadata& lhs,
 }
 
 avifGainMapMetadata GetTestGainMapMetadata(bool base_rendition_is_hdr) {
-  avifGainMapMetadata metadata;
+  avifGainMapMetadata metadata = {};
   metadata.backwardDirection = base_rendition_is_hdr;
+  metadata.useBaseColorSpace = true;
   metadata.baseHdrHeadroomN = 0;
   metadata.baseHdrHeadroomD = 1;
   metadata.alternateHdrHeadroomN = 6;

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -819,7 +819,8 @@ TEST(GainMapTest, ConvertMetadataToDoubleInvalid) {
 }
 
 static void SwapBaseAndAlternate(avifGainMapMetadata& metadata) {
-  metadata.backwardDirection = true;
+  metadata.backwardDirection = !metadata.backwardDirection;
+  metadata.useBaseColorSpace = !metadata.useBaseColorSpace;
   std::swap(metadata.baseHdrHeadroomN, metadata.alternateHdrHeadroomN);
   std::swap(metadata.baseHdrHeadroomD, metadata.alternateHdrHeadroomD);
   for (int c = 0; c < 3; ++c) {


### PR DESCRIPTION
Fixes b/309764546