### PR TITLE
test_cmd.sh: Correct test for are-images-different

### DIFF
--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -75,7 +75,11 @@ pushd ${TMP_DIR}
     cp ${INPUT_Y4M} ${INPUT_UTF8_Y4M}
     "${AVIFENC}" -s 8 "${INPUT_UTF8_Y4M}" -o "${ENCODED_UTF8_FILE}"
     "${AVIFDEC}" "${ENCODED_UTF8_FILE}" "${DECODED_UTF8_FILE}"
-    "${ARE_IMAGES_EQUAL}" "${INPUT_UTF8_Y4M}" "${DECODED_UTF8_FILE}" 0 && exit 1
+    RET=0
+    "${ARE_IMAGES_EQUAL}" "${INPUT_UTF8_Y4M}" "${DECODED_UTF8_FILE}" 0 || RET=$?
+    if [ ${RET} -ne 1 ]; then
+      exit 1
+    fi
   fi
 
   # Argument parsing test with filenames starting with a dash.

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -77,7 +77,7 @@ pushd ${TMP_DIR}
     "${AVIFDEC}" "${ENCODED_UTF8_FILE}" "${DECODED_UTF8_FILE}"
     RET=0
     "${ARE_IMAGES_EQUAL}" "${INPUT_UTF8_Y4M}" "${DECODED_UTF8_FILE}" 0 || RET=$?
-    if [ ${RET} -ne 1 ]; then
+    if [[ ${RET} -ne 1 ]]; then
       exit 1
     fi
   fi


### PR DESCRIPTION
are_images_equal exits with status 1 when the images are different, and exits with status 2 when there is an error, such as file not found.

When we want to test if the images are different, we should test specifically for status 1 rather than any nonzero (failure) status.