### PR TITLE
Add 'convert' command to avifgainmaputil.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -827,9 +827,15 @@ if(AVIF_BUILD_APPS)
             set(AVIF_ENABLE_AVIFGAINMAPUTIL TRUE)
 
             set(AVIFGAINMAPUTIL_SRCS
-                apps/avifgainmaputil/avifgainmaputil.cc apps/avifgainmaputil/combine_command.cc apps/avifgainmaputil/extractgainmap_command.cc
-                apps/avifgainmaputil/imageio.cc apps/avifgainmaputil/printmetadata_command.cc apps/avifgainmaputil/tonemap_command.cc
-                apps/avifgainmaputil/program_command.cc apps/avifgainmaputil/swapbase_command.cc
+                apps/avifgainmaputil/avifgainmaputil.cc
+                apps/avifgainmaputil/convert_command.cc
+                apps/avifgainmaputil/combine_command.cc
+                apps/avifgainmaputil/extractgainmap_command.cc
+                apps/avifgainmaputil/imageio.cc
+                apps/avifgainmaputil/printmetadata_command.cc
+                apps/avifgainmaputil/tonemap_command.cc
+                apps/avifgainmaputil/program_command.cc
+                apps/avifgainmaputil/swapbase_command.cc
             )
 
             add_executable(avifgainmaputil "${AVIFGAINMAPUTIL_SRCS}")

--- a/apps/avifgainmaputil/avifgainmaputil.cc
+++ b/apps/avifgainmaputil/avifgainmaputil.cc
@@ -9,6 +9,7 @@
 #include "avif/avif.h"
 #include "avifutil.h"
 #include "combine_command.h"
+#include "convert_command.h"
 #include "extractgainmap_command.h"
 #include "printmetadata_command.h"
 #include "program_command.h"
@@ -59,6 +60,7 @@ MAIN() {
   std::vector<std::unique_ptr<avif::ProgramCommand>> commands;
   commands.emplace_back(std::make_unique<avif::HelpCommand>());
   commands.emplace_back(std::make_unique<avif::CombineCommand>());
+  commands.emplace_back(std::make_unique<avif::ConvertCommand>());
   commands.emplace_back(std::make_unique<avif::TonemapCommand>());
   commands.emplace_back(std::make_unique<avif::SwapBaseCommand>());
   commands.emplace_back(std::make_unique<avif::ExtractGainMapCommand>());

--- a/apps/avifgainmaputil/convert_command.cc
+++ b/apps/avifgainmaputil/convert_command.cc
@@ -1,0 +1,108 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "convert_command.h"
+
+#include "avif/avif_cxx.h"
+#include "avifutil.h"
+#include "imageio.h"
+#include "swapbase_command.h"
+
+namespace avif {
+
+ConvertCommand::ConvertCommand()
+    : ProgramCommand("convert", "Convert a jpeg with a gain map to avif.") {
+  argparse_.add_argument(arg_input_filename_, "input_filename.jpg");
+  argparse_.add_argument(arg_output_filename_, "output_image.avif");
+  argparse_.add_argument(arg_swap_base_, "--swap-base")
+      .help("Make the HDR image the base image")
+      .action(argparse::Action::STORE_TRUE)
+      .default_value("false");
+  argparse_.add_argument(arg_gain_map_quality_, "--qgain-map")
+      .help("Quality for the gain map (0-100, where 100 is lossless)")
+      .default_value("60");
+  argparse_.add_argument<CicpValues, CicpConverter>(arg_cicp_, "--cicp")
+      .help(
+          "Set the cicp values for the input image, expressed as "
+          "P/T/M where P = color primaries, T = transfer characteristics, "
+          "M = matrix coefficients.");
+  arg_image_encode_.Init(argparse_, /*can_have_alpha=*/false);
+  arg_image_read_.Init(argparse_);
+}
+
+avifResult ConvertCommand::Run() {
+  const avifPixelFormat pixel_format =
+      static_cast<avifPixelFormat>(arg_image_read_.pixel_format.value());
+
+  ImagePtr image(avifImageCreateEmpty());
+  if (image == nullptr) {
+    return AVIF_RESULT_OUT_OF_MEMORY;
+  }
+
+  const avifAppFileFormat file_format = avifReadImage(
+      arg_input_filename_.value().c_str(), pixel_format, arg_image_read_.depth,
+      AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC, arg_image_read_.ignore_profile,
+      /*ignoreExif=*/false,
+      /*ignoreXMP=*/false,
+      /*allowChangingCicp=*/true,
+      /*ignoreGainMap=*/false, image.get(),
+      /*outDepth=*/nullptr,
+      /*sourceTiming=*/nullptr,
+      /*frameIter=*/nullptr);
+  if (file_format == AVIF_APP_FILE_FORMAT_UNKNOWN) {
+    std::cout << "Failed to decode image: " << arg_input_filename_;
+    return AVIF_RESULT_INVALID_ARGUMENT;
+  }
+  if (arg_cicp_.provenance() == argparse::Provenance::SPECIFIED) {
+    image->colorPrimaries = arg_cicp_.value().color_primaries;
+    image->transferCharacteristics = arg_cicp_.value().transfer_characteristics;
+    image->matrixCoefficients = arg_cicp_.value().matrix_coefficients;
+  } else if (image->icc.size == 0 &&
+             image->colorPrimaries == AVIF_COLOR_PRIMARIES_UNSPECIFIED &&
+             image->transferCharacteristics ==
+                 AVIF_COLOR_PRIMARIES_UNSPECIFIED) {
+    // If there is no ICC and no CICP, assume sRGB by default.
+    image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
+    image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
+  }
+
+  if (image->gainMap.image == nullptr) {
+    std::cerr << "Input image " << arg_input_filename_
+              << " does not contain a gain map\n";
+    return AVIF_RESULT_INVALID_ARGUMENT;
+  }
+
+  if (arg_swap_base_) {
+    int depth = arg_image_read_.depth;
+    if (depth == 0) {
+      depth = image->gainMap.metadata.alternateHdrHeadroomN == 0 ? 8 : 10;
+    }
+    ImagePtr new_base(
+        avifImageCreate(image->width, image->height, depth, image->yuvFormat));
+    const avifResult result = ChangeBase(std::move(*image), new_base.get());
+    if (result != AVIF_RESULT_OK) {
+      return result;
+    }
+    std::swap(image, new_base);
+  }
+
+  EncoderPtr encoder(avifEncoderCreate());
+  if (encoder == nullptr) {
+    return AVIF_RESULT_OUT_OF_MEMORY;
+  }
+  encoder->quality = arg_image_encode_.quality;
+  encoder->qualityAlpha = arg_image_encode_.quality_alpha;
+  encoder->qualityGainMap = arg_gain_map_quality_;
+  encoder->speed = arg_image_encode_.speed;
+  const avifResult result =
+      WriteAvif(image.get(), encoder.get(), arg_output_filename_);
+  if (result != AVIF_RESULT_OK) {
+    std::cout << "Failed to encode image: " << avifResultToString(result)
+              << " (" << encoder->diag.error << ")\n";
+    return result;
+  }
+
+  return AVIF_RESULT_OK;
+}
+
+}  // namespace avif

--- a/apps/avifgainmaputil/convert_command.cc
+++ b/apps/avifgainmaputil/convert_command.cc
@@ -79,7 +79,7 @@ avifResult ConvertCommand::Run() {
     }
     ImagePtr new_base(
         avifImageCreate(image->width, image->height, depth, image->yuvFormat));
-    const avifResult result = ChangeBase(std::move(*image), new_base.get());
+    const avifResult result = ChangeBase(*image, new_base.get());
     if (result != AVIF_RESULT_OK) {
       return result;
     }

--- a/apps/avifgainmaputil/convert_command.h
+++ b/apps/avifgainmaputil/convert_command.h
@@ -1,0 +1,32 @@
+// Copyright 2023 Google LLC
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef LIBAVIF_APPS_AVIFGAINMAPUTIL_CONVERT_COMMAND_H_
+#define LIBAVIF_APPS_AVIFGAINMAPUTIL_CONVERT_COMMAND_H_
+
+#include "avif/avif.h"
+#include "program_command.h"
+
+namespace avif {
+
+class ConvertCommand : public ProgramCommand {
+ public:
+  ConvertCommand();
+  avifResult Run() override;
+
+ private:
+  argparse::ArgValue<std::string> arg_input_filename_;
+  argparse::ArgValue<std::string> arg_output_filename_;
+  argparse::ArgValue<bool> arg_swap_base_;
+  argparse::ArgValue<CicpValues> arg_cicp_;
+  argparse::ArgValue<int> arg_downscaling_;
+  argparse::ArgValue<int> arg_gain_map_quality_;
+  argparse::ArgValue<int> arg_gain_map_depth_;
+  argparse::ArgValue<int> arg_gain_map_pixel_format_;
+  BasicImageEncodeArgs arg_image_encode_;
+  ImageReadArgs arg_image_read_;
+};
+
+}  // namespace avif
+
+#endif  // LIBAVIF_APPS_AVIFGAINMAPUTIL_CONVERT_COMMAND_H_

--- a/apps/avifgainmaputil/extractgainmap_command.cc
+++ b/apps/avifgainmaputil/extractgainmap_command.cc
@@ -31,7 +31,7 @@ avifResult ExtractGainMapCommand::Run() {
   }
 
   if (decoder->image->gainMap.image == nullptr) {
-    std::cerr << "Input image " << arg_output_filename_
+    std::cerr << "Input image " << arg_input_filename_
               << " does not contain a gain map\n";
     return AVIF_RESULT_INVALID_ARGUMENT;
   }

--- a/apps/avifgainmaputil/program_command.h
+++ b/apps/avifgainmaputil/program_command.h
@@ -81,9 +81,7 @@ struct BasicImageEncodeArgs {
     argparse.add_argument(speed, "--speed", "-s")
         .help("Encoder speed (0-10, slowest-fastest)")
         .default_value("6");
-    argparse
-        .add_argument(quality, (can_have_alpha ? "--qcolor" : "--quality"),
-                      "-q")
+    argparse.add_argument(quality, "--qcolor", "-q")
         .help((can_have_alpha
                    ? "Quality for color (0-100, where 100 is lossless)"
                    : "Quality (0-100, where 100 is lossless)"))

--- a/apps/avifgainmaputil/swapbase_command.cc
+++ b/apps/avifgainmaputil/swapbase_command.cc
@@ -8,7 +8,7 @@
 
 namespace avif {
 
-avifResult ChangeBase(avifImage&& image, avifImage* swapped) {
+avifResult ChangeBase(avifImage& image, avifImage* swapped) {
   if (image.gainMap.image == nullptr) {
     return AVIF_RESULT_INVALID_ARGUMENT;
   }
@@ -144,7 +144,7 @@ avifResult SwapBaseCommand::Run() {
   }
   ImagePtr new_base(avifImageCreate(
       decoder->image->width, decoder->image->height, depth, pixel_format));
-  result = ChangeBase(std::move(*decoder->image), new_base.get());
+  result = ChangeBase(*decoder->image, new_base.get());
   if (result != AVIF_RESULT_OK) {
     return result;
   }

--- a/apps/avifgainmaputil/swapbase_command.h
+++ b/apps/avifgainmaputil/swapbase_command.h
@@ -9,6 +9,12 @@
 
 namespace avif {
 
+// Given an 'image' with a gain map, tone maps it to get the "alternate" image,
+// and saves it to 'output'. Also steals the gain map of 'image' to give it to
+// 'output'. To avoid unnecessary copies, 'image' is modified and should not be
+// used afterwards.
+avifResult ChangeBase(avifImage&& image, avifImage* output);
+
 class SwapBaseCommand : public ProgramCommand {
  public:
   SwapBaseCommand();

--- a/apps/avifgainmaputil/swapbase_command.h
+++ b/apps/avifgainmaputil/swapbase_command.h
@@ -11,9 +11,8 @@ namespace avif {
 
 // Given an 'image' with a gain map, tone maps it to get the "alternate" image,
 // and saves it to 'output'. Also steals the gain map of 'image' to give it to
-// 'output'. To avoid unnecessary copies, 'image' is modified and should not be
-// used afterwards.
-avifResult ChangeBase(avifImage&& image, avifImage* output);
+// 'output'. To avoid unnecessary copies, the input 'image' is modified.
+avifResult ChangeBase(avifImage& image, avifImage* output);
 
 class SwapBaseCommand : public ProgramCommand {
  public:

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -280,6 +280,11 @@ avifResult avifImageApplyGainMap(const avifImage * baseImage,
 {
     avifDiagnosticsClearError(diag);
 
+    if (baseImage->icc.size > 0) {
+        avifDiagnosticsPrintf(diag, "Tone mapping for images with ICC profiles is not supported");
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
+
     avifRGBImage baseImageRgb;
     avifRGBImageSetDefaults(&baseImageRgb, baseImage);
     AVIF_CHECKRES(avifRGBImageAllocatePixels(&baseImageRgb));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -251,7 +251,7 @@ if(AVIF_BUILD_APPS)
 
     if(AVIF_ENABLE_AVIFGAINMAPUTIL)
         add_test(NAME test_cmd_avifgainmaputil COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd_avifgainmaputil.sh
-                                                    ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/data
+                                                       ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/data
         )
     endif()
 

--- a/tests/test_cmd_avifgainmaputil.sh
+++ b/tests/test_cmd_avifgainmaputil.sh
@@ -68,6 +68,12 @@ pushd ${TMP_DIR}
   "${ARE_IMAGES_EQUAL}" "${PNG_OUTPUT}" "${JPEG_AVIF_GAINMAP_SDR}" 0 40
 
   "${AVIFGAINMAPUTIL}" swapbase "${INPUT_AVIF_GAINMAP_SDR}" "${AVIF_OUTPUT}" --qcolor 90 --qgain-map 90
+
+  "${AVIFGAINMAPUTIL}" convert "${JPEG_AVIF_GAINMAP_SDR}" "${AVIF_OUTPUT}"
+   # should fail because of icc profiles are not supported
+  "${AVIFGAINMAPUTIL}" convert "${JPEG_AVIF_GAINMAP_SDR}" "${AVIF_OUTPUT}" --swap-base && exit 1
+  "${AVIFGAINMAPUTIL}" convert "${JPEG_AVIF_GAINMAP_SDR}" "${AVIF_OUTPUT}" --swap-base --ignore-profile \
+      --cicp 2/3/4
 popd
 
 exit 0

--- a/tests/test_cmd_avifgainmaputil.sh
+++ b/tests/test_cmd_avifgainmaputil.sh
@@ -57,7 +57,7 @@ pushd ${TMP_DIR}
   "${AVIFGAINMAPUTIL}" combine "${INPUT_AVIF_GAINMAP_SDR}" "${INPUT_AVIF_GAINMAP_HDR}" "${AVIF_OUTPUT}" \
       -q 50 --downscaling 2 --yuv-gain-map 400
   "${AVIFGAINMAPUTIL}" combine "${JPEG_AVIF_GAINMAP_SDR}" "${INPUT_AVIF_GAINMAP_HDR}" "${AVIF_OUTPUT}" \
-      -q 50 --qgain-map 90 && exit 1 # should fail because of icc profiles are not supported
+      -q 50 --qgain-map 90 && exit 1 # should fail because icc profiles are not supported
   "${AVIFGAINMAPUTIL}" combine "${JPEG_AVIF_GAINMAP_SDR}" "${INPUT_AVIF_GAINMAP_HDR}" "${AVIF_OUTPUT}" \
       -q 50 --qgain-map 90 --ignore-profile
 
@@ -70,7 +70,7 @@ pushd ${TMP_DIR}
   "${AVIFGAINMAPUTIL}" swapbase "${INPUT_AVIF_GAINMAP_SDR}" "${AVIF_OUTPUT}" --qcolor 90 --qgain-map 90
 
   "${AVIFGAINMAPUTIL}" convert "${JPEG_AVIF_GAINMAP_SDR}" "${AVIF_OUTPUT}"
-   # should fail because of icc profiles are not supported
+   # should fail because icc profiles are not supported
   "${AVIFGAINMAPUTIL}" convert "${JPEG_AVIF_GAINMAP_SDR}" "${AVIF_OUTPUT}" --swap-base && exit 1
   "${AVIFGAINMAPUTIL}" convert "${JPEG_AVIF_GAINMAP_SDR}" "${AVIF_OUTPUT}" --swap-base --ignore-profile \
       --cicp 2/3/4


### PR DESCRIPTION
Allows converting a jpeg+gainmap to avif, which you can also do with avifenc but this version also has a --swap-base flag, and seems appropriate for the avifgainmaputil tool.