### PR TITLE
Convert color conversion internals to matrices stored as 1D array

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -104,14 +104,14 @@ void avifColorPrimariesComputeYCoeffs(avifColorPrimaries colorPrimaries, float c
 AVIF_NODISCARD avifBool avifColorPrimariesComputeRGBToXYZD50Matrix(avifColorPrimaries colorPrimaries, double coeffs[9]);
 // Computes a row-major conversion matrix (stored as an array) from XYZ with a D50 white point to RGB.
 AVIF_NODISCARD avifBool avifColorPrimariesComputeXYZD50ToRGBMatrix(avifColorPrimaries colorPrimaries, double coeffs[9]);
-// Computes the RGB->RGB conversion matrix to convert from one set of RGB primaries to another.
+// Computes the RGB->RGB conversion matrix (stored as an array) to convert from one set of RGB primaries to another.
 AVIF_NODISCARD avifBool avifColorPrimariesComputeRGBToRGBMatrix(avifColorPrimaries srcColorPrimaries,
                                                                 avifColorPrimaries dstColorPrimaries,
-                                                                double coeffs[3][3]);
+                                                                double coeffs[9]);
 // Converts the given linear RGB pixel from one color space to another using the provided coefficients.
 // The coefficients can be obtained with avifColorPrimariesComputeRGBToRGBMatrix().
 // The output values are not clamped and may be < 0 or > 1.
