### PR TITLE
Add metadata about the alternate image to the gainMap struct.

### DIFF
--- a/apps/avifgainmaputil/swapbase_command.cc
+++ b/apps/avifgainmaputil/swapbase_command.cc
@@ -18,21 +18,25 @@ avifResult ChangeBase(avifImage& image, avifImage* swapped) {
       image.gainMap->metadata.alternateHdrHeadroomD;
   const bool tone_mapping_to_sdr = (headroom == 0.0f);
 
-  if (image.gainMap->altColorPrimaries != AVIF_COLOR_PRIMARIES_UNSPECIFIED ||
-      image.gainMap->altTransferCharacteristics !=
-          AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED) {
-    swapped->colorPrimaries = image.gainMap->altColorPrimaries;
-    swapped->transferCharacteristics =
-        image.gainMap->altTransferCharacteristics;
-    swapped->matrixCoefficients = image.gainMap->altMatrixCoefficients;
-  } else {
-    // If there is no cicp on the gain map, use the same values as the old base
-    // image, except for the transfer characteristics.
+  swapped->colorPrimaries = image.gainMap->altColorPrimaries;
+  if (swapped->colorPrimaries == AVIF_COLOR_PRIMARIES_UNSPECIFIED) {
+    // Default to the same primaries as the base image if unspecified.
     swapped->colorPrimaries = image.colorPrimaries;
+  }
+
+  swapped->transferCharacteristics = image.gainMap->altTransferCharacteristics;
+  if (swapped->transferCharacteristics ==
+      AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED) {
+    // Default to PQ for HDR and sRGB for SDR if unspecified.
     const avifTransferCharacteristics transfer_characteristics =
         tone_mapping_to_sdr ? AVIF_TRANSFER_CHARACTERISTICS_SRGB
                             : AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084;
     swapped->transferCharacteristics = transfer_characteristics;
+  }
+
+  swapped->matrixCoefficients = image.gainMap->altMatrixCoefficients;
+  if (swapped->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED) {
+    // Default to the same matrix as the base image if unspecified.
     swapped->matrixCoefficients = image.matrixCoefficients;
   }
 

--- a/apps/avifgainmaputil/tonemap_command.cc
+++ b/apps/avifgainmaputil/tonemap_command.cc
@@ -65,18 +65,7 @@ avifResult TonemapCommand::Run() {
   }
 
   const float headroom = arg_headroom_;
-  const bool tone_mapping_to_sdr = (headroom == 0.0f);
-
-  CicpValues cicp;
-  if (arg_output_cicp_.provenance() == argparse::Provenance::SPECIFIED) {
-    cicp = arg_output_cicp_;
-  } else {
-    const avifTransferCharacteristics transfer_characteristics =
-        tone_mapping_to_sdr ? AVIF_TRANSFER_CHARACTERISTICS_SRGB
-                            : AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084;
-    cicp = {AVIF_COLOR_PRIMARIES_UNKNOWN, transfer_characteristics,
-            AVIF_MATRIX_COEFFICIENTS_BT601};
-  }
+  const bool tone_mapping_to_hdr = (headroom > 0.0f);
 
   DecoderPtr decoder(avifDecoderCreate());
   if (decoder == NULL) {
@@ -90,66 +79,121 @@ avifResult TonemapCommand::Run() {
     return result;
   }
 
-  if (arg_input_cicp_.provenance() == argparse::Provenance::SPECIFIED) {
-    decoder->image->colorPrimaries = arg_input_cicp_.value().color_primaries;
-    decoder->image->transferCharacteristics =
-        arg_input_cicp_.value().transfer_characteristics;
-    decoder->image->matrixCoefficients =
-        arg_input_cicp_.value().matrix_coefficients;
-  }
-
-  if (decoder->image->gainMap == nullptr ||
-      decoder->image->gainMap->image == nullptr) {
+  avifImage* image = decoder->image;
+  if (image->gainMap == nullptr || image->gainMap->image == nullptr) {
     std::cerr << "Input image " << arg_input_filename_
               << " does not contain a gain map\n";
     return AVIF_RESULT_INVALID_ARGUMENT;
   }
 
   avifGainMapMetadataDouble metadata;
-  if (!avifGainMapMetadataFractionsToDouble(
-          &metadata, &decoder->image->gainMap->metadata)) {
+  if (!avifGainMapMetadataFractionsToDouble(&metadata,
+                                            &image->gainMap->metadata)) {
     std::cerr << "Input image " << arg_input_filename_
               << " has invalid gain map metadata\n";
     return AVIF_RESULT_INVALID_ARGUMENT;
   }
-  if (!clli_set) {
-    // Use the clli from the base image or the alternate image if the headroom
-    // is outside of the [baseHdrHeadroom, alternateHdrHeadroom] range.
-    if ((headroom <= metadata.baseHdrHeadroom &&
-         metadata.baseHdrHeadroom <= metadata.alternateHdrHeadroom) ||
-        (headroom >= metadata.baseHdrHeadroom &&
-         metadata.baseHdrHeadroom >= metadata.alternateHdrHeadroom)) {
-      clli_box = decoder->image->clli;
-    } else if ((headroom <= metadata.alternateHdrHeadroom &&
-                metadata.alternateHdrHeadroom <= metadata.baseHdrHeadroom) ||
-               (headroom >= metadata.alternateHdrHeadroom &&
-                metadata.alternateHdrHeadroom >= metadata.baseHdrHeadroom)) {
-      clli_box = decoder->image->gainMap->image->clli;
-    }
-    clli_set = (clli_box.maxCLL != 0) || (clli_box.maxPALL != 0);
+
+  // We are either tone mapping to the base image (i.e. leaving it as is),
+  // or tone mapping to the alternate image (i.e. fully applying the gain map),
+  // or tone mapping in between (partially applying the gain map).
+  const bool tone_mapping_to_base =
+      (headroom <= metadata.baseHdrHeadroom &&
+       metadata.baseHdrHeadroom <= metadata.alternateHdrHeadroom) ||
+      (headroom >= metadata.baseHdrHeadroom &&
+       metadata.baseHdrHeadroom >= metadata.alternateHdrHeadroom);
+  const bool tone_mapping_to_alternate =
+      (headroom <= metadata.alternateHdrHeadroom &&
+       metadata.alternateHdrHeadroom <= metadata.baseHdrHeadroom) ||
+      (headroom >= metadata.alternateHdrHeadroom &&
+       metadata.alternateHdrHeadroom >= metadata.baseHdrHeadroom);
+  const bool base_is_hdr = (metadata.baseHdrHeadroom != 0.0f);
+
+  // Determine output CICP.
+  CicpValues cicp;
+  if (arg_output_cicp_.provenance() == argparse::Provenance::SPECIFIED) {
+    cicp = arg_output_cicp_;  // User provided values.
+  } else if (tone_mapping_to_base || (tone_mapping_to_hdr && base_is_hdr)) {
+    cicp = {image->colorPrimaries, image->transferCharacteristics,
+            image->matrixCoefficients};
+  } else {
+    cicp = {image->gainMap->altColorPrimaries,
+            image->gainMap->altTransferCharacteristics,
+            image->gainMap->altMatrixCoefficients};
+  }
+  if (cicp.color_primaries == AVIF_COLOR_PRIMARIES_UNSPECIFIED) {
+    // TODO(maryla): for now avifImageApplyGainMap always uses the primaries of
+    // the base image, but it should take into account the metadata's
+    // useBaseColorSpace property.
+    cicp.color_primaries = image->colorPrimaries;
+  }
+  if (cicp.transfer_characteristics ==
+      AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED) {
+    cicp.transfer_characteristics =
+        tone_mapping_to_hdr ? AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084
+                            : AVIF_TRANSFER_CHARACTERISTICS_SRGB;
   }
 
+  // Determine output depth.
   int depth = arg_image_read_.depth;
   if (depth == 0) {
-    depth = tone_mapping_to_sdr ? 8 : decoder->image->depth;
+    if (tone_mapping_to_base) {
+      depth = image->depth;
+    } else if (tone_mapping_to_alternate) {
+      depth = image->gainMap->altDepth;
+    }
+    if (depth == 0) {
+      // Default to the max depth between the base image, the gain map and
+      // the specified 'altDepth'.
+      depth = std::max(std::max(image->depth, image->gainMap->image->depth),
+                       image->gainMap->altDepth);
+    }
   }
+
+  // Determine output pixel format.
   avifPixelFormat pixel_format =
       (avifPixelFormat)arg_image_read_.pixel_format.value();
+  const avifPixelFormat alt_yuv_format =
+      (image->gainMap->altPlaneCount == 1)
+          ? AVIF_PIXEL_FORMAT_YUV400
+          : std::min(image->yuvFormat, image->gainMap->image->yuvFormat);
   if (pixel_format == AVIF_PIXEL_FORMAT_NONE) {
-    pixel_format = AVIF_PIXEL_FORMAT_YUV444;
+    if (tone_mapping_to_base) {
+      pixel_format = image->yuvFormat;
+    } else if (tone_mapping_to_alternate) {
+      pixel_format = alt_yuv_format;
+    }
+    if (pixel_format == AVIF_PIXEL_FORMAT_NONE) {
+      // Default to the least chroma subsampled format provided.
+      pixel_format =
+          std::min(std::min(image->yuvFormat, image->gainMap->image->yuvFormat),
+                   alt_yuv_format);
+    }
   }
-  ImagePtr tone_mapped(avifImageCreate(
-      decoder->image->width, decoder->image->height, depth, pixel_format));
+
+  // Use the clli from the base image or the alternate image if the headroom
+  // is outside of the (baseHdrHeadroom, alternateHdrHeadroom) range.
+  if (!clli_set) {
+    if (tone_mapping_to_base) {
+      clli_box = image->clli;
+    } else if (tone_mapping_to_alternate) {
+      clli_box = image->gainMap->image->clli;
+    }
+  }
+  clli_set = (clli_box.maxCLL != 0) || (clli_box.maxPALL != 0);
+
+  ImagePtr tone_mapped(
+      avifImageCreate(image->width, image->height, depth, pixel_format));
   if (tone_mapped == nullptr) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
   avifRGBImage tone_mapped_rgb;
   avifRGBImageSetDefaults(&tone_mapped_rgb, tone_mapped.get());
   avifDiagnostics diag;
-  result = avifImageApplyGainMap(decoder->image, decoder->image->gainMap,
-                                 arg_headroom_, cicp.transfer_characteristics,
-                                 &tone_mapped_rgb,
-                                 clli_set ? nullptr : &clli_box, &diag);
+  result =
+      avifImageApplyGainMap(decoder->image, image->gainMap, arg_headroom_,
+                            cicp.transfer_characteristics, &tone_mapped_rgb,
+                            clli_set ? nullptr : &clli_box, &diag);
   if (result != AVIF_RESULT_OK) {
     std::cout << "Failed to tone map image: " << avifResultToString(result)
               << " (" << diag.error << ")\n";
@@ -161,12 +205,7 @@ avifResult TonemapCommand::Run() {
               << "\n";
     return result;
   }
-  if (cicp.color_primaries == AVIF_COLOR_PRIMARIES_UNKNOWN) {
-    // TODO(maryla): for now avifImageApplyGainMap always uses the primaries of
-    // the base image, but it should take into account the metadata's
-    // useBaseColorSpace property.
-    cicp.color_primaries = decoder->image->colorPrimaries;
-  }
+
   tone_mapped->clli = clli_box;
   tone_mapped->transferCharacteristics = cicp.transfer_characteristics;
   tone_mapped->colorPrimaries = cicp.color_primaries;

--- a/apps/avifgainmaputil/tonemap_command.cc
+++ b/apps/avifgainmaputil/tonemap_command.cc
@@ -156,6 +156,7 @@ avifResult TonemapCommand::Run() {
   const avifPixelFormat alt_yuv_format =
       (image->gainMap->altPlaneCount == 1)
           ? AVIF_PIXEL_FORMAT_YUV400
+          // Favor the least chroma subsampled format.
           : std::min(image->yuvFormat, image->gainMap->image->yuvFormat);
   if (pixel_format == AVIF_PIXEL_FORMAT_NONE) {
     if (tone_mapping_to_base) {

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -1138,6 +1138,11 @@ static avifBool avifJPEGReadInternal(FILE * f,
         // Ignore the return value: continue even if we fail to find/parse/decode the gain map.
         avifGainMap * gainMap = avifGainMapCreate();
         if (avifJPEGExtractGainMapImage(f, &cinfo, gainMap, chromaDownsampling)) {
+            // Since jpeg doesn't provide this metadata, assume the values are the same as the base image
+            // with a PQ transfer curve.
+            gainMap->altColorPrimaries = avif->colorPrimaries;
+            gainMap->altTransferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084;
+            gainMap->altMatrixCoefficients = avif->matrixCoefficients;
             avif->gainMap = gainMap;
         } else {
             avifGainMapDestroy(gainMap);

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -550,11 +550,18 @@ typedef struct avifContentLightLevelInformationBox
 // to be stable, and might even be removed in the future. Use are your own risk.
 // This is based on ISO/IEC JTC 1/SC 29/WG 3 m64379
 // This product includes Gain Map technology under license by Adobe.
+//
+// Terms:
+// base image: main image stored in the file, shown by viewers that do not support
+//     gain maps
+// alternate image: image  obtained by combining the base image and the gain map
+// gain map: data structure that contains pixels and metadata used for conversion
+//     between the base image and the alternate image
 
 struct avifImage;
 
-// Gain map metadata, to apply the gain map. Fully applying the gain map to the "base"
-// image results in the "alternate" image.
+// Gain map metadata, to apply the gain map. Fully applying the gain map to the base
+// image results in the alternate image.
 // All field pairs ending with 'N' and 'D' are fractional values (numerator and denominator).
 typedef struct avifGainMapMetadata
 {
@@ -633,12 +640,28 @@ typedef struct avifGainMap
     // Owned by the avifGainMap and gets freed when calling avifGainMapDestroy().
     // Used fields: width, height, depth, yufFormat, yuvRange,
     // yuvChromaSamplePosition, yuvPlanes, yuvRowBytes, imageOwnsYUVPlanes,
-    // matrixCoefficients, transferCharacteristics. Other fields are ignored.
+    // matrixCoefficients. colorPrimaries and transferCharacteristics shall be 2.
+    // Other fields are ignored.
     struct avifImage * image;
 
     // Gain map metadata.
     // For an image grid, the metadata shall be identical for all cells.
     avifGainMapMetadata metadata;
+
+    // Colorimetry of the alternate image.
+    avifRWData altICC;
+    avifColorPrimaries altColorPrimaries;
+    avifTransferCharacteristics altTransferCharacteristics;
+    avifMatrixCoefficients altMatrixCoefficients;
+    avifRange altYUVRange;
+
+    // Hint on the approximate amount of colour resolution available after fully
+    // applying the gain map.
+    uint32_t altDepth;
+    uint32_t altPlaneCount;
+
+    // Optimal viewing conditions of the alternate image.
+    avifContentLightLevelInformationBox altCLLI;
 } avifGainMap;
 
 // Allocates a gain map. Returns NULL if a memory allocation failed.

--- a/src/avif.c
+++ b/src/avif.c
@@ -264,6 +264,14 @@ avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifP
             AVIF_CHECKERR(dstImage->gainMap, AVIF_RESULT_OUT_OF_MEMORY);
         }
         dstImage->gainMap->metadata = srcImage->gainMap->metadata;
+        AVIF_CHECKRES(avifRWDataSet(&dstImage->gainMap->altICC, srcImage->gainMap->altICC.data, srcImage->gainMap->altICC.size));
+        dstImage->gainMap->altColorPrimaries = srcImage->gainMap->altColorPrimaries;
+        dstImage->gainMap->altTransferCharacteristics = srcImage->gainMap->altTransferCharacteristics;
+        dstImage->gainMap->altMatrixCoefficients = srcImage->gainMap->altMatrixCoefficients;
+        dstImage->gainMap->altDepth = srcImage->gainMap->altDepth;
+        dstImage->gainMap->altPlaneCount = srcImage->gainMap->altPlaneCount;
+        dstImage->gainMap->altCLLI = srcImage->gainMap->altCLLI;
+
         if (srcImage->gainMap->image) {
             if (!dstImage->gainMap->image) {
                 dstImage->gainMap->image = avifImageCreateEmpty();
@@ -1149,6 +1157,10 @@ avifGainMap * avifGainMapCreate()
         return NULL;
     }
     memset(gainMap, 0, sizeof(avifGainMap));
+    gainMap->altColorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
+    gainMap->altTransferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
+    gainMap->altMatrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
+    gainMap->altYUVRange = AVIF_RANGE_FULL;
     return gainMap;
 }
 

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -566,6 +566,9 @@ avifResult avifImageComputeGainMap(const avifImage * baseImage, const avifImage 
 {
     avifDiagnosticsClearError(diag);
 
+    if (baseImage == NULL || altImage == NULL || gainMap == NULL) {
+        return AVIF_RESULT_INVALID_ARGUMENT;
+    }
     if (baseImage->icc.size > 0 || altImage->icc.size > 0) {
         avifDiagnosticsPrintf(diag, "Computing gain maps for images with ICC profiles is not supported");
         return AVIF_RESULT_NOT_IMPLEMENTED;
@@ -617,6 +620,18 @@ avifResult avifImageComputeGainMap(const avifImage * baseImage, const avifImage 
                                      baseImage->colorPrimaries,
                                      gainMap,
                                      diag);
+
+    if (res != AVIF_RESULT_OK) {
+        goto cleanup;
+    }
+
+    AVIF_CHECKRES(avifRWDataSet(&gainMap->altICC, altImage->icc.data, altImage->icc.size));
+    gainMap->altColorPrimaries = altImage->colorPrimaries;
+    gainMap->altTransferCharacteristics = altImage->transferCharacteristics;
+    gainMap->altMatrixCoefficients = altImage->matrixCoefficients;
+    gainMap->altDepth = altImage->depth;
+    gainMap->altPlaneCount = (altImage->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) ? 1 : 3;
+    gainMap->altCLLI = altImage->clli;
 
 cleanup:
     avifRGBImageFreePixels(&baseImageRgb);

--- a/src/read.c
+++ b/src/read.c
@@ -4363,6 +4363,54 @@ static avifResult avifMetaFindAlphaItem(avifMeta * meta,
     return AVIF_RESULT_OK;
 }
 
+static avifResult avifReadColorProperties(avifIO * io,
+                                          const avifPropertyArray * properties,
+                                          avifRWData * icc,
+                                          avifColorPrimaries * colorPrimaries,
+                                          avifTransferCharacteristics * transferCharacteristics,
+                                          avifMatrixCoefficients * matrixCoefficients,
+                                          avifRange * yuvRange,
+                                          avifBool * cicpSet)
+{
+    // Find and adopt all colr boxes "at most one for a given value of colour type" (HEIF 6.5.5.1, from Amendment 3)
+    // Accept one of each type, and bail out if more than one of a given type is provided.
+    avifBool colrICCSeen = AVIF_FALSE;
+    avifBool colrNCLXSeen = AVIF_FALSE;
+    for (uint32_t propertyIndex = 0; propertyIndex < properties->count; ++propertyIndex) {
+        avifProperty * prop = &properties->prop[propertyIndex];
+
+        if (!memcmp(prop->type, "colr", 4)) {
+            if (prop->u.colr.hasICC) {
+                if (colrICCSeen) {
+                    return AVIF_RESULT_BMFF_PARSE_FAILED;
+                }
+                avifROData iccRead;
+                const avifResult readResult = io->read(io, 0, prop->u.colr.iccOffset, prop->u.colr.iccSize, &iccRead);
+                if (readResult != AVIF_RESULT_OK) {
+                    return readResult;
+                }
+                colrICCSeen = AVIF_TRUE;
+                AVIF_CHECKRES(avifRWDataSet(icc, iccRead.data, iccRead.size));
+            }
+            if (prop->u.colr.hasNCLX) {
+                if (colrNCLXSeen) {
+                    return AVIF_RESULT_BMFF_PARSE_FAILED;
+                }
+                colrNCLXSeen = AVIF_TRUE;
+                if (cicpSet != NULL) {
+                    *cicpSet = AVIF_TRUE;
+                }
+                *colorPrimaries = prop->u.colr.colorPrimaries;
+                *transferCharacteristics = prop->u.colr.transferCharacteristics;
+                *matrixCoefficients = prop->u.colr.matrixCoefficients;
+                *yuvRange = prop->u.colr.range;
+            }
+        }
+    }
+
+    return AVIF_RESULT_OK;
+}
+
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
 // Finds a 'tmap' (tone mapped image item) box associated with the given 'colorItem'.
 // If found, fills 'toneMappedImageItem' and  sets 'gainMapItemID' to the id of the gain map
@@ -4467,26 +4515,39 @@ static avifResult avifDecoderFindGainMapItem(const avifDecoder * decoder,
         AVIF_CHECKERR(decoder->image->gainMap, AVIF_RESULT_OUT_OF_MEMORY);
         decoder->image->gainMap->image = avifImageCreateEmpty();
         AVIF_CHECKERR(decoder->image->gainMap->image, AVIF_RESULT_OUT_OF_MEMORY);
+        avifGainMap * gainMap = decoder->image->gainMap;
 
         // Look for a colr nclx box. Other colr box types (e.g. ICC) are not supported.
         for (uint32_t propertyIndex = 0; propertyIndex < gainMapItem->properties.count; ++propertyIndex) {
             avifProperty * prop = &gainMapItem->properties.prop[propertyIndex];
             if (!memcmp(prop->type, "colr", 4) && prop->u.colr.hasNCLX) {
-                decoder->image->gainMap->image->colorPrimaries = prop->u.colr.colorPrimaries;
-                decoder->image->gainMap->image->transferCharacteristics = prop->u.colr.transferCharacteristics;
-                decoder->image->gainMap->image->matrixCoefficients = prop->u.colr.matrixCoefficients;
-                decoder->image->gainMap->image->yuvRange = prop->u.colr.range;
+                gainMap->image->colorPrimaries = prop->u.colr.colorPrimaries;
+                gainMap->image->transferCharacteristics = prop->u.colr.transferCharacteristics;
+                gainMap->image->matrixCoefficients = prop->u.colr.matrixCoefficients;
+                gainMap->image->yuvRange = prop->u.colr.range;
                 break;
             }
         }
 
-        // Copy HDR properties associated with the tmap box to the gain map image.
-        // Technically, the gain map is not an HDR image, but in the API, this is the most convenient
-        // place to put this data.
-        // TODO(maryla): add other HDR boxes: mdcv, cclv, etc.
+        AVIF_CHECKRES(avifReadColorProperties(decoder->io,
+                                              &toneMappedImageItemTmp->properties,
+                                              &gainMap->altICC,
+                                              &gainMap->altColorPrimaries,
+                                              &gainMap->altTransferCharacteristics,
+                                              &gainMap->altMatrixCoefficients,
+                                              &gainMap->altYUVRange,
+                                              /*cicpSet=*/NULL));
+
         const avifProperty * clliProp = avifPropertyArrayFind(&toneMappedImageItemTmp->properties, "clli");
         if (clliProp) {
-            decoder->image->gainMap->image->clli = clliProp->u.clli;
+            gainMap->altCLLI = clliProp->u.clli;
+        }
+
+        const avifProperty * pixiProp = avifPropertyArrayFind(&toneMappedImageItemTmp->properties, "pixi");
+        if (pixiProp && pixiProp->u.pixi.planeCount > 0) {
+            gainMap->altPlaneCount = pixiProp->u.pixi.planeCount;
+            // Assume all planes have the same depth.
+            gainMap->altDepth = pixiProp->u.pixi.planeDepths[0];
         }
     }
 
@@ -4903,39 +4964,14 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         }
     }
 
-    // Find and adopt all colr boxes "at most one for a given value of colour type" (HEIF 6.5.5.1, from Amendment 3)
-    // Accept one of each type, and bail out if more than one of a given type is provided.
-    avifBool colrICCSeen = AVIF_FALSE;
-    avifBool colrNCLXSeen = AVIF_FALSE;
-    for (uint32_t propertyIndex = 0; propertyIndex < colorProperties->count; ++propertyIndex) {
-        avifProperty * prop = &colorProperties->prop[propertyIndex];
-
-        if (!memcmp(prop->type, "colr", 4)) {
-            if (prop->u.colr.hasICC) {
-                if (colrICCSeen) {
-                    return AVIF_RESULT_BMFF_PARSE_FAILED;
-                }
-                avifROData icc;
-                const avifResult readResult = decoder->io->read(decoder->io, 0, prop->u.colr.iccOffset, prop->u.colr.iccSize, &icc);
-                if (readResult != AVIF_RESULT_OK) {
-                    return readResult;
-                }
-                colrICCSeen = AVIF_TRUE;
-                AVIF_CHECKRES(avifImageSetProfileICC(decoder->image, icc.data, icc.size));
-            }
-            if (prop->u.colr.hasNCLX) {
-                if (colrNCLXSeen) {
-                    return AVIF_RESULT_BMFF_PARSE_FAILED;
-                }
-                colrNCLXSeen = AVIF_TRUE;
-                data->cicpSet = AVIF_TRUE;
-                decoder->image->colorPrimaries = prop->u.colr.colorPrimaries;
-                decoder->image->transferCharacteristics = prop->u.colr.transferCharacteristics;
-                decoder->image->matrixCoefficients = prop->u.colr.matrixCoefficients;
-                decoder->image->yuvRange = prop->u.colr.range;
-            }
-        }
-    }
+    AVIF_CHECKRES(avifReadColorProperties(decoder->io,
+                                          colorProperties,
+                                          &decoder->image->icc,
+                                          &decoder->image->colorPrimaries,
+                                          &decoder->image->transferCharacteristics,
+                                          &decoder->image->matrixCoefficients,
+                                          &decoder->image->yuvRange,
+                                          &data->cicpSet));
 
     const avifProperty * clliProp = avifPropertyArrayFind(colorProperties, "clli");
     if (clliProp) {

--- a/src/read.c
+++ b/src/read.c
@@ -4543,7 +4543,7 @@ static avifResult avifDecoderFindGainMapItem(const avifDecoder * decoder,
         const avifProperty * pixiProp = avifPropertyArrayFind(&toneMappedImageItemTmp->properties, "pixi");
         if (pixiProp) {
             if (pixiProp->u.pixi.planeCount == 0) {
-                avifDiagnosticsPrintf(data->diag, "Box[pixi] of tmap item contains invalid plane count [%u]", pixiProp->u.pixi.planeCount);
+                avifDiagnosticsPrintf(data->diag, "Box[pixi] of tmap item contains unsupported plane count [%u]", pixiProp->u.pixi.planeCount);
                 return AVIF_RESULT_BMFF_PARSE_FAILED;
             }
             gainMap->altPlaneCount = pixiProp->u.pixi.planeCount;

--- a/src/write.c
+++ b/src/write.c
@@ -229,6 +229,11 @@ typedef struct avifEncoderData
     int lastTileRowsLog2;
     int lastTileColsLog2;
     avifImage * imageMetadata;
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+    // For convenience, holds metadata derived from the avifGainMap struct (when present) about the
+    // altenate image
+    avifImage * altImageMetadata;
+#endif
     uint16_t lastItemID;
     uint16_t primaryItemID;
     avifEncoderItemIdArray alternativeItemIDs; // list of item ids for an 'altr' box (group of alternatives to each other)
@@ -251,6 +256,9 @@ static avifEncoderData * avifEncoderDataCreate()
     }
     memset(data, 0, sizeof(avifEncoderData));
     data->imageMetadata = avifImageCreateEmpty();
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+    data->altImageMetadata = avifImageCreateEmpty();
+#endif
     if (!data->imageMetadata) {
         goto error;
     }
@@ -325,6 +333,11 @@ static void avifEncoderDataDestroy(avifEncoderData * data)
     if (data->imageMetadata) {
         avifImageDestroy(data->imageMetadata);
     }
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+    if (data->altImageMetadata) {
+        avifImageDestroy(data->altImageMetadata);
+    }
+#endif
     avifArrayDestroy(&data->items);
     avifArrayDestroy(&data->frames);
     avifArrayDestroy(&data->alternativeItemIDs);
@@ -947,6 +960,24 @@ size_t avifEncoderGetGainMapSizeBytes(avifEncoder * encoder)
 {
     return encoder->data->gainMapSizeBytes;
 }
+
+// Sets altImageMetadata's metadata values to represent the "alternate" image after applying the gain map to the base image.
+static avifResult avifImageCopyAltImageMetadata(avifImage * altImageMetadata, const avifImage * imageWithGainMap)
+{
+    altImageMetadata->width = imageWithGainMap->width;
+    altImageMetadata->height = imageWithGainMap->height;
+    AVIF_CHECKRES(avifRWDataSet(&altImageMetadata->icc, imageWithGainMap->gainMap->altICC.data, imageWithGainMap->gainMap->altICC.size));
+    altImageMetadata->colorPrimaries = imageWithGainMap->gainMap->altColorPrimaries;
+    altImageMetadata->transferCharacteristics = imageWithGainMap->gainMap->altTransferCharacteristics;
+    altImageMetadata->matrixCoefficients = imageWithGainMap->gainMap->altMatrixCoefficients;
+    altImageMetadata->yuvRange = imageWithGainMap->gainMap->altYUVRange;
+    altImageMetadata->depth = imageWithGainMap->gainMap->altDepth
+                                  ? imageWithGainMap->gainMap->altDepth
+                                  : AVIF_MAX(imageWithGainMap->depth, imageWithGainMap->gainMap->image->depth);
+    altImageMetadata->yuvFormat = (imageWithGainMap->gainMap->altPlaneCount == 1) ? AVIF_PIXEL_FORMAT_YUV400 : AVIF_PIXEL_FORMAT_YUV444;
+    altImageMetadata->clli = imageWithGainMap->gainMap->altCLLI;
+    return AVIF_RESULT_OK;
+}
 #endif // AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP
 
 static avifResult avifEncoderDataCreateExifItem(avifEncoderData * data, const avifRWData * exif)
@@ -1325,8 +1356,21 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             return AVIF_RESULT_INVALID_IMAGE_GRID;
         }
         if (hasGainMap) {
-            const avifGainMapMetadata * firstMetadata = &firstCell->gainMap->metadata;
-            const avifGainMapMetadata * cellMetadata = &cellImage->gainMap->metadata;
+            const avifGainMap * firstGainMap = firstCell->gainMap;
+            const avifGainMap * cellGainMap = cellImage->gainMap;
+            if (cellGainMap->altICC.size != firstGainMap->altICC.size ||
+                memcmp(cellGainMap->altICC.data, firstGainMap->altICC.data, cellGainMap->altICC.size) != 0 ||
+                cellGainMap->altColorPrimaries != firstGainMap->altColorPrimaries ||
+                cellGainMap->altTransferCharacteristics != firstGainMap->altTransferCharacteristics ||
+                cellGainMap->altMatrixCoefficients != firstGainMap->altMatrixCoefficients ||
+                cellGainMap->altYUVRange != firstGainMap->altYUVRange || cellGainMap->altDepth != firstGainMap->altDepth ||
+                cellGainMap->altPlaneCount != firstGainMap->altPlaneCount || cellGainMap->altCLLI.maxCLL != firstGainMap->altCLLI.maxCLL ||
+                cellGainMap->altCLLI.maxPALL != firstGainMap->altCLLI.maxPALL) {
+                avifDiagnosticsPrintf(&encoder->diag, "all cells should have the same alternate image metadata in the gain map");
+                return AVIF_RESULT_INVALID_IMAGE_GRID;
+            }
+            const avifGainMapMetadata * firstMetadata = &firstGainMap->metadata;
+            const avifGainMapMetadata * cellMetadata = &cellGainMap->metadata;
             if (cellMetadata->backwardDirection != firstMetadata->backwardDirection ||
                 cellMetadata->baseHdrHeadroomN != firstMetadata->baseHdrHeadroomN ||
                 cellMetadata->baseHdrHeadroomD != firstMetadata->baseHdrHeadroomD ||
@@ -1356,6 +1400,10 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
     if (hasGainMap) {
         AVIF_CHECKRES(avifValidateImageBasicProperties(firstCell->gainMap->image));
         AVIF_CHECKRES(avifValidateGrid(gridCols, gridRows, cellImages, /*validateGainMap=*/AVIF_TRUE, &encoder->diag));
+        if (firstCell->gainMap->image->colorPrimaries != 2 || firstCell->gainMap->image->transferCharacteristics != 2) {
+            avifDiagnosticsPrintf(&encoder->diag, "the gain map image must have colorPrimaries = 2 and transferCharacteristics = 2");
+            return AVIF_RESULT_INVALID_ARGUMENT;
+        }
     }
 #endif // AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP
 
@@ -1439,10 +1487,12 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
 
     if (encoder->data->items.count == 0) {
         // Make a copy of the first image's metadata (sans pixels) for future writing/validation
-        const avifResult copyResult = avifImageCopy(encoder->data->imageMetadata, firstCell, 0);
-        if (copyResult != AVIF_RESULT_OK) {
-            return copyResult;
+        AVIF_CHECKRES(avifImageCopy(encoder->data->imageMetadata, firstCell, 0));
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+        if (hasGainMap) {
+            AVIF_CHECKRES(avifImageCopyAltImageMetadata(encoder->data->altImageMetadata, encoder->data->imageMetadata));
         }
+#endif
 
         // Prepare all AV1 items
         uint16_t colorItemID;
@@ -1498,7 +1548,7 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
                 avifDiagnosticsPrintf(&encoder->diag, "failed to write gain map metadata, some values may be negative or too large");
                 return AVIF_RESULT_ENCODE_GAIN_MAP_FAILED;
             }
-            // Even though the 'tmap' item is related to the gain map, it shares most of its properties (width/height, depth etc.) with the color item.
+            // Even though the 'tmap' item is related to the gain map, it represents a color image and its metadata is more similar to the color item.
             toneMappedItem->itemCategory = AVIF_ITEM_COLOR;
             uint16_t toneMappedItemID = toneMappedItem->id;
 
@@ -2145,7 +2195,8 @@ static avifResult avifEncoderWriteCondensedImageBox(avifEncoder * encoder, avifR
 static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedup,
                                               avifRWStream * const s,
                                               const avifEncoder * const encoder,
-                                              const avifImage * const imageMetadata)
+                                              const avifImage * const imageMetadata,
+                                              const avifImage * const altImageMetadata)
 {
     for (uint32_t itemIndex = 0; itemIndex < encoder->data->items.count; ++itemIndex) {
         avifEncoderItem * item = &encoder->data->items.item[itemIndex];
@@ -2183,10 +2234,14 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
 
         const avifImage * itemMetadata = imageMetadata;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-        if (item->itemCategory == AVIF_ITEM_GAIN_MAP) {
+        if (isToneMappedImage) {
+            itemMetadata = altImageMetadata;
+        } else if (item->itemCategory == AVIF_ITEM_GAIN_MAP) {
             assert(itemMetadata->gainMap && itemMetadata->gainMap->image);
             itemMetadata = itemMetadata->gainMap->image;
         }
+#else
+        (void)altImageMetadata;
 #endif
         uint32_t imageWidth = itemMetadata->width;
         uint32_t imageHeight = itemMetadata->height;
@@ -2196,6 +2251,7 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
         }
 
         // Properties all image items need
+        // ispe = image spatial extent (width, height)
         avifItemPropertyDedupStart(dedup);
         avifBoxMarker ispe;
         AVIF_CHECKRES(avifRWStreamWriteFullBox(&dedup->s, "ispe", AVIF_BOX_SIZE_TBD, 0, 0, &ispe));
@@ -2204,17 +2260,29 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
         avifRWStreamFinishBox(&dedup->s, ispe);
         AVIF_CHECKRES(avifItemPropertyDedupFinish(dedup, s, &item->ipma, AVIF_FALSE));
 
-        avifItemPropertyDedupStart(dedup);
-        uint8_t channelCount = (item->itemCategory == AVIF_ITEM_ALPHA || (itemMetadata->yuvFormat == AVIF_PIXEL_FORMAT_YUV400)) ? 1 : 3;
-        avifBoxMarker pixi;
-        AVIF_CHECKRES(avifRWStreamWriteFullBox(&dedup->s, "pixi", AVIF_BOX_SIZE_TBD, 0, 0, &pixi));
-        AVIF_CHECKRES(avifRWStreamWriteU8(&dedup->s, channelCount)); // unsigned int (8) num_channels;
-        for (uint8_t chan = 0; chan < channelCount; ++chan) {
-            AVIF_CHECKRES(avifRWStreamWriteU8(&dedup->s, (uint8_t)itemMetadata->depth)); // unsigned int (8) bits_per_channel;
+        // pixi = pixel information (depth, channel count)
+        avifBool hasPixi = AVIF_TRUE;
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+        // Pixi is optional for the 'tmap' item.
+        if (isToneMappedImage && imageMetadata->gainMap->altDepth == 0 && imageMetadata->gainMap->altPlaneCount == 0) {
+            hasPixi = AVIF_FALSE;
         }
-        avifRWStreamFinishBox(&dedup->s, pixi);
-        AVIF_CHECKRES(avifItemPropertyDedupFinish(dedup, s, &item->ipma, AVIF_FALSE));
+#endif
+        if (hasPixi) {
+            avifItemPropertyDedupStart(dedup);
+            uint8_t channelCount =
+                (item->itemCategory == AVIF_ITEM_ALPHA || (itemMetadata->yuvFormat == AVIF_PIXEL_FORMAT_YUV400)) ? 1 : 3;
+            avifBoxMarker pixi;
+            AVIF_CHECKRES(avifRWStreamWriteFullBox(&dedup->s, "pixi", AVIF_BOX_SIZE_TBD, 0, 0, &pixi));
+            AVIF_CHECKRES(avifRWStreamWriteU8(&dedup->s, channelCount)); // unsigned int (8) num_channels;
+            for (uint8_t chan = 0; chan < channelCount; ++chan) {
+                AVIF_CHECKRES(avifRWStreamWriteU8(&dedup->s, (uint8_t)itemMetadata->depth)); // unsigned int (8) bits_per_channel;
+            }
+            avifRWStreamFinishBox(&dedup->s, pixi);
+            AVIF_CHECKRES(avifItemPropertyDedupFinish(dedup, s, &item->ipma, AVIF_FALSE));
+        }
 
+        // Codec configuration box ('av1C' or 'av2C')
         if (item->codec) {
             avifItemPropertyDedupStart(dedup);
             AVIF_CHECKRES(writeConfigBox(&dedup->s, &item->av1C, encoder->data->configPropName));
@@ -2232,19 +2300,10 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
             AVIF_CHECKRES(avifItemPropertyDedupFinish(dedup, s, &item->ipma, AVIF_FALSE));
         } else if (item->itemCategory == AVIF_ITEM_COLOR) {
             // Color specific properties
+            // Note the 'tmap' (tone mapped image) item when a gain map is present also has itemCategory AVIF_ITEM_COLOR.
 
             AVIF_CHECKRES(avifEncoderWriteColorProperties(s, itemMetadata, &item->ipma, dedup));
-            if (isToneMappedImage) {
-#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-                // HDR properties for the tone mapped image ('tmap' box) are taken from the gain map image.
-                // Technically, the gain map is not an HDR image, but in the API, this is the most convenient
-                // place to put this data.
-
-                AVIF_CHECKRES(avifEncoderWriteHDRProperties(&dedup->s, s, imageMetadata->gainMap->image, &item->ipma, dedup));
-#endif
-            } else {
-                AVIF_CHECKRES(avifEncoderWriteHDRProperties(&dedup->s, s, itemMetadata, &item->ipma, dedup));
-            }
+            AVIF_CHECKRES(avifEncoderWriteHDRProperties(&dedup->s, s, itemMetadata, &item->ipma, dedup));
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         } else if (item->itemCategory == AVIF_ITEM_GAIN_MAP) {
             // Gain map specific properties
@@ -2602,7 +2661,11 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     AVIF_CHECKERR(dedup != NULL, AVIF_RESULT_OUT_OF_MEMORY);
     avifBoxMarker ipco;
     AVIF_CHECKRES(avifRWStreamWriteBox(&s, "ipco", AVIF_BOX_SIZE_TBD, &ipco));
-    avifResult result = avifRWStreamWriteProperties(dedup, &s, encoder, imageMetadata);
+    avifImage * altImageMetadata = NULL;
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+    altImageMetadata = encoder->data->altImageMetadata;
+#endif
+    avifResult result = avifRWStreamWriteProperties(dedup, &s, encoder, imageMetadata, altImageMetadata);
     avifItemPropertyDedupDestroy(dedup);
     AVIF_CHECKRES(result);
     avifRWStreamFinishBox(&s, ipco);

--- a/tests/data/goldens/paris_exif_xmp_gainmap_bigendian.jpg.avif.xml
+++ b/tests/data/goldens/paris_exif_xmp_gainmap_bigendian.jpg.avif.xml
@@ -8,7 +8,7 @@
 <BrandEntry AlternateBrand="miaf"/>
 <BrandEntry AlternateBrand="MA1B"/>
 </FileTypeBox>
-<MetaBox Size="587" Type="meta" Version="0" Flags="0" Specification="p12" Container="file moov trak moof traf udta" >
+<MetaBox Size="605" Type="meta" Version="0" Flags="0" Specification="p12" Container="file moov trak moof traf udta" >
 <HandlerBox Size="40" Type="hdlr" Version="0" Flags="0" Specification="p12" Container="mdia meta minf" hdlrType="pict" Name="libavif" reserved1="0" reserved2="data:application/octet-string,000000000000000000000000">
 </HandlerBox>
 <PrimaryItemBox Size="14" Type="pitm" Version="0" Flags="0" Specification="p12" Container="meta" item_ID="1">
@@ -54,8 +54,8 @@
 <ItemReferenceBoxEntry ItemID="1"/>
 </ItemReferenceBox>
 </ItemReferenceBox>
-<ItemPropertiesBox Size="184" Type="iprp" Specification="iff" Container="meta" >
-<ItemPropertyContainerBox Size="140" Type="ipco" Specification="iff" Container="iprp" >
+<ItemPropertiesBox Size="202" Type="iprp" Specification="iff" Container="meta" >
+<ItemPropertyContainerBox Size="159" Type="ipco" Specification="iff" Container="iprp" >
 <ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="403" image_height="302">
 </ImageSpatialExtentsPropertyBox>
 <PixelInformationPropertyBox Size="16" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
@@ -69,6 +69,8 @@
 </AV1ConfigurationBox>
 <ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="1" transfer_characteristics="13" matrix_coefficients="6" full_range_flag="1">
 </ColourInformationBox>
+<ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="2" transfer_characteristics="16" matrix_coefficients="6" full_range_flag="1">
+</ColourInformationBox>
 <ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="512" image_height="384">
 </ImageSpatialExtentsPropertyBox>
 <PixelInformationPropertyBox Size="14" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
@@ -81,23 +83,22 @@
 <ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="2" transfer_characteristics="2" matrix_coefficients="6" full_range_flag="1">
 </ColourInformationBox>
 </ItemPropertyContainerBox>
-<ItemPropertyAssociationBox Size="36" Type="ipma" Version="0" Flags="0" Specification="iff" Container="iprp" entry_count="3">
+<ItemPropertyAssociationBox Size="35" Type="ipma" Version="0" Flags="0" Specification="iff" Container="iprp" entry_count="3">
 <AssociationEntry item_ID="1" association_count="4">
 <Property index="1" essential="0"/>
 <Property index="2" essential="0"/>
 <Property index="3" essential="1"/>
 <Property index="4" essential="0"/>
 </AssociationEntry>
-<AssociationEntry item_ID="2" association_count="3">
+<AssociationEntry item_ID="2" association_count="2">
 <Property index="1" essential="0"/>
-<Property index="2" essential="0"/>
-<Property index="4" essential="0"/>
+<Property index="5" essential="0"/>
 </AssociationEntry>
 <AssociationEntry item_ID="3" association_count="4">
-<Property index="5" essential="0"/>
 <Property index="6" essential="0"/>
-<Property index="7" essential="1"/>
-<Property index="8" essential="0"/>
+<Property index="7" essential="0"/>
+<Property index="8" essential="1"/>
+<Property index="9" essential="0"/>
 </AssociationEntry>
 </ItemPropertyAssociationBox>
 </ItemPropertiesBox>

--- a/tests/data/goldens/paris_exif_xmp_gainmap_littleendian.jpg.avif.xml
+++ b/tests/data/goldens/paris_exif_xmp_gainmap_littleendian.jpg.avif.xml
@@ -8,7 +8,7 @@
 <BrandEntry AlternateBrand="miaf"/>
 <BrandEntry AlternateBrand="MA1B"/>
 </FileTypeBox>
-<MetaBox Size="587" Type="meta" Version="0" Flags="0" Specification="p12" Container="file moov trak moof traf udta" >
+<MetaBox Size="605" Type="meta" Version="0" Flags="0" Specification="p12" Container="file moov trak moof traf udta" >
 <HandlerBox Size="40" Type="hdlr" Version="0" Flags="0" Specification="p12" Container="mdia meta minf" hdlrType="pict" Name="libavif" reserved1="0" reserved2="data:application/octet-string,000000000000000000000000">
 </HandlerBox>
 <PrimaryItemBox Size="14" Type="pitm" Version="0" Flags="0" Specification="p12" Container="meta" item_ID="1">
@@ -54,8 +54,8 @@
 <ItemReferenceBoxEntry ItemID="1"/>
 </ItemReferenceBox>
 </ItemReferenceBox>
-<ItemPropertiesBox Size="184" Type="iprp" Specification="iff" Container="meta" >
-<ItemPropertyContainerBox Size="140" Type="ipco" Specification="iff" Container="iprp" >
+<ItemPropertiesBox Size="202" Type="iprp" Specification="iff" Container="meta" >
+<ItemPropertyContainerBox Size="159" Type="ipco" Specification="iff" Container="iprp" >
 <ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="403" image_height="302">
 </ImageSpatialExtentsPropertyBox>
 <PixelInformationPropertyBox Size="16" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
@@ -69,6 +69,8 @@
 </AV1ConfigurationBox>
 <ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="1" transfer_characteristics="13" matrix_coefficients="6" full_range_flag="1">
 </ColourInformationBox>
+<ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="2" transfer_characteristics="16" matrix_coefficients="6" full_range_flag="1">
+</ColourInformationBox>
 <ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="512" image_height="384">
 </ImageSpatialExtentsPropertyBox>
 <PixelInformationPropertyBox Size="14" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
@@ -81,23 +83,22 @@
 <ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="2" transfer_characteristics="2" matrix_coefficients="6" full_range_flag="1">
 </ColourInformationBox>
 </ItemPropertyContainerBox>
-<ItemPropertyAssociationBox Size="36" Type="ipma" Version="0" Flags="0" Specification="iff" Container="iprp" entry_count="3">
+<ItemPropertyAssociationBox Size="35" Type="ipma" Version="0" Flags="0" Specification="iff" Container="iprp" entry_count="3">
 <AssociationEntry item_ID="1" association_count="4">
 <Property index="1" essential="0"/>
 <Property index="2" essential="0"/>
 <Property index="3" essential="1"/>
 <Property index="4" essential="0"/>
 </AssociationEntry>
-<AssociationEntry item_ID="2" association_count="3">
+<AssociationEntry item_ID="2" association_count="2">
 <Property index="1" essential="0"/>
-<Property index="2" essential="0"/>
-<Property index="4" essential="0"/>
+<Property index="5" essential="0"/>
 </AssociationEntry>
 <AssociationEntry item_ID="3" association_count="4">
-<Property index="5" essential="0"/>
 <Property index="6" essential="0"/>
-<Property index="7" essential="1"/>
-<Property index="8" essential="0"/>
+<Property index="7" essential="0"/>
+<Property index="8" essential="1"/>
+<Property index="9" essential="0"/>
 </AssociationEntry>
 </ItemPropertyAssociationBox>
 </ItemPropertiesBox>

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -98,11 +98,21 @@ ImagePtr CreateTestImageWithGainMap(bool base_rendition_is_hdr) {
   if (base_rendition_is_hdr) {
     image->clli.maxCLL = 10;
     image->clli.maxPALL = 5;
+    image->gainMap->altDepth = 8;
+    image->gainMap->altPlaneCount = 3;
+    image->gainMap->altColorPrimaries = AVIF_COLOR_PRIMARIES_BT601;
+    image->gainMap->altTransferCharacteristics =
+        AVIF_TRANSFER_CHARACTERISTICS_SRGB;
+    image->gainMap->altMatrixCoefficients = AVIF_MATRIX_COEFFICIENTS_SMPTE2085;
   } else {
-    // Even though this is attached to the gain map, it represents the clli
-    // information of the tone mapped image.
-    image->gainMap->image->clli.maxCLL = 10;
-    image->gainMap->image->clli.maxPALL = 5;
+    image->gainMap->altCLLI.maxCLL = 10;
+    image->gainMap->altCLLI.maxPALL = 5;
+    image->gainMap->altDepth = 10;
+    image->gainMap->altPlaneCount = 3;
+    image->gainMap->altColorPrimaries = AVIF_COLOR_PRIMARIES_BT2020;
+    image->gainMap->altTransferCharacteristics =
+        AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084;
+    image->gainMap->altMatrixCoefficients = AVIF_MATRIX_COEFFICIENTS_SMPTE2085;
   }
 
   return image;
@@ -140,10 +150,15 @@ TEST(GainMapTest, EncodeDecodeBaseImageSdr) {
   ASSERT_NE(decoded->gainMap->image, nullptr);
   EXPECT_EQ(decoded->gainMap->image->matrixCoefficients,
             image->gainMap->image->matrixCoefficients);
-  EXPECT_EQ(decoded->gainMap->image->clli.maxCLL,
-            image->gainMap->image->clli.maxCLL);
-  EXPECT_EQ(decoded->gainMap->image->clli.maxPALL,
-            image->gainMap->image->clli.maxPALL);
+  EXPECT_EQ(decoded->gainMap->altCLLI.maxCLL, image->gainMap->altCLLI.maxCLL);
+  EXPECT_EQ(decoded->gainMap->altCLLI.maxPALL, image->gainMap->altCLLI.maxPALL);
+  EXPECT_EQ(decoded->gainMap->altDepth, 10u);
+  EXPECT_EQ(decoded->gainMap->altPlaneCount, 3u);
+  EXPECT_EQ(decoded->gainMap->altColorPrimaries, AVIF_COLOR_PRIMARIES_BT2020);
+  EXPECT_EQ(decoded->gainMap->altTransferCharacteristics,
+            AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084);
+  EXPECT_EQ(decoded->gainMap->altMatrixCoefficients,
+            AVIF_MATRIX_COEFFICIENTS_SMPTE2085);
   EXPECT_EQ(decoded->gainMap->image->width, image->gainMap->image->width);
   EXPECT_EQ(decoded->gainMap->image->height, image->gainMap->image->height);
   EXPECT_EQ(decoded->gainMap->image->depth, image->gainMap->image->depth);
@@ -196,6 +211,18 @@ TEST(GainMapTest, EncodeDecodeBaseImageHdr) {
             40.0);
   EXPECT_EQ(decoded->clli.maxCLL, image->clli.maxCLL);
   EXPECT_EQ(decoded->clli.maxPALL, image->clli.maxPALL);
+  EXPECT_EQ(decoded->gainMap->altCLLI.maxCLL, 0u);
+  EXPECT_EQ(decoded->gainMap->altCLLI.maxPALL, 0u);
+  EXPECT_EQ(decoded->gainMap->altDepth, 8u);
+  EXPECT_EQ(decoded->gainMap->altPlaneCount, 3u);
+  EXPECT_EQ(decoded->gainMap->altColorPrimaries, AVIF_COLOR_PRIMARIES_BT601);
+  EXPECT_EQ(decoded->gainMap->altTransferCharacteristics,
+            AVIF_TRANSFER_CHARACTERISTICS_SRGB);
+  EXPECT_EQ(decoded->gainMap->altMatrixCoefficients,
+            AVIF_MATRIX_COEFFICIENTS_SMPTE2085);
+  EXPECT_EQ(decoded->gainMap->image->width, image->gainMap->image->width);
+  EXPECT_EQ(decoded->gainMap->image->height, image->gainMap->image->height);
+  EXPECT_EQ(decoded->gainMap->image->depth, image->gainMap->image->depth);
   CheckGainMapMetadataMatches(decoded->gainMap->metadata,
                               image->gainMap->metadata);
 


### PR DESCRIPTION
In avif files, write the following boxes:
- for the tmap derived item: colr (icc and/or cicp), pixi (optional), clli (optional)
- fot the gain map image: colr (cicp) where color_primaries and transfer_characteristics must be 2

Follows the latest draft specs.