### PR TITLE
Use AVIF_CHECKERR() in avifImageCreate()

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -137,18 +137,11 @@ void avifImageSetDefaults(avifImage * image)
 avifImage * avifImageCreate(uint32_t width, uint32_t height, uint32_t depth, avifPixelFormat yuvFormat)
 {
     // width and height are checked when actually used, for example by avifImageAllocatePlanes().
-    if (depth > 16) {
-        // avifImage only supports up to 16 bits per sample. See avifImageUsesU16().
-        return NULL;
-    }
-    if ((yuvFormat < AVIF_PIXEL_FORMAT_NONE) || (yuvFormat > AVIF_PIXEL_FORMAT_YUV400)) {
-        return NULL;
-    }
+    AVIF_CHECKERR(depth <= 16, NULL); // avifImage only supports up to 16 bits per sample. See avifImageUsesU16().
+    AVIF_CHECKERR(yuvFormat >= AVIF_PIXEL_FORMAT_NONE && yuvFormat < AVIF_PIXEL_FORMAT_COUNT, NULL);
 
     avifImage * image = (avifImage *)avifAlloc(sizeof(avifImage));
-    if (!image) {
-        return NULL;
-    }
+    AVIF_CHECKERR(image, NULL);
     avifImageSetDefaults(image);
     image->width = width;
     image->height = height;

--- a/src/avif.c
+++ b/src/avif.c
@@ -138,7 +138,8 @@ avifImage * avifImageCreate(uint32_t width, uint32_t height, uint32_t depth, avi
 {
     // width and height are checked when actually used, for example by avifImageAllocatePlanes().
     AVIF_CHECKERR(depth <= 16, NULL); // avifImage only supports up to 16 bits per sample. See avifImageUsesU16().
-    AVIF_CHECKERR(yuvFormat >= AVIF_PIXEL_FORMAT_NONE && yuvFormat < AVIF_PIXEL_FORMAT_COUNT, NULL);
+    // Cast to silence "comparison of unsigned expression is always true" warning.
+    AVIF_CHECKERR((int)yuvFormat >= AVIF_PIXEL_FORMAT_NONE && yuvFormat < AVIF_PIXEL_FORMAT_COUNT, NULL);
 
     avifImage * image = (avifImage *)avifAlloc(sizeof(avifImage));
     AVIF_CHECKERR(image, NULL);

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -46,13 +46,10 @@ static avifBool avifPrepareReformatState(const avifImage * image, const avifRGBI
     if (rgb->format == AVIF_RGB_FORMAT_RGB_565) {
         AVIF_CHECK(rgb->depth == 8);
     }
-    if (image->yuvFormat <= AVIF_PIXEL_FORMAT_NONE || image->yuvFormat >= AVIF_PIXEL_FORMAT_COUNT) {
-        return AVIF_FALSE;
-    }
-    AVIF_CHECK(rgb->format >= AVIF_RGB_FORMAT_RGB && rgb->format < AVIF_RGB_FORMAT_COUNT);
-    if (image->yuvRange != AVIF_RANGE_LIMITED && image->yuvRange != AVIF_RANGE_FULL) {
-        return AVIF_FALSE;
-    }
+    AVIF_CHECK(image->yuvFormat >= AVIF_PIXEL_FORMAT_YUV444 && image->yuvFormat < AVIF_PIXEL_FORMAT_COUNT);
+    // Cast to silence "comparison of unsigned expression is always true" warning.
+    AVIF_CHECK((int)rgb->format >= AVIF_RGB_FORMAT_RGB && rgb->format < AVIF_RGB_FORMAT_COUNT);
+    AVIF_CHECK(image->yuvRange == AVIF_RANGE_LIMITED || image->yuvRange == AVIF_RANGE_FULL);
 
     // These matrix coefficients values are currently unsupported. Revise this list as more support is added.
     //

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -33,25 +33,23 @@ static avifBool avifPrepareReformatState(const avifImage * image, const avifRGBI
     if ((image->depth != 8) && (image->depth != 10) && (image->depth != 12) && (image->depth != 16)) {
         return AVIF_FALSE;
     }
-    if ((rgb->depth != 8) && (rgb->depth != 10) && (rgb->depth != 12) && (rgb->depth != 16)) {
-        return AVIF_FALSE;
-    }
+    AVIF_CHECK(rgb->depth == 8 || rgb->depth == 10 || rgb->depth == 12 || rgb->depth == 16);
     if (useYCgCoRe || useYCgCoRo) {
         const int bitOffset = (useYCgCoRe) ? 2 : 1;
         if (image->depth - bitOffset != rgb->depth) {
             return AVIF_FALSE;
         }
     }
-    if (rgb->isFloat && rgb->depth != 16) {
+    if (rgb->isFloat) {
+        AVIF_CHECK(rgb->depth == 16);
+    }
+    if (rgb->format == AVIF_RGB_FORMAT_RGB_565) {
+        AVIF_CHECK(rgb->depth == 8);
+    }
+    if (image->yuvFormat <= AVIF_PIXEL_FORMAT_NONE || image->yuvFormat >= AVIF_PIXEL_FORMAT_COUNT) {
         return AVIF_FALSE;
     }
-    if (rgb->format == AVIF_RGB_FORMAT_RGB_565 && rgb->depth != 8) {
-        return AVIF_FALSE;
-    }
-    if (image->yuvFormat <= AVIF_PIXEL_FORMAT_NONE || image->yuvFormat >= AVIF_PIXEL_FORMAT_COUNT ||
-        rgb->format < AVIF_RGB_FORMAT_RGB || rgb->format >= AVIF_RGB_FORMAT_COUNT) {
-        return AVIF_FALSE;
-    }
+    AVIF_CHECK(rgb->format >= AVIF_RGB_FORMAT_RGB && rgb->format < AVIF_RGB_FORMAT_COUNT);
     if (image->yuvRange != AVIF_RANGE_LIMITED && image->yuvRange != AVIF_RANGE_FULL) {
         return AVIF_FALSE;
     }


### PR DESCRIPTION
Cherry-pick of 1c3de07e440623dd2bd0b38fd3c76b6e69b8cbdc and 8ca862da585c5cac95d0803f4670b2dab4627823 (mostly as an exercise).