### PR TITLE
Disable AVX2 on CI workflows that run on macos.

### DIFF
--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -26,6 +26,11 @@ jobs:
       if: runner.os == 'Linux'
       run: echo "CC=gcc-11" >> $GITHUB_ENV && echo "CXX=g++-11" >> $GITHUB_ENV
 
+    # Prevent spurious errors on macos, see https://github.com/AOMediaCodec/libavif/issues/1769
+    - name: Disable AVX2 in libaom
+      if: runner.os == 'macOS'
+      working-directory: ./ext
+      run: sed -i'' -e 's/^cmake /cmake -DENABLE_AVX2=OFF /' aom.cmd
     - name: Cache external dependencies
       id: cache-ext
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -34,6 +34,11 @@ jobs:
       with:
         python-version: '3.x'
 
+    # Prevent spurious errors on macos, see https://github.com/AOMediaCodec/libavif/issues/1769
+    - name: Disable AVX2 in libaom
+      if: runner.os == 'macOS'
+      working-directory: ./ext
+      run: sed -i'' -e 's/^cmake /cmake -DENABLE_AVX2=OFF /' aom.cmd
     - name: Cache external dependencies
       id: cache-ext
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -32,6 +32,11 @@ jobs:
         toolchain: stable
         override: true
 
+    # Prevent spurious errors on macos, see https://github.com/AOMediaCodec/libavif/issues/1769
+    - name: Disable AVX2 in libaom
+      if: runner.os == 'macOS'
+      working-directory: ./ext
+      run: sed -i'' -e 's/^cmake /cmake -DENABLE_AVX2=OFF /' aom.cmd
     - name: Cache external dependencies
       id: cache-ext
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1


### PR DESCRIPTION
Workaround for #1769