### PR TITLE
Remove execution permission on raw fuzztest fuzzer

### DIFF
--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -92,7 +92,8 @@ then
 this_dir=\$(dirname \"\$0\")
 export TEST_DATA_DIRS=\$this_dir/corpus
 chmod +x \$this_dir/$fuzz_basename
-\$this_dir/$fuzz_basename --fuzz=$fuzz_entrypoint -- \$@" > $OUT/$TARGET_FUZZER
+\$this_dir/$fuzz_basename --fuzz=$fuzz_entrypoint -- \$@
+chmod -x \$this_dir/$fuzz_basename" > $OUT/$TARGET_FUZZER
       chmod +x $OUT/$TARGET_FUZZER
     done
   done


### PR DESCRIPTION
This is to try to remove it from the list of official fuzzers on https://oss-fuzz.com/fuzzer-stats?project=libavif&fuzzer=libFuzzer&job=libfuzzer_asan_libavif&group_by=by-fuzzer There is no clear rule of which files from /out appear there. My guess is that it is the executables.