### PR TITLE
Do not store colorproperties until alpha item is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Fix memory errors reported in crbug.com/1504792.
+
 ## [1.0.2] - 2023-11-16
 
 ### Changed

--- a/src/read.c
+++ b/src/read.c
@@ -3938,7 +3938,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             avifDiagnosticsPrintf(&decoder->diag, "Primary item not found");
             return AVIF_RESULT_MISSING_IMAGE_ITEM;
         }
-        colorProperties = &colorItem->properties;
         if (!memcmp(colorItem->type, "grid", 4)) {
             avifROData readData;
             AVIF_CHECKRES(avifDecoderItemRead(colorItem, decoder->io, &readData, 0, 0, data->diag));
@@ -3994,6 +3993,8 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                 assert(alphaCodecType != AVIF_CODEC_TYPE_UNKNOWN);
             }
         }
+
+        colorProperties = &colorItem->properties;
 
         // Find Exif and/or XMP metadata, if any
         AVIF_CHECKRES(avifDecoderFindMetadata(decoder, data->meta, decoder->image, colorItem->id));


### PR DESCRIPTION
colorProperties could be pointing to a dangling pointer if findAlphaItem() resizes the meta.items array.

Manual cherry-pick of PR #1808 to the v1.0.x branch.