### PR TITLE
fix(svt): Don't clamp enc_mode to [0,8]

### DIFF
--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -156,8 +156,12 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
             svt_config->tile_columns = tileColsLog2;
         }
         if (encoder->speed != AVIF_SPEED_DEFAULT) {
+#if SVT_AV1_CHECK_VERSION(0, 9, 0)
+            svt_config->enc_mode = (int8_t)encoder->speed;
+#else
             int speed = AVIF_CLAMP(encoder->speed, 0, 8);
             svt_config->enc_mode = (int8_t)speed;
+#endif
         }
 
         if (color_format == EB_YUV422 || image->depth > 10) {


### PR DESCRIPTION
SVT-AV1 added encoder modes 9-12 in v0.9. Because speed is still clamped to max 8 it's not possible to use any of these faster presets.

This still would prevent users from selecting M11 or M12, but addressing that would require broader changes.