### PR TITLE
Remove dependency on AVM internal headers.

### DIFF
--- a/src/obu.c
+++ b/src/obu.c
@@ -41,10 +41,6 @@
 
 #if defined(AVIF_CODEC_AVM)
 #include "config/aom_config.h"
-#if CONFIG_LR_IMPROVEMENTS
-#include "av1/common/enums.h"
-#include "av1/common/restoration.h"
-#endif
 #endif
 
 // ---------------------------------------------------------------------------
@@ -383,14 +379,9 @@ static avifBool parseAV2SequenceHeader(avifBits * bits, avifSequenceHeader * hea
     avifBitsRead(bits, 2);       // enable_superres, enable_cdef
     if (avifBitsRead(bits, 1)) { // enable_restoration
 #if CONFIG_LR_IMPROVEMENTS
-        avifBitsRead(bits, RESTORE_SWITCHABLE_TYPES); // lr_tools_disable_mask[0]
+        avifBitsRead(bits, /*RESTORE_SWITCHABLE_TYPES=*/5); // lr_tools_disable_mask[0]
         if (avifBitsRead(bits, 1)) {
-            for (int i = 1; i < RESTORE_SWITCHABLE_TYPES; ++i) {
-                if (DEF_UV_LR_TOOLS_DISABLE_MASK & (1 << i)) {
-                    continue;
-                }
-                avifBitsRead(bits, 1); // lr_tools_disable_mask[1]
-            }
+            avifBitsRead(bits, /*RESTORE_SWITCHABLE_TYPES=*/5 - 1); // lr_tools_disable_mask[1]
         }
 #endif
     }


### PR DESCRIPTION
Releases are unfrequent anyway so we might as well use the proper values and not the enums.