### PR TITLE
Use default yuv format and depth for the gain map when converting jpegs.

### DIFF
--- a/apps/avifgainmaputil/program_command.h
+++ b/apps/avifgainmaputil/program_command.h
@@ -105,8 +105,7 @@ struct ImageReadArgs {
   void Init(argparse::ArgumentParser& argparse) {
     argparse
         .add_argument<int, PixelFormatConverter>(pixel_format, "--yuv", "-y")
-        .help("Output YUV format for avif")
-        .default_value("444");
+        .help("Output YUV format for avif (default = automatic)");
     argparse.add_argument(depth, "--depth", "-d")
         .choices({"0", "8", "10", "12"})
         .help("Output depth (0 = automatic)");

--- a/tests/data/goldens/paris_exif_xmp_gainmap_bigendian.jpg.avif.xml
+++ b/tests/data/goldens/paris_exif_xmp_gainmap_bigendian.jpg.avif.xml
@@ -8,7 +8,7 @@
 <BrandEntry AlternateBrand="miaf"/>
 <BrandEntry AlternateBrand="MA1B"/>
 </FileTypeBox>
-<MetaBox Size="573" Type="meta" Version="0" Flags="0" Specification="p12" Container="file moov trak moof traf udta" >
+<MetaBox Size="587" Type="meta" Version="0" Flags="0" Specification="p12" Container="file moov trak moof traf udta" >
 <HandlerBox Size="40" Type="hdlr" Version="0" Flags="0" Specification="p12" Container="mdia meta minf" hdlrType="pict" Name="libavif" reserved1="0" reserved2="data:application/octet-string,000000000000000000000000">
 </HandlerBox>
 <PrimaryItemBox Size="14" Type="pitm" Version="0" Flags="0" Specification="p12" Container="meta" item_ID="1">
@@ -54,8 +54,8 @@
 <ItemReferenceBoxEntry ItemID="1"/>
 </ItemReferenceBox>
 </ItemReferenceBox>
-<ItemPropertiesBox Size="170" Type="iprp" Specification="iff" Container="meta" >
-<ItemPropertyContainerBox Size="126" Type="ipco" Specification="iff" Container="iprp" >
+<ItemPropertiesBox Size="184" Type="iprp" Specification="iff" Container="meta" >
+<ItemPropertyContainerBox Size="140" Type="ipco" Specification="iff" Container="iprp" >
 <ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="403" image_height="302">
 </ImageSpatialExtentsPropertyBox>
 <PixelInformationPropertyBox Size="16" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
@@ -71,11 +71,14 @@
 </ColourInformationBox>
 <ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="512" image_height="384">
 </ImageSpatialExtentsPropertyBox>
+<PixelInformationPropertyBox Size="14" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
+<BitPerChannel bits_per_channel="8"/>
+</PixelInformationPropertyBox>
 <AV1ConfigurationBox>
-<AV1Config version="1" profile="1" level_idx0="1" tier="0" high_bitdepth="0" twelve_bit="0" monochrome="0" chroma_subsampling_x="0" chroma_subsampling_y="0" chroma_sample_position="0" initial_presentation_delay="1" OBUs_count="0">
+<AV1Config version="1" profile="0" level_idx0="1" tier="0" high_bitdepth="0" twelve_bit="0" monochrome="1" chroma_subsampling_x="1" chroma_subsampling_y="1" chroma_sample_position="0" initial_presentation_delay="1" OBUs_count="0">
 </AV1Config>
 </AV1ConfigurationBox>
-<ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="2" transfer_characteristics="2" matrix_coefficients="2" full_range_flag="1">
+<ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="2" transfer_characteristics="2" matrix_coefficients="6" full_range_flag="1">
 </ColourInformationBox>
 </ItemPropertyContainerBox>
 <ItemPropertyAssociationBox Size="36" Type="ipma" Version="0" Flags="0" Specification="iff" Container="iprp" entry_count="3">
@@ -92,9 +95,9 @@
 </AssociationEntry>
 <AssociationEntry item_ID="3" association_count="4">
 <Property index="5" essential="0"/>
-<Property index="2" essential="0"/>
-<Property index="6" essential="1"/>
-<Property index="7" essential="0"/>
+<Property index="6" essential="0"/>
+<Property index="7" essential="1"/>
+<Property index="8" essential="0"/>
 </AssociationEntry>
 </ItemPropertyAssociationBox>
 </ItemPropertiesBox>

--- a/tests/data/goldens/paris_exif_xmp_gainmap_littleendian.jpg.avif.xml
+++ b/tests/data/goldens/paris_exif_xmp_gainmap_littleendian.jpg.avif.xml
@@ -8,7 +8,7 @@
 <BrandEntry AlternateBrand="miaf"/>
 <BrandEntry AlternateBrand="MA1B"/>
 </FileTypeBox>
-<MetaBox Size="573" Type="meta" Version="0" Flags="0" Specification="p12" Container="file moov trak moof traf udta" >
+<MetaBox Size="587" Type="meta" Version="0" Flags="0" Specification="p12" Container="file moov trak moof traf udta" >
 <HandlerBox Size="40" Type="hdlr" Version="0" Flags="0" Specification="p12" Container="mdia meta minf" hdlrType="pict" Name="libavif" reserved1="0" reserved2="data:application/octet-string,000000000000000000000000">
 </HandlerBox>
 <PrimaryItemBox Size="14" Type="pitm" Version="0" Flags="0" Specification="p12" Container="meta" item_ID="1">
@@ -54,8 +54,8 @@
 <ItemReferenceBoxEntry ItemID="1"/>
 </ItemReferenceBox>
 </ItemReferenceBox>
-<ItemPropertiesBox Size="170" Type="iprp" Specification="iff" Container="meta" >
-<ItemPropertyContainerBox Size="126" Type="ipco" Specification="iff" Container="iprp" >
+<ItemPropertiesBox Size="184" Type="iprp" Specification="iff" Container="meta" >
+<ItemPropertyContainerBox Size="140" Type="ipco" Specification="iff" Container="iprp" >
 <ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="403" image_height="302">
 </ImageSpatialExtentsPropertyBox>
 <PixelInformationPropertyBox Size="16" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
@@ -71,11 +71,14 @@
 </ColourInformationBox>
 <ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="512" image_height="384">
 </ImageSpatialExtentsPropertyBox>
+<PixelInformationPropertyBox Size="14" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
+<BitPerChannel bits_per_channel="8"/>
+</PixelInformationPropertyBox>
 <AV1ConfigurationBox>
-<AV1Config version="1" profile="1" level_idx0="1" tier="0" high_bitdepth="0" twelve_bit="0" monochrome="0" chroma_subsampling_x="0" chroma_subsampling_y="0" chroma_sample_position="0" initial_presentation_delay="1" OBUs_count="0">
+<AV1Config version="1" profile="0" level_idx0="1" tier="0" high_bitdepth="0" twelve_bit="0" monochrome="1" chroma_subsampling_x="1" chroma_subsampling_y="1" chroma_sample_position="0" initial_presentation_delay="1" OBUs_count="0">
 </AV1Config>
 </AV1ConfigurationBox>
-<ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="2" transfer_characteristics="2" matrix_coefficients="2" full_range_flag="1">
+<ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="2" transfer_characteristics="2" matrix_coefficients="6" full_range_flag="1">
 </ColourInformationBox>
 </ItemPropertyContainerBox>
 <ItemPropertyAssociationBox Size="36" Type="ipma" Version="0" Flags="0" Specification="iff" Container="iprp" entry_count="3">
@@ -92,9 +95,9 @@
 </AssociationEntry>
 <AssociationEntry item_ID="3" association_count="4">
 <Property index="5" essential="0"/>
-<Property index="2" essential="0"/>
-<Property index="6" essential="1"/>
-<Property index="7" essential="0"/>
+<Property index="6" essential="0"/>
+<Property index="7" essential="1"/>
+<Property index="8" essential="0"/>
 </AssociationEntry>
 </ItemPropertyAssociationBox>
 </ItemPropertiesBox>


### PR DESCRIPTION
When converting jpeg files with gain maps, the same depth and pixelFormat were used as for the main image. However, increasing the gain map's bit depth or changing its pixelFormat would be rarely needed, and retaining gain map's actual depth (8 ) and pixelFormat (i.e. 400 if it's grayscale) is a more sensible default. Different input paramters could also be added to allow finer control if needed.