### PR TITLE
Revert "Windows: add a manifest to use UTF-8 code pages"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,35 +677,20 @@ endif()
 
 if(AVIF_BUILD_APPS)
     add_executable(avifenc apps/avifenc.c)
-    if(WIN32)
-        # MinGW doesn't have a manifest tool (mt.exe), so we need to wrap
-        # utf8.manifest in a resource-definition script (.rc file).
-        target_sources(avifenc PRIVATE apps/utf8.rc)
-        # The MSVC linker (link.exe) fails with the following error if we
-        # don't use the /MANIFEST:NO linker option:
-        #   /MANIFEST:EMBED,ID=1" failed (exit code 1123) with the following
-        #   output:
-        #   CVTRES : fatal error CVT1100: duplicate resource.  type:MANIFEST,
-        #   name:1, language:0x0409
-        if(NOT MINGW)
-            target_link_options(avifenc PRIVATE /MANIFEST:NO)
-        endif()
-    endif()
     if(AVIF_USE_CXX)
         set_target_properties(avifenc PROPERTIES LINKER_LANGUAGE "CXX")
     endif()
     target_link_libraries(avifenc avif_apps)
     add_executable(avifdec apps/avifdec.c)
-    if(WIN32)
-        target_sources(avifdec PRIVATE apps/utf8.rc)
-        if(NOT MINGW)
-            target_link_options(avifdec PRIVATE /MANIFEST:NO)
-        endif()
-    endif()
     if(AVIF_USE_CXX)
         set_target_properties(avifdec PROPERTIES LINKER_LANGUAGE "CXX")
     endif()
     target_link_libraries(avifdec avif_apps)
+    if(MINGW AND NOT "$ENV{MSYSTEM}" MATCHES "(MINGW32|MINGW64)")
+        # MINGW* are legacy environments that link against MSVCRT which does not support UTF8.
+        target_link_options(avifenc PRIVATE -municode)
+        target_link_options(avifdec PRIVATE -municode)
+    endif()
 
     if(NOT SKIP_INSTALL_APPS AND NOT SKIP_INSTALL_ALL)
         install(
@@ -733,12 +718,6 @@ if(AVIF_BUILD_APPS)
             )
 
             add_executable(avifgainmaputil "${AVIFGAINMAPUTIL_SRCS}")
-            if(WIN32)
-                target_sources(avifgainmaputil PRIVATE apps/utf8.rc)
-                if(NOT MINGW)
-                    target_link_options(avifgainmaputil PRIVATE /MANIFEST:NO)
-                endif()
-            endif()
             set_target_properties(avifgainmaputil PROPERTIES LINKER_LANGUAGE "CXX")
             target_include_directories(avifgainmaputil PRIVATE apps/avifgainmaputil/)
             target_link_libraries(avifgainmaputil libargparse avif_apps)

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -18,6 +18,11 @@
 // for setmode()
 #include <fcntl.h>
 #include <io.h>
+#include <locale.h>
+#define WIN32_LEAN_AND_MEAN
+// Avoid the DEFAULT_QUALITY macro redefinition warning caused by including wingdi.h.
+#define NOGDI
+#include <windows.h>
 #endif
 
 #define NEXTARG()                                                     \
@@ -1391,13 +1396,13 @@ static avifBool avifEncodeImages(avifSettings * settings,
     return AVIF_TRUE;
 }
 
-int main(int argc, char * argv[])
+MAIN()
 {
     if (argc < 2) {
         syntaxShort();
         return 1;
     }
-
+    INIT_ARGV()
     const char * outputFilename = NULL;
 
     avifInput input;
@@ -2588,6 +2593,6 @@ cleanup:
         avifCodecSpecificOptionsFree(&file->settings.codecSpecificOptions);
     }
     free(input.files);
-
+    FREE_ARGV()
     return returnCode;
 }

--- a/apps/avifgainmaputil/avifgainmaputil.cc
+++ b/apps/avifgainmaputil/avifgainmaputil.cc
@@ -16,6 +16,12 @@
 #include "swapbase_command.h"
 #include "tonemap_command.h"
 
+#if defined(_WIN32)
+#include <locale.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 namespace avif {
 namespace {
 
@@ -50,7 +56,7 @@ void PrintUsage(const std::vector<std::unique_ptr<ProgramCommand>>& commands) {
 }  // namespace
 }  // namespace avif
 
-int main(int argc, char** argv) {
+MAIN() {
   std::vector<std::unique_ptr<avif::ProgramCommand>> commands;
   commands.emplace_back(std::make_unique<avif::HelpCommand>());
   commands.emplace_back(std::make_unique<avif::CombineCommand>());
@@ -65,6 +71,8 @@ int main(int argc, char** argv) {
     avif::PrintUsage(commands);
     return 1;
   }
+
+  INIT_ARGV()
 
   const std::string command_name(argv[1]);
   if (command_name == "help") {

--- a/apps/utf8.manifest
+++ b/apps/utf8.manifest
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <application>
-    <windowsSettings>
-      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
-    </windowsSettings>
-  </application>
-</assembly>

--- a/apps/utf8.rc
+++ b/apps/utf8.rc
@@ -1,3 +1,0 @@
-#include <winuser.h>
-
-CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "utf8.manifest"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -224,16 +224,19 @@ if(AVIF_BUILD_APPS)
     # When building apps, test the avifenc/avifdec.
     # 'are_images_equal' is used to make sure inputs/outputs are unchanged.
     add_executable(are_images_equal gtest/are_images_equal.cc)
-    if(WIN32)
-        target_sources(are_images_equal PRIVATE ${CMAKE_SOURCE_DIR}/apps/utf8.rc)
-        if(NOT MINGW)
-            target_link_options(are_images_equal PRIVATE /MANIFEST:NO)
-        endif()
-    endif()
     target_link_libraries(are_images_equal aviftest_helpers)
     add_test(NAME test_cmd COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd.sh ${CMAKE_BINARY_DIR}
                                    ${CMAKE_CURRENT_SOURCE_DIR}/data
     )
+    set_tests_properties(test_cmd PROPERTIES ENVIRONMENT "AVIF_TEST_UTF8=1")
+    if(MINGW)
+        if("$ENV{MSYSTEM}" MATCHES "(MINGW32|MINGW64)")
+            # Those legacy environments link against MSVCRT which does not support UTF8.
+            set_tests_properties(test_cmd PROPERTIES ENVIRONMENT "AVIF_TEST_UTF8=0")
+        else()
+            target_link_options(are_images_equal PRIVATE -municode)
+        endif()
+    endif()
     add_test(NAME test_cmd_animation COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_cmd_animation.sh ${CMAKE_BINARY_DIR}
                                              ${CMAKE_CURRENT_SOURCE_DIR}/data
     )

--- a/tests/gtest/are_images_equal.cc
+++ b/tests/gtest/are_images_equal.cc
@@ -9,9 +9,17 @@
 #include "aviftest_helpers.h"
 #include "avifutil.h"
 
+#if defined(_WIN32)
+#include <locale.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 using avif::ImagePtr;
 
-int main(int argc, char** argv) {
+MAIN() {
+  INIT_ARGV()
+
   if (argc != 4 && argc != 5) {
     std::cerr << "Wrong argument: " << argv[0]
               << " file1 file2 ignore_alpha_flag [psnr_threshold]" << std::endl;
@@ -70,6 +78,8 @@ int main(int argc, char** argv) {
     std::cout << "PSNR: " << psnr << ", images " << argv[1] << " and "
               << argv[2] << " are similar." << std::endl;
   }
+
+  FREE_ARGV()
 
   return 0;
 }

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -71,13 +71,15 @@ pushd ${TMP_DIR}
   "${AVIFENC}" -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}"
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}"
   "${ARE_IMAGES_EQUAL}" "${INPUT_Y4M}" "${DECODED_FILE}" 0 && exit 1
-  cp ${INPUT_Y4M} ${INPUT_UTF8_Y4M}
-  "${AVIFENC}" -s 8 "${INPUT_UTF8_Y4M}" -o "${ENCODED_UTF8_FILE}"
-  "${AVIFDEC}" "${ENCODED_UTF8_FILE}" "${DECODED_UTF8_FILE}"
-  RET=0
-  "${ARE_IMAGES_EQUAL}" "${INPUT_UTF8_Y4M}" "${DECODED_UTF8_FILE}" 0 || RET=$?
-  if [[ ${RET} -ne 1 ]]; then
-    exit 1
+  if [[ "${AVIF_TEST_UTF8}" == "1" ]]; then
+    cp ${INPUT_Y4M} ${INPUT_UTF8_Y4M}
+    "${AVIFENC}" -s 8 "${INPUT_UTF8_Y4M}" -o "${ENCODED_UTF8_FILE}"
+    "${AVIFDEC}" "${ENCODED_UTF8_FILE}" "${DECODED_UTF8_FILE}"
+    RET=0
+    "${ARE_IMAGES_EQUAL}" "${INPUT_UTF8_Y4M}" "${DECODED_UTF8_FILE}" 0 || RET=$?
+    if [[ ${RET} -ne 1 ]]; then
+      exit 1
+    fi
   fi
 
   # Argument parsing test with filenames starting with a dash.


### PR DESCRIPTION
This reverts commit 3ec01cefd1ddd266a622d5e114a0888581b68f4a.

Revert the commit to see if it fixes the test_cmd_icc_profile failures in MinGW (mingw64, ucrt64, and clang64):
+ magick avif_test_cmd_icc_profile_decoded.png -profile D:/a/libavif/libavif/tests/data/sRGB2014.icc avif_test_cmd_icc_profile_corrected.png magick.exe: no decode delegate for this image format `PNG' @ error/constitute.c/ReadImage/746.