### PR TITLE
fix: build cargo-c with --locked to work around rust-lang/cargo#13002…

### DIFF
--- a/ext/rav1e.cmd
+++ b/ext/rav1e.cmd
@@ -13,7 +13,7 @@
 git clone -b v0.6.6 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
-cargo install cargo-c
+cargo install --locked cargo-c
 
 mkdir build.libavif
 cargo cinstall --release --library-type=staticlib --prefix=/usr --destdir build.libavif


### PR DESCRIPTION
… (#1785)

(cherry picked from commit 5ba0e1412921aa90fc9e26a4818aa0b0c67c0c7a)