### PR TITLE
svt.sh: Pass disable-native to build.sh

### DIFF
--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       with:
         path: ext
-        key: ${{ runner.os }}-disable-gtest-${{ hashFiles('ext/*.cmd') }}
+        key: ${{ runner.os }}-disable-gtest-${{ hashFiles('ext/*.cmd', 'ext/svt.sh') }}
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@187efd9581ed20ee4e03c0dfb9ac2cd5896c4835 # v1.14.1
       with:

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       with:
         path: ext
-        key: ${{ runner.os }}-static-av2-${{ hashFiles('ext/*.cmd') }}
+        key: ${{ runner.os }}-static-av2-${{ hashFiles('ext/*.cmd', 'ext/svt.sh') }}
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@187efd9581ed20ee4e03c0dfb9ac2cd5896c4835 # v1.14.1
       with:

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       with:
         path: ext
-        key: ${{ runner.os }}-${{ runner.build-type }}-${{ hashFiles('ext/*.cmd') }}
+        key: ${{ runner.os }}-${{ runner.build-type }}-${{ hashFiles('ext/*.cmd', 'ext/svt.sh') }}
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@187efd9581ed20ee4e03c0dfb9ac2cd5896c4835 # v1.14.1
       with:

--- a/ext/svt.sh
+++ b/ext/svt.sh
@@ -9,7 +9,7 @@ git clone -b v1.7.0 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 cd SVT-AV1
 cd Build/linux
 
-./build.sh release static no-dec no-apps
+./build.sh disable-native release static no-dec no-apps
 cd ../..
 mkdir -p include/svt-av1
 cp Source/API/*.h include/svt-av1


### PR DESCRIPTION
Disable the use of -march=native.

Hopefully this will fix
https://github.com/AOMediaCodec/libavif/issues/1769.