### PR TITLE
Do not store colorproperties until alpha item is found

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -4742,7 +4742,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                                                   /*isItemInInput=*/AVIF_TRUE,
                                                   &data->tileInfos[AVIF_ITEM_COLOR].grid,
                                                   &codecType[AVIF_ITEM_COLOR]));
-        colorProperties = &data->meta->items.item[mainItemIndices[AVIF_ITEM_COLOR]].properties;
         colorCodecType = codecType[AVIF_ITEM_COLOR];
 
         // Optional alpha auxiliary item
@@ -4803,6 +4802,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
             mainItems[c] = (mainItemIndices[c] == -1) ? NULL : &data->meta->items.item[mainItemIndices[c]];
         }
+        colorProperties = &mainItems[AVIF_ITEM_COLOR]->properties;
 
         // Find Exif and/or XMP metadata, if any
         AVIF_CHECKRES(avifDecoderFindMetadata(decoder, data->meta, decoder->image, mainItems[AVIF_ITEM_COLOR]->id));


### PR DESCRIPTION
colorProperties could be pointing to a dangling pointer if findAlphaItem() resizes the meta.items array.