### PR TITLE
fix: avif_android jni build.gradle config ndkVersion

### DIFF
--- a/android_jni/avifandroidjni/build.gradle
+++ b/android_jni/avifandroidjni/build.gradle
@@ -5,6 +5,7 @@ plugins {
 android {
     namespace 'org.aomedia.avif.android'
     compileSdk 30
+    ndkVersion "25.2.9519653"
 
     defaultConfig {
         minSdk 21


### PR DESCRIPTION
Setting `ANDROID_NDK_HOME` no longer has any effect in gradle. When you run `./gradlew --info` the log outputs:

```
C/C++: Not considering ANDROID_NDK_HOME because support was removed after deprecation period.
C/C++: Because no explicit NDK was requested, the default version [23.1.7779620] for this Android Gradle Plugin will be used
C/C++: android.ndkVersion from module build.gradle is [not set]
C/C++: android.ndkPath from module build.gradle is not set
C/C++: ndk.dir in local.properties is not set
```

This sets `android.ndkVersion` so that it matches the NDK version used in the github actions workflows.