### PR TITLE
Use a manifest on Windows for UTF8 handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -784,16 +784,27 @@ endif()
 
 if(AVIF_BUILD_APPS)
     add_executable(avifenc apps/avifenc.c)
-    if(AVIF_USE_CXX)
-        set_target_properties(avifenc PROPERTIES LINKER_LANGUAGE "CXX")
-    endif()
-    target_link_libraries(avifenc avif_apps)
     add_executable(avifdec apps/avifdec.c)
-    if(AVIF_USE_CXX)
-        set_target_properties(avifdec PROPERTIES LINKER_LANGUAGE "CXX")
-    endif()
-    target_link_libraries(avifdec avif_apps)
-
+    foreach(PROG IN ITEMS avifenc avifdec)
+        if(AVIF_USE_CXX)
+            set_target_properties(${PROG} PROPERTIES LINKER_LANGUAGE "CXX")
+        endif()
+        target_link_libraries(${PROG} avif_apps)
+        if(WIN32)
+            # Add a manifest file to deal with UTF8.
+            if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+                target_sources(${PROG} PUBLIC ${CMAKE_SOURCE_DIR}/src/utf8.manifest)
+            else()
+                add_custom_command(
+                    TARGET ${PROG}
+                    POST_BUILD
+                    COMMAND "mt.exe" -manifest \"${CMAKE_SOURCE_DIR}\\src\\utf8.manifest\"
+                            -inputresource:\"$<TARGET_FILE:${PROG}>\"\;\#1 -outputresource:\"$<TARGET_FILE:${PROG}>\"\;\#1
+                    COMMENT "Adding manifest..."
+                )
+            endif()
+        endif()
+    endforeach()
     if(NOT SKIP_INSTALL_APPS AND NOT SKIP_INSTALL_ALL)
         install(
             TARGETS avifenc avifdec

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -18,11 +18,6 @@
 // for setmode()
 #include <fcntl.h>
 #include <io.h>
-#include <locale.h>
-#define WIN32_LEAN_AND_MEAN
-// Avoid the DEFAULT_QUALITY macro redefinition warning caused by including wingdi.h.
-#define NOGDI
-#include <windows.h>
 #endif
 
 #define NEXTARG()                                                     \
@@ -1396,13 +1391,13 @@ static avifBool avifEncodeImages(avifSettings * settings,
     return AVIF_TRUE;
 }
 
-MAIN()
+int main(int argc, char * argv[])
 {
     if (argc < 2) {
         syntaxShort();
         return 1;
     }
-    INIT_ARGV()
+
     const char * outputFilename = NULL;
 
     avifInput input;
@@ -2580,6 +2575,6 @@ cleanup:
         avifCodecSpecificOptionsFree(&file->settings.codecSpecificOptions);
     }
     free(input.files);
-    FREE_ARGV()
+
     return returnCode;
 }

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -10,66 +10,6 @@
 extern "C" {
 #endif
 
-// MAIN(), INIT_ARGV(), FREE_ARGV() for UTF8-aware command line parsing.
-#if defined(_WIN32)
-#define MAIN() int wmain(int argc, wchar_t * wargv[])
-#else
-#define MAIN() int main(int argc, char * argv[])
-#endif
-
-#if defined(_WIN32)
-#ifdef __cplusplus
-#define INIT_ARGV()                                                                                           \
-    if (setlocale(LC_ALL, ".UTF8") == NULL) {                                                                 \
-        fprintf(stderr, "setlocale failed\n");                                                                \
-        return 1;                                                                                             \
-    }                                                                                                         \
-    std::vector<char> argvAllVector(1024 * argc);                                                             \
-    std::vector<char *> argvVector(argc);                                                                     \
-    char ** argv = argvVector.data();                                                                         \
-    for (int i = 0; i < argc; ++i) {                                                                          \
-        argvVector[i] = &argvAllVector[1024 * i];                                                             \
-        int rc = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wargv[i], -1, argv[i], 1024, NULL, NULL); \
-        if (rc == 0) {                                                                                        \
-            fprintf(stderr, "WideCharToMultiByte() failed\n");                                                \
-            return 1;                                                                                         \
-        }                                                                                                     \
-    }
-#else
-#define INIT_ARGV()                                                                                           \
-    char * argvAll = NULL;                                                                                    \
-    char ** argv = NULL;                                                                                      \
-    if (setlocale(LC_ALL, ".UTF8") == NULL) {                                                                 \
-        fprintf(stderr, "setlocale failed\n");                                                                \
-        return 1;                                                                                             \
-    }                                                                                                         \
-    argvAll = (char *)malloc(1024 * argc * sizeof(*argvAll));                                                 \
-    argv = (char **)malloc(argc * sizeof(*argv));                                                             \
-    if (argv == NULL || argvAll == NULL) {                                                                    \
-        FREE_ARGV()                                                                                           \
-        return 1;                                                                                             \
-    }                                                                                                         \
-    for (int i = 0; i < argc; ++i) {                                                                          \
-        argv[i] = argvAll + 1024 * i;                                                                         \
-        int rc = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wargv[i], -1, argv[i], 1024, NULL, NULL); \
-        if (rc == 0) {                                                                                        \
-            fprintf(stderr, "WideCharToMultiByte() failed\n");                                                \
-            FREE_ARGV()                                                                                       \
-            return 1;                                                                                         \
-        }                                                                                                     \
-    }
-#endif // __cplusplus
-#else
-#define INIT_ARGV()
-#endif
-#if defined(_WIN32) && !defined(__cplusplus)
-#define FREE_ARGV() \
-    free(argv);     \
-    free(argvAll);
-#else
-#define FREE_ARGV()
-#endif
-
 // The %z format specifier is not available in the old Windows CRT msvcrt,
 // hence the %I format specifier must be used instead to print out `size_t`.
 // The new Windows CRT UCRT, which is used by Visual Studio 2015 or later,