-void avifLinearRGBConvertColorSpace(float rgb[4], const double coeffs[3][3]);
+void avifLinearRGBConvertColorSpace(float rgb[4], const double coeffs[9]);
 
 #define AVIF_ARRAY_DECLARE(TYPENAME, ITEMSTYPE, ITEMSNAME) \
     typedef struct TYPENAME                                \

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -100,10 +100,10 @@ avifTransferFunction avifTransferCharacteristicsGetLinearToGammaFunction(avifTra
 // Computes the RGB->YUV conversion coefficients kr, kg, kb, such that Y=kr*R+kg*G+kb*B.
 void avifColorPrimariesComputeYCoeffs(avifColorPrimaries colorPrimaries, float coeffs[3]);
 
-// Computes a conversion matrix from RGB to XYZ with a D50 white point.
-AVIF_NODISCARD avifBool avifColorPrimariesComputeRGBToXYZD50Matrix(avifColorPrimaries colorPrimaries, double coeffs[3][3]);
-// Computes a conversion matrix from XYZ with a D50 white point to RGB.
-AVIF_NODISCARD avifBool avifColorPrimariesComputeXYZD50ToRGBMatrix(avifColorPrimaries colorPrimaries, double coeffs[3][3]);
+// Computes a row-major conversion matrix (stored as an array) from RGB to XYZ with a D50 white point.
+AVIF_NODISCARD avifBool avifColorPrimariesComputeRGBToXYZD50Matrix(avifColorPrimaries colorPrimaries, double coeffs[9]);
+// Computes a row-major conversion matrix (stored as an array) from XYZ with a D50 white point to RGB.
+AVIF_NODISCARD avifBool avifColorPrimariesComputeXYZD50ToRGBMatrix(avifColorPrimaries colorPrimaries, double coeffs[9]);
 // Computes the RGB->RGB conversion matrix to convert from one set of RGB primaries to another.
 AVIF_NODISCARD avifBool avifColorPrimariesComputeRGBToRGBMatrix(avifColorPrimaries srcColorPrimaries,
                                                                 avifColorPrimaries dstColorPrimaries,

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -179,7 +179,7 @@ avifResult avifRGBImageApplyGainMap(const avifRGBImage * baseImage,
     // Early exit if the gain map does not need to be applied.
     if (weight == 0.0f) {
         const avifBool primariesDiffer = (baseColorPrimaries != outputColorPrimaries);
-        double conversionCoeffs[3][3];
+        double conversionCoeffs[9];
         if (primariesDiffer && !avifColorPrimariesComputeRGBToRGBMatrix(baseColorPrimaries, outputColorPrimaries, conversionCoeffs)) {
             avifDiagnosticsPrintf(diag, "Unsupported RGB color space conversion");
             res = AVIF_RESULT_NOT_IMPLEMENTED;
@@ -207,8 +207,8 @@ avifResult avifRGBImageApplyGainMap(const avifRGBImage * baseImage,
         goto cleanup;
     }
 
-    double inputConversionCoeffs[3][3];
-    double outputConversionCoeffs[3][3];
+    double inputConversionCoeffs[9];
+    double outputConversionCoeffs[9];
     if (needsInputColorConversion &&
         !avifColorPrimariesComputeRGBToRGBMatrix(baseColorPrimaries, gainMapMathPrimaries, inputConversionCoeffs)) {
         avifDiagnosticsPrintf(diag, "Unsupported RGB color space conversion");
@@ -465,8 +465,8 @@ static avifResult avifChooseColorSpaceForGainMapMath(avifColorPrimaries basePrim
     }
     // Color convert pure red, pure green and pure blue in turn and see if they result in negative values.
     float rgba[4] = { 0 };
-    double baseToAltCoeffs[3][3];
-    double altToBaseCoeffs[3][3];
+    double baseToAltCoeffs[9];
+    double altToBaseCoeffs[9];
     if (!avifColorPrimariesComputeRGBToRGBMatrix(basePrimaries, altPrimaries, baseToAltCoeffs) ||
         !avifColorPrimariesComputeRGBToRGBMatrix(altPrimaries, basePrimaries, altToBaseCoeffs)) {
         return AVIF_RESULT_NOT_IMPLEMENTED;
@@ -555,7 +555,7 @@ avifResult avifRGBImageComputeGainMap(const avifRGBImage * baseRgbImage,
     float yCoeffs[3];
     avifColorPrimariesComputeYCoeffs(gainMapMathPrimaries, yCoeffs);
 
-    double rgbConversionCoeffs[3][3];
+    double rgbConversionCoeffs[9];
     if (colorSpacesDiffer) {
         if (useBaseColorSpace) {
             if (!avifColorPrimariesComputeRGBToRGBMatrix(altColorPrimaries, baseColorPrimaries, rgbConversionCoeffs)) {

--- a/tests/gtest/avifcolrconverttest.cc
+++ b/tests/gtest/avifcolrconverttest.cc
@@ -29,8 +29,19 @@ void ExpectMatrixNear(const double actual[3][3],
   EXPECT_NEAR(actual[2][2], expected[2][2], epsilon);
 }
 
+void ExpectMatrixNear(const double actual[9],
+                      const std::array<std::array<double, 3>, 3>& expected,
+                      const double epsilon) {
+  const double actualTmp[3][3] = {
+      {actual[0], actual[1], actual[2]},  // row 0
+      {actual[3], actual[4], actual[5]},  // row 1
+      {actual[6], actual[7], actual[8]}   // row 2
+  };
+  ExpectMatrixNear(actualTmp, expected, epsilon);
+}
+
 TEST(RgbToXyzD50Matrix, GoldenValues) {
-  double coeffs[3][3];
+  double coeffs[9];
   ASSERT_TRUE(avifColorPrimariesComputeRGBToXYZD50Matrix(
       AVIF_COLOR_PRIMARIES_BT709, coeffs));
   // Golden values from
@@ -44,7 +55,7 @@ TEST(RgbToXyzD50Matrix, GoldenValues) {
 }
 
 TEST(XyzD50ToRgbMatrix, GoldenValues) {
-  double coeffs[3][3];
+  double coeffs[9];
   ASSERT_TRUE(avifColorPrimariesComputeXYZD50ToRGBMatrix(
       AVIF_COLOR_PRIMARIES_BT709, coeffs));
   // Golden values from

--- a/tests/gtest/avifcolrconverttest.cc
+++ b/tests/gtest/avifcolrconverttest.cc
@@ -15,29 +15,18 @@ namespace {
 // Used to pass the data folder path to the GoogleTest suites.
 const char* data_path = nullptr;
 
-void ExpectMatrixNear(const double actual[3][3],
-                      const std::array<std::array<double, 3>, 3>& expected,
-                      const double epsilon) {
-  EXPECT_NEAR(actual[0][0], expected[0][0], epsilon);
-  EXPECT_NEAR(actual[0][1], expected[0][1], epsilon);
-  EXPECT_NEAR(actual[0][2], expected[0][2], epsilon);
-  EXPECT_NEAR(actual[1][0], expected[1][0], epsilon);
-  EXPECT_NEAR(actual[1][1], expected[1][1], epsilon);
-  EXPECT_NEAR(actual[1][2], expected[1][2], epsilon);
-  EXPECT_NEAR(actual[2][0], expected[2][0], epsilon);
-  EXPECT_NEAR(actual[2][1], expected[2][1], epsilon);
-  EXPECT_NEAR(actual[2][2], expected[2][2], epsilon);
-}
-
 void ExpectMatrixNear(const double actual[9],
                       const std::array<std::array<double, 3>, 3>& expected,
                       const double epsilon) {
-  const double actualTmp[3][3] = {
-      {actual[0], actual[1], actual[2]},  // row 0
-      {actual[3], actual[4], actual[5]},  // row 1
-      {actual[6], actual[7], actual[8]}   // row 2
-  };
-  ExpectMatrixNear(actualTmp, expected, epsilon);
+  EXPECT_NEAR(actual[0], expected[0][0], epsilon);
+  EXPECT_NEAR(actual[1], expected[0][1], epsilon);
+  EXPECT_NEAR(actual[2], expected[0][2], epsilon);
+  EXPECT_NEAR(actual[3], expected[1][0], epsilon);
+  EXPECT_NEAR(actual[4], expected[1][1], epsilon);
+  EXPECT_NEAR(actual[5], expected[1][2], epsilon);
+  EXPECT_NEAR(actual[6], expected[2][0], epsilon);
+  EXPECT_NEAR(actual[7], expected[2][1], epsilon);
+  EXPECT_NEAR(actual[8], expected[2][2], epsilon);
 }
 
 TEST(RgbToXyzD50Matrix, GoldenValues) {
@@ -48,9 +37,11 @@ TEST(RgbToXyzD50Matrix, GoldenValues) {
   // http://brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
   const double kEpsilon = 0.00015;
   ExpectMatrixNear(coeffs,
-                   {{{0.4360747, 0.3850649, 0.1430804},
-                     {0.2225045, 0.7168786, 0.0606169},
-                     {0.0139322, 0.0971045, 0.7141733}}},
+                   {{
+                       0.4360747, 0.3850649, 0.1430804,  // row 0
+                       0.2225045, 0.7168786, 0.0606169,  // row 1
+                       0.0139322, 0.0971045, 0.7141733   // row 2
+                   }},
                    kEpsilon);
 }
 
@@ -75,41 +66,51 @@ TEST(RgbToRgbConversion, Identity) {
   const double kEpsilon = 0.000001;
   for (int primaries = AVIF_COLOR_PRIMARIES_UNKNOWN;
        primaries <= AVIF_COLOR_PRIMARIES_SMPTE432; ++primaries) {
-    double coeffs[3][3];
+    double coeffs[9];
     ASSERT_TRUE(avifColorPrimariesComputeRGBToRGBMatrix(
         (avifColorPrimaries)primaries, (avifColorPrimaries)primaries, coeffs));
     ExpectMatrixNear(coeffs,
-                     {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}},
+                     {{
+                         1.0, 0.0, 0.0,  // row 0
+                         0.0, 1.0, 0.0,  // row 1
+                         0.0, 0.0, 1.0   // row 2
+                     }},
                      kEpsilon);
   }
 }
 
 TEST(ColorPrimariesComputeRGBToRGBMatrix, GoldenValues) {
   // Golden values from http://color.support/colorspacecalculator.html
-  double coeffs[3][3];
+  double coeffs[9];
   ASSERT_TRUE(avifColorPrimariesComputeRGBToRGBMatrix(
       AVIF_COLOR_PRIMARIES_BT709, AVIF_COLOR_PRIMARIES_BT2020, coeffs));
   const double kEpsilon = 0.0001;
   ExpectMatrixNear(coeffs,
-                   {{{0.627404, 0.329283, 0.043313},
-                     {0.069097, 0.919540, 0.011362},
-                     {0.016391, 0.088013, 0.895595}}},
+                   {{
+                       0.627404, 0.329283, 0.043313,  // row 0
+                       0.069097, 0.919540, 0.011362,  // row 1
+                       0.016391, 0.088013, 0.895595   // row 2
+                   }},
                    kEpsilon);
 
   ASSERT_TRUE(avifColorPrimariesComputeRGBToRGBMatrix(
       AVIF_COLOR_PRIMARIES_BT2020, AVIF_COLOR_PRIMARIES_BT709, coeffs));
   ExpectMatrixNear(coeffs,
-                   {{{1.660491, -0.587641, -0.072850},
-                     {-0.124550, 1.132900, -0.008349},
-                     {-0.018151, -0.100579, 1.118730}}},
+                   {{
+                       1.660491, -0.587641, -0.072850,  // row 0
+                       -0.124550, 1.132900, -0.008349,  // row 1
+                       -0.018151, -0.100579, 1.118730   // row 2
+                   }},
                    kEpsilon);
 
   ASSERT_TRUE(avifColorPrimariesComputeRGBToRGBMatrix(
       AVIF_COLOR_PRIMARIES_BT709, AVIF_COLOR_PRIMARIES_XYZ, coeffs));
   ExpectMatrixNear(coeffs,
-                   {{{0.438449, 0.392176, 0.169375},
-                     {0.222828, 0.708691, 0.068481},
-                     {0.017314, 0.110445, 0.872241}}},
+                   {{
+                       0.438449, 0.392176, 0.169375,  // row 0
+                       0.222828, 0.708691, 0.068481,  // row 1
+                       0.017314, 0.110445, 0.872241   // row 2
+                   }},
                    kEpsilon);
 }
 
@@ -178,7 +179,7 @@ TEST_P(ConvertImageColorspaceTest, ConvertImage) {
       avifTransferCharacteristicsGetLinearToGammaFunction(
           reference_image->transferCharacteristics);
 
-  double coeffs[3][3];
+  double coeffs[9];
   ASSERT_TRUE(avifColorPrimariesComputeRGBToRGBMatrix(
       src_image->colorPrimaries, reference_image->colorPrimaries, coeffs));
 


### PR DESCRIPTION
This is to prevent passing M[3][3] and make sure they are const, cf https://c-faq.com/ansi/constmismatch.html