### PR TITLE
Rename avifImageCopySamples to avifImageCopyPlanes

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -126,11 +126,11 @@ void avifImageSetDefaults(avifImage * image);
 // Copies all fields that do not need to be freed/allocated from srcImage to dstImage.
 void avifImageCopyNoAlloc(avifImage * dstImage, const avifImage * srcImage);
 
-// Copies the samples from srcImage to dstImage. dstImage must be allocated.
+// Copies the planes from srcImage to dstImage. dstImage must be allocated.
 // srcImage and dstImage must have the same width, height, and depth.
 // If the AVIF_PLANES_YUV bit is set in planes, then srcImage and dstImage must have the same yuvFormat and yuvRange.
 // Ignores the gainMap field (which exists only if AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP is defined).
-void avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes);
+void avifImageCopyPlanes(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes);
 
 typedef struct avifAlphaParams
 {

--- a/src/avif.c
+++ b/src/avif.c
@@ -189,7 +189,7 @@ void avifImageCopyNoAlloc(avifImage * dstImage, const avifImage * srcImage)
     dstImage->imir = srcImage->imir;
 }
 
-void avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes)
+void avifImageCopyPlanes(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes)
 {
     assert(srcImage->depth == dstImage->depth);
     if (planes & AVIF_PLANES_YUV) {
@@ -255,7 +255,7 @@ avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifP
             return allocationResult;
         }
     }
-    avifImageCopySamples(dstImage, srcImage, planes);
+    avifImageCopyPlanes(dstImage, srcImage, planes);
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     if (srcImage->gainMap) {

--- a/src/read.c
+++ b/src/read.c
@@ -1576,7 +1576,7 @@ static avifBool avifDecoderDataCopyTileToImage(avifDecoderData * data,
         assert(AVIF_FALSE);
         return AVIF_FALSE;
     }
-    avifImageCopySamples(&dstView, &srcView, (tile->input->itemCategory == AVIF_ITEM_ALPHA) ? AVIF_PLANES_A : AVIF_PLANES_YUV);
+    avifImageCopyPlanes(&dstView, &srcView, (tile->input->itemCategory == AVIF_ITEM_ALPHA) ? AVIF_PLANES_A : AVIF_PLANES_YUV);
 
     return AVIF_TRUE;
 }

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -380,7 +380,7 @@ avifResult MergeGrid(int grid_cols, int grid_rows,
       rect.width = image->width;
       rect.height = image->height;
       AVIF_CHECKRES(avifImageSetViewRect(view.get(), merged, &rect));
-      avifImageCopySamples(/*dstImage=*/view.get(), image, AVIF_PLANES_ALL);
+      avifImageCopyPlanes(/*dstImage=*/view.get(), image, AVIF_PLANES_ALL);
       assert(!view->imageOwnsYUVPlanes);
       rect.x += rect.width;
     }


### PR DESCRIPTION
This matches the names of similar functions avifImageAllocatePlanes, avifImageFreePlanes, and avifImageStealPlanes that take an "avifPlanesFlags planes" parameter.

This is to prepare for exporting this function in the public header avif.h so that aviftest_helpers.cc doesn't need to include internal.h.