### PR TITLE
Have DecodeIncrementally return an avifResult instead of asserting

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,7 +82,7 @@ if(AVIF_ENABLE_GTEST OR AVIF_ENABLE_FUZZTEST)
     endif()
 
     add_library(avifincrtest_helpers OBJECT gtest/avifincrtest_helpers.cc)
-    target_link_libraries(avifincrtest_helpers avif GTest::gtest)
+    target_link_libraries(avifincrtest_helpers avif_internal GTest::gtest)
 endif()
 
 if(AVIF_ENABLE_GTEST)

--- a/tests/gtest/avif_fuzztest_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_dec_incr.cc
@@ -81,9 +81,11 @@ void DecodeIncr(const std::string& arbitrary_bytes, bool is_persistent,
     // the underlying AV1 frame (for example a 1x1000000 AVIF for a 1x1 AV1).
     // Otherwise we could use the minimum of reference->height and 65536u below.
     const uint32_t max_cell_height = reference->height;
-    DecodeIncrementally(encoded_data, decoder.get(), is_persistent,
-                        give_size_hint, use_nth_image_api, *reference,
-                        max_cell_height);
+    const avifResult result = DecodeIncrementally(
+        encoded_data, decoder.get(), is_persistent, give_size_hint,
+        use_nth_image_api, *reference, max_cell_height);
+    // The result does not matter, as long as we do not crash.
+    (void)result;
   }
 }
 

--- a/tests/gtest/avif_fuzztest_enc_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_incr.cc
@@ -59,9 +59,10 @@ void EncodeDecodeGridValid(ImagePtr image, EncoderPtr encoder,
       avifEncoderFinish(encoder.get(), &encoded_data);
   ASSERT_EQ(finish_result, AVIF_RESULT_OK) << avifResultToString(finish_result);
 
-  DecodeNonIncrementallyAndIncrementally(
+  const avifResult decode_result = DecodeNonIncrementallyAndIncrementally(
       encoded_data, decoder.get(), is_encoded_data_persistent,
       give_size_hint_to_decoder, /*use_nth_image_api=*/true, cell_height);
+  ASSERT_EQ(decode_result, AVIF_RESULT_OK) << avifResultToString(decode_result);
 }
 
 FUZZ_TEST(EncodeDecodeAvifFuzzTest, EncodeDecodeGridValid)

--- a/tests/gtest/avif_fuzztest_enc_dec_incr_experimental.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_incr_experimental.cc
@@ -90,10 +90,11 @@ void EncodeDecodeGridValid(ImagePtr image, EncoderPtr encoder,
   const bool expect_whole_file_read = decoder->enableDecodingGainMap &&
                                       decoder->enableParsingGainMapMetadata &&
                                       !decoder->ignoreColorAndAlpha;
-  DecodeNonIncrementallyAndIncrementally(
+  const avifResult decode_result = DecodeNonIncrementallyAndIncrementally(
       encoded_data, decoder.get(), is_encoded_data_persistent,
       give_size_hint_to_decoder, /*use_nth_image_api=*/true, cell_height,
       /*enable_fine_incremental_check=*/false, expect_whole_file_read);
+  ASSERT_EQ(decode_result, AVIF_RESULT_OK) << avifResultToString(decode_result);
 }
 
 // Note that avifGainMapMetadata is passed as a byte array

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -393,11 +393,12 @@ TEST(GainMapTest, EncodeDecodeGrid) {
 
   // Check that non-incremental and incremental decodings of a grid AVIF produce
   // the same pixels.
-  testutil::DecodeNonIncrementallyAndIncrementally(
-      encoded, decoder.get(),
-      /*is_persistent=*/true, /*give_size_hint=*/true,
-      /*use_nth_image_api=*/false, kCellHeight,
-      /*enable_fine_incremental_check=*/true);
+  ASSERT_EQ(testutil::DecodeNonIncrementallyAndIncrementally(
+                encoded, decoder.get(),
+                /*is_persistent=*/true, /*give_size_hint=*/true,
+                /*use_nth_image_api=*/false, kCellHeight,
+                /*enable_fine_incremental_check=*/true),
+            AVIF_RESULT_OK);
 
   // Uncomment the following to save the encoded image as an AVIF file.
   //  std::ofstream("/tmp/avifgainmaptest_grid.avif", std::ios::binary)

--- a/tests/gtest/avifincrtest.cc
+++ b/tests/gtest/avifincrtest.cc
@@ -55,11 +55,13 @@ TEST(IncrementalTest, Decode) {
 
   // Cell height is hardcoded because there is no API to extract it from an
   // encoded payload.
-  testutil::DecodeIncrementally(encoded_avif, decoder.get(),
-                                /*is_persistent=*/true, /*give_size_hint=*/true,
-                                /*use_nth_image_api=*/false, *reference,
-                                /*cell_height=*/154,
-                                /*enable_fine_incremental_check=*/true);
+  ASSERT_EQ(testutil::DecodeIncrementally(
+                encoded_avif, decoder.get(),
+                /*is_persistent=*/true, /*give_size_hint=*/true,
+                /*use_nth_image_api=*/false, *reference,
+                /*cell_height=*/154,
+                /*enable_fine_incremental_check=*/true),
+            AVIF_RESULT_OK);
 }
 
 //------------------------------------------------------------------------------
@@ -100,9 +102,11 @@ TEST_P(IncrementalTest, EncodeDecode) {
                                     flat_cells, &encoded_avif, &cell_width,
                                     &cell_height);
 
-  testutil::DecodeNonIncrementallyAndIncrementally(
-      encoded_avif, decoder.get(), encoded_avif_is_persistent, give_size_hint,
-      use_nth_image_api, cell_height, /*enable_fine_incremental_check=*/true);
+  ASSERT_EQ(testutil::DecodeNonIncrementallyAndIncrementally(
+                encoded_avif, decoder.get(), encoded_avif_is_persistent,
+                give_size_hint, use_nth_image_api, cell_height,
+                /*enable_fine_incremental_check=*/true),
+            AVIF_RESULT_OK);
 }
 
 INSTANTIATE_TEST_SUITE_P(WholeImage, IncrementalTest,

--- a/tests/gtest/avifincrtest_helpers.h
+++ b/tests/gtest/avifincrtest_helpers.h
@@ -26,16 +26,16 @@ void EncodeRectAsIncremental(const avifImage& image, uint32_t width,
 // incremental granularity. enable_fine_incremental_check checks that sample
 // rows are gradually output when feeding more and more input bytes to the
 // decoder.
-void DecodeIncrementally(const avifRWData& encoded_avif, avifDecoder* decoder,
-                         bool is_persistent, bool give_size_hint,
-                         bool use_nth_image_api, const avifImage& reference,
-                         uint32_t cell_height,
-                         bool enable_fine_incremental_check = false,
-                         bool expect_whole_file_read = true);
+avifResult DecodeIncrementally(const avifRWData& encoded_avif,
+                               avifDecoder* decoder, bool is_persistent,
+                               bool give_size_hint, bool use_nth_image_api,
+                               const avifImage& reference, uint32_t cell_height,
+                               bool enable_fine_incremental_check = false,
+                               bool expect_whole_file_read = true);
 
 // Calls DecodeIncrementally() with the reference being a regular decoding of
 // encoded_avif.
-void DecodeNonIncrementallyAndIncrementally(
+avifResult DecodeNonIncrementallyAndIncrementally(
     const avifRWData& encoded_avif, avifDecoder* decoder, bool is_persistent,
     bool give_size_hint, bool use_nth_image_api, uint32_t cell_height,
     bool enable_fine_incremental_check = false,


### PR DESCRIPTION
This way the fuzzer avif_fuzztest_dec_incr can call that function on invalid data and fail gracefully.