### PR TITLE
ci: Fix a typo in the ci-unix-static-av2 workflow so AV1+AV2 tests run 

### DIFF
--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -86,9 +86,9 @@ jobs:
         cmake .. -G Ninja
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AVM=ON -DAVIF_LOCAL_AVM=ON
-        -DAVIF_CODEC_DAV1D=${{ runner.also-enable-av1-codecs }} -DAVIF_LOCAL_DAV1D=ON
-        -DAVIF_CODEC_RAV1E=${{ runner.also-enable-av1-codecs }} -DAVIF_LOCAL_RAV1E=ON
-        -DAVIF_CODEC_SVT=${{ runner.also-enable-av1-codecs }} -DAVIF_LOCAL_SVT=ON
+        -DAVIF_CODEC_DAV1D=${{ matrix.also-enable-av1-codecs }} -DAVIF_LOCAL_DAV1D=ON
+        -DAVIF_CODEC_RAV1E=${{ matrix.also-enable-av1-codecs }} -DAVIF_LOCAL_RAV1E=ON
+        -DAVIF_CODEC_SVT=${{ matrix.also-enable-av1-codecs }} -DAVIF_LOCAL_SVT=ON
         -DAVIF_LOCAL_LIBYUV=ON
         -DAVIF_LOCAL_LIBSHARPYUV=ON
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON


### PR DESCRIPTION
A typo in the ci-unix-static-av2  GHA workflow prevented it from executing tests where AVM is enabled alongside other AV1 codecs.