### PR TITLE
Revert pointer storage workarounds

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -770,8 +770,6 @@ static void avifMetaDestroy(avifMeta * meta)
     avifFree(meta);
 }
 
-// CAUTION: This function could potentially resize the meta->items array thereby invalidating all existing pointers that are being
-// stored locally. So if this function is being called, exercise caution in the caller to not use invalid pointers.
 static avifDecoderItem * avifMetaFindItem(avifMeta * meta, uint32_t itemID)
 {
     if (itemID == 0) {
@@ -3620,20 +3618,17 @@ static avifBool avifDecoderItemIsAlphaAux(avifDecoderItem * item, uint32_t color
     return auxCProp && isAlphaURN(auxCProp->u.auxC.auxType);
 }
 
-// Finds the alpha item whose parent item is *colorItemPtr and sets it in the alphaItem output parameter. Returns AVIF_RESULT_OK
-// on success. Note that *alphaItem can be NULL even if the return value is AVIF_RESULT_OK. If the *colorItemPtr is a grid and the
-// alpha item is represented as a set of auxl items to each color tile, then a fake item will be created and *isAlphaItemInInput
-// will be set to AVIF_FALSE. In this case, the alpha item merely exists to hold the locations of the alpha tile items. The data
-// of this item need not be read and the pixi property cannot be validated. Otherwise, *isAlphaItemInInput will be set to
-// AVIF_TRUE when *alphaItem is not NULL. If the data->meta->items array is resized, then the value in *colorItemPtr could become
-// invalid. This function also resets *colorItemPtr to the right value if an alpha item was found and added to the data->meta->items
-// array.
+// Finds the alpha item whose parent item is colorItem and sets it in the alphaItem output parameter. Returns AVIF_RESULT_OK on
+// success. Note that *alphaItem can be NULL even if the return value is AVIF_RESULT_OK. If the colorItem is a grid and the alpha
+// item is represented as a set of auxl items to each color tile, then a fake item will be created and *isAlphaItemInInput will be
+// set to AVIF_FALSE. In this case, the alpha item merely exists to hold the locations of the alpha tile items. The data of this
+// item need not be read and the pixi property cannot be validated. Otherwise, *isAlphaItemInInput will be set to AVIF_TRUE when
+// *alphaItem is not NULL.
 static avifResult avifDecoderDataFindAlphaItem(avifDecoderData * data,
-                                               avifDecoderItem ** colorItemPtr,
+                                               avifDecoderItem * colorItem,
                                                avifDecoderItem ** alphaItem,
                                                avifBool * isAlphaItemInInput)
 {
-    const avifDecoderItem * colorItem = *colorItemPtr;
     for (uint32_t itemIndex = 0; itemIndex < data->meta->items.count; ++itemIndex) {
         avifDecoderItem * item = data->meta->items.item[itemIndex];
         if (avifDecoderItemShouldBeSkipped(item)) {
@@ -3695,26 +3690,12 @@ static avifResult avifDecoderDataFindAlphaItem(avifDecoderData * data,
         }
     }
     assert(alphaItemCount == colorItemCount);
-
-    int colorItemIndex = -1;
-    for (uint32_t i = 0; i < data->meta->items.count; ++i) {
-        if (colorItem->id == data->meta->items.item[i]->id) {
-            colorItemIndex = i;
-            break;
-        }
-    }
-    assert(colorItemIndex >= 0);
-
     *alphaItem = avifMetaFindItem(colorItem->meta, maxItemID + 1);
     if (*alphaItem == NULL) {
         avifFree(alphaItemIndices);
         *isAlphaItemInInput = AVIF_FALSE;
         return AVIF_RESULT_OUT_OF_MEMORY;
     }
-    // avifMetaFindItem() could invalidate all existing item pointers. So reset the colorItem pointers.
-    *colorItemPtr = data->meta->items.item[colorItemIndex];
-    colorItem = *colorItemPtr;
-
     memcpy((*alphaItem)->type, "grid", 4);
     (*alphaItem)->width = colorItem->width;
     (*alphaItem)->height = colorItem->height;
@@ -3942,6 +3923,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             avifDiagnosticsPrintf(&decoder->diag, "Primary item not found");
             return AVIF_RESULT_MISSING_IMAGE_ITEM;
         }
+        colorProperties = &colorItem->properties;
         if (!memcmp(colorItem->type, "grid", 4)) {
             avifROData readData;
             AVIF_CHECKRES(avifDecoderItemRead(colorItem, decoder->io, &readData, 0, 0, data->diag));
@@ -3973,7 +3955,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 
         avifBool isAlphaItemInInput;
         avifDecoderItem * alphaItem;
-        AVIF_CHECKRES(avifDecoderDataFindAlphaItem(data, &colorItem, &alphaItem, &isAlphaItemInInput));
+        AVIF_CHECKRES(avifDecoderDataFindAlphaItem(data, colorItem, &alphaItem, &isAlphaItemInInput));
         avifCodecType alphaCodecType = AVIF_CODEC_TYPE_UNKNOWN;
         if (alphaItem) {
             if (!memcmp(alphaItem->type, "grid", 4)) {
@@ -3997,8 +3979,6 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                 assert(alphaCodecType != AVIF_CODEC_TYPE_UNKNOWN);
             }
         }
-
-        colorProperties = &colorItem->properties;
 
         // Find Exif and/or XMP metadata, if any
         AVIF_CHECKRES(avifDecoderFindMetadata(decoder, data->meta, decoder->image, colorItem->id));


### PR DESCRIPTION
Port commit f03ee46619497b6c3e3b46db35d03a436bfc9f9f to the v1.0.x branch.

After PR #1837, there is no need to safeguard against potential dangling pointers. So restore the old code which is simpler and does not have unnecessary intermediaries (like storing the index instead of pointers).

This PR manually reverts the following commits:
b984f48be99b41405cb4a7d443806e01b46936fb
456f78a3b2d3eacb8ca4193b79129b23785e41e9