### PR TITLE
Build libargparse in ci-unix-static.yml

### DIFF
--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -80,6 +80,10 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash -e libsharpyuv.cmd
+    - name: Build libargparse
+      if: steps.cache-ext.outputs.cache-hit != 'true'
+      working-directory: ./ext
+      run: bash -e libargparse.cmd
     - name: Build GoogleTest
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext

--- a/ext/libargparse.cmd
+++ b/ext/libargparse.cmd
@@ -1,5 +1,5 @@
 : # Script to get a local build of libargparse (not to be confused with other similarly named libraries)
-: # needed by some of the command line tools in the apps/ directory.
+: # needed by some of the command line tools in the apps/ directory e.g. avifgainmaputil.
 
 : # The odd choice of comment style in this file is to try to share this script between *nix and win32.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -249,6 +249,12 @@ if(AVIF_BUILD_APPS)
                                               ${CMAKE_CURRENT_SOURCE_DIR}/data
     )
 
+    if(AVIF_ENABLE_AVIFGAINMAPUTIL)
+        add_test(NAME test_cmd_avifgainmaputil COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd_avifgainmaputil.sh
+                                                    ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/data
+        )
+    endif()
+
     if(AVIF_ENABLE_GOLDEN_TESTS AND AVIF_CODEC_AOM_ENCODE)
         # test_cmd_enc_boxes_golden.sh depends on MP4Box
         # Only allow a locally built version to avoid differences with versioning.
@@ -263,12 +269,6 @@ if(AVIF_BUILD_APPS)
                  COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd_enc_boxes_golden.sh ${CMAKE_BINARY_DIR} ${MP4BOX_DIR}
                          ${CMAKE_CURRENT_SOURCE_DIR}/data ${GOLDEN_TESTS_OUTPUT_DIR}
         )
-
-        if(AVIF_ENABLE_AVIFGAINMAPUTIL)
-            add_test(NAME test_cmd_avifgainmaputil COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd_avifgainmaputil.sh
-                                                           ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/data
-            )
-        endif()
 
         if(AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION)
             add_test(NAME test_cmd_gainmap COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd_gainmap.sh ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
And make sure test_cmd_avifgainmaputil gets run.

Contains a small unimportant change in ext/libargparse.cmd just to make sure that existing CI cache files get invalidated.