### PR TITLE
Bump gav1 to v0.19.0

### DIFF
--- a/ext/libgav1.cmd
+++ b/ext/libgav1.cmd
@@ -9,7 +9,7 @@
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
 # When updating the libgav1 version, make the same change to libgav1_android.sh.
-git clone -b v0.18.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
+git clone -b v0.19.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
 
 cd libgav1
 mkdir build

--- a/ext/libgav1_android.sh
+++ b/ext/libgav1_android.sh
@@ -16,7 +16,7 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 # When updating the libgav1 version, make the same change to libgav1.cmd.
-git clone -b v0.18.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
+git clone -b v0.19.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
 
 cd libgav1
 mkdir build


### PR DESCRIPTION
This should quiet the CI failures that just appeared. The fix was in https://chromium.googlesource.com/codecs/libgav1/+/5cf722e659014ebaf2f573a6dd935116d36eadf1