### PR TITLE
Return DECODE_FAILED on tile/choice codec mismatch

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -4115,6 +4115,21 @@ static avifResult avifCodecCreateInternal(avifCodecChoice choice, const avifTile
         choice = AVIF_CODEC_CHOICE_AVM;
     }
 #endif
+
+    const avifCodecType codecTypeFromChoice = avifCodecTypeFromChoice(choice, AVIF_CODEC_FLAG_CAN_DECODE);
+    if (codecTypeFromChoice == AVIF_CODEC_TYPE_UNKNOWN) {
+        avifDiagnosticsPrintf(diag,
+                              "Tile type is %s but there is no compatible codec available to decode it",
+                              avifGetConfigurationPropertyName(tile->codecType));
+        return AVIF_RESULT_NO_CODEC_AVAILABLE;
+    } else if (choice != AVIF_CODEC_CHOICE_AUTO && codecTypeFromChoice != tile->codecType) {
+        avifDiagnosticsPrintf(diag,
+                              "Tile type is %s but incompatible %s codec was explicitly set as decoding implementation",
+                              avifGetConfigurationPropertyName(tile->codecType),
+                              avifCodecName(choice, AVIF_CODEC_FLAG_CAN_DECODE));
+        return AVIF_RESULT_DECODE_COLOR_FAILED;
+    }
+
     AVIF_CHECKRES(avifCodecCreate(choice, AVIF_CODEC_FLAG_CAN_DECODE, codec));
     AVIF_CHECKERR(*codec, AVIF_RESULT_OUT_OF_MEMORY);
     (*codec)->diag = diag;

--- a/tests/gtest/avifavmtest.cc
+++ b/tests/gtest/avifavmtest.cc
@@ -51,11 +51,13 @@ TEST_P(AvmTest, EncodeDecode) {
        {AVIF_CODEC_CHOICE_AOM, AVIF_CODEC_CHOICE_DAV1D,
         AVIF_CODEC_CHOICE_LIBGAV1}) {
     decoder->codecChoice = av1_codec;
-    // AVIF_RESULT_NO_CODEC_AVAILABLE is expected because av1_codec is not
-    // enabled or because we are trying to decode an AV2 file with an AV1 codec.
+    // An error is expected because av1_codec is not enabled or because we are
+    // trying to decode an AV2 file with an AV1 codec.
     ASSERT_EQ(avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
                                     encoded.size),
-              AVIF_RESULT_NO_CODEC_AVAILABLE);
+              avifCodecName(av1_codec, AVIF_CODEC_FLAG_CAN_DECODE)
+                  ? AVIF_RESULT_DECODE_COLOR_FAILED
+                  : AVIF_RESULT_NO_CODEC_AVAILABLE);
   }
 }
 
@@ -114,7 +116,7 @@ TEST(AvmTest, Av1StillWorksWhenAvmIsEnabled) {
   decoder->codecChoice = AVIF_CODEC_CHOICE_AVM;
   ASSERT_EQ(avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
                                   encoded.size),
-            AVIF_RESULT_NO_CODEC_AVAILABLE);
+            AVIF_RESULT_DECODE_COLOR_FAILED);
 }
 
 }  // namespace


### PR DESCRIPTION
See https://github.com/AOMediaCodec/libavif/pull/1748.