### PR TITLE
Create a bigger seed corpus for avif_decode_fuzzer

### DIFF
--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -35,5 +35,12 @@ $CXX $CXXFLAGS -std=c++11 -I../include \
     $LIB_FUZZING_ENGINE libavif.a ../ext/dav1d/build/src/libdav1d.a \
     ../ext/libyuv/build/libyuv.a
 
-# copy seed corpus
-cp $SRC/avif_decode_seed_corpus.zip $OUT/
+# WIP: copy seed corpus for fuzztest tests
+mkdir $OUT/corpus
+unzip $SRC/avif_decode_seed_corpus.zip -d $OUT/corpus
+cp $SRC/libavif/tests/data/* $OUT/corpus
+
+# create a bigger seed corpus for avif_decode_fuzzer
+cd $OUT/corpus
+zip -j $SRC/corpus.zip $OUT/corpus/*
+cp $SRC/corpus.zip $OUT/avif_decode_fuzzer_seed_corpus.zip

--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -41,6 +41,4 @@ unzip $SRC/avif_decode_seed_corpus.zip -d $OUT/corpus
 cp $SRC/libavif/tests/data/* $OUT/corpus
 
 # create a bigger seed corpus for avif_decode_fuzzer
-cd $OUT/corpus
-zip -j $SRC/corpus.zip $OUT/corpus/*
-cp $SRC/corpus.zip $OUT/avif_decode_fuzzer_seed_corpus.zip
+zip -j $OUT/avif_decode_fuzzer_seed_corpus.zip $OUT/corpus/*


### PR DESCRIPTION
And mostly, name it properly, cf:
https://google.github.io/oss-fuzz/getting-started/new-project-guide/#seed-corpus "To provide a corpus for my_fuzzer, put my_fuzzer_seed_corpus.zip file next to ..."
The corpus for avif_decode_fuzzer should hence be
avif_decode_fuzzer_seed_corpus.zip, not avif_decode_seed_corpus.zip