### PR TITLE
Make the gainMap member of avifImage a pointer.

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -531,10 +531,10 @@ static avifBool avifInputReadImage(avifInput * input,
             assert(AVIF_FALSE);
         }
 #if defined(AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION)
-        if (cached->image->gainMap.image != NULL) {
-            image->gainMap.image = avifImageCreateEmpty();
-            const avifCropRect gainMapRect = { 0, 0, cached->image->gainMap.image->width, cached->image->gainMap.image->height };
-            if (avifImageSetViewRect(image->gainMap.image, cached->image->gainMap.image, &gainMapRect) != AVIF_RESULT_OK) {
+        if (cached->image->gainMap && cached->image->gainMap->image) {
+            image->gainMap->image = avifImageCreateEmpty();
+            const avifCropRect gainMapRect = { 0, 0, cached->image->gainMap->image->width, cached->image->gainMap->image->height };
+            if (avifImageSetViewRect(image->gainMap->image, cached->image->gainMap->image, &gainMapRect) != AVIF_RESULT_OK) {
                 assert(AVIF_FALSE);
             }
         }
@@ -1192,7 +1192,7 @@ static avifBool avifEncodeImagesFixedQuality(const avifSettings * settings,
     }
     char gainMapStr[100] = { 0 };
 #if defined(AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION)
-    if (firstImage->gainMap.image != NULL) {
+    if (firstImage->gainMap && firstImage->gainMap->image) {
         snprintf(gainMapStr, sizeof(gainMapStr), ", gain map quality [%d (%s)]", encoder->qualityGainMap, qualityString(encoder->qualityGainMap));
     }
 #endif
@@ -1305,7 +1305,7 @@ static avifBool avifEncodeImages(avifSettings * settings,
     avifBool hasGainMap = AVIF_FALSE;
     avifBool allQualitiesConstrained = settings->qualityIsConstrained && settings->qualityAlphaIsConstrained;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION)
-    hasGainMap = (firstImage->gainMap.image != NULL);
+    hasGainMap = (firstImage->gainMap && firstImage->gainMap->image);
     if (hasGainMap) {
         allQualitiesConstrained = allQualitiesConstrained && settings->qualityGainMapIsConstrained;
     }
@@ -2503,7 +2503,7 @@ MAIN()
     const avifImage * avif = gridCells ? gridCells[0] : image;
     avifBool gainMapPresent = AVIF_FALSE;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION)
-    gainMapPresent = (avif->gainMap.image != NULL);
+    gainMapPresent = (avif->gainMap && avif->gainMap->image);
 #endif
     avifImageDump(avif,
                   settings.gridDims[0],

--- a/apps/avifgainmaputil/combine_command.cc
+++ b/apps/avifgainmaputil/combine_command.cc
@@ -105,15 +105,16 @@ avifResult CombineCommand::Run() {
   std::cout << "Creating a gain map of size " << gain_map_width << " x "
             << gain_map_height << "\n";
 
-  base_image->gainMap.image =
+  base_image->gainMap = avifGainMapCreate();
+  base_image->gainMap->image =
       avifImageCreate(gain_map_width, gain_map_height, arg_gain_map_depth_,
                       gain_map_pixel_format);
-  if (base_image->gainMap.image == nullptr) {
+  if (base_image->gainMap->image == nullptr) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
   avifDiagnostics diag;
   result = avifImageComputeGainMap(base_image.get(), alternate_image.get(),
-                                   &base_image->gainMap, &diag);
+                                   base_image->gainMap, &diag);
   if (result != AVIF_RESULT_OK) {
     std::cout << "Failed to compute gain map: " << avifResultToString(result)
               << " (" << diag.error << ")\n";

--- a/apps/avifgainmaputil/convert_command.cc
+++ b/apps/avifgainmaputil/convert_command.cc
@@ -66,7 +66,7 @@ avifResult ConvertCommand::Run() {
     image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
   }
 
-  if (image->gainMap.image == nullptr) {
+  if (image->gainMap == nullptr || image->gainMap->image == nullptr) {
     std::cerr << "Input image " << arg_input_filename_
               << " does not contain a gain map\n";
     return AVIF_RESULT_INVALID_ARGUMENT;
@@ -75,7 +75,7 @@ avifResult ConvertCommand::Run() {
   if (arg_swap_base_) {
     int depth = arg_image_read_.depth;
     if (depth == 0) {
-      depth = image->gainMap.metadata.alternateHdrHeadroomN == 0 ? 8 : 10;
+      depth = image->gainMap->metadata.alternateHdrHeadroomN == 0 ? 8 : 10;
     }
     ImagePtr new_base(
         avifImageCreate(image->width, image->height, depth, image->yuvFormat));

--- a/apps/avifgainmaputil/extractgainmap_command.cc
+++ b/apps/avifgainmaputil/extractgainmap_command.cc
@@ -30,13 +30,14 @@ avifResult ExtractGainMapCommand::Run() {
     return result;
   }
 
-  if (decoder->image->gainMap.image == nullptr) {
+  if (decoder->image->gainMap == nullptr ||
+      decoder->image->gainMap->image == nullptr) {
     std::cerr << "Input image " << arg_input_filename_
               << " does not contain a gain map\n";
     return AVIF_RESULT_INVALID_ARGUMENT;
   }
 
-  return WriteImage(decoder->image->gainMap.image, arg_output_filename_,
+  return WriteImage(decoder->image->gainMap->image, arg_output_filename_,
                     arg_image_encode_.quality, arg_image_encode_.speed);
 }
 

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -66,10 +66,11 @@ avifResult WriteAvif(const avifImage* image, avifEncoder* encoder,
                      const std::string& output_filename) {
   avifRWData encoded = AVIF_DATA_EMPTY;
   std::cout << "AVIF to be written:\n";
+  const bool gain_map_present =
+      (image->gainMap != nullptr && image->gainMap->image != nullptr);
   avifImageDump(image,
                 /*gridCols=*/1,
-                /*gridRows=*/1,
-                /*gainMapPresent=*/image->gainMap.image != nullptr,
+                /*gridRows=*/1, gain_map_present,
                 AVIF_PROGRESSIVE_STATE_UNAVAILABLE);
   std::cout << "Encoding AVIF at quality " << encoder->quality << " speed "
             << encoder->speed << ", please wait...\n";

--- a/apps/avifgainmaputil/printmetadata_command.cc
+++ b/apps/avifgainmaputil/printmetadata_command.cc
@@ -3,6 +3,7 @@
 
 #include "printmetadata_command.h"
 
+#include <cassert>
 #include <iomanip>
 
 #include "avif/avif_cxx.h"
@@ -57,11 +58,12 @@ avifResult PrintMetadataCommand::Run() {
               << decoder->diag.error << ")\n";
     return result;
   }
-  if (!decoder->gainMapPresent || decoder->image->gainMap == nullptr) {
+  if (!decoder->gainMapPresent) {
     std::cerr << "Input image " << arg_input_filename_
               << " does not contain a gain map\n";
     return AVIF_RESULT_INVALID_ARGUMENT;
   }
+  assert(decoder->image->gainMap);
 
   const avifGainMapMetadata& metadata = decoder->image->gainMap->metadata;
   const int w = 20;

--- a/apps/avifgainmaputil/printmetadata_command.cc
+++ b/apps/avifgainmaputil/printmetadata_command.cc
@@ -57,13 +57,13 @@ avifResult PrintMetadataCommand::Run() {
               << decoder->diag.error << ")\n";
     return result;
   }
-  if (!decoder->gainMapPresent) {
+  if (!decoder->gainMapPresent || decoder->image->gainMap == nullptr) {
     std::cerr << "Input image " << arg_input_filename_
               << " does not contain a gain map\n";
     return AVIF_RESULT_INVALID_ARGUMENT;
   }
 
-  const avifGainMapMetadata& metadata = decoder->image->gainMap.metadata;
+  const avifGainMapMetadata& metadata = decoder->image->gainMap->metadata;
   const int w = 20;
   std::cout << " * " << std::left << std::setw(w) << "Base headroom: "
             << FormatFraction(metadata.baseHdrHeadroomN,

--- a/apps/avifgainmaputil/tonemap_command.cc
+++ b/apps/avifgainmaputil/tonemap_command.cc
@@ -98,7 +98,8 @@ avifResult TonemapCommand::Run() {
         arg_input_cicp_.value().matrix_coefficients;
   }
 
-  if (decoder->image->gainMap.image == nullptr) {
+  if (decoder->image->gainMap == nullptr ||
+      decoder->image->gainMap->image == nullptr) {
     std::cerr << "Input image " << arg_input_filename_
               << " does not contain a gain map\n";
     return AVIF_RESULT_INVALID_ARGUMENT;
@@ -106,7 +107,7 @@ avifResult TonemapCommand::Run() {
 
   avifGainMapMetadataDouble metadata;
   if (!avifGainMapMetadataFractionsToDouble(
-          &metadata, &decoder->image->gainMap.metadata)) {
+          &metadata, &decoder->image->gainMap->metadata)) {
     std::cerr << "Input image " << arg_input_filename_
               << " has invalid gain map metadata\n";
     return AVIF_RESULT_INVALID_ARGUMENT;
@@ -123,7 +124,7 @@ avifResult TonemapCommand::Run() {
                 metadata.alternateHdrHeadroom <= metadata.baseHdrHeadroom) ||
                (headroom >= metadata.alternateHdrHeadroom &&
                 metadata.alternateHdrHeadroom >= metadata.baseHdrHeadroom)) {
-      clli_box = decoder->image->gainMap.image->clli;
+      clli_box = decoder->image->gainMap->image->clli;
     }
     clli_set = (clli_box.maxCLL != 0) || (clli_box.maxPALL != 0);
   }
@@ -145,7 +146,7 @@ avifResult TonemapCommand::Run() {
   avifRGBImage tone_mapped_rgb;
   avifRGBImageSetDefaults(&tone_mapped_rgb, tone_mapped.get());
   avifDiagnostics diag;
-  result = avifImageApplyGainMap(decoder->image, &decoder->image->gainMap,
+  result = avifImageApplyGainMap(decoder->image, decoder->image->gainMap,
                                  arg_headroom_, cicp.transfer_characteristics,
                                  &tone_mapped_rgb,
                                  clli_set ? nullptr : &clli_box, &diag);

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -1136,7 +1136,12 @@ static avifBool avifJPEGReadInternal(FILE * f,
     // The primary XMP block (for the main image) must contain a node with an hdrgm:Version field if and only if a gain map is present.
     if (!ignoreGainMap && avifJPEGHasGainMapXMPNode(avif->xmp.data, avif->xmp.size)) {
         // Ignore the return value: continue even if we fail to find/parse/decode the gain map.
-        avifJPEGExtractGainMapImage(f, &cinfo, &avif->gainMap, chromaDownsampling);
+        avifGainMap * gainMap = avifGainMapCreate();
+        if (avifJPEGExtractGainMapImage(f, &cinfo, gainMap, chromaDownsampling)) {
+            avif->gainMap = gainMap;
+        } else {
+            avifGainMapDestroy(gainMap);
+        }
     }
 
     if (avif->xmp.size > 0 && ignoreXMP) {

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -132,7 +132,7 @@ static void avifImageDumpInternal(const avifImage * avif,
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     printf(" * Gain map       : ");
-    avifImage * gainMap = avif->gainMap.image;
+    avifImage * gainMap = avif->gainMap ? avif->gainMap->image : NULL;
     if (gainMap != NULL) {
         printf("%ux%u pixels, %u bit, %s, %s Range, Matrix Coeffs. %u, Base Image is %s\n",
                gainMap->width,
@@ -141,7 +141,7 @@ static void avifImageDumpInternal(const avifImage * avif,
                avifPixelFormatToString(gainMap->yuvFormat),
                (gainMap->yuvRange == AVIF_RANGE_FULL) ? "Full" : "Limited",
                gainMap->matrixCoefficients,
-               (avif->gainMap.metadata.baseHdrHeadroomN == 0) ? "SDR" : "HDR");
+               (avif->gainMap->metadata.baseHdrHeadroomN == 0) ? "SDR" : "HDR");
         printf("    * Color Primaries: %u\n", gainMap->colorPrimaries);
         printf("    * Transfer Char. : %u\n", gainMap->transferCharacteristics);
         printf("    * Matrix Coeffs. : %u\n", gainMap->matrixCoefficients);

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -630,7 +630,7 @@ typedef struct avifGainMapMetadata
 typedef struct avifGainMap
 {
     // Gain map pixels.
-    // Owned by the avifGainMap and gets freed when calling avifGainMapDestro().
+    // Owned by the avifGainMap and gets freed when calling avifGainMapDestroy().
     // Used fields: width, height, depth, yufFormat, yuvRange,
     // yuvChromaSamplePosition, yuvPlanes, yuvRowBytes, imageOwnsYUVPlanes,
     // matrixCoefficients, transferCharacteristics. Other fields are ignored.

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -626,9 +626,11 @@ typedef struct avifGainMapMetadata
 } avifGainMapMetadata;
 
 // Gain map image and associated metadata.
+// Must be allocated by calling avifGainMapCreate().
 typedef struct avifGainMap
 {
     // Gain map pixels.
+    // Owned by the avifGainMap and gets freed when calling avifGainMapDestro().
     // Used fields: width, height, depth, yufFormat, yuvRange,
     // yuvChromaSamplePosition, yuvPlanes, yuvRowBytes, imageOwnsYUVPlanes,
     // matrixCoefficients, transferCharacteristics. Other fields are ignored.
@@ -638,6 +640,12 @@ typedef struct avifGainMap
     // For an image grid, the metadata shall be identical for all cells.
     avifGainMapMetadata metadata;
 } avifGainMap;
+
+// Allocates a gain map. Returns NULL if a memory allocation failed.
+// The 'image' field is NULL by default and must be allocated separately.
+AVIF_API avifGainMap * avifGainMapCreate();
+// Frees a gain map, including the 'image' field if non NULL.
+AVIF_API void avifGainMapDestroy(avifGainMap * gainMap);
 
 // Same as avifGainMapMetadata, but with fields of type double instead of uint32_t fractions.
 // Use avifGainMapMetadataDoubleToFractions() to convert this to a avifGainMapMetadata.
@@ -731,10 +739,9 @@ typedef struct avifImage
     // Version 1.0.0 ends here. Add any new members after this line.
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-    // Gain map image and metadata. If no gain map is present, gainMap.image is NULL.
-    // When calling avifImageDestroy on the containing image, the gain map image is also destroyed
-    // (the containing image "owns" the gain map).
-    avifGainMap gainMap;
+    // Gain map image and metadata. NULL if no gain map is present.
+    // Owned by the avifImage and gets freed when calling avifImageDestroy().
+    avifGainMap * gainMap;
 #endif
 } avifImage;
 

--- a/tests/gtest/avif_fuzztest_enc_dec_experimental.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_experimental.cc
@@ -67,21 +67,24 @@ void EncodeDecodeValid(ImagePtr image, EncoderPtr encoder, DecoderPtr decoder) {
   EXPECT_EQ(decoded_image->depth, image->depth);
   EXPECT_EQ(decoded_image->yuvFormat, image->yuvFormat);
 
-  EXPECT_EQ(image->gainMap.image != nullptr, decoder->gainMapPresent);
+  ASSERT_EQ(image->gainMap != nullptr, decoder->gainMapPresent);
+  ASSERT_EQ(image->gainMap->image != nullptr, decoder->gainMapPresent);
   if (decoder->gainMapPresent && decoder->enableDecodingGainMap) {
-    ASSERT_NE(decoded_image->gainMap.image, nullptr);
-    EXPECT_EQ(decoded_image->gainMap.image->width, image->gainMap.image->width);
-    EXPECT_EQ(decoded_image->gainMap.image->height,
-              image->gainMap.image->height);
-    EXPECT_EQ(decoded_image->gainMap.image->depth, image->gainMap.image->depth);
-    EXPECT_EQ(decoded_image->gainMap.image->yuvFormat,
-              image->gainMap.image->yuvFormat);
-    EXPECT_EQ(image->gainMap.image->gainMap.image, nullptr);
-    EXPECT_EQ(decoded_image->gainMap.image->alphaPlane, nullptr);
+    ASSERT_NE(decoded_image->gainMap->image, nullptr);
+    EXPECT_EQ(decoded_image->gainMap->image->width,
+              image->gainMap->image->width);
+    EXPECT_EQ(decoded_image->gainMap->image->height,
+              image->gainMap->image->height);
+    EXPECT_EQ(decoded_image->gainMap->image->depth,
+              image->gainMap->image->depth);
+    EXPECT_EQ(decoded_image->gainMap->image->yuvFormat,
+              image->gainMap->image->yuvFormat);
+    EXPECT_EQ(image->gainMap->image->gainMap->image, nullptr);
+    EXPECT_EQ(decoded_image->gainMap->image->alphaPlane, nullptr);
 
     if (decoder->enableParsingGainMapMetadata) {
-      CheckGainMapMetadataMatches(decoded_image->gainMap.metadata,
-                                  image->gainMap.metadata);
+      CheckGainMapMetadataMatches(decoded_image->gainMap->metadata,
+                                  image->gainMap->metadata);
     }
   }
 
@@ -97,10 +100,11 @@ void EncodeDecodeValid(ImagePtr image, EncoderPtr encoder, DecoderPtr decoder) {
 // because the C array fields in the struct seem to prevent fuzztest from
 // handling it natively.
 ImagePtr AddGainMapToImage(
-    ImagePtr image, ImagePtr gainMap,
+    ImagePtr image, ImagePtr gain_map,
     const std::array<uint8_t, sizeof(avifGainMapMetadata)>& metadata) {
-  image->gainMap.image = gainMap.release();
-  std::memcpy(&image->gainMap.metadata, metadata.data(), metadata.size());
+  image->gainMap = avifGainMapCreate();
+  image->gainMap->image = gain_map.release();
+  std::memcpy(&image->gainMap->metadata, metadata.data(), metadata.size());
   return image;
 }
 

--- a/tests/gtest/avifincrtest_helpers.cc
+++ b/tests/gtest/avifincrtest_helpers.cc
@@ -65,10 +65,11 @@ void ComparePartialYuva(const avifImage& image1, const avifImage& image2,
   }
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-  if (image1.gainMap.image != nullptr && image2.gainMap.image != nullptr) {
+  if (image1.gainMap != nullptr && image1.gainMap->image != nullptr &&
+      image2.gainMap != nullptr && image2.gainMap->image != nullptr) {
     const uint32_t gain_map_row_count = (uint32_t)roundf(
-        (float)row_count / image1.height * image1.gainMap.image->height);
-    ComparePartialYuva(*image1.gainMap.image, *image2.gainMap.image,
+        (float)row_count / image1.height * image1.gainMap->image->height);
+    ComparePartialYuva(*image1.gainMap->image, *image2.gainMap->image,
                        gain_map_row_count);
   }
 #endif

--- a/tests/gtest/avifjpeggainmaptest.cc
+++ b/tests/gtest/avifjpeggainmaptest.cc
@@ -82,14 +82,15 @@ TEST(JpegTest, ReadJpegWithGainMap) {
                             /*ignore_xmp=*/true, /*allow_changing_cicp=*/true,
                             /*ignore_gain_map=*/false);
     ASSERT_NE(image, nullptr);
-    ASSERT_NE(image->gainMap.image, nullptr);
-    EXPECT_EQ(image->gainMap.image->width, 512u);
-    EXPECT_EQ(image->gainMap.image->height, 384u);
+    ASSERT_NE(image->gainMap, nullptr);
+    ASSERT_NE(image->gainMap->image, nullptr);
+    EXPECT_EQ(image->gainMap->image->width, 512u);
+    EXPECT_EQ(image->gainMap->image->height, 384u);
     // Since ignore_xmp is true, there should be no XMP, even if it had to
     // be read to parse the gain map.
     EXPECT_EQ(image->xmp.size, 0u);
 
-    CheckGainMapMetadata(image->gainMap.metadata,
+    CheckGainMapMetadata(image->gainMap->metadata,
                          /*gain_map_min=*/{0.0, 0.0, 0.0},
                          /*gain_map_max=*/{3.5, 3.6, 3.7},
                          /*gain_map_gamma=*/{1.0, 1.0, 1.0},
@@ -109,7 +110,7 @@ TEST(JpegTest, IgnoreGainMap) {
       /*ignore_xmp=*/false, /*allow_changing_cicp=*/true,
       /*ignore_gain_map=*/true);
   ASSERT_NE(image, nullptr);
-  EXPECT_EQ(image->gainMap.image, nullptr);
+  ASSERT_EQ(image->gainMap, nullptr);
   // Check there is xmp since ignore_xmp is false (just making sure that
   // ignore_gain_map=true has no impact on this).
   EXPECT_GT(image->xmp.size, 0u);


### PR DESCRIPTION
Allows adding members in the future without breaking the ABI.