### PR TITLE
Add flags to override cicp in 'combine' command of avifgainmaputil.

### DIFF
--- a/apps/avifgainmaputil/combine_command.h
+++ b/apps/avifgainmaputil/combine_command.h
@@ -18,6 +18,8 @@ class CombineCommand : public ProgramCommand {
   argparse::ArgValue<std::string> arg_base_filename_;
   argparse::ArgValue<std::string> arg_alternate_filename_;
   argparse::ArgValue<std::string> arg_output_filename_;
+  argparse::ArgValue<CicpValues> arg_base_cicp_;
+  argparse::ArgValue<CicpValues> arg_alternate_cicp_;
   argparse::ArgValue<int> arg_downscaling_;
   argparse::ArgValue<int> arg_gain_map_quality_;
   argparse::ArgValue<int> arg_gain_map_depth_;

--- a/apps/avifgainmaputil/tonemap_command.cc
+++ b/apps/avifgainmaputil/tonemap_command.cc
@@ -23,14 +23,14 @@ TonemapCommand::TonemapCommand()
           "SDR luminance. 0 means SDR.")
       .default_value("0");
   argparse_
-      .add_argument<CicpValues, CicpConverter>(arg_input_cicp_, "--input_cicp")
+      .add_argument<CicpValues, CicpConverter>(arg_input_cicp_, "--cicp-input")
       .help(
           "Override input CICP values, expressed as P/T/M "
           "where P = color primaries, T = transfer characteristics, "
           "M = matrix coefficients.");
   argparse_
       .add_argument<CicpValues, CicpConverter>(arg_output_cicp_,
-                                               "--output_cicp")
+                                               "--cicp-output")
       .help(
           "CICP values for the output, expressed as P/T/M "
           "where P = color primaries, T = transfer characteristics, "


### PR DESCRIPTION
Rename cicp flags in 'tonemap' command for consistency.