### PR TITLE
Add imageSizeLimit arg to avifutil avifReadImage()

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -582,7 +582,7 @@ static avifBool avifInputReadImage(avifInput * input,
         if (feof(stdin)) {
             return AVIF_FALSE;
         }
-        if (!y4mRead(NULL, dstImage, dstSourceTiming, &input->frameIter)) {
+        if (!y4mRead(NULL, AVIF_DEFAULT_IMAGE_SIZE_LIMIT, dstImage, dstSourceTiming, &input->frameIter)) {
             fprintf(stderr, "ERROR: Cannot read y4m through standard input");
             return AVIF_FALSE;
         }
@@ -611,6 +611,7 @@ static avifBool avifInputReadImage(avifInput * input,
                                                             ignoreXMP,
                                                             allowChangingCicp,
                                                             ignoreGainMap,
+                                                            AVIF_DEFAULT_IMAGE_SIZE_LIMIT,
                                                             dstImage,
                                                             dstDepth,
                                                             dstSourceTiming,

--- a/apps/avifgainmaputil/convert_command.cc
+++ b/apps/avifgainmaputil/convert_command.cc
@@ -45,7 +45,7 @@ avifResult ConvertCommand::Run() {
       /*ignoreExif=*/false,
       /*ignoreXMP=*/false,
       /*allowChangingCicp=*/true,
-      /*ignoreGainMap=*/false, image.get(),
+      /*ignoreGainMap=*/false, AVIF_DEFAULT_IMAGE_SIZE_LIMIT, image.get(),
       /*outDepth=*/nullptr,
       /*sourceTiming=*/nullptr,
       /*frameIter=*/nullptr);

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -119,16 +119,13 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
       }
     }
   } else {
-    const avifAppFileFormat file_format =
-        avifReadImage(input_filename.c_str(), requested_format, requested_depth,
-                      AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC, ignore_profile,
-                      /*ignoreExif=*/false,
-                      /*ignoreXMP=*/false,
-                      /*allowChangingCicp=*/true,
-                      /*ignoreGainMap=*/true, image,
-                      /*outDepth=*/nullptr,
-                      /*sourceTiming=*/nullptr,
-                      /*frameIter=*/nullptr);
+    const avifAppFileFormat file_format = avifReadImage(
+        input_filename.c_str(), requested_format,
+        static_cast<int>(requested_depth), AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC,
+        ignore_profile, /*ignoreExif=*/false, /*ignoreXMP=*/false,
+        /*allowChangingCicp=*/true, /*ignoreGainMap=*/true,
+        AVIF_DEFAULT_IMAGE_SIZE_LIMIT, image, /*outDepth=*/nullptr,
+        /*sourceTiming=*/nullptr, /*frameIter=*/nullptr);
     if (file_format == AVIF_APP_FILE_FORMAT_UNKNOWN) {
       std::cout << "Failed to decode image: " << input_filename;
       return AVIF_RESULT_INVALID_ARGUMENT;

--- a/apps/shared/avifjpeg.h
+++ b/apps/shared/avifjpeg.h
@@ -11,6 +11,7 @@ extern "C" {
 #endif
 
 // Decodes the jpeg file at path 'inputFilename' into 'avif'.
+// At most imageSizeLimit pixels will be read or an error returned.
 // 'ignoreGainMap' is only relevant for jpeg files that have a gain map
 // and only if AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION is ON
 // (requires AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP and libxml2). Otherwise
@@ -23,7 +24,8 @@ avifBool avifJPEGRead(const char * inputFilename,
                       avifBool ignoreColorProfile,
                       avifBool ignoreExif,
                       avifBool ignoreXMP,
-                      avifBool ignoreGainMap);
+                      avifBool ignoreGainMap,
+                      uint32_t imageSizeLimit);
 avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int jpegQuality, avifChromaUpsampling chromaUpsampling);
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION)

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -233,6 +233,7 @@ avifBool avifPNGRead(const char * inputFilename,
                      avifBool ignoreExif,
                      avifBool ignoreXMP,
                      avifBool allowChangingCicp,
+                     uint32_t imageSizeLimit,
                      uint32_t * outPNGDepth)
 {
     volatile avifBool readResult = AVIF_FALSE;
@@ -451,6 +452,10 @@ avifBool avifPNGRead(const char * inputFilename,
     const int numChannels = png_get_channels(png, info);
     if ((numChannels != 3) && (numChannels != 4)) {
         fprintf(stderr, "png_get_channels() should return 3 or 4 but returns %d.\n", numChannels);
+        goto cleanup;
+    }
+    if ((uint32_t)avif->width > imageSizeLimit / (uint32_t)avif->height) {
+        fprintf(stderr, "Too big PNG dimensions (%d x %d > %u px): %s\n", avif->width, avif->height, imageSizeLimit, inputFilename);
         goto cleanup;
     }
 

--- a/apps/shared/avifpng.h
+++ b/apps/shared/avifpng.h
@@ -20,6 +20,7 @@ avifBool avifPNGRead(const char * inputFilename,
                      avifBool ignoreExif,
                      avifBool ignoreXMP,
                      avifBool allowChangingCicp,
+                     uint32_t imageSizeLimit,
                      uint32_t * outPNGDepth);
 avifBool avifPNGWrite(const char * outputFilename,
                       const avifImage * avif,

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -306,6 +306,7 @@ avifAppFileFormat avifReadImage(const char * filename,
                                 avifBool ignoreXMP,
                                 avifBool allowChangingCicp,
                                 avifBool ignoreGainMap,
+                                uint32_t imageSizeLimit,
                                 avifImage * image,
                                 uint32_t * outDepth,
                                 avifAppSourceTiming * sourceTiming,
@@ -313,21 +314,31 @@ avifAppFileFormat avifReadImage(const char * filename,
 {
     const avifAppFileFormat format = avifGuessFileFormat(filename);
     if (format == AVIF_APP_FILE_FORMAT_Y4M) {
-        if (!y4mRead(filename, image, sourceTiming, frameIter)) {
+        if (!y4mRead(filename, imageSizeLimit, image, sourceTiming, frameIter)) {
             return AVIF_APP_FILE_FORMAT_UNKNOWN;
         }
         if (outDepth) {
             *outDepth = image->depth;
         }
     } else if (format == AVIF_APP_FILE_FORMAT_JPEG) {
-        if (!avifJPEGRead(filename, image, requestedFormat, requestedDepth, chromaDownsampling, ignoreColorProfile, ignoreExif, ignoreXMP, ignoreGainMap)) {
+        if (!avifJPEGRead(filename, image, requestedFormat, requestedDepth, chromaDownsampling, ignoreColorProfile, ignoreExif, ignoreXMP, ignoreGainMap, imageSizeLimit)) {
             return AVIF_APP_FILE_FORMAT_UNKNOWN;
         }
         if (outDepth) {
             *outDepth = 8;
         }
     } else if (format == AVIF_APP_FILE_FORMAT_PNG) {
-        if (!avifPNGRead(filename, image, requestedFormat, requestedDepth, chromaDownsampling, ignoreColorProfile, ignoreExif, ignoreXMP, allowChangingCicp, outDepth)) {
+        if (!avifPNGRead(filename,
+                         image,
+                         requestedFormat,
+                         requestedDepth,
+                         chromaDownsampling,
+                         ignoreColorProfile,
+                         ignoreExif,
+                         ignoreXMP,
+                         allowChangingCicp,
+                         imageSizeLimit,
+                         outDepth)) {
             return AVIF_APP_FILE_FORMAT_UNKNOWN;
         }
     } else {

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -62,6 +62,7 @@ typedef struct avifAppSourceTiming
 
 struct y4mFrameIterator;
 // Reads an image from a file with the requested format and depth.
+// At most imageSizeLimit pixels will be read or an error returned.
 // In case of a y4m file, sourceTiming and frameIter can be set.
 // Returns AVIF_APP_FILE_FORMAT_UNKNOWN in case of error.
 // 'ignoreGainMap' is only relevant for jpeg files that have a gain map
@@ -77,6 +78,7 @@ avifAppFileFormat avifReadImage(const char * filename,
                                 avifBool ignoreXMP,
                                 avifBool allowChangingCicp,
                                 avifBool ignoreGainMap,
+                                uint32_t imageSizeLimit,
                                 avifImage * image,
                                 uint32_t * outDepth,
                                 avifAppSourceTiming * sourceTiming,

--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -262,7 +262,11 @@ static avifBool y4mClampSamples(avifImage * avif)
             goto cleanup; \
     } while (0)
 
-avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTiming * sourceTiming, struct y4mFrameIterator ** iter)
+avifBool y4mRead(const char * inputFilename,
+                 uint32_t imageSizeLimit,
+                 avifImage * avif,
+                 avifAppSourceTiming * sourceTiming,
+                 struct y4mFrameIterator ** iter)
 {
     avifBool result = AVIF_FALSE;
 
@@ -398,6 +402,10 @@ avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTimi
 
     if ((frame.width < 1) || (frame.height < 1) || ((frame.depth != 8) && (frame.depth != 10) && (frame.depth != 12))) {
         fprintf(stderr, "Failed to parse y4m header (not enough information): %s\n", frame.displayFilename);
+        goto cleanup;
+    }
+    if ((uint32_t)frame.width > imageSizeLimit / (uint32_t)frame.height) {
+        fprintf(stderr, "Too big y4m dimensions (%d x %d > %u px): %s\n", frame.width, frame.height, imageSizeLimit, frame.displayFilename);
         goto cleanup;
     }
 

--- a/apps/shared/y4m.h
+++ b/apps/shared/y4m.h
@@ -18,7 +18,11 @@ extern "C" {
 // The structure will always be freed upon failure or reaching EOF.
 struct y4mFrameIterator;
 
-avifBool y4mRead(const char * inputFilename, avifImage * avif, avifAppSourceTiming * sourceTiming, struct y4mFrameIterator ** iter);
+avifBool y4mRead(const char * inputFilename,
+                 uint32_t imageSizeLimit,
+                 avifImage * avif,
+                 avifAppSourceTiming * sourceTiming,
+                 struct y4mFrameIterator ** iter);
 avifBool y4mWrite(const char * outputFilename, const avifImage * avif);
 
 #ifdef __cplusplus

--- a/tests/gtest/are_images_equal.cc
+++ b/tests/gtest/are_images_equal.cc
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <limits>
 #include <string>
 
 #include "aviftest_helpers.h"
@@ -36,8 +37,10 @@ int main(int argc, char** argv) {
                       /*ignoreExif=*/AVIF_FALSE,
                       /*ignoreXMP=*/AVIF_FALSE, /*allowChangingCicp=*/AVIF_TRUE,
                       // TODO(maryla): also compare gain maps.
-                      /*ignoreGainMap=*/AVIF_TRUE, decoded[i].get(), &depth[i],
-                      nullptr, nullptr) == AVIF_APP_FILE_FORMAT_UNKNOWN) {
+                      /*ignoreGainMap=*/AVIF_TRUE,
+                      /*imageSizeLimit=*/std::numeric_limits<uint32_t>::max(),
+                      decoded[i].get(), &depth[i], nullptr,
+                      nullptr) == AVIF_APP_FILE_FORMAT_UNKNOWN) {
       std::cerr << "Image " << argv[i + 1] << " cannot be read." << std::endl;
       return 2;
     }

--- a/tests/gtest/avif_fuzztest_read_image.cc
+++ b/tests/gtest/avif_fuzztest_read_image.cc
@@ -60,10 +60,13 @@ void ReadImageFile(const std::string& arbitrary_bytes,
   ImagePtr avif_image(avifImageCreateEmpty());
   avif_image->matrixCoefficients = matrix_coefficients;
 
+  // OSS-Fuzz limits the allocated memory to 2560 MB. Consider 16-bit samples.
+  constexpr uint32_t kImageSizeLimit =
+      2560u * 1024 * 1024 / AVIF_MAX_AV1_LAYER_COUNT / sizeof(uint16_t);
   const avifAppFileFormat file_format = avifReadImage(
       file_path.c_str(), requested_format, requested_depth, chroma_downsampling,
       ignore_color_profile, ignore_exif, ignore_xmp, allow_changing_cicp,
-      ignore_gain_map, avif_image.get(), &out_depth, &timing,
+      ignore_gain_map, kImageSizeLimit, avif_image.get(), &out_depth, &timing,
       /*frameIter=*/nullptr);
 
   if (file_format != AVIF_APP_FILE_FORMAT_UNKNOWN) {

--- a/tests/gtest/aviflosslesstest.cc
+++ b/tests/gtest/aviflosslesstest.cc
@@ -38,7 +38,7 @@ TEST(BasicTest, EncodeDecodeMatrixCoefficients) {
           /*chromaDownsampling=*/AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC,
           /*ignoreColorProfile=*/false, /*ignoreExif=*/false,
           /*ignoreXMP=*/false, /*allowChangingCicp=*/true,
-          /*ignoreGainMap=*/true, image.get(),
+          /*ignoreGainMap=*/true, AVIF_DEFAULT_IMAGE_SIZE_LIMIT, image.get(),
           /*outDepth=*/nullptr, /*sourceTiming=*/nullptr,
           /*frameIter=*/nullptr);
 #if defined(AVIF_ENABLE_EXPERIMENTAL_YCGCO_R)

--- a/tests/gtest/avifpng16bittest.cc
+++ b/tests/gtest/avifpng16bittest.cc
@@ -37,7 +37,7 @@ ImagePtr ReadImageLosslessBitDepth(const std::string& path,
                     /*ignoreColorProfile=*/true,
                     /*ignoreExif=*/true, /*ignoreXMP=*/true,
                     /*allowChangingCicp=*/true, /*ignoreGainMap=*/true,
-                    image.get(), &output_depth,
+                    AVIF_DEFAULT_IMAGE_SIZE_LIMIT, image.get(), &output_depth,
                     /*sourceTiming=*/nullptr,
                     /*frameIter=*/nullptr) == AVIF_APP_FILE_FORMAT_UNKNOWN) {
     return nullptr;

--- a/tests/gtest/aviftest_helpers.cc
+++ b/tests/gtest/aviftest_helpers.cc
@@ -467,7 +467,7 @@ ImagePtr ReadImage(const char* folder_path, const char* file_name,
       avifReadImage((std::string(folder_path) + file_name).c_str(),
                     requested_format, requested_depth, chroma_downsampling,
                     ignore_icc, ignore_exif, ignore_xmp, allow_changing_cicp,
-                    ignore_gain_map, image.get(),
+                    ignore_gain_map, AVIF_DEFAULT_IMAGE_SIZE_LIMIT, image.get(),
                     /*outDepth=*/nullptr, /*sourceTiming=*/nullptr,
                     /*frameIter=*/nullptr) == AVIF_APP_FILE_FORMAT_UNKNOWN) {
     return nullptr;

--- a/tests/gtest/avify4mtest.cc
+++ b/tests/gtest/avify4mtest.cc
@@ -50,8 +50,9 @@ TEST_P(Y4mTest, EncodeDecode) {
 
   ImagePtr decoded(avifImageCreateEmpty());
   ASSERT_NE(decoded, nullptr);
-  ASSERT_TRUE(y4mRead(file_path.str().c_str(), decoded.get(),
-                      /*sourceTiming=*/nullptr, /*iter=*/nullptr));
+  ASSERT_TRUE(y4mRead(file_path.str().c_str(), AVIF_DEFAULT_IMAGE_SIZE_LIMIT,
+                      decoded.get(), /*sourceTiming=*/nullptr,
+                      /*iter=*/nullptr));
 
   EXPECT_TRUE(testutil::AreImagesEqual(*image, *decoded));
 }
@@ -87,8 +88,9 @@ TEST_P(Y4mTest, OutOfRange) {
   // that tag along, it is ignored by the compression algorithm.
   ImagePtr decoded(avifImageCreateEmpty());
   ASSERT_NE(decoded, nullptr);
-  ASSERT_TRUE(y4mRead(file_path.str().c_str(), decoded.get(),
-                      /*sourceTiming=*/nullptr, /*iter=*/nullptr));
+  ASSERT_TRUE(y4mRead(file_path.str().c_str(), AVIF_DEFAULT_IMAGE_SIZE_LIMIT,
+                      decoded.get(), /*sourceTiming=*/nullptr,
+                      /*iter=*/nullptr));
 
   // Pass it through the libavif API to make sure reading a bad y4m does not
   // trigger undefined behavior.


### PR DESCRIPTION
Use AVIF_DEFAULT_IMAGE_SIZE_LIMIT in places where the image is encoded as AVIF afterwards anyway. Use 2^32-1 in other places for a reasonable threshold.

Avoids out-of-memory issues in fuzztest targets.

No entry in CHANGES.md as it should not impact the set of valid workflows in the public API or tools, besides the returned error code or message.

[BUG=oss-fuzz:65700](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65700)