### PR TITLE
Allow for several directories in TEST_DATA_DIR (and rename it)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,7 +180,7 @@ if(AVIF_ENABLE_FUZZTEST)
         target_link_libraries(${TEST_NAME} PRIVATE aviftest_helpers ${ARGN})
         link_fuzztest(${TEST_NAME})
         add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
-        set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "TEST_DATA_DIR=${CMAKE_CURRENT_SOURCE_DIR}/data/")
+        set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "TEST_DATA_DIRS=${CMAKE_CURRENT_SOURCE_DIR}/data/")
     endmacro()
 
     if(AVIF_LOCAL_FUZZTEST)

--- a/tests/gtest/avif_fuzztest_dec.cc
+++ b/tests/gtest/avif_fuzztest_dec.cc
@@ -21,7 +21,7 @@ namespace {
 //------------------------------------------------------------------------------
 
 void Decode(const std::string& arbitrary_bytes, DecoderPtr decoder) {
-  ASSERT_NE(GetSeedDataDir(), nullptr);  // Make sure seeds are available.
+  ASSERT_FALSE(GetSeedDataDirs().empty());  // Make sure seeds are available.
 
   ImagePtr decoded(avifImageCreateEmpty());
   ASSERT_NE(decoded, nullptr);

--- a/tests/gtest/avif_fuzztest_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_dec_incr.cc
@@ -46,7 +46,7 @@ avifResult AvifIoRead(struct avifIO* io, uint32_t read_flags, uint64_t offset,
 
 void DecodeIncr(const std::string& arbitrary_bytes, bool is_persistent,
                 bool give_size_hint, bool use_nth_image_api) {
-  ASSERT_NE(GetSeedDataDir(), nullptr);  // Make sure seeds are available.
+  ASSERT_FALSE(GetSeedDataDirs().empty());  // Make sure seeds are available.
 
   ImagePtr reference(avifImageCreateEmpty());
   ASSERT_NE(reference.get(), nullptr);

--- a/tests/gtest/avif_fuzztest_helpers.h
+++ b/tests/gtest/avif_fuzztest_helpers.h
@@ -195,31 +195,32 @@ inline ::testing::Environment* SetStackLimitTo512x1024Bytes() {
 
 //------------------------------------------------------------------------------
 
-// Returns the value of the 'TEST_DATA_DIR' environment variable.
+// Returns the paths contained in the 'TEST_DATA_DIRS' environment variable.
+// Several paths can be set in the variable, separated by ';'.
 // Returns nullptr if not set.
 // Tests that use ArbitraryImageWithSeeds() should
-// ASSERT_NE(GetSeedDataDir(), nullptr) if they want to make sure that seeds are
-// actually used.
-const char* GetSeedDataDir();
+// ASSERT_FALSE(GetSeedDataDirs().empty()) if they want to make sure that seeds
+// are actually used.
+std::vector<std::string> GetSeedDataDirs();
 
 // Returns a list of test images contents (not paths) from the directory set in
-// the 'TEST_DATA_DIR' environment variable, that are smaller than
+// the 'TEST_DATA_DIRS' environment variable, that are smaller than
 // 'max_file_size' and have one of the formats in 'image_formats' (or any format
 // if 'image_formats' is empty).
-// If TEST_DATA_DIR is not set, returns an empty set.
-// Tests that use this should ASSERT_NE(GetSeedDataDir(), nullptr)
+// If TEST_DATA_DIRS is not set, returns an empty set.
+// Tests that use this should ASSERT_FALSE(GetSeedDataDirs().empty())
 // if they want to make sure that seeds are actually used.
-// Terminates the program with abort() if TEST_DATA_DIR is set but doesn't
+// Terminates the program with abort() if TEST_DATA_DIRS is set but doesn't
 // contain any matching images.
 std::vector<std::string> GetTestImagesContents(
     size_t max_file_size, const std::vector<avifAppFileFormat>& image_formats);
 
 // Generator for an arbitrary ImagePtr that uses test image files as seeds.
-// Uses the 'TEST_DATA_DIR' environment variable to load the seeds.
-// If TEST_DATA_DIR is not set, no seeds are used.
-// Tests that use this should ASSERT_NE(GetSeedDataDir(), nullptr)
+// Uses the 'TEST_DATA_DIRS' environment variable to load the seeds.
+// If TEST_DATA_DIRS is not set, no seeds are used.
+// Tests that use this should ASSERT_FALSE(GetSeedDataDirs().empty())
 // if they want to make sure that seeds are actually used.
-// Terminates the program with abort() if TEST_DATA_DIR is set but doesn't
+// Terminates the program with abort() if TEST_DATA_DIRS is set but doesn't
 // contain any matching images.
 inline auto ArbitraryImageWithSeeds(
     const std::vector<avifAppFileFormat>& image_formats) {

--- a/tests/gtest/avif_fuzztest_read_image.cc
+++ b/tests/gtest/avif_fuzztest_read_image.cc
@@ -46,7 +46,7 @@ void ReadImageFile(const std::string& arbitrary_bytes,
                    bool ignore_color_profile, bool ignore_exif, bool ignore_xmp,
                    bool allow_changing_cicp, bool ignore_gain_map,
                    avifMatrixCoefficients matrix_coefficients) {
-  ASSERT_NE(GetSeedDataDir(), nullptr);  // Make sure seeds are available.
+  ASSERT_FALSE(GetSeedDataDirs().empty());  // Make sure seeds are available.
 
   // Write the byte stream to a temp file since avifReadImage() takes a file
   // path as input.


### PR DESCRIPTION
This can be useful when analyzing different corpuses