--- a/src/utf8.manifest
+++ b/src/utf8.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="..." version="6.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -224,6 +224,22 @@ if(AVIF_BUILD_APPS)
     # 'are_images_equal' is used to make sure inputs/outputs are unchanged.
     add_executable(are_images_equal gtest/are_images_equal.cc)
     target_link_libraries(are_images_equal aviftest_helpers)
+    if(WIN32)
+        # Add a manifest file to deal with UTF8.
+        if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+            target_sources(are_images_equal PUBLIC ${CMAKE_SOURCE_DIR}/src/utf8.manifest)
+        else()
+            add_custom_command(
+                TARGET are_images_equal
+                POST_BUILD
+                COMMAND
+                    "mt.exe" -manifest \"${CMAKE_SOURCE_DIR}\\src\\utf8.manifest\"
+                    -inputresource:\"$<TARGET_FILE:are_images_equal>\"\;\#1
+                    -outputresource:\"$<TARGET_FILE:are_images_equal>\"\;\#1
+                COMMENT "Adding manifest..."
+            )
+        endif()
+    endif()
     add_test(NAME test_cmd COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd.sh ${CMAKE_BINARY_DIR}
                                    ${CMAKE_CURRENT_SOURCE_DIR}/data
     )

--- a/tests/gtest/are_images_equal.cc
+++ b/tests/gtest/are_images_equal.cc
@@ -9,17 +9,9 @@
 #include "aviftest_helpers.h"
 #include "avifutil.h"
 
-#if defined(_WIN32)
-#include <locale.h>
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
-
 using avif::ImagePtr;
 
-MAIN() {
-  INIT_ARGV()
-
+int main(int argc, char** argv) {
   if (argc != 4 && argc != 5) {
     std::cerr << "Wrong argument: " << argv[0]
               << " file1 file2 ignore_alpha_flag [psnr_threshold]" << std::endl;
@@ -78,8 +70,6 @@ MAIN() {
     std::cout << "PSNR: " << psnr << ", images " << argv[1] << " and "
               << argv[2] << " are similar." << std::endl;
   }
-
-  FREE_ARGV()
 
   return 0;
 }


### PR DESCRIPTION
This first reverts https://github.com/AOMediaCodec/libavif/pull/1693 (except for test_cmd.sh) and applies a manifest on Windows platforms.

CMake handles manifests as source files on Windows but most likely only for MSVC (cf https://cmake.org/cmake/help/v3.4/release/3.4.html#other).