### PR TITLE
Only call enable_language and set CMAKE_CXX_STANDARD once.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ option(
 
 set(AVIF_USE_CXX OFF)
 
-if(AVIF_LOCAL_LIBGAV1)
+if(AVIF_BUILD_APPS OR AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST OR AVIF_LOCAL_LIBGAV1)
     set(AVIF_USE_CXX ON)
 endif()
 
@@ -725,6 +725,7 @@ endif()
 
 if(AVIF_USE_CXX)
     enable_language(CXX)
+    set(CMAKE_CXX_STANDARD 14)
 endif()
 
 option(AVIF_BUILD_APPS "Build avif apps." OFF)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,8 +40,6 @@ foreach(AVIFYUV_MODE limited rgb) # Modes drift and premultiply take more than 2
 endforeach()
 
 if(AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST OR AVIF_BUILD_APPS)
-    enable_language(CXX)
-    set(CMAKE_CXX_STANDARD 14)
     add_library(aviftest_helpers OBJECT gtest/aviftest_helpers.cc)
     target_link_libraries(aviftest_helpers avif_apps avif_internal)
 endif()


### PR DESCRIPTION
This is to make sure CMAKE_CXX_STANDARD is the smallest value that fits all needs.