### PR TITLE
Format iccjpeg.h/c

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,9 @@ sources from the top-level folder:
 
 ```sh
 clang-format -style=file -i \
-  apps/*.c apps/shared/avifexif.* apps/shared/avifjpeg.* \
-  apps/shared/avifpng.* apps/shared/avifutil.* apps/shared/y4m.* \
-  examples/*.c include/avif/*.h src/*.c tests/*.c \
-  tests/gtest/*.h tests/gtest/*.cc tests/oss-fuzz/*.cc
+  apps/*.c apps/**/*.c apps/**/*.h  examples/*.c \
+  include/avif/*.h src/*.c src/*.cc \
+  tests/*.c tests/**/*.cc tests/**/*.h
 ```
 
 Use [cmake-format](https://github.com/cheshirekow/cmake_format) to format the

--- a/apps/shared/iccjpeg.c
+++ b/apps/shared/iccjpeg.c
@@ -18,8 +18,7 @@
  */
 
 #include "iccjpeg.h"
-#include <stdlib.h>			/* define malloc() */
-
+#include <stdlib.h> /* define malloc() */
 
 /*
  * Since an ICC profile can be larger than the maximum size of a JPEG marker
@@ -34,11 +33,10 @@
  * rather than assuming that the APP2 markers appear in the correct sequence.
  */
 
-#define ICC_MARKER  (JPEG_APP0 + 2)	/* JPEG marker code for ICC */
-#define ICC_OVERHEAD_LEN  14		/* size of non-profile data in APP2 */
-#define MAX_BYTES_IN_MARKER  65533	/* maximum data len of a JPEG marker */
-#define MAX_DATA_BYTES_IN_MARKER  (MAX_BYTES_IN_MARKER - ICC_OVERHEAD_LEN)
-
+#define ICC_MARKER (JPEG_APP0 + 2) /* JPEG marker code for ICC */
+#define ICC_OVERHEAD_LEN 14        /* size of non-profile data in APP2 */
+#define MAX_BYTES_IN_MARKER 65533  /* maximum data len of a JPEG marker */
+#define MAX_DATA_BYTES_IN_MARKER (MAX_BYTES_IN_MARKER - ICC_OVERHEAD_LEN)
 
 /*
  * This routine writes the given ICC profile data into a JPEG file.
@@ -48,99 +46,80 @@
  * SOI and JFIF or Adobe markers, but before all else.)
  */
 
-void
-write_icc_profile (j_compress_ptr cinfo,
-		   const JOCTET *icc_data_ptr,
-		   unsigned int icc_data_len)
+void write_icc_profile(j_compress_ptr cinfo, const JOCTET * icc_data_ptr, unsigned int icc_data_len)
 {
-  unsigned int num_markers;	/* total number of markers we'll write */
-  int cur_marker = 1;		/* per spec, counting starts at 1 */
-  unsigned int length;		/* number of bytes to write in this marker */
+    unsigned int num_markers; /* total number of markers we'll write */
+    int cur_marker = 1;       /* per spec, counting starts at 1 */
+    unsigned int length;      /* number of bytes to write in this marker */
 
-  /* Calculate the number of markers we'll need, rounding up of course */
-  num_markers = icc_data_len / MAX_DATA_BYTES_IN_MARKER;
-  if (num_markers * MAX_DATA_BYTES_IN_MARKER != icc_data_len)
-    num_markers++;
+    /* Calculate the number of markers we'll need, rounding up of course */
+    num_markers = icc_data_len / MAX_DATA_BYTES_IN_MARKER;
+    if (num_markers * MAX_DATA_BYTES_IN_MARKER != icc_data_len)
+        num_markers++;
 
-  while (icc_data_len > 0) {
-    /* length of profile to put in this marker */
-    length = icc_data_len;
-    if (length > MAX_DATA_BYTES_IN_MARKER)
-      length = MAX_DATA_BYTES_IN_MARKER;
-    icc_data_len -= length;
+    while (icc_data_len > 0) {
+        /* length of profile to put in this marker */
+        length = icc_data_len;
+        if (length > MAX_DATA_BYTES_IN_MARKER)
+            length = MAX_DATA_BYTES_IN_MARKER;
+        icc_data_len -= length;
 
-    /* Write the JPEG marker header (APP2 code and marker length) */
-    jpeg_write_m_header(cinfo, ICC_MARKER,
-			(unsigned int) (length + ICC_OVERHEAD_LEN));
+        /* Write the JPEG marker header (APP2 code and marker length) */
+        jpeg_write_m_header(cinfo, ICC_MARKER, (unsigned int)(length + ICC_OVERHEAD_LEN));
 
-    /* Write the marker identifying string "ICC_PROFILE" (null-terminated).
+        /* Write the marker identifying string "ICC_PROFILE" (null-terminated).
      * We code it in this less-than-transparent way so that the code works
      * even if the local character set is not ASCII.
      */
-    jpeg_write_m_byte(cinfo, 0x49);
-    jpeg_write_m_byte(cinfo, 0x43);
-    jpeg_write_m_byte(cinfo, 0x43);
-    jpeg_write_m_byte(cinfo, 0x5F);
-    jpeg_write_m_byte(cinfo, 0x50);
-    jpeg_write_m_byte(cinfo, 0x52);
-    jpeg_write_m_byte(cinfo, 0x4F);
-    jpeg_write_m_byte(cinfo, 0x46);
-    jpeg_write_m_byte(cinfo, 0x49);
-    jpeg_write_m_byte(cinfo, 0x4C);
-    jpeg_write_m_byte(cinfo, 0x45);
-    jpeg_write_m_byte(cinfo, 0x0);
+        jpeg_write_m_byte(cinfo, 0x49);
+        jpeg_write_m_byte(cinfo, 0x43);
+        jpeg_write_m_byte(cinfo, 0x43);
+        jpeg_write_m_byte(cinfo, 0x5F);
+        jpeg_write_m_byte(cinfo, 0x50);
+        jpeg_write_m_byte(cinfo, 0x52);
+        jpeg_write_m_byte(cinfo, 0x4F);
+        jpeg_write_m_byte(cinfo, 0x46);
+        jpeg_write_m_byte(cinfo, 0x49);
+        jpeg_write_m_byte(cinfo, 0x4C);
+        jpeg_write_m_byte(cinfo, 0x45);
+        jpeg_write_m_byte(cinfo, 0x0);
 
-    /* Add the sequencing info */
-    jpeg_write_m_byte(cinfo, cur_marker);
-    jpeg_write_m_byte(cinfo, (int) num_markers);
+        /* Add the sequencing info */
+        jpeg_write_m_byte(cinfo, cur_marker);
+        jpeg_write_m_byte(cinfo, (int)num_markers);
 
-    /* Add the profile data */
-    while (length--) {
-      jpeg_write_m_byte(cinfo, *icc_data_ptr);
-      icc_data_ptr++;
+        /* Add the profile data */
+        while (length--) {
+            jpeg_write_m_byte(cinfo, *icc_data_ptr);
+            icc_data_ptr++;
+        }
+        cur_marker++;
     }
-    cur_marker++;
-  }
 }
-
 
 /*
  * Prepare for reading an ICC profile
  */
 
-void
-setup_read_icc_profile (j_decompress_ptr cinfo)
+void setup_read_icc_profile(j_decompress_ptr cinfo)
 {
-  /* Tell the library to keep any APP2 data it may find */
-  jpeg_save_markers(cinfo, ICC_MARKER, 0xFFFF);
+    /* Tell the library to keep any APP2 data it may find */
+    jpeg_save_markers(cinfo, ICC_MARKER, 0xFFFF);
 }
-
 
 /*
  * Handy subroutine to test whether a saved marker is an ICC profile marker.
  */
 
-static boolean
-marker_is_icc (jpeg_saved_marker_ptr marker)
+static boolean marker_is_icc(jpeg_saved_marker_ptr marker)
 {
-  return
-    marker->marker == ICC_MARKER &&
-    marker->data_length >= ICC_OVERHEAD_LEN &&
-    /* verify the identifying string */
-    GETJOCTET(marker->data[0]) == 0x49 &&
-    GETJOCTET(marker->data[1]) == 0x43 &&
-    GETJOCTET(marker->data[2]) == 0x43 &&
-    GETJOCTET(marker->data[3]) == 0x5F &&
-    GETJOCTET(marker->data[4]) == 0x50 &&
-    GETJOCTET(marker->data[5]) == 0x52 &&
-    GETJOCTET(marker->data[6]) == 0x4F &&
-    GETJOCTET(marker->data[7]) == 0x46 &&
-    GETJOCTET(marker->data[8]) == 0x49 &&
-    GETJOCTET(marker->data[9]) == 0x4C &&
-    GETJOCTET(marker->data[10]) == 0x45 &&
-    GETJOCTET(marker->data[11]) == 0x0;
+    return marker->marker == ICC_MARKER && marker->data_length >= ICC_OVERHEAD_LEN &&
+           /* verify the identifying string */
+           GETJOCTET(marker->data[0]) == 0x49 && GETJOCTET(marker->data[1]) == 0x43 && GETJOCTET(marker->data[2]) == 0x43 &&
+           GETJOCTET(marker->data[3]) == 0x5F && GETJOCTET(marker->data[4]) == 0x50 && GETJOCTET(marker->data[5]) == 0x52 &&
+           GETJOCTET(marker->data[6]) == 0x4F && GETJOCTET(marker->data[7]) == 0x46 && GETJOCTET(marker->data[8]) == 0x49 &&
+           GETJOCTET(marker->data[9]) == 0x4C && GETJOCTET(marker->data[10]) == 0x45 && GETJOCTET(marker->data[11]) == 0x0;
 }
-
 
 /*
  * See if there was an ICC profile in the JPEG file being read;
@@ -161,88 +140,85 @@ marker_is_icc (jpeg_saved_marker_ptr marker)
  * return FALSE.  You might want to issue an error message instead.
  */
 
-boolean
-read_icc_profile (j_decompress_ptr cinfo,
-		  JOCTET **icc_data_ptr,
-		  unsigned int *icc_data_len)
+boolean read_icc_profile(j_decompress_ptr cinfo, JOCTET ** icc_data_ptr, unsigned int * icc_data_len)
 {
-  jpeg_saved_marker_ptr marker;
-  int num_markers = 0;
-  int seq_no;
-  JOCTET *icc_data;
-  unsigned int total_length;
-#define MAX_SEQ_NO  255		/* sufficient since marker numbers are bytes */
-  char marker_present[MAX_SEQ_NO+1];	  /* 1 if marker found */
-  unsigned int data_length[MAX_SEQ_NO+1]; /* size of profile data in marker */
-  unsigned int data_offset[MAX_SEQ_NO+1]; /* offset for data in marker */
+    jpeg_saved_marker_ptr marker;
+    int num_markers = 0;
+    int seq_no;
+    JOCTET * icc_data;
+    unsigned int total_length;
+#define MAX_SEQ_NO 255                        /* sufficient since marker numbers are bytes */
+    char marker_present[MAX_SEQ_NO + 1];      /* 1 if marker found */
+    unsigned int data_length[MAX_SEQ_NO + 1]; /* size of profile data in marker */
+    unsigned int data_offset[MAX_SEQ_NO + 1]; /* offset for data in marker */
 
-  *icc_data_ptr = NULL;		/* avoid confusion if FALSE return */
-  *icc_data_len = 0;
+    *icc_data_ptr = NULL; /* avoid confusion if FALSE return */
+    *icc_data_len = 0;
 
-  /* This first pass over the saved markers discovers whether there are
+    /* This first pass over the saved markers discovers whether there are
    * any ICC markers and verifies the consistency of the marker numbering.
    */
 
-  for (seq_no = 1; seq_no <= MAX_SEQ_NO; seq_no++)
-    marker_present[seq_no] = 0;
+    for (seq_no = 1; seq_no <= MAX_SEQ_NO; seq_no++)
+        marker_present[seq_no] = 0;
 
-  for (marker = cinfo->marker_list; marker != NULL; marker = marker->next) {
-    if (marker_is_icc(marker)) {
-      if (num_markers == 0)
-	num_markers = GETJOCTET(marker->data[13]);
-      else if (num_markers != GETJOCTET(marker->data[13]))
-	return FALSE;		/* inconsistent num_markers fields */
-      seq_no = GETJOCTET(marker->data[12]);
-      if (seq_no <= 0 || seq_no > num_markers)
-	return FALSE;		/* bogus sequence number */
-      if (marker_present[seq_no])
-	return FALSE;		/* duplicate sequence numbers */
-      marker_present[seq_no] = 1;
-      data_length[seq_no] = marker->data_length - ICC_OVERHEAD_LEN;
+    for (marker = cinfo->marker_list; marker != NULL; marker = marker->next) {
+        if (marker_is_icc(marker)) {
+            if (num_markers == 0)
+                num_markers = GETJOCTET(marker->data[13]);
+            else if (num_markers != GETJOCTET(marker->data[13]))
+                return FALSE; /* inconsistent num_markers fields */
+            seq_no = GETJOCTET(marker->data[12]);
+            if (seq_no <= 0 || seq_no > num_markers)
+                return FALSE; /* bogus sequence number */
+            if (marker_present[seq_no])
+                return FALSE; /* duplicate sequence numbers */
+            marker_present[seq_no] = 1;
+            data_length[seq_no] = marker->data_length - ICC_OVERHEAD_LEN;
+        }
     }
-  }
 
-  if (num_markers == 0)
-    return FALSE;
+    if (num_markers == 0)
+        return FALSE;
 
-  /* Check for missing markers, count total space needed,
+    /* Check for missing markers, count total space needed,
    * compute offset of each marker's part of the data.
    */
 
-  total_length = 0;
-  for (seq_no = 1; seq_no <= num_markers; seq_no++) {
-    if (marker_present[seq_no] == 0)
-      return FALSE;		/* missing sequence number */
-    data_offset[seq_no] = total_length;
-    total_length += data_length[seq_no];
-  }
-
-  if (total_length == 0)
-    return FALSE;		/* found only empty markers? */
-
-  /* Allocate space for assembled data */
-  icc_data = (JOCTET *) malloc(total_length * sizeof(JOCTET));
-  if (icc_data == NULL)
-    return FALSE;		/* oops, out of memory */
-
-  /* and fill it in */
-  for (marker = cinfo->marker_list; marker != NULL; marker = marker->next) {
-    if (marker_is_icc(marker)) {
-      JOCTET FAR *src_ptr;
-      JOCTET *dst_ptr;
-      unsigned int length;
-      seq_no = GETJOCTET(marker->data[12]);
-      dst_ptr = icc_data + data_offset[seq_no];
-      src_ptr = marker->data + ICC_OVERHEAD_LEN;
-      length = data_length[seq_no];
-      while (length--) {
-	*dst_ptr++ = *src_ptr++;
-      }
+    total_length = 0;
+    for (seq_no = 1; seq_no <= num_markers; seq_no++) {
+        if (marker_present[seq_no] == 0)
+            return FALSE; /* missing sequence number */
+        data_offset[seq_no] = total_length;
+        total_length += data_length[seq_no];
     }
-  }
 
-  *icc_data_ptr = icc_data;
-  *icc_data_len = total_length;
+    if (total_length == 0)
+        return FALSE; /* found only empty markers? */
 
-  return TRUE;
+    /* Allocate space for assembled data */
+    icc_data = (JOCTET *)malloc(total_length * sizeof(JOCTET));
+    if (icc_data == NULL)
+        return FALSE; /* oops, out of memory */
+
+    /* and fill it in */
+    for (marker = cinfo->marker_list; marker != NULL; marker = marker->next) {
+        if (marker_is_icc(marker)) {
+            JOCTET FAR * src_ptr;
+            JOCTET * dst_ptr;
+            unsigned int length;
+            seq_no = GETJOCTET(marker->data[12]);
+            dst_ptr = icc_data + data_offset[seq_no];
+            src_ptr = marker->data + ICC_OVERHEAD_LEN;
+            length = data_length[seq_no];
+            while (length--) {
+                *dst_ptr++ = *src_ptr++;
+            }
+        }
+    }
+
+    *icc_data_ptr = icc_data;
+    *icc_data_len = total_length;
+
+    return TRUE;
 }

--- a/apps/shared/iccjpeg.h
+++ b/apps/shared/iccjpeg.h
@@ -16,9 +16,9 @@
  * for details.
  */
 
-#include <stdio.h>		/* needed to define "FILE", "NULL" */
-#include "jpeglib.h"
+#include <stdio.h> /* needed to define "FILE", "NULL" */
 
+#include "jpeglib.h"
 
 /*
  * This routine writes the given ICC profile data into a JPEG file.
@@ -28,10 +28,7 @@
  * SOI and JFIF or Adobe markers, but before all else.)
  */
 
-extern void write_icc_profile JPP((j_compress_ptr cinfo,
-				   const JOCTET *icc_data_ptr,
-				   unsigned int icc_data_len));
-
+extern void write_icc_profile JPP((j_compress_ptr cinfo, const JOCTET * icc_data_ptr, unsigned int icc_data_len));
 
 /*
  * Reading a JPEG file that may contain an ICC profile requires two steps:
@@ -44,13 +41,11 @@ extern void write_icc_profile JPP((j_compress_ptr cinfo,
  *    whether there was a profile and obtain it if so.
  */
 
-
 /*
  * Prepare for reading an ICC profile
  */
 
 extern void setup_read_icc_profile JPP((j_decompress_ptr cinfo));
-
 
 /*
  * See if there was an ICC profile in the JPEG file being read;
@@ -68,6 +63,4 @@ extern void setup_read_icc_profile JPP((j_decompress_ptr cinfo));
  * will prefer to have the data stick around after decompression finishes.)
  */
 
-extern boolean read_icc_profile JPP((j_decompress_ptr cinfo,
-				     JOCTET **icc_data_ptr,
-				     unsigned int *icc_data_len));
+extern boolean read_icc_profile JPP((j_decompress_ptr cinfo, JOCTET ** icc_data_ptr, unsigned int * icc_data_len));


### PR DESCRIPTION
I'm not sure if the clang-format command line is supposed to be windows compatible, and if it is, if windows supports the double wildcards (if not I can remove them).
If we don't need that much compatibility, then a version with 'find' would be more future proof I think:
`find apps/ examples/ include/ src/ tests/ -regex '.*\.\(c\|cc\|h\)' | xargs clang-format -style=file -i`
Also, should contrib/ be added as well?