### PR TITLE
Remove MINGW32 support

### DIFF
--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         sys:
-          - mingw32
           - mingw64
           - ucrt64
           - clang64


### PR DESCRIPTION
ImageMagick is not supported anymore:
https://www.msys2.org/news/#2023-12-13-starting-to-drop-some-32-bit-packages

This partly fixes https://github.com/AOMediaCodec/libavif/issues/1912