### PR TITLE
fix: android jni unused-parameter

### DIFF
--- a/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
+++ b/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
@@ -24,7 +24,7 @@
   JNIEXPORT RETURN_TYPE Java_org_aomedia_avif_android_AvifDecoder_##NAME( \
       JNIEnv* env, jobject thiz, ##__VA_ARGS__)
 
-#define IGNORE_UNUSED_JNIPARAMETERS \
+#define IGNORE_UNUSED_JNI_PARAMETERS \
   (void) env; \
   (void) thiz
 
@@ -237,7 +237,7 @@ jint JNI_OnLoad(JavaVM* vm, void* /*reserved*/) {
 }
 
 FUNC(jboolean, isAvifImage, jobject encoded, int length) {
-  IGNORE_UNUSED_JNIPARAMETERS;
+  IGNORE_UNUSED_JNI_PARAMETERS;
   const uint8_t* const buffer =
       static_cast<const uint8_t*>(env->GetDirectBufferAddress(encoded));
   const avifROData avif = {buffer, static_cast<size_t>(length)};
@@ -260,7 +260,7 @@ FUNC(jboolean, isAvifImage, jobject encoded, int length) {
   if (var == nullptr) return ret
 
 FUNC(jboolean, getInfo, jobject encoded, int length, jobject info) {
-  IGNORE_UNUSED_JNIPARAMETERS;
+  IGNORE_UNUSED_JNI_PARAMETERS;
   const uint8_t* const buffer =
       static_cast<const uint8_t*>(env->GetDirectBufferAddress(encoded));
   AvifDecoderWrapper decoder;
@@ -285,7 +285,7 @@ FUNC(jboolean, getInfo, jobject encoded, int length, jobject info) {
 
 FUNC(jboolean, decode, jobject encoded, int length, jobject bitmap,
      jint threads) {
-  IGNORE_UNUSED_JNIPARAMETERS;
+  IGNORE_UNUSED_JNI_PARAMETERS;
   if (threads < 0) {
     LOGE("Invalid value for threads (%d).", threads);
     return false;
@@ -372,33 +372,33 @@ FUNC(jlong, createDecoder, jobject encoded, jint length, jint threads) {
 #undef CHECK_EXCEPTION
 
 FUNC(jint, nextFrame, jlong jdecoder, jobject bitmap) {
-  IGNORE_UNUSED_JNIPARAMETERS;
+  IGNORE_UNUSED_JNI_PARAMETERS;
   AvifDecoderWrapper* const decoder =
       reinterpret_cast<AvifDecoderWrapper*>(jdecoder);
   return DecodeNextImage(env, decoder, bitmap);
 }
 
 FUNC(jint, nextFrameIndex, jlong jdecoder) {
-  IGNORE_UNUSED_JNIPARAMETERS;
+  IGNORE_UNUSED_JNI_PARAMETERS;
   AvifDecoderWrapper* const decoder =
       reinterpret_cast<AvifDecoderWrapper*>(jdecoder);
   return decoder->decoder->imageIndex + 1;
 }
 
 FUNC(jint, nthFrame, jlong jdecoder, jint n, jobject bitmap) {
-  IGNORE_UNUSED_JNIPARAMETERS;
+  IGNORE_UNUSED_JNI_PARAMETERS;
   AvifDecoderWrapper* const decoder =
       reinterpret_cast<AvifDecoderWrapper*>(jdecoder);
   return DecodeNthImage(env, decoder, n, bitmap);
 }
 
 FUNC(jstring, resultToString, jint result) {
-  IGNORE_UNUSED_JNIPARAMETERS;
+  IGNORE_UNUSED_JNI_PARAMETERS;
   return env->NewStringUTF(avifResultToString(static_cast<avifResult>(result)));
 }
 
 FUNC(jstring, versionString) {
-  IGNORE_UNUSED_JNIPARAMETERS;
+  IGNORE_UNUSED_JNI_PARAMETERS;
   char codec_versions[256];
   avifCodecVersions(codec_versions);
   char libyuv_version[64];
@@ -416,7 +416,7 @@ FUNC(jstring, versionString) {
 }
 
 FUNC(void, destroyDecoder, jlong jdecoder) {
-  IGNORE_UNUSED_JNIPARAMETERS;
+  IGNORE_UNUSED_JNI_PARAMETERS;
   AvifDecoderWrapper* const decoder =
       reinterpret_cast<AvifDecoderWrapper*>(jdecoder);
   delete decoder;


### PR DESCRIPTION
The more stringent error and warning compiler flags in the root CMakeLists.txt are set with `add_compile_options` and so, as directory properties, they don't get applied to the avif_android target. If `-Wall -Werror` or `/W4 /WX` are enabled for avif_android, the compiler fails on `-Werror,-Wunused-parameter`. This issue is fixed by defining a macro, `IGNORE_UNUSED_JNIPARAMETERS`, that is called at the top of any functions that don't reference the `env` or `thiz` parameters.

Note: this file appears to not have had clang-format run on it, so I didn't do any reformatting.