### PR TITLE
fix: build cargo-c with --locked to work around rust-lang/cargo#13002

### DIFF
--- a/ext/rav1e.cmd
+++ b/ext/rav1e.cmd
@@ -13,7 +13,7 @@
 git clone -b v0.6.6 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
-cargo install cargo-c
+cargo install cargo-c --locked
 
 mkdir build.libavif
 cargo cinstall --release --library-type=staticlib --prefix=/usr --destdir build.libavif

--- a/ext/rav1e.cmd
+++ b/ext/rav1e.cmd
@@ -13,7 +13,7 @@
 git clone -b v0.6.6 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
-cargo install cargo-c --locked
+cargo install --locked cargo-c
 
 mkdir build.libavif
 cargo cinstall --release --library-type=staticlib --prefix=/usr --destdir build.libavif


### PR DESCRIPTION
rust-lang/cargo#13002 is the cause of the build failures currently on the main branch.

There is a pull request to fix the issue in cargo (https://github.com/rust-lang/cargo/pull/13004), but using `--locked` might be advisable anyway to ensure reproducible builds.