### PR TITLE
Gainmap computation: fix handling of extreme values.

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -670,6 +670,19 @@ typedef struct avifSequenceHeader
 
 AVIF_NODISCARD avifBool avifSequenceHeaderParse(avifSequenceHeader * header, const avifROData * sample, avifCodecType codecType);
 
+// ---------------------------------------------------------------------------
+// gain maps
+
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+
+// Finds the approximate min/max values from the given gain map values, excluding outliers.
+// Uses a histogram, with outliers defined as having at least one empty bucket between them
+// and the rest of the distribution. Discards at most 0.1% of values.
+// Removing outliers helps with accuracy/compression.
+avifResult avifFindMinMaxWithoutOutliers(const float * gainMapF, int numPixels, float * rangeMin, float * rangeMax);
+
+#endif // AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP
+
 #define AVIF_INDEFINITE_DURATION64 UINT64_MAX
 #define AVIF_INDEFINITE_DURATION32 UINT32_MAX
 

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -1311,8 +1311,8 @@ TEST_P(CreateGainMapTest, Create) {
 
   // Results should be about the same whether the gain map was computed from sdr
   // to hdr or the other way around.
-  EXPECT_NEAR(psnr_sdr_to_hdr_backward, psnr_sdr_to_hdr_forward, 0.5f);
-  EXPECT_NEAR(psnr_hdr_to_sdr_forward, psnr_hdr_to_sdr_backward, 0.5f);
+  EXPECT_NEAR(psnr_sdr_to_hdr_backward, psnr_sdr_to_hdr_forward, 0.6f);
+  EXPECT_NEAR(psnr_hdr_to_sdr_forward, psnr_hdr_to_sdr_backward, 0.6f);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Gain map values outside of [-6, +6] were being clamped.