### PR TITLE
appveyor.yml: only build on v1.0.x branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 image: Visual Studio 2022
 configuration: Release
+branches:
+  only:
+    - v1.0.x
 skip_commits:
   files:
     - '.github/*'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 image: Visual Studio 2022
 configuration: Release
-branches:
-  only:
-    - v1.0.x
+skip_non_tags: true
 skip_commits:
   files:
     - '.github/*'


### PR DESCRIPTION
This should hopefully avoid creating unstable artifacts from PRs.

See issue #1889.
