### PR TITLE
pkgconf: add UAVIF_DLL for static linking with pkgconf

### DIFF
--- a/libavif.pc.cmake
+++ b/libavif.pc.cmake
@@ -8,3 +8,4 @@ Description: Library for encoding and decoding .avif files
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lavif
 Cflags: -I${includedir}@AVIF_PKG_CONFIG_EXTRA_CFLAGS@
+Cflags.private: -UAVIF_DLL


### PR DESCRIPTION

    allows for the usage of `pkgconf --static --cflags libavif' to produce
    the proper CFLAGS for static linking. Relies on pkgconf rather than pkg-config.


This is as similar as https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/1911

@kmilos @1480c1 @mechakotik 