### PR TITLE
Bump gav1 in tests/docker/build.sh too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Update aom.cmd: v3.8.0
+* Update libgav1.cmd: v0.19.0
 * Update svt.cmd/svt.sh: v1.7.0
 * Update zlibpng.cmd: zlib 1.3 and libpng 1.6.40
 * AVIF sequences encoded by libavif will now also have the "avio" brand when

--- a/tests/docker/build.sh
+++ b/tests/docker/build.sh
@@ -44,7 +44,7 @@ ninja install
 
 # libgav1
 cd
-git clone -b v0.18.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
+git clone -b v0.19.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
 cd libgav1
 mkdir build
 cd build


### PR DESCRIPTION
This is a follow-up of https://github.com/AOMediaCodec/libavif/pull/1891