### PR TITLE
Remove const in const double**

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -111,7 +111,7 @@ AVIF_NODISCARD avifBool avifColorPrimariesComputeRGBToRGBMatrix(avifColorPrimari
 // Converts the given linear RGB pixel from one color space to another using the provided coefficients.
 // The coefficients can be obtained with avifColorPrimariesComputeRGBToRGBMatrix().
 // The output values are not clamped and may be < 0 or > 1.
-void avifLinearRGBConvertColorSpace(float rgb[4], const double coeffs[3][3]);
+void avifLinearRGBConvertColorSpace(float rgb[4], double coeffs[3][3]);
 
 #define AVIF_ARRAY_DECLARE(TYPENAME, ITEMSTYPE, ITEMSNAME) \
     typedef struct TYPENAME                                \

--- a/src/colrconvert.c
+++ b/src/colrconvert.c
@@ -82,7 +82,7 @@ static void avifVecMul(double M[3][3], const double x[3], double y[3])
 
 // Bradford chromatic adaptation matrix
 // from https://www.researchgate.net/publication/253799640_A_uniform_colour_space_based_upon_CIECAM97s
-static const double avifBradford[3][3] = {
+static double avifBradford[3][3] = {
     { 0.8951, 0.2664, -0.1614 },
     { -0.7502, 1.7135, 0.0367 },
     { 0.0389, -0.0685, 1.0296 },
@@ -99,7 +99,7 @@ avifBool avifColorPrimariesComputeRGBToXYZD50Matrix(avifColorPrimaries colorPrim
     double whitePointXYZ[3];
     AVIF_CHECK(avifXyToXYZ(&primaries[6], whitePointXYZ));
 
-    const double rgbPrimaries[3][3] = {
+    double rgbPrimaries[3][3] = {
         { primaries[0], primaries[2], primaries[4] },
         { primaries[1], primaries[3], primaries[5] },
         { 1.0 - primaries[0] - primaries[1], 1.0 - primaries[2] - primaries[3], 1.0 - primaries[4] - primaries[5] }
@@ -175,7 +175,7 @@ avifBool avifColorPrimariesComputeRGBToRGBMatrix(avifColorPrimaries srcColorPrim
 // better to clamp the output to [0, 1]. Linear values don't need clamping because values
 // > 1.0 are valid for HDR transfer curves, and the gamma compression function will do the
 // clamping as necessary.
-void avifLinearRGBConvertColorSpace(float rgb[4], const double coeffs[3][3])
+void avifLinearRGBConvertColorSpace(float rgb[4], double coeffs[3][3])
 {
     const double rgbDouble[3] = { rgb[0], rgb[1], rgb[2] };
     double converted[3];

--- a/src/colrconvert.c
+++ b/src/colrconvert.c
@@ -22,7 +22,7 @@ static avifBool avifXyToXYZ(const float xy[2], double XYZ[3])
 }
 
 // Computes I = M^-1. Returns false if M seems to be singular.
-static avifBool avifMatInv(const double M[3][3], double I[3][3])
+static avifBool avifMatInv(double M[3][3], double I[3][3])
 {
     double det = M[0][0] * (M[1][1] * M[2][2] - M[2][1] * M[1][2]) - M[0][1] * (M[1][0] * M[2][2] - M[1][2] * M[2][0]) +
                  M[0][2] * (M[1][0] * M[2][1] - M[1][1] * M[2][0]);
@@ -45,7 +45,7 @@ static avifBool avifMatInv(const double M[3][3], double I[3][3])
 }
 
 // Computes C = A*B
-static void avifMatMul(const double A[3][3], const double B[3][3], double C[3][3])
+static void avifMatMul(double A[3][3], double B[3][3], double C[3][3])
 {
     C[0][0] = A[0][0] * B[0][0] + A[0][1] * B[1][0] + A[0][2] * B[2][0];
     C[0][1] = A[0][0] * B[0][1] + A[0][1] * B[1][1] + A[0][2] * B[2][1];
@@ -73,7 +73,7 @@ static void avifMatDiag(const double d[3], double M[3][3])
 }
 
 // Computes y = M.x
-static void avifVecMul(const double M[3][3], const double x[3], double y[3])
+static void avifVecMul(double M[3][3], const double x[3], double y[3])
 {
     y[0] = M[0][0] * x[0] + M[0][1] * x[1] + M[0][2] * x[2];
     y[1] = M[1][0] * x[0] + M[1][1] * x[1] + M[1][2] * x[2];


### PR DESCRIPTION
We cannot keep the const meaning unless we switch to storing the 2d array as a 1d array which make the code harder to read. cf https://c-faq.com/ansi/constmismatch.html