### PR TITLE
Use full path for fuzztest tests

### DIFF
--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -88,7 +88,7 @@ then
 this_dir=\$(dirname \"\$0\")
 export TEST_DATA_DIRS=\$this_dir/corpus
 chmod +x \$this_dir/$fuzz_basename
-$fuzz_basename --fuzz=$fuzz_entrypoint -- \$@" > $OUT/$TARGET_FUZZER
+\$this_dir/$fuzz_basename --fuzz=$fuzz_entrypoint -- \$@" > $OUT/$TARGET_FUZZER
       chmod +x $OUT/$TARGET_FUZZER
     done
   done


### PR DESCRIPTION
Though it is not needed for local debugs, it seems needed for some dockers.