### PR TITLE
test_cmd.sh: rm -f to ignore nonexistent files

### DIFF
--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -60,7 +60,7 @@ OUT_MSG="avif_test_cmd_out_msg.txt"
 # Cleanup
 cleanup() {
   pushd ${TMP_DIR}
-    rm -- "${ENCODED_FILE}" "${ENCODED_FILE_WITH_DASH}" "${DECODED_FILE}" "${OUT_MSG}"
+    rm -f -- "${ENCODED_FILE}" "${ENCODED_FILE_WITH_DASH}" "${DECODED_FILE}" "${OUT_MSG}"
   popd
 }
 trap cleanup EXIT


### PR DESCRIPTION
If test_cmd.sh exits prematurely because of a test failure, some of the files cleanup() wants to remove may not exist. Pass -f to the rm command to ignore nonexistent files.