### PR TITLE
Replace some assertions by AVIF_ASSERT()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add avif_cxx.h as a C++ header with basic functionality.
 * Add enum aliases AVIF_COLOR_PRIMARIES_SRGB, AVIF_COLOR_PRIMARIES_BT2100,
   AVIF_COLOR_PRIMARIES_DCI_P3, AVIF_TRANSFER_CHARACTERISTICS_PQ.
+* Add avifResult enum entry AVIF_RESULT_INTERNAL_ERROR.
 
 ### Changed
 * Update aom.cmd: v3.8.1

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -186,10 +186,11 @@ typedef enum AVIF_NODISCARD avifResult
     AVIF_RESULT_OUT_OF_MEMORY = 26,
     AVIF_RESULT_CANNOT_CHANGE_SETTING = 27, // a setting that can't change is changed during encoding
     AVIF_RESULT_INCOMPATIBLE_IMAGE = 28,    // the image is incompatible with already encoded images
+    AVIF_RESULT_INTERNAL_ERROR = 29,        // some invariants have not been satisfied
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-    AVIF_RESULT_ENCODE_GAIN_MAP_FAILED = 29,
-    AVIF_RESULT_DECODE_GAIN_MAP_FAILED = 30,
-    AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE = 31,
+    AVIF_RESULT_ENCODE_GAIN_MAP_FAILED = 30,
+    AVIF_RESULT_DECODE_GAIN_MAP_FAILED = 31,
+    AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE = 32,
 #endif
 
     // Kept for backward compatibility; please use the symbols above instead.

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -186,7 +186,7 @@ typedef enum AVIF_NODISCARD avifResult
     AVIF_RESULT_OUT_OF_MEMORY = 26,
     AVIF_RESULT_CANNOT_CHANGE_SETTING = 27, // a setting that can't change is changed during encoding
     AVIF_RESULT_INCOMPATIBLE_IMAGE = 28,    // the image is incompatible with already encoded images
-    AVIF_RESULT_INTERNAL_ERROR = 29,        // some invariants have not been satisfied
+    AVIF_RESULT_INTERNAL_ERROR = 29,        // some invariants have not been satisfied (likely a bug in libavif)
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     AVIF_RESULT_ENCODE_GAIN_MAP_FAILED = 30,
     AVIF_RESULT_DECODE_GAIN_MAP_FAILED = 31,

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -59,17 +59,6 @@ static inline void avifBreakOnError()
         }                                 \
     } while (0)
 
-// Same as AVIF_CHECKERR() but also assert() in debug build configuration.
-// Can be used instead of assert() for extra security.
-#define AVIF_ASSERT(A, ERR)     \
-    do {                        \
-        if (!(A)) {             \
-            assert(AVIF_FALSE); \
-            avifBreakOnError(); \
-            return ERR;         \
-        }                       \
-    } while (0)
-
 // ---------------------------------------------------------------------------
 // URNs and Content-Types
 

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -59,6 +59,17 @@ static inline void avifBreakOnError()
         }                                 \
     } while (0)
 
+// Same as AVIF_CHECKERR() but also assert() in debug build configuration.
+// Can be used instead of assert() for extra security.
+#define AVIF_ASSERT(A, ERR)     \
+    do {                        \
+        if (!(A)) {             \
+            assert(AVIF_FALSE); \
+            avifBreakOnError(); \
+            return ERR;         \
+        }                       \
+    } while (0)
+
 // ---------------------------------------------------------------------------
 // URNs and Content-Types
 

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -59,16 +59,12 @@ static inline void avifBreakOnError()
         }                                 \
     } while (0)
 
-// Same as AVIF_CHECKERR() but also assert() in debug build configuration.
-// Can be used instead of assert() for extra security in release builds.
-#define AVIF_ASSERT_OR_RETURN(A, ERR) \
-    do {                              \
-        if (!(A)) {                   \
-            assert(AVIF_FALSE);       \
-            avifBreakOnError();       \
-            return ERR;               \
-        }                             \
-    } while (0)
+// AVIF_ASSERT_OR_RETURN() can be used instead of assert() for extra security in release builds.
+#ifdef NDEBUG
+#define AVIF_ASSERT_OR_RETURN(A) AVIF_CHECKERR((A), AVIF_RESULT_INTERNAL_ERROR)
+#else
+#define AVIF_ASSERT_OR_RETURN(A) assert(A)
+#endif
 
 // ---------------------------------------------------------------------------
 // URNs and Content-Types

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -59,6 +59,17 @@ static inline void avifBreakOnError()
         }                                 \
     } while (0)
 
+// Same as AVIF_CHECKERR() but also assert() in debug build configuration.
+// Can be used instead of assert() for extra security in release builds.
+#define AVIF_ASSERT_OR_RETURN(A, ERR) \
+    do {                              \
+        if (!(A)) {                   \
+            assert(AVIF_FALSE);       \
+            avifBreakOnError();       \
+            return ERR;               \
+        }                             \
+    } while (0)
+
 // ---------------------------------------------------------------------------
 // URNs and Content-Types
 

--- a/src/avif.c
+++ b/src/avif.c
@@ -103,6 +103,7 @@ const char * avifResultToString(avifResult result)
         case AVIF_RESULT_OUT_OF_MEMORY:                 return "Out of memory";
         case AVIF_RESULT_CANNOT_CHANGE_SETTING:         return "Cannot change some setting during encoding";
         case AVIF_RESULT_INCOMPATIBLE_IMAGE:            return "The image is incompatible with already encoded images";
+        case AVIF_RESULT_INTERNAL_ERROR:                return "Some invariants have not been satisfied";
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         case AVIF_RESULT_ENCODE_GAIN_MAP_FAILED:        return "Encoding of gain map planes failed";
         case AVIF_RESULT_DECODE_GAIN_MAP_FAILED:        return "Decoding of gain map planes failed";

--- a/src/avif.c
+++ b/src/avif.c
@@ -103,7 +103,7 @@ const char * avifResultToString(avifResult result)
         case AVIF_RESULT_OUT_OF_MEMORY:                 return "Out of memory";
         case AVIF_RESULT_CANNOT_CHANGE_SETTING:         return "Cannot change some setting during encoding";
         case AVIF_RESULT_INCOMPATIBLE_IMAGE:            return "The image is incompatible with already encoded images";
-        case AVIF_RESULT_INTERNAL_ERROR:                return "Some invariants have not been satisfied";
+        case AVIF_RESULT_INTERNAL_ERROR:                return "Internal error";
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         case AVIF_RESULT_ENCODE_GAIN_MAP_FAILED:        return "Encoding of gain map planes failed";
         case AVIF_RESULT_DECODE_GAIN_MAP_FAILED:        return "Decoding of gain map planes failed";

--- a/src/read.c
+++ b/src/read.c
@@ -5556,7 +5556,7 @@ uint32_t avifDecoderDecodedRowCount(const avifDecoder * decoder)
                     const uint32_t scaledGainMapRowCount =
                         (uint32_t)floorf((float)gainMapRowCount / gainMap->height * decoder->image->height);
                     // Make sure it matches the formula described in the comment of avifDecoderDecodedRowCount() in avif.h.
-                    AVIF_ASSERT((uint32_t)lround((double)scaledGainMapRowCount / decoder->image->height *
+                    AVIF_CHECKERR((uint32_t)lround((double)scaledGainMapRowCount / decoder->image->height *
                                                  decoder->image->gainMap->image->height) <= gainMapRowCount,
                                 0);
                     gainMapRowCount = scaledGainMapRowCount;

--- a/src/read.c
+++ b/src/read.c
@@ -1574,10 +1574,10 @@ static avifResult avifDecoderDataAllocateGridImagePlanes(avifDecoderData * data,
 // After verifying that the relevant properties of the tile match those of the first tile, copies over the pixels from the tile
 // into dstImage.
 static avifResult avifDecoderDataCopyTileToImage(avifDecoderData * data,
-                                               const avifTileInfo * info,
-                                               avifImage * dstImage,
-                                               const avifTile * tile,
-                                               unsigned int tileIndex)
+                                                 const avifTileInfo * info,
+                                                 avifImage * dstImage,
+                                                 const avifTile * tile,
+                                                 unsigned int tileIndex)
 {
     const avifImageGrid * grid = &info->grid;
     const avifTile * firstTile = &data->tiles.tile[info->firstTileIndex];
@@ -1617,8 +1617,8 @@ static avifResult avifDecoderDataCopyTileToImage(avifDecoderData * data,
     }
 #endif
     AVIF_CHECKERR(avifImageSetViewRect(&dstView, dst, &dstViewRect) == AVIF_RESULT_OK &&
-                    avifImageSetViewRect(&srcView, tile->image, &srcViewRect) == AVIF_RESULT_OK,
-                AVIF_RESULT_INTERNAL_ERROR);
+                      avifImageSetViewRect(&srcView, tile->image, &srcViewRect) == AVIF_RESULT_OK,
+                  AVIF_RESULT_INTERNAL_ERROR);
     avifImageCopySamples(&dstView, &srcView, (tile->input->itemCategory == AVIF_ITEM_ALPHA) ? AVIF_PLANES_A : AVIF_PLANES_YUV);
 
     return AVIF_RESULT_OK;
@@ -2426,24 +2426,11 @@ static avifResult avifParseItemPropertyAssociation(avifMeta * meta, const uint8_
             // Copy property to item
             const avifProperty * srcProp = &meta->properties.prop[propertyIndex];
 
-            static const char * supportedTypes[] = {
-                "ispe",
-                "auxC",
-                "colr",
-                "av1C",
+            static const char * supportedTypes[] = { "ispe", "auxC", "colr", "av1C",
 #if defined(AVIF_CODEC_AVM)
-                "av2C",
+                                                     "av2C",
 #endif
-                "pasp",
-                "clap",
-                "irot",
-                "imir",
-                "pixi",
-                "a1op",
-                "lsel",
-                "a1lx",
-                "clli"
-            };
+                                                     "pasp", "clap", "irot", "imir", "pixi", "a1op", "lsel", "a1lx", "clli" };
             size_t supportedTypesCount = sizeof(supportedTypes) / sizeof(supportedTypes[0]);
             avifBool supportedType = AVIF_FALSE;
             for (size_t i = 0; i < supportedTypesCount; ++i) {
@@ -5333,8 +5320,8 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
     }
 
     AVIF_CHECKERR(decoder->data->tiles.count == (decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].firstTileIndex +
-                                               decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].tileCount),
-                AVIF_RESULT_INTERNAL_ERROR);
+                                                 decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].tileCount),
+                  AVIF_RESULT_INTERNAL_ERROR);
 
     const uint32_t nextImageIndex = (uint32_t)(decoder->imageIndex + 1);
 
@@ -5369,7 +5356,7 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
         avifResult firstNonOkResult = AVIF_RESULT_OK;
         for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
             AVIF_CHECKERR(prepareTileResult[c] == AVIF_RESULT_OK || prepareTileResult[c] == AVIF_RESULT_WAITING_ON_IO,
-                        AVIF_RESULT_INTERNAL_ERROR);
+                          AVIF_RESULT_INTERNAL_ERROR);
             if (firstNonOkResult == AVIF_RESULT_OK) {
                 firstNonOkResult = prepareTileResult[c];
             }
@@ -5557,8 +5544,8 @@ uint32_t avifDecoderDecodedRowCount(const avifDecoder * decoder)
                         (uint32_t)floorf((float)gainMapRowCount / gainMap->height * decoder->image->height);
                     // Make sure it matches the formula described in the comment of avifDecoderDecodedRowCount() in avif.h.
                     AVIF_CHECKERR((uint32_t)lround((double)scaledGainMapRowCount / decoder->image->height *
-                                                 decoder->image->gainMap->image->height) <= gainMapRowCount,
-                                0);
+                                                   decoder->image->gainMap->image->height) <= gainMapRowCount,
+                                  0);
                     gainMapRowCount = scaledGainMapRowCount;
                 }
                 minRowCount = AVIF_MIN(minRowCount, gainMapRowCount);

--- a/src/read.c
+++ b/src/read.c
@@ -566,7 +566,7 @@ static avifResult avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput *
             }
         }
         if (remainingSize > 0) {
-            AVIF_CHECKERR(layerCount == 3, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(layerCount == 3, AVIF_RESULT_INTERNAL_ERROR);
             ++layerCount;
             layerSizes[3] = remainingSize;
         }
@@ -611,7 +611,7 @@ static avifResult avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput *
         sample->itemID = item->id;
         sample->offset = 0;
         sample->size = sampleSize;
-        AVIF_CHECKERR(lselProp->u.lsel.layerID < AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(lselProp->u.lsel.layerID < AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_INTERNAL_ERROR);
         sample->spatialID = (uint8_t)lselProp->u.lsel.layerID;
         sample->sync = AVIF_TRUE;
     } else if (allowProgressive && item->progressive) {
@@ -790,7 +790,7 @@ static avifResult avifCheckItemID(const char * boxFourcc, uint32_t itemID, avifD
 static avifResult avifMetaFindOrCreateItem(avifMeta * meta, uint32_t itemID, avifDecoderItem ** item, avifDiagnostics * diag)
 {
     *item = NULL;
-    AVIF_CHECKERR(itemID != 0, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(itemID != 0, AVIF_RESULT_INTERNAL_ERROR);
 
     for (uint32_t i = 0; i < meta->items.count; ++i) {
         if (meta->items.item[i]->id == itemID) {
@@ -1055,7 +1055,7 @@ static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, const a
     size_t remainingBytes = sample->size; // This may be smaller than item->size if the item is progressive
 
     // Assert that the for loop below will execute at least one iteration.
-    AVIF_CHECKERR(item->extents.count != 0, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(item->extents.count != 0, AVIF_RESULT_INTERNAL_ERROR);
     uint64_t minOffset = UINT64_MAX;
     uint64_t maxOffset = 0;
     for (uint32_t extentIter = 0; extentIter < item->extents.count; ++extentIter) {
@@ -1380,8 +1380,8 @@ static avifResult avifDecoderItemRead(avifDecoderItem * item,
             memcpy(&item->mergedExtents, &offsetBuffer, sizeof(avifRWData));
             item->mergedExtents.size = bytesToRead;
         } else {
-            AVIF_CHECKERR(item->ownsMergedExtents, AVIF_RESULT_INTERNAL_ERROR);
-            AVIF_CHECKERR(front, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(item->ownsMergedExtents, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(front, AVIF_RESULT_INTERNAL_ERROR);
             memcpy(front, offsetBuffer.data, bytesToRead);
             front += bytesToRead;
         }
@@ -1526,7 +1526,7 @@ static avifResult avifDecoderDataAllocateGridImagePlanes(avifDecoderData * data,
     avifBool alpha = (tile->input->itemCategory == AVIF_ITEM_ALPHA);
     if (alpha) {
         // An alpha tile does not contain any YUV pixels.
-        AVIF_CHECKERR(tile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(tile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE, AVIF_RESULT_INTERNAL_ERROR);
     }
     if (!avifAreGridDimensionsValid(tile->image->yuvFormat, grid->outputWidth, grid->outputHeight, tile->image->width, tile->image->height, data->diag)) {
         return AVIF_RESULT_INVALID_IMAGE_GRID;
@@ -1612,13 +1612,13 @@ static avifResult avifDecoderDataCopyTileToImage(avifDecoderData * data,
     avifImage * dst = dstImage;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-        AVIF_CHECKERR(dst->gainMap && dst->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(dst->gainMap && dst->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
         dst = dst->gainMap->image;
     }
 #endif
-    AVIF_CHECKERR(avifImageSetViewRect(&dstView, dst, &dstViewRect) == AVIF_RESULT_OK &&
-                      avifImageSetViewRect(&srcView, tile->image, &srcViewRect) == AVIF_RESULT_OK,
-                  AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(avifImageSetViewRect(&dstView, dst, &dstViewRect) == AVIF_RESULT_OK &&
+                              avifImageSetViewRect(&srcView, tile->image, &srcViewRect) == AVIF_RESULT_OK,
+                          AVIF_RESULT_INTERNAL_ERROR);
     avifImageCopySamples(&dstView, &srcView, (tile->input->itemCategory == AVIF_ITEM_ALPHA) ? AVIF_PLANES_A : AVIF_PLANES_YUV);
 
     return AVIF_RESULT_OK;
@@ -1925,7 +1925,7 @@ static avifBool avifParseToneMappedImageBox(avifGainMapMetadata * metadata, cons
     uint8_t flags;
     AVIF_CHECK(avifROStreamRead(&s, &flags, 1)); // unsigned int(8) flags;
     uint8_t channelCount = (flags & 1) * 2 + 1;
-    AVIF_CHECKERR(channelCount == 1 || channelCount == 3, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(channelCount == 1 || channelCount == 3, AVIF_RESULT_INTERNAL_ERROR);
     metadata->useBaseColorSpace = (flags & 2) != 0;
     metadata->backwardDirection = (flags & 4) != 0;
     const avifBool useCommonDenominator = (flags & 8) != 0;
@@ -2023,13 +2023,13 @@ static avifResult avifDecoderItemReadAndParse(const avifDecoder * decoder,
         } else {
             // item was generated for convenience and is not part of the bitstream.
             // grid information should already be set.
-            AVIF_CHECKERR(grid->rows > 0 && grid->columns > 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(grid->rows > 0 && grid->columns > 0, AVIF_RESULT_INTERNAL_ERROR);
         }
         *codecType = avifDecoderItemGetGridCodecType(item);
         AVIF_CHECKERR(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INVALID_IMAGE_GRID);
     } else {
         *codecType = avifGetCodecType(item->type);
-        AVIF_CHECKERR(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INTERNAL_ERROR);
     }
     return AVIF_RESULT_OK;
 }
@@ -2354,7 +2354,7 @@ static avifResult avifParseItemPropertyAssociation(avifMeta * meta, const uint8_
     if (meta->fromMini) {
         // The CondensedImageBox will always create 8 item properties, so to refer to the
         // first property in the ItemPropertyContainerBox of its extendedMeta field, use index 9.
-        AVIF_CHECKERR(meta->properties.count >= 8, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(meta->properties.count >= 8, AVIF_RESULT_INTERNAL_ERROR);
     }
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
 
@@ -2641,7 +2641,7 @@ static avifResult avifParseItemInfoEntry(avifMeta * meta, const uint8_t * raw, s
         AVIF_CHECKERR(avifROStreamReadU16(&s, &tmp), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(16) item_ID;
         itemID = tmp;
     } else {
-        AVIF_CHECKERR(version == 3, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(version == 3, AVIF_RESULT_INTERNAL_ERROR);
         AVIF_CHECKERR(avifROStreamReadU32(&s, &itemID), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) item_ID;
     }
     AVIF_CHECKRES(avifCheckItemID("infe", itemID, diag));
@@ -3312,7 +3312,7 @@ static avifResult avifParseTrackBox(avifDecoderData * data,
             //
             // Since libavif uses repetitionCount (which is 0-based), we subtract the value by 1 to derive the number of
             // repetitions.
-            AVIF_CHECKERR(track->segmentDuration != 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(track->segmentDuration != 0, AVIF_RESULT_INTERNAL_ERROR);
             // We specifically check for trackDuration == 0 here and not when it is actually read in order to accept files which
             // inadvertently has a trackDuration of 0 without any edit lists.
             if (track->trackDuration == 0) {
@@ -3722,7 +3722,7 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
     // The ExtendedMetaBox may reuse items and properties created above so it must be parsed last.
 
     if (hasExtendedMeta) {
-        AVIF_CHECKERR(avifROStreamHasBytesLeft(&s, extendedMetaSize), AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(avifROStreamHasBytesLeft(&s, extendedMetaSize), AVIF_RESULT_INTERNAL_ERROR);
         AVIF_CHECKRES(avifParseExtendedMeta(meta, rawOffset + avifROStreamOffset(&s), avifROStreamCurrent(&s), extendedMetaSize, diag));
     }
     return AVIF_RESULT_OK;
@@ -3790,7 +3790,7 @@ static avifResult avifParse(avifDecoder * decoder)
         avifBoxHeader header;
         AVIF_CHECKERR(avifROStreamReadBoxHeaderPartial(&headerStream, &header), AVIF_RESULT_BMFF_PARSE_FAILED);
         parseOffset += headerStream.offset;
-        AVIF_CHECKERR(decoder->io->sizeHint == 0 || parseOffset <= decoder->io->sizeHint, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(decoder->io->sizeHint == 0 || parseOffset <= decoder->io->sizeHint, AVIF_RESULT_INTERNAL_ERROR);
 
         // Try to get the remainder of the box, if necessary
         uint64_t boxOffset = 0;
@@ -4411,7 +4411,7 @@ static avifResult avifMetaFindAlphaItem(avifMeta * meta,
             }
         }
     }
-    AVIF_CHECKERR(alphaItemCount == colorItemCount, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(alphaItemCount == colorItemCount, AVIF_RESULT_INTERNAL_ERROR);
     // Figure out the last used itemID.
     avifResult result;
     const uint32_t lastID = meta->items.item[meta->items.count - 1]->id;
@@ -4512,7 +4512,7 @@ static avifResult avifDecoderDataFindToneMappedImageItem(const avifDecoderData *
                     continue;
                 }
                 if (otherItem->dimgIdx < 2) {
-                    AVIF_CHECKERR(dimgItemIDs[otherItem->dimgIdx] == 0, AVIF_RESULT_INTERNAL_ERROR);
+                    AVIF_ASSERT_OR_RETURN(dimgItemIDs[otherItem->dimgIdx] == 0, AVIF_RESULT_INTERNAL_ERROR);
                     dimgItemIDs[otherItem->dimgIdx] = otherItem->id;
                 }
                 numDimgItemIDs++;
@@ -4561,7 +4561,7 @@ static avifResult avifDecoderFindGainMapItem(const avifDecoder * decoder,
         return AVIF_RESULT_OK;
     }
 
-    AVIF_CHECKERR(gainMapItemID != 0, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(gainMapItemID != 0, AVIF_RESULT_INTERNAL_ERROR);
     avifDecoderItem * gainMapItemTmp;
     AVIF_CHECKRES(avifMetaFindOrCreateItem(data->meta, gainMapItemID, &gainMapItemTmp, data->diag));
     if (avifDecoderItemShouldBeSkipped(gainMapItemTmp)) {
@@ -4643,7 +4643,7 @@ static avifResult avifDecoderGenerateImageTiles(avifDecoder * decoder, avifTileI
         AVIF_CHECKERR(item->size != 0, AVIF_RESULT_MISSING_IMAGE_ITEM);
 
         const avifCodecType codecType = avifGetCodecType(item->type);
-        AVIF_CHECKERR(codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INTERNAL_ERROR);
         avifTile * tile =
             avifDecoderDataCreateTile(decoder->data, codecType, item->width, item->height, avifDecoderItemOperatingPoint(item));
         AVIF_CHECKERR(tile, AVIF_RESULT_OUT_OF_MEMORY);
@@ -4961,7 +4961,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 #endif
             if (c == AVIF_ITEM_ALPHA && !mainItems[c]->width && !mainItems[c]->height) {
                 // NON-STANDARD: Alpha subimage does not have an ispe property; adopt width/height from color item
-                AVIF_CHECKERR(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED), AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED), AVIF_RESULT_INTERNAL_ERROR);
                 mainItems[c]->width = mainItems[AVIF_ITEM_COLOR]->width;
                 mainItems[c]->height = mainItems[AVIF_ITEM_COLOR]->height;
             }
@@ -4996,7 +4996,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         if (mainItems[AVIF_ITEM_GAIN_MAP]) {
-            AVIF_CHECKERR(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
             decoder->image->gainMap->image->width = mainItems[AVIF_ITEM_GAIN_MAP]->width;
             decoder->image->gainMap->image->height = mainItems[AVIF_ITEM_GAIN_MAP]->height;
             decoder->gainMapPresent = AVIF_TRUE;
@@ -5186,7 +5186,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
 
         const avifDecodeSample * sample = &tile->input->samples.sample[nextImageIndex];
         if (sample->data.size < sample->size) {
-            AVIF_CHECKERR(decoder->allowIncremental, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(decoder->allowIncremental, AVIF_RESULT_INTERNAL_ERROR);
             // Data is missing but there is no error yet. Output available pixel rows.
             return AVIF_RESULT_OK;
         }
@@ -5247,7 +5247,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
                 avifImage * dstImage = decoder->image;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
                 if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                    AVIF_CHECKERR(dstImage->gainMap && dstImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                    AVIF_ASSERT_OR_RETURN(dstImage->gainMap && dstImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
                     dstImage = dstImage->gainMap->image;
                 }
 #endif
@@ -5256,14 +5256,14 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
             AVIF_CHECKRES(avifDecoderDataCopyTileToImage(decoder->data, info, decoder->image, tile, tileIndex));
         } else {
             // Non-grid path. Just steal the planes from the only "tile".
-            AVIF_CHECKERR(info->tileCount == 1, AVIF_RESULT_INTERNAL_ERROR);
-            AVIF_CHECKERR(tileIndex == 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(info->tileCount == 1, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(tileIndex == 0, AVIF_RESULT_INTERNAL_ERROR);
             avifImage * src = tile->image;
 
             switch (tile->input->itemCategory) {
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
                 case AVIF_ITEM_GAIN_MAP:
-                    AVIF_CHECKERR(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                    AVIF_ASSERT_OR_RETURN(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
                     decoder->image->gainMap->image->width = src->width;
                     decoder->image->gainMap->image->height = src->height;
                     decoder->image->gainMap->image->depth = src->depth;
@@ -5290,7 +5290,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
                 avifImageStealPlanes(decoder->image, src, AVIF_PLANES_A);
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
             } else if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                AVIF_CHECKERR(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
                 avifImageStealPlanes(decoder->image->gainMap->image, src, AVIF_PLANES_YUV);
 #endif
             } else { // AVIF_ITEM_COLOR
@@ -5332,9 +5332,9 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
         }
     }
 
-    AVIF_CHECKERR(decoder->data->tiles.count == (decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].firstTileIndex +
-                                                 decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].tileCount),
-                  AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(decoder->data->tiles.count == (decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].firstTileIndex +
+                                                         decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].tileCount),
+                          AVIF_RESULT_INTERNAL_ERROR);
 
     const uint32_t nextImageIndex = (uint32_t)(decoder->imageIndex + 1);
 
@@ -5363,23 +5363,23 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
     }
 
     if (!avifDecoderDataFrameFullyDecoded(decoder->data)) {
-        AVIF_CHECKERR(decoder->allowIncremental, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(decoder->allowIncremental, AVIF_RESULT_INTERNAL_ERROR);
         // The image is not completely decoded. There should be no error unrelated to missing bytes,
         // and at least some missing bytes.
         avifResult firstNonOkResult = AVIF_RESULT_OK;
         for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
-            AVIF_CHECKERR(prepareTileResult[c] == AVIF_RESULT_OK || prepareTileResult[c] == AVIF_RESULT_WAITING_ON_IO,
-                          AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(prepareTileResult[c] == AVIF_RESULT_OK || prepareTileResult[c] == AVIF_RESULT_WAITING_ON_IO,
+                                  AVIF_RESULT_INTERNAL_ERROR);
             if (firstNonOkResult == AVIF_RESULT_OK) {
                 firstNonOkResult = prepareTileResult[c];
             }
         }
-        AVIF_CHECKERR(firstNonOkResult != AVIF_RESULT_OK, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(firstNonOkResult != AVIF_RESULT_OK, AVIF_RESULT_INTERNAL_ERROR);
         // Return the "not enough bytes" status now instead of moving on to the next frame.
         return AVIF_RESULT_WAITING_ON_IO;
     }
     for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
-        AVIF_CHECKERR(prepareTileResult[c] == AVIF_RESULT_OK, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(prepareTileResult[c] == AVIF_RESULT_OK, AVIF_RESULT_INTERNAL_ERROR);
     }
 
     // Only advance decoder->imageIndex once the image is completely decoded, so that

--- a/src/read.c
+++ b/src/read.c
@@ -566,7 +566,7 @@ static avifResult avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput *
             }
         }
         if (remainingSize > 0) {
-            assert(layerCount == 3);
+            AVIF_ASSERT(layerCount == 3, AVIF_RESULT_UNKNOWN_ERROR);
             ++layerCount;
             layerSizes[3] = remainingSize;
         }
@@ -611,7 +611,7 @@ static avifResult avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput *
         sample->itemID = item->id;
         sample->offset = 0;
         sample->size = sampleSize;
-        assert(lselProp->u.lsel.layerID < AVIF_MAX_AV1_LAYER_COUNT);
+        AVIF_ASSERT(lselProp->u.lsel.layerID < AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_UNKNOWN_ERROR);
         sample->spatialID = (uint8_t)lselProp->u.lsel.layerID;
         sample->sync = AVIF_TRUE;
     } else if (allowProgressive && item->progressive) {
@@ -790,7 +790,7 @@ static avifResult avifCheckItemID(const char * boxFourcc, uint32_t itemID, avifD
 static avifResult avifMetaFindOrCreateItem(avifMeta * meta, uint32_t itemID, avifDecoderItem ** item, avifDiagnostics * diag)
 {
     *item = NULL;
-    assert(itemID != 0);
+    AVIF_ASSERT(itemID != 0, AVIF_RESULT_UNKNOWN_ERROR);
 
     for (uint32_t i = 0; i < meta->items.count; ++i) {
         if (meta->items.item[i]->id == itemID) {
@@ -1055,7 +1055,7 @@ static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, const a
     size_t remainingBytes = sample->size; // This may be smaller than item->size if the item is progressive
 
     // Assert that the for loop below will execute at least one iteration.
-    assert(item->extents.count != 0);
+    AVIF_ASSERT(item->extents.count != 0, AVIF_RESULT_UNKNOWN_ERROR);
     uint64_t minOffset = UINT64_MAX;
     uint64_t maxOffset = 0;
     for (uint32_t extentIter = 0; extentIter < item->extents.count; ++extentIter) {
@@ -1380,8 +1380,8 @@ static avifResult avifDecoderItemRead(avifDecoderItem * item,
             memcpy(&item->mergedExtents, &offsetBuffer, sizeof(avifRWData));
             item->mergedExtents.size = bytesToRead;
         } else {
-            assert(item->ownsMergedExtents);
-            assert(front);
+            AVIF_ASSERT(item->ownsMergedExtents, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_ASSERT(front, AVIF_RESULT_UNKNOWN_ERROR);
             memcpy(front, offsetBuffer.data, bytesToRead);
             front += bytesToRead;
         }
@@ -1526,7 +1526,7 @@ static avifResult avifDecoderDataAllocateGridImagePlanes(avifDecoderData * data,
     avifBool alpha = (tile->input->itemCategory == AVIF_ITEM_ALPHA);
     if (alpha) {
         // An alpha tile does not contain any YUV pixels.
-        assert(tile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE);
+        AVIF_ASSERT(tile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE, AVIF_RESULT_UNKNOWN_ERROR);
     }
     if (!avifAreGridDimensionsValid(tile->image->yuvFormat, grid->outputWidth, grid->outputHeight, tile->image->width, tile->image->height, data->diag)) {
         return AVIF_RESULT_INVALID_IMAGE_GRID;
@@ -1612,15 +1612,13 @@ static avifBool avifDecoderDataCopyTileToImage(avifDecoderData * data,
     avifImage * dst = dstImage;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-        assert(dst->gainMap && dst->gainMap->image);
+        AVIF_ASSERT(dst->gainMap && dst->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
         dst = dst->gainMap->image;
     }
 #endif
-    if ((avifImageSetViewRect(&dstView, dst, &dstViewRect) != AVIF_RESULT_OK) ||
-        (avifImageSetViewRect(&srcView, tile->image, &srcViewRect) != AVIF_RESULT_OK)) {
-        assert(AVIF_FALSE);
-        return AVIF_FALSE;
-    }
+    AVIF_ASSERT(avifImageSetViewRect(&dstView, dst, &dstViewRect) == AVIF_RESULT_OK &&
+                    avifImageSetViewRect(&srcView, tile->image, &srcViewRect) == AVIF_RESULT_OK,
+                AVIF_FALSE);
     avifImageCopySamples(&dstView, &srcView, (tile->input->itemCategory == AVIF_ITEM_ALPHA) ? AVIF_PLANES_A : AVIF_PLANES_YUV);
 
     return AVIF_TRUE;
@@ -1927,7 +1925,7 @@ static avifBool avifParseToneMappedImageBox(avifGainMapMetadata * metadata, cons
     uint8_t flags;
     AVIF_CHECK(avifROStreamRead(&s, &flags, 1)); // unsigned int(8) flags;
     uint8_t channelCount = (flags & 1) * 2 + 1;
-    assert(channelCount == 1 || channelCount == 3);
+    AVIF_ASSERT(channelCount == 1 || channelCount == 3, AVIF_RESULT_UNKNOWN_ERROR);
     metadata->useBaseColorSpace = (flags & 2) != 0;
     metadata->backwardDirection = (flags & 4) != 0;
     const avifBool useCommonDenominator = (flags & 8) != 0;
@@ -2025,13 +2023,13 @@ static avifResult avifDecoderItemReadAndParse(const avifDecoder * decoder,
         } else {
             // item was generated for convenience and is not part of the bitstream.
             // grid information should already be set.
-            assert(grid->rows > 0 && grid->columns > 0);
+            AVIF_ASSERT(grid->rows > 0 && grid->columns > 0, AVIF_RESULT_UNKNOWN_ERROR);
         }
         *codecType = avifDecoderItemGetGridCodecType(item);
         AVIF_CHECKERR(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INVALID_IMAGE_GRID);
     } else {
         *codecType = avifGetCodecType(item->type);
-        assert(*codecType != AVIF_CODEC_TYPE_UNKNOWN);
+        AVIF_ASSERT(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_UNKNOWN_ERROR);
     }
     return AVIF_RESULT_OK;
 }
@@ -2356,7 +2354,7 @@ static avifResult avifParseItemPropertyAssociation(avifMeta * meta, const uint8_
     if (meta->fromMini) {
         // The CondensedImageBox will always create 8 item properties, so to refer to the
         // first property in the ItemPropertyContainerBox of its extendedMeta field, use index 9.
-        assert(meta->properties.count >= 8);
+        AVIF_ASSERT(meta->properties.count >= 8, AVIF_RESULT_UNKNOWN_ERROR);
     }
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
 
@@ -2643,7 +2641,7 @@ static avifResult avifParseItemInfoEntry(avifMeta * meta, const uint8_t * raw, s
         AVIF_CHECKERR(avifROStreamReadU16(&s, &tmp), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(16) item_ID;
         itemID = tmp;
     } else {
-        assert(version == 3);
+        AVIF_ASSERT(version == 3, AVIF_RESULT_UNKNOWN_ERROR);
         AVIF_CHECKERR(avifROStreamReadU32(&s, &itemID), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) item_ID;
     }
     AVIF_CHECKRES(avifCheckItemID("infe", itemID, diag));
@@ -3314,7 +3312,7 @@ static avifResult avifParseTrackBox(avifDecoderData * data,
             //
             // Since libavif uses repetitionCount (which is 0-based), we subtract the value by 1 to derive the number of
             // repetitions.
-            assert(track->segmentDuration != 0);
+            AVIF_ASSERT(track->segmentDuration != 0, AVIF_RESULT_UNKNOWN_ERROR);
             // We specifically check for trackDuration == 0 here and not when it is actually read in order to accept files which
             // inadvertently has a trackDuration of 0 without any edit lists.
             if (track->trackDuration == 0) {
@@ -3724,7 +3722,7 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
     // The ExtendedMetaBox may reuse items and properties created above so it must be parsed last.
 
     if (hasExtendedMeta) {
-        assert(avifROStreamHasBytesLeft(&s, extendedMetaSize));
+        AVIF_ASSERT(avifROStreamHasBytesLeft(&s, extendedMetaSize), AVIF_RESULT_UNKNOWN_ERROR);
         AVIF_CHECKRES(avifParseExtendedMeta(meta, rawOffset + avifROStreamOffset(&s), avifROStreamCurrent(&s), extendedMetaSize, diag));
     }
     return AVIF_RESULT_OK;
@@ -3792,7 +3790,7 @@ static avifResult avifParse(avifDecoder * decoder)
         avifBoxHeader header;
         AVIF_CHECKERR(avifROStreamReadBoxHeaderPartial(&headerStream, &header), AVIF_RESULT_BMFF_PARSE_FAILED);
         parseOffset += headerStream.offset;
-        assert((decoder->io->sizeHint == 0) || (parseOffset <= decoder->io->sizeHint));
+        AVIF_ASSERT(decoder->io->sizeHint == 0 || parseOffset <= decoder->io->sizeHint, AVIF_RESULT_UNKNOWN_ERROR);
 
         // Try to get the remainder of the box, if necessary
         uint64_t boxOffset = 0;
@@ -4413,7 +4411,7 @@ static avifResult avifMetaFindAlphaItem(avifMeta * meta,
             }
         }
     }
-    assert(alphaItemCount == colorItemCount);
+    AVIF_ASSERT(alphaItemCount == colorItemCount, AVIF_RESULT_UNKNOWN_ERROR);
     // Figure out the last used itemID.
     avifResult result;
     const uint32_t lastID = meta->items.item[meta->items.count - 1]->id;
@@ -4514,7 +4512,7 @@ static avifResult avifDecoderDataFindToneMappedImageItem(const avifDecoderData *
                     continue;
                 }
                 if (otherItem->dimgIdx < 2) {
-                    assert(dimgItemIDs[otherItem->dimgIdx] == 0);
+                    AVIF_ASSERT(dimgItemIDs[otherItem->dimgIdx] == 0, AVIF_RESULT_UNKNOWN_ERROR);
                     dimgItemIDs[otherItem->dimgIdx] = otherItem->id;
                 }
                 numDimgItemIDs++;
@@ -4563,7 +4561,7 @@ static avifResult avifDecoderFindGainMapItem(const avifDecoder * decoder,
         return AVIF_RESULT_OK;
     }
 
-    assert(gainMapItemID != 0);
+    AVIF_ASSERT(gainMapItemID != 0, AVIF_RESULT_UNKNOWN_ERROR);
     avifDecoderItem * gainMapItemTmp;
     AVIF_CHECKRES(avifMetaFindOrCreateItem(data->meta, gainMapItemID, &gainMapItemTmp, data->diag));
     if (avifDecoderItemShouldBeSkipped(gainMapItemTmp)) {
@@ -4645,7 +4643,7 @@ static avifResult avifDecoderGenerateImageTiles(avifDecoder * decoder, avifTileI
         AVIF_CHECKERR(item->size != 0, AVIF_RESULT_MISSING_IMAGE_ITEM);
 
         const avifCodecType codecType = avifGetCodecType(item->type);
-        assert(codecType != AVIF_CODEC_TYPE_UNKNOWN);
+        AVIF_ASSERT(codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_UNKNOWN_ERROR);
         avifTile * tile =
             avifDecoderDataCreateTile(decoder->data, codecType, item->width, item->height, avifDecoderItemOperatingPoint(item));
         AVIF_CHECKERR(tile, AVIF_RESULT_OUT_OF_MEMORY);
@@ -4963,7 +4961,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 #endif
             if (c == AVIF_ITEM_ALPHA && !mainItems[c]->width && !mainItems[c]->height) {
                 // NON-STANDARD: Alpha subimage does not have an ispe property; adopt width/height from color item
-                assert(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED));
+                AVIF_ASSERT(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED), AVIF_RESULT_UNKNOWN_ERROR);
                 mainItems[c]->width = mainItems[AVIF_ITEM_COLOR]->width;
                 mainItems[c]->height = mainItems[AVIF_ITEM_COLOR]->height;
             }
@@ -4998,7 +4996,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         if (mainItems[AVIF_ITEM_GAIN_MAP]) {
-            assert(decoder->image->gainMap && decoder->image->gainMap->image);
+            AVIF_ASSERT(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
             decoder->image->gainMap->image->width = mainItems[AVIF_ITEM_GAIN_MAP]->width;
             decoder->image->gainMap->image->height = mainItems[AVIF_ITEM_GAIN_MAP]->height;
             decoder->gainMapPresent = AVIF_TRUE;
@@ -5188,7 +5186,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
 
         const avifDecodeSample * sample = &tile->input->samples.sample[nextImageIndex];
         if (sample->data.size < sample->size) {
-            assert(decoder->allowIncremental);
+            AVIF_ASSERT(decoder->allowIncremental, AVIF_RESULT_UNKNOWN_ERROR);
             // Data is missing but there is no error yet. Output available pixel rows.
             return AVIF_RESULT_OK;
         }
@@ -5249,7 +5247,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
                 avifImage * dstImage = decoder->image;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
                 if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                    assert(dstImage->gainMap && dstImage->gainMap->image);
+                    AVIF_ASSERT(dstImage->gainMap && dstImage->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
                     dstImage = dstImage->gainMap->image;
                 }
 #endif
@@ -5260,14 +5258,14 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
             }
         } else {
             // Non-grid path. Just steal the planes from the only "tile".
-            assert(info->tileCount == 1);
-            assert(tileIndex == 0);
+            AVIF_ASSERT(info->tileCount == 1, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_ASSERT(tileIndex == 0, AVIF_RESULT_UNKNOWN_ERROR);
             avifImage * src = tile->image;
 
             switch (tile->input->itemCategory) {
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
                 case AVIF_ITEM_GAIN_MAP:
-                    assert(decoder->image->gainMap && decoder->image->gainMap->image);
+                    AVIF_ASSERT(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
                     decoder->image->gainMap->image->width = src->width;
                     decoder->image->gainMap->image->height = src->height;
                     decoder->image->gainMap->image->depth = src->depth;
@@ -5294,7 +5292,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
                 avifImageStealPlanes(decoder->image, src, AVIF_PLANES_A);
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
             } else if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                assert(decoder->image->gainMap && decoder->image->gainMap->image);
+                AVIF_ASSERT(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
                 avifImageStealPlanes(decoder->image->gainMap->image, src, AVIF_PLANES_YUV);
 #endif
             } else { // AVIF_ITEM_COLOR
@@ -5336,8 +5334,9 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
         }
     }
 
-    assert(decoder->data->tiles.count == (decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].firstTileIndex +
-                                          decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].tileCount));
+    AVIF_ASSERT(decoder->data->tiles.count == (decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].firstTileIndex +
+                                               decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].tileCount),
+                AVIF_RESULT_UNKNOWN_ERROR);
 
     const uint32_t nextImageIndex = (uint32_t)(decoder->imageIndex + 1);
 
@@ -5366,22 +5365,23 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
     }
 
     if (!avifDecoderDataFrameFullyDecoded(decoder->data)) {
-        assert(decoder->allowIncremental);
+        AVIF_ASSERT(decoder->allowIncremental, AVIF_RESULT_UNKNOWN_ERROR);
         // The image is not completely decoded. There should be no error unrelated to missing bytes,
         // and at least some missing bytes.
         avifResult firstNonOkResult = AVIF_RESULT_OK;
         for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
-            assert((prepareTileResult[c] == AVIF_RESULT_OK) || (prepareTileResult[c] == AVIF_RESULT_WAITING_ON_IO));
+            AVIF_ASSERT(prepareTileResult[c] == AVIF_RESULT_OK || prepareTileResult[c] == AVIF_RESULT_WAITING_ON_IO,
+                        AVIF_RESULT_UNKNOWN_ERROR);
             if (firstNonOkResult == AVIF_RESULT_OK) {
                 firstNonOkResult = prepareTileResult[c];
             }
         }
-        assert(firstNonOkResult != AVIF_RESULT_OK);
+        AVIF_ASSERT(firstNonOkResult != AVIF_RESULT_OK, AVIF_RESULT_UNKNOWN_ERROR);
         // Return the "not enough bytes" status now instead of moving on to the next frame.
         return AVIF_RESULT_WAITING_ON_IO;
     }
     for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
-        assert(prepareTileResult[c] == AVIF_RESULT_OK);
+        AVIF_ASSERT(prepareTileResult[c] == AVIF_RESULT_OK, AVIF_RESULT_UNKNOWN_ERROR);
     }
 
     // Only advance decoder->imageIndex once the image is completely decoded, so that
@@ -5558,8 +5558,9 @@ uint32_t avifDecoderDecodedRowCount(const avifDecoder * decoder)
                     const uint32_t scaledGainMapRowCount =
                         (uint32_t)floorf((float)gainMapRowCount / gainMap->height * decoder->image->height);
                     // Make sure it matches the formula described in the comment of avifDecoderDecodedRowCount() in avif.h.
-                    assert((uint32_t)lround((double)scaledGainMapRowCount / decoder->image->height *
-                                            decoder->image->gainMap->image->height) <= gainMapRowCount);
+                    AVIF_ASSERT((uint32_t)lround((double)scaledGainMapRowCount / decoder->image->height *
+                                                 decoder->image->gainMap->image->height) <= gainMapRowCount,
+                                0);
                     gainMapRowCount = scaledGainMapRowCount;
                 }
                 minRowCount = AVIF_MIN(minRowCount, gainMapRowCount);

--- a/src/read.c
+++ b/src/read.c
@@ -566,7 +566,7 @@ static avifResult avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput *
             }
         }
         if (remainingSize > 0) {
-            AVIF_ASSERT(layerCount == 3, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_CHECKERR(layerCount == 3, AVIF_RESULT_INTERNAL_ERROR);
             ++layerCount;
             layerSizes[3] = remainingSize;
         }
@@ -611,7 +611,7 @@ static avifResult avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput *
         sample->itemID = item->id;
         sample->offset = 0;
         sample->size = sampleSize;
-        AVIF_ASSERT(lselProp->u.lsel.layerID < AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(lselProp->u.lsel.layerID < AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_INTERNAL_ERROR);
         sample->spatialID = (uint8_t)lselProp->u.lsel.layerID;
         sample->sync = AVIF_TRUE;
     } else if (allowProgressive && item->progressive) {
@@ -790,7 +790,7 @@ static avifResult avifCheckItemID(const char * boxFourcc, uint32_t itemID, avifD
 static avifResult avifMetaFindOrCreateItem(avifMeta * meta, uint32_t itemID, avifDecoderItem ** item, avifDiagnostics * diag)
 {
     *item = NULL;
-    AVIF_ASSERT(itemID != 0, AVIF_RESULT_UNKNOWN_ERROR);
+    AVIF_CHECKERR(itemID != 0, AVIF_RESULT_INTERNAL_ERROR);
 
     for (uint32_t i = 0; i < meta->items.count; ++i) {
         if (meta->items.item[i]->id == itemID) {
@@ -1055,7 +1055,7 @@ static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, const a
     size_t remainingBytes = sample->size; // This may be smaller than item->size if the item is progressive
 
     // Assert that the for loop below will execute at least one iteration.
-    AVIF_ASSERT(item->extents.count != 0, AVIF_RESULT_UNKNOWN_ERROR);
+    AVIF_CHECKERR(item->extents.count != 0, AVIF_RESULT_INTERNAL_ERROR);
     uint64_t minOffset = UINT64_MAX;
     uint64_t maxOffset = 0;
     for (uint32_t extentIter = 0; extentIter < item->extents.count; ++extentIter) {
@@ -1380,8 +1380,8 @@ static avifResult avifDecoderItemRead(avifDecoderItem * item,
             memcpy(&item->mergedExtents, &offsetBuffer, sizeof(avifRWData));
             item->mergedExtents.size = bytesToRead;
         } else {
-            AVIF_ASSERT(item->ownsMergedExtents, AVIF_RESULT_UNKNOWN_ERROR);
-            AVIF_ASSERT(front, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_CHECKERR(item->ownsMergedExtents, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_CHECKERR(front, AVIF_RESULT_INTERNAL_ERROR);
             memcpy(front, offsetBuffer.data, bytesToRead);
             front += bytesToRead;
         }
@@ -1526,7 +1526,7 @@ static avifResult avifDecoderDataAllocateGridImagePlanes(avifDecoderData * data,
     avifBool alpha = (tile->input->itemCategory == AVIF_ITEM_ALPHA);
     if (alpha) {
         // An alpha tile does not contain any YUV pixels.
-        AVIF_ASSERT(tile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(tile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE, AVIF_RESULT_INTERNAL_ERROR);
     }
     if (!avifAreGridDimensionsValid(tile->image->yuvFormat, grid->outputWidth, grid->outputHeight, tile->image->width, tile->image->height, data->diag)) {
         return AVIF_RESULT_INVALID_IMAGE_GRID;
@@ -1925,7 +1925,7 @@ static avifBool avifParseToneMappedImageBox(avifGainMapMetadata * metadata, cons
     uint8_t flags;
     AVIF_CHECK(avifROStreamRead(&s, &flags, 1)); // unsigned int(8) flags;
     uint8_t channelCount = (flags & 1) * 2 + 1;
-    AVIF_ASSERT(channelCount == 1 || channelCount == 3, AVIF_RESULT_UNKNOWN_ERROR);
+    AVIF_CHECKERR(channelCount == 1 || channelCount == 3, AVIF_RESULT_INTERNAL_ERROR);
     metadata->useBaseColorSpace = (flags & 2) != 0;
     metadata->backwardDirection = (flags & 4) != 0;
     const avifBool useCommonDenominator = (flags & 8) != 0;
@@ -2023,13 +2023,13 @@ static avifResult avifDecoderItemReadAndParse(const avifDecoder * decoder,
         } else {
             // item was generated for convenience and is not part of the bitstream.
             // grid information should already be set.
-            AVIF_ASSERT(grid->rows > 0 && grid->columns > 0, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_CHECKERR(grid->rows > 0 && grid->columns > 0, AVIF_RESULT_INTERNAL_ERROR);
         }
         *codecType = avifDecoderItemGetGridCodecType(item);
         AVIF_CHECKERR(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INVALID_IMAGE_GRID);
     } else {
         *codecType = avifGetCodecType(item->type);
-        AVIF_ASSERT(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INTERNAL_ERROR);
     }
     return AVIF_RESULT_OK;
 }
@@ -2354,7 +2354,7 @@ static avifResult avifParseItemPropertyAssociation(avifMeta * meta, const uint8_
     if (meta->fromMini) {
         // The CondensedImageBox will always create 8 item properties, so to refer to the
         // first property in the ItemPropertyContainerBox of its extendedMeta field, use index 9.
-        AVIF_ASSERT(meta->properties.count >= 8, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(meta->properties.count >= 8, AVIF_RESULT_INTERNAL_ERROR);
     }
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
 
@@ -2641,7 +2641,7 @@ static avifResult avifParseItemInfoEntry(avifMeta * meta, const uint8_t * raw, s
         AVIF_CHECKERR(avifROStreamReadU16(&s, &tmp), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(16) item_ID;
         itemID = tmp;
     } else {
-        AVIF_ASSERT(version == 3, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(version == 3, AVIF_RESULT_INTERNAL_ERROR);
         AVIF_CHECKERR(avifROStreamReadU32(&s, &itemID), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) item_ID;
     }
     AVIF_CHECKRES(avifCheckItemID("infe", itemID, diag));
@@ -3312,7 +3312,7 @@ static avifResult avifParseTrackBox(avifDecoderData * data,
             //
             // Since libavif uses repetitionCount (which is 0-based), we subtract the value by 1 to derive the number of
             // repetitions.
-            AVIF_ASSERT(track->segmentDuration != 0, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_CHECKERR(track->segmentDuration != 0, AVIF_RESULT_INTERNAL_ERROR);
             // We specifically check for trackDuration == 0 here and not when it is actually read in order to accept files which
             // inadvertently has a trackDuration of 0 without any edit lists.
             if (track->trackDuration == 0) {
@@ -3722,7 +3722,7 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
     // The ExtendedMetaBox may reuse items and properties created above so it must be parsed last.
 
     if (hasExtendedMeta) {
-        AVIF_ASSERT(avifROStreamHasBytesLeft(&s, extendedMetaSize), AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(avifROStreamHasBytesLeft(&s, extendedMetaSize), AVIF_RESULT_INTERNAL_ERROR);
         AVIF_CHECKRES(avifParseExtendedMeta(meta, rawOffset + avifROStreamOffset(&s), avifROStreamCurrent(&s), extendedMetaSize, diag));
     }
     return AVIF_RESULT_OK;
@@ -3790,7 +3790,7 @@ static avifResult avifParse(avifDecoder * decoder)
         avifBoxHeader header;
         AVIF_CHECKERR(avifROStreamReadBoxHeaderPartial(&headerStream, &header), AVIF_RESULT_BMFF_PARSE_FAILED);
         parseOffset += headerStream.offset;
-        AVIF_ASSERT(decoder->io->sizeHint == 0 || parseOffset <= decoder->io->sizeHint, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(decoder->io->sizeHint == 0 || parseOffset <= decoder->io->sizeHint, AVIF_RESULT_INTERNAL_ERROR);
 
         // Try to get the remainder of the box, if necessary
         uint64_t boxOffset = 0;
@@ -4411,7 +4411,7 @@ static avifResult avifMetaFindAlphaItem(avifMeta * meta,
             }
         }
     }
-    AVIF_ASSERT(alphaItemCount == colorItemCount, AVIF_RESULT_UNKNOWN_ERROR);
+    AVIF_CHECKERR(alphaItemCount == colorItemCount, AVIF_RESULT_INTERNAL_ERROR);
     // Figure out the last used itemID.
     avifResult result;
     const uint32_t lastID = meta->items.item[meta->items.count - 1]->id;
@@ -4512,7 +4512,7 @@ static avifResult avifDecoderDataFindToneMappedImageItem(const avifDecoderData *
                     continue;
                 }
                 if (otherItem->dimgIdx < 2) {
-                    AVIF_ASSERT(dimgItemIDs[otherItem->dimgIdx] == 0, AVIF_RESULT_UNKNOWN_ERROR);
+                    AVIF_CHECKERR(dimgItemIDs[otherItem->dimgIdx] == 0, AVIF_RESULT_INTERNAL_ERROR);
                     dimgItemIDs[otherItem->dimgIdx] = otherItem->id;
                 }
                 numDimgItemIDs++;
@@ -4561,7 +4561,7 @@ static avifResult avifDecoderFindGainMapItem(const avifDecoder * decoder,
         return AVIF_RESULT_OK;
     }
 
-    AVIF_ASSERT(gainMapItemID != 0, AVIF_RESULT_UNKNOWN_ERROR);
+    AVIF_CHECKERR(gainMapItemID != 0, AVIF_RESULT_INTERNAL_ERROR);
     avifDecoderItem * gainMapItemTmp;
     AVIF_CHECKRES(avifMetaFindOrCreateItem(data->meta, gainMapItemID, &gainMapItemTmp, data->diag));
     if (avifDecoderItemShouldBeSkipped(gainMapItemTmp)) {
@@ -4643,7 +4643,7 @@ static avifResult avifDecoderGenerateImageTiles(avifDecoder * decoder, avifTileI
         AVIF_CHECKERR(item->size != 0, AVIF_RESULT_MISSING_IMAGE_ITEM);
 
         const avifCodecType codecType = avifGetCodecType(item->type);
-        AVIF_ASSERT(codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INTERNAL_ERROR);
         avifTile * tile =
             avifDecoderDataCreateTile(decoder->data, codecType, item->width, item->height, avifDecoderItemOperatingPoint(item));
         AVIF_CHECKERR(tile, AVIF_RESULT_OUT_OF_MEMORY);
@@ -4961,7 +4961,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 #endif
             if (c == AVIF_ITEM_ALPHA && !mainItems[c]->width && !mainItems[c]->height) {
                 // NON-STANDARD: Alpha subimage does not have an ispe property; adopt width/height from color item
-                AVIF_ASSERT(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED), AVIF_RESULT_UNKNOWN_ERROR);
+                AVIF_CHECKERR(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED), AVIF_RESULT_INTERNAL_ERROR);
                 mainItems[c]->width = mainItems[AVIF_ITEM_COLOR]->width;
                 mainItems[c]->height = mainItems[AVIF_ITEM_COLOR]->height;
             }
@@ -4996,7 +4996,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         if (mainItems[AVIF_ITEM_GAIN_MAP]) {
-            AVIF_ASSERT(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_CHECKERR(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
             decoder->image->gainMap->image->width = mainItems[AVIF_ITEM_GAIN_MAP]->width;
             decoder->image->gainMap->image->height = mainItems[AVIF_ITEM_GAIN_MAP]->height;
             decoder->gainMapPresent = AVIF_TRUE;
@@ -5186,7 +5186,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
 
         const avifDecodeSample * sample = &tile->input->samples.sample[nextImageIndex];
         if (sample->data.size < sample->size) {
-            AVIF_ASSERT(decoder->allowIncremental, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_CHECKERR(decoder->allowIncremental, AVIF_RESULT_INTERNAL_ERROR);
             // Data is missing but there is no error yet. Output available pixel rows.
             return AVIF_RESULT_OK;
         }
@@ -5247,7 +5247,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
                 avifImage * dstImage = decoder->image;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
                 if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                    AVIF_ASSERT(dstImage->gainMap && dstImage->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
+                    AVIF_CHECKERR(dstImage->gainMap && dstImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
                     dstImage = dstImage->gainMap->image;
                 }
 #endif
@@ -5258,14 +5258,14 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
             }
         } else {
             // Non-grid path. Just steal the planes from the only "tile".
-            AVIF_ASSERT(info->tileCount == 1, AVIF_RESULT_UNKNOWN_ERROR);
-            AVIF_ASSERT(tileIndex == 0, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_CHECKERR(info->tileCount == 1, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_CHECKERR(tileIndex == 0, AVIF_RESULT_INTERNAL_ERROR);
             avifImage * src = tile->image;
 
             switch (tile->input->itemCategory) {
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
                 case AVIF_ITEM_GAIN_MAP:
-                    AVIF_ASSERT(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
+                    AVIF_CHECKERR(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
                     decoder->image->gainMap->image->width = src->width;
                     decoder->image->gainMap->image->height = src->height;
                     decoder->image->gainMap->image->depth = src->depth;
@@ -5292,7 +5292,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
                 avifImageStealPlanes(decoder->image, src, AVIF_PLANES_A);
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
             } else if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                AVIF_ASSERT(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
+                AVIF_CHECKERR(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
                 avifImageStealPlanes(decoder->image->gainMap->image, src, AVIF_PLANES_YUV);
 #endif
             } else { // AVIF_ITEM_COLOR
@@ -5334,9 +5334,9 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
         }
     }
 
-    AVIF_ASSERT(decoder->data->tiles.count == (decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].firstTileIndex +
+    AVIF_CHECKERR(decoder->data->tiles.count == (decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].firstTileIndex +
                                                decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].tileCount),
-                AVIF_RESULT_UNKNOWN_ERROR);
+                AVIF_RESULT_INTERNAL_ERROR);
 
     const uint32_t nextImageIndex = (uint32_t)(decoder->imageIndex + 1);
 
@@ -5365,23 +5365,23 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
     }
 
     if (!avifDecoderDataFrameFullyDecoded(decoder->data)) {
-        AVIF_ASSERT(decoder->allowIncremental, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(decoder->allowIncremental, AVIF_RESULT_INTERNAL_ERROR);
         // The image is not completely decoded. There should be no error unrelated to missing bytes,
         // and at least some missing bytes.
         avifResult firstNonOkResult = AVIF_RESULT_OK;
         for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
-            AVIF_ASSERT(prepareTileResult[c] == AVIF_RESULT_OK || prepareTileResult[c] == AVIF_RESULT_WAITING_ON_IO,
-                        AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_CHECKERR(prepareTileResult[c] == AVIF_RESULT_OK || prepareTileResult[c] == AVIF_RESULT_WAITING_ON_IO,
+                        AVIF_RESULT_INTERNAL_ERROR);
             if (firstNonOkResult == AVIF_RESULT_OK) {
                 firstNonOkResult = prepareTileResult[c];
             }
         }
-        AVIF_ASSERT(firstNonOkResult != AVIF_RESULT_OK, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(firstNonOkResult != AVIF_RESULT_OK, AVIF_RESULT_INTERNAL_ERROR);
         // Return the "not enough bytes" status now instead of moving on to the next frame.
         return AVIF_RESULT_WAITING_ON_IO;
     }
     for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
-        AVIF_ASSERT(prepareTileResult[c] == AVIF_RESULT_OK, AVIF_RESULT_UNKNOWN_ERROR);
+        AVIF_CHECKERR(prepareTileResult[c] == AVIF_RESULT_OK, AVIF_RESULT_INTERNAL_ERROR);
     }
 
     // Only advance decoder->imageIndex once the image is completely decoded, so that

--- a/src/read.c
+++ b/src/read.c
@@ -566,7 +566,7 @@ static avifResult avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput *
             }
         }
         if (remainingSize > 0) {
-            AVIF_ASSERT_OR_RETURN(layerCount == 3, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(layerCount == 3);
             ++layerCount;
             layerSizes[3] = remainingSize;
         }
@@ -611,7 +611,7 @@ static avifResult avifCodecDecodeInputFillFromDecoderItem(avifCodecDecodeInput *
         sample->itemID = item->id;
         sample->offset = 0;
         sample->size = sampleSize;
-        AVIF_ASSERT_OR_RETURN(lselProp->u.lsel.layerID < AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(lselProp->u.lsel.layerID < AVIF_MAX_AV1_LAYER_COUNT);
         sample->spatialID = (uint8_t)lselProp->u.lsel.layerID;
         sample->sync = AVIF_TRUE;
     } else if (allowProgressive && item->progressive) {
@@ -790,7 +790,7 @@ static avifResult avifCheckItemID(const char * boxFourcc, uint32_t itemID, avifD
 static avifResult avifMetaFindOrCreateItem(avifMeta * meta, uint32_t itemID, avifDecoderItem ** item, avifDiagnostics * diag)
 {
     *item = NULL;
-    AVIF_ASSERT_OR_RETURN(itemID != 0, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(itemID != 0);
 
     for (uint32_t i = 0; i < meta->items.count; ++i) {
         if (meta->items.item[i]->id == itemID) {
@@ -1055,7 +1055,7 @@ static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, const a
     size_t remainingBytes = sample->size; // This may be smaller than item->size if the item is progressive
 
     // Assert that the for loop below will execute at least one iteration.
-    AVIF_ASSERT_OR_RETURN(item->extents.count != 0, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(item->extents.count != 0);
     uint64_t minOffset = UINT64_MAX;
     uint64_t maxOffset = 0;
     for (uint32_t extentIter = 0; extentIter < item->extents.count; ++extentIter) {
@@ -1380,8 +1380,8 @@ static avifResult avifDecoderItemRead(avifDecoderItem * item,
             memcpy(&item->mergedExtents, &offsetBuffer, sizeof(avifRWData));
             item->mergedExtents.size = bytesToRead;
         } else {
-            AVIF_ASSERT_OR_RETURN(item->ownsMergedExtents, AVIF_RESULT_INTERNAL_ERROR);
-            AVIF_ASSERT_OR_RETURN(front, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(item->ownsMergedExtents);
+            AVIF_ASSERT_OR_RETURN(front);
             memcpy(front, offsetBuffer.data, bytesToRead);
             front += bytesToRead;
         }
@@ -1526,7 +1526,7 @@ static avifResult avifDecoderDataAllocateGridImagePlanes(avifDecoderData * data,
     avifBool alpha = (tile->input->itemCategory == AVIF_ITEM_ALPHA);
     if (alpha) {
         // An alpha tile does not contain any YUV pixels.
-        AVIF_ASSERT_OR_RETURN(tile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(tile->image->yuvFormat == AVIF_PIXEL_FORMAT_NONE);
     }
     if (!avifAreGridDimensionsValid(tile->image->yuvFormat, grid->outputWidth, grid->outputHeight, tile->image->width, tile->image->height, data->diag)) {
         return AVIF_RESULT_INVALID_IMAGE_GRID;
@@ -1612,13 +1612,12 @@ static avifResult avifDecoderDataCopyTileToImage(avifDecoderData * data,
     avifImage * dst = dstImage;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-        AVIF_ASSERT_OR_RETURN(dst->gainMap && dst->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(dst->gainMap && dst->gainMap->image);
         dst = dst->gainMap->image;
     }
 #endif
     AVIF_ASSERT_OR_RETURN(avifImageSetViewRect(&dstView, dst, &dstViewRect) == AVIF_RESULT_OK &&
-                              avifImageSetViewRect(&srcView, tile->image, &srcViewRect) == AVIF_RESULT_OK,
-                          AVIF_RESULT_INTERNAL_ERROR);
+                          avifImageSetViewRect(&srcView, tile->image, &srcViewRect) == AVIF_RESULT_OK);
     avifImageCopySamples(&dstView, &srcView, (tile->input->itemCategory == AVIF_ITEM_ALPHA) ? AVIF_PLANES_A : AVIF_PLANES_YUV);
 
     return AVIF_RESULT_OK;
@@ -1925,7 +1924,7 @@ static avifBool avifParseToneMappedImageBox(avifGainMapMetadata * metadata, cons
     uint8_t flags;
     AVIF_CHECK(avifROStreamRead(&s, &flags, 1)); // unsigned int(8) flags;
     uint8_t channelCount = (flags & 1) * 2 + 1;
-    AVIF_ASSERT_OR_RETURN(channelCount == 1 || channelCount == 3, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(channelCount == 1 || channelCount == 3);
     metadata->useBaseColorSpace = (flags & 2) != 0;
     metadata->backwardDirection = (flags & 4) != 0;
     const avifBool useCommonDenominator = (flags & 8) != 0;
@@ -2023,13 +2022,13 @@ static avifResult avifDecoderItemReadAndParse(const avifDecoder * decoder,
         } else {
             // item was generated for convenience and is not part of the bitstream.
             // grid information should already be set.
-            AVIF_ASSERT_OR_RETURN(grid->rows > 0 && grid->columns > 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(grid->rows > 0 && grid->columns > 0);
         }
         *codecType = avifDecoderItemGetGridCodecType(item);
         AVIF_CHECKERR(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INVALID_IMAGE_GRID);
     } else {
         *codecType = avifGetCodecType(item->type);
-        AVIF_ASSERT_OR_RETURN(*codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(*codecType != AVIF_CODEC_TYPE_UNKNOWN);
     }
     return AVIF_RESULT_OK;
 }
@@ -2354,7 +2353,7 @@ static avifResult avifParseItemPropertyAssociation(avifMeta * meta, const uint8_
     if (meta->fromMini) {
         // The CondensedImageBox will always create 8 item properties, so to refer to the
         // first property in the ItemPropertyContainerBox of its extendedMeta field, use index 9.
-        AVIF_ASSERT_OR_RETURN(meta->properties.count >= 8, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(meta->properties.count >= 8);
     }
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
 
@@ -2641,7 +2640,7 @@ static avifResult avifParseItemInfoEntry(avifMeta * meta, const uint8_t * raw, s
         AVIF_CHECKERR(avifROStreamReadU16(&s, &tmp), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(16) item_ID;
         itemID = tmp;
     } else {
-        AVIF_ASSERT_OR_RETURN(version == 3, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(version == 3);
         AVIF_CHECKERR(avifROStreamReadU32(&s, &itemID), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) item_ID;
     }
     AVIF_CHECKRES(avifCheckItemID("infe", itemID, diag));
@@ -3312,7 +3311,7 @@ static avifResult avifParseTrackBox(avifDecoderData * data,
             //
             // Since libavif uses repetitionCount (which is 0-based), we subtract the value by 1 to derive the number of
             // repetitions.
-            AVIF_ASSERT_OR_RETURN(track->segmentDuration != 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(track->segmentDuration != 0);
             // We specifically check for trackDuration == 0 here and not when it is actually read in order to accept files which
             // inadvertently has a trackDuration of 0 without any edit lists.
             if (track->trackDuration == 0) {
@@ -3722,7 +3721,7 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
     // The ExtendedMetaBox may reuse items and properties created above so it must be parsed last.
 
     if (hasExtendedMeta) {
-        AVIF_ASSERT_OR_RETURN(avifROStreamHasBytesLeft(&s, extendedMetaSize), AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(avifROStreamHasBytesLeft(&s, extendedMetaSize));
         AVIF_CHECKRES(avifParseExtendedMeta(meta, rawOffset + avifROStreamOffset(&s), avifROStreamCurrent(&s), extendedMetaSize, diag));
     }
     return AVIF_RESULT_OK;
@@ -3790,7 +3789,7 @@ static avifResult avifParse(avifDecoder * decoder)
         avifBoxHeader header;
         AVIF_CHECKERR(avifROStreamReadBoxHeaderPartial(&headerStream, &header), AVIF_RESULT_BMFF_PARSE_FAILED);
         parseOffset += headerStream.offset;
-        AVIF_ASSERT_OR_RETURN(decoder->io->sizeHint == 0 || parseOffset <= decoder->io->sizeHint, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(decoder->io->sizeHint == 0 || parseOffset <= decoder->io->sizeHint);
 
         // Try to get the remainder of the box, if necessary
         uint64_t boxOffset = 0;
@@ -4411,7 +4410,7 @@ static avifResult avifMetaFindAlphaItem(avifMeta * meta,
             }
         }
     }
-    AVIF_ASSERT_OR_RETURN(alphaItemCount == colorItemCount, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(alphaItemCount == colorItemCount);
     // Figure out the last used itemID.
     avifResult result;
     const uint32_t lastID = meta->items.item[meta->items.count - 1]->id;
@@ -4512,7 +4511,7 @@ static avifResult avifDecoderDataFindToneMappedImageItem(const avifDecoderData *
                     continue;
                 }
                 if (otherItem->dimgIdx < 2) {
-                    AVIF_ASSERT_OR_RETURN(dimgItemIDs[otherItem->dimgIdx] == 0, AVIF_RESULT_INTERNAL_ERROR);
+                    AVIF_ASSERT_OR_RETURN(dimgItemIDs[otherItem->dimgIdx] == 0);
                     dimgItemIDs[otherItem->dimgIdx] = otherItem->id;
                 }
                 numDimgItemIDs++;
@@ -4561,7 +4560,7 @@ static avifResult avifDecoderFindGainMapItem(const avifDecoder * decoder,
         return AVIF_RESULT_OK;
     }
 
-    AVIF_ASSERT_OR_RETURN(gainMapItemID != 0, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(gainMapItemID != 0);
     avifDecoderItem * gainMapItemTmp;
     AVIF_CHECKRES(avifMetaFindOrCreateItem(data->meta, gainMapItemID, &gainMapItemTmp, data->diag));
     if (avifDecoderItemShouldBeSkipped(gainMapItemTmp)) {
@@ -4643,7 +4642,7 @@ static avifResult avifDecoderGenerateImageTiles(avifDecoder * decoder, avifTileI
         AVIF_CHECKERR(item->size != 0, AVIF_RESULT_MISSING_IMAGE_ITEM);
 
         const avifCodecType codecType = avifGetCodecType(item->type);
-        AVIF_ASSERT_OR_RETURN(codecType != AVIF_CODEC_TYPE_UNKNOWN, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(codecType != AVIF_CODEC_TYPE_UNKNOWN);
         avifTile * tile =
             avifDecoderDataCreateTile(decoder->data, codecType, item->width, item->height, avifDecoderItemOperatingPoint(item));
         AVIF_CHECKERR(tile, AVIF_RESULT_OUT_OF_MEMORY);
@@ -4961,7 +4960,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 #endif
             if (c == AVIF_ITEM_ALPHA && !mainItems[c]->width && !mainItems[c]->height) {
                 // NON-STANDARD: Alpha subimage does not have an ispe property; adopt width/height from color item
-                AVIF_ASSERT_OR_RETURN(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED), AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(!(decoder->strictFlags & AVIF_STRICT_ALPHA_ISPE_REQUIRED));
                 mainItems[c]->width = mainItems[AVIF_ITEM_COLOR]->width;
                 mainItems[c]->height = mainItems[AVIF_ITEM_COLOR]->height;
             }
@@ -4996,7 +4995,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         if (mainItems[AVIF_ITEM_GAIN_MAP]) {
-            AVIF_ASSERT_OR_RETURN(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(decoder->image->gainMap && decoder->image->gainMap->image);
             decoder->image->gainMap->image->width = mainItems[AVIF_ITEM_GAIN_MAP]->width;
             decoder->image->gainMap->image->height = mainItems[AVIF_ITEM_GAIN_MAP]->height;
             decoder->gainMapPresent = AVIF_TRUE;
@@ -5186,7 +5185,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
 
         const avifDecodeSample * sample = &tile->input->samples.sample[nextImageIndex];
         if (sample->data.size < sample->size) {
-            AVIF_ASSERT_OR_RETURN(decoder->allowIncremental, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(decoder->allowIncremental);
             // Data is missing but there is no error yet. Output available pixel rows.
             return AVIF_RESULT_OK;
         }
@@ -5247,7 +5246,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
                 avifImage * dstImage = decoder->image;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
                 if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                    AVIF_ASSERT_OR_RETURN(dstImage->gainMap && dstImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                    AVIF_ASSERT_OR_RETURN(dstImage->gainMap && dstImage->gainMap->image);
                     dstImage = dstImage->gainMap->image;
                 }
 #endif
@@ -5256,14 +5255,14 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
             AVIF_CHECKRES(avifDecoderDataCopyTileToImage(decoder->data, info, decoder->image, tile, tileIndex));
         } else {
             // Non-grid path. Just steal the planes from the only "tile".
-            AVIF_ASSERT_OR_RETURN(info->tileCount == 1, AVIF_RESULT_INTERNAL_ERROR);
-            AVIF_ASSERT_OR_RETURN(tileIndex == 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(info->tileCount == 1);
+            AVIF_ASSERT_OR_RETURN(tileIndex == 0);
             avifImage * src = tile->image;
 
             switch (tile->input->itemCategory) {
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
                 case AVIF_ITEM_GAIN_MAP:
-                    AVIF_ASSERT_OR_RETURN(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                    AVIF_ASSERT_OR_RETURN(decoder->image->gainMap && decoder->image->gainMap->image);
                     decoder->image->gainMap->image->width = src->width;
                     decoder->image->gainMap->image->height = src->height;
                     decoder->image->gainMap->image->depth = src->depth;
@@ -5290,7 +5289,7 @@ static avifResult avifDecoderDecodeTiles(avifDecoder * decoder, uint32_t nextIma
                 avifImageStealPlanes(decoder->image, src, AVIF_PLANES_A);
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
             } else if (tile->input->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                AVIF_ASSERT_OR_RETURN(decoder->image->gainMap && decoder->image->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(decoder->image->gainMap && decoder->image->gainMap->image);
                 avifImageStealPlanes(decoder->image->gainMap->image, src, AVIF_PLANES_YUV);
 #endif
             } else { // AVIF_ITEM_COLOR
@@ -5333,8 +5332,7 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
     }
 
     AVIF_ASSERT_OR_RETURN(decoder->data->tiles.count == (decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].firstTileIndex +
-                                                         decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].tileCount),
-                          AVIF_RESULT_INTERNAL_ERROR);
+                                                         decoder->data->tileInfos[AVIF_ITEM_CATEGORY_COUNT - 1].tileCount));
 
     const uint32_t nextImageIndex = (uint32_t)(decoder->imageIndex + 1);
 
@@ -5363,23 +5361,22 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
     }
 
     if (!avifDecoderDataFrameFullyDecoded(decoder->data)) {
-        AVIF_ASSERT_OR_RETURN(decoder->allowIncremental, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(decoder->allowIncremental);
         // The image is not completely decoded. There should be no error unrelated to missing bytes,
         // and at least some missing bytes.
         avifResult firstNonOkResult = AVIF_RESULT_OK;
         for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
-            AVIF_ASSERT_OR_RETURN(prepareTileResult[c] == AVIF_RESULT_OK || prepareTileResult[c] == AVIF_RESULT_WAITING_ON_IO,
-                                  AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(prepareTileResult[c] == AVIF_RESULT_OK || prepareTileResult[c] == AVIF_RESULT_WAITING_ON_IO);
             if (firstNonOkResult == AVIF_RESULT_OK) {
                 firstNonOkResult = prepareTileResult[c];
             }
         }
-        AVIF_ASSERT_OR_RETURN(firstNonOkResult != AVIF_RESULT_OK, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(firstNonOkResult != AVIF_RESULT_OK);
         // Return the "not enough bytes" status now instead of moving on to the next frame.
         return AVIF_RESULT_WAITING_ON_IO;
     }
     for (int c = 0; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
-        AVIF_ASSERT_OR_RETURN(prepareTileResult[c] == AVIF_RESULT_OK, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(prepareTileResult[c] == AVIF_RESULT_OK);
     }
 
     // Only advance decoder->imageIndex once the image is completely decoded, so that

--- a/src/read.c
+++ b/src/read.c
@@ -2426,11 +2426,24 @@ static avifResult avifParseItemPropertyAssociation(avifMeta * meta, const uint8_
             // Copy property to item
             const avifProperty * srcProp = &meta->properties.prop[propertyIndex];
 
-            static const char * supportedTypes[] = { "ispe", "auxC", "colr", "av1C",
+            static const char * supportedTypes[] = {
+                "ispe",
+                "auxC",
+                "colr",
+                "av1C",
 #if defined(AVIF_CODEC_AVM)
-                                                     "av2C",
+                "av2C",
 #endif
-                                                     "pasp", "clap", "irot", "imir", "pixi", "a1op", "lsel", "a1lx", "clli" };
+                "pasp",
+                "clap",
+                "irot",
+                "imir",
+                "pixi",
+                "a1op",
+                "lsel",
+                "a1lx",
+                "clli"
+            };
             size_t supportedTypesCount = sizeof(supportedTypes) / sizeof(supportedTypes[0]);
             avifBool supportedType = AVIF_FALSE;
             for (size_t i = 0; i < supportedTypesCount; ++i) {

--- a/src/write.c
+++ b/src/write.c
@@ -1025,7 +1025,7 @@ static avifResult avifEncoderDataCreateXMPItem(avifEncoderData * data, const avi
 static avifResult avifImageCopyAndPad(avifImage * const dstImage, const avifImage * srcImage, uint32_t dstWidth, uint32_t dstHeight)
 {
     AVIF_CHECKERR(dstImage, AVIF_RESULT_INTERNAL_ERROR);
-    AVIF_CHECKERR(dstImage->width || dstImage->height, AVIF_RESULT_INTERNAL_ERROR);  // dstImage is not set yet.
+    AVIF_CHECKERR(dstImage->width || dstImage->height, AVIF_RESULT_INTERNAL_ERROR); // dstImage is not set yet.
     AVIF_CHECKERR(dstWidth >= srcImage->width, AVIF_RESULT_INTERNAL_ERROR);
     AVIF_CHECKERR(dstHeight >= srcImage->height, AVIF_RESULT_INTERNAL_ERROR);
 
@@ -2485,17 +2485,17 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
 
     avifBoxMarker ftyp;
     AVIF_CHECKRES(avifRWStreamWriteBox(&s, "ftyp", AVIF_BOX_SIZE_TBD, &ftyp));
-    AVIF_CHECKRES(avifRWStreamWriteChars(&s, majorBrand, 4));              // unsigned int(32) major_brand;
-    AVIF_CHECKRES(avifRWStreamWriteU32(&s, minorVersion));                 // unsigned int(32) minor_version;
-    AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avif", 4));                  // unsigned int(32) compatible_brands[];
-    if (useAvioBrand) {                                                    //
-        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avio", 4));              // ... compatible_brands[]
-    }                                                                      //
-    if (isSequence) {                                                      //
-        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avis", 4));              // ... compatible_brands[]
-        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "msf1", 4));              // ... compatible_brands[]
-        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "iso8", 4));              // ... compatible_brands[]
-    }                                                                      //
+    AVIF_CHECKRES(avifRWStreamWriteChars(&s, majorBrand, 4)); // unsigned int(32) major_brand;
+    AVIF_CHECKRES(avifRWStreamWriteU32(&s, minorVersion));    // unsigned int(32) minor_version;
+    AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avif", 4));     // unsigned int(32) compatible_brands[];
+    if (useAvioBrand) {                                       //
+        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avio", 4)); // ... compatible_brands[]
+    } //
+    if (isSequence) {                                         //
+        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avis", 4)); // ... compatible_brands[]
+        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "msf1", 4)); // ... compatible_brands[]
+        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "iso8", 4)); // ... compatible_brands[]
+    } //
     AVIF_CHECKRES(avifRWStreamWriteChars(&s, "mif1", 4));                  // ... compatible_brands[]
     AVIF_CHECKRES(avifRWStreamWriteChars(&s, "miaf", 4));                  // ... compatible_brands[]
     if ((imageMetadata->depth == 8) || (imageMetadata->depth == 10)) {     //

--- a/src/write.c
+++ b/src/write.c
@@ -425,7 +425,7 @@ static avifResult avifItemPropertyDedupFinish(avifItemPropertyDedup * dedup, avi
             !memcmp(&outputStream->raw->data[property->offset], dedup->buffer.data, newPropertySize)) {
             // We've already written this exact property, reuse it
             propertyIndex = property->index;
-            AVIF_CHECKERR(propertyIndex != 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(propertyIndex != 0, AVIF_RESULT_INTERNAL_ERROR);
             break;
         }
     }
@@ -639,7 +639,7 @@ static avifResult avifEncoderWriteColorProperties(avifRWStream * outputStream,
     // of an already stored property.
     avifRWStream * dedupStream = outputStream;
     if (dedup) {
-        AVIF_CHECKERR(ipma, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(ipma, AVIF_RESULT_INTERNAL_ERROR);
 
         // Use the dedup's temporary stream for box writes.
         dedupStream = &dedup->s;
@@ -821,7 +821,7 @@ static avifResult avifEncoderWriteTrackMetaBox(avifEncoder * encoder, avifRWStre
             continue;
         }
 
-        AVIF_CHECKERR(!item->hiddenImage, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(!item->hiddenImage, AVIF_RESULT_INTERNAL_ERROR);
         avifBoxMarker infe;
         AVIF_CHECKRES(avifRWStreamWriteFullBox(s, "infe", AVIF_BOX_SIZE_TBD, 2, 0, &infe));
         AVIF_CHECKRES(avifRWStreamWriteU16(s, item->id));                             // unsigned int(16) item_ID;
@@ -1024,10 +1024,10 @@ static avifResult avifEncoderDataCreateXMPItem(avifEncoderData * data, const avi
 // Same as avifImageCopy() but pads the dstImage with border pixel values to reach dstWidth and dstHeight.
 static avifResult avifImageCopyAndPad(avifImage * const dstImage, const avifImage * srcImage, uint32_t dstWidth, uint32_t dstHeight)
 {
-    AVIF_CHECKERR(dstImage, AVIF_RESULT_INTERNAL_ERROR);
-    AVIF_CHECKERR(!dstImage->width && !dstImage->height, AVIF_RESULT_INTERNAL_ERROR); // dstImage is not set yet.
-    AVIF_CHECKERR(dstWidth >= srcImage->width, AVIF_RESULT_INTERNAL_ERROR);
-    AVIF_CHECKERR(dstHeight >= srcImage->height, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(dstImage, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(!dstImage->width && !dstImage->height, AVIF_RESULT_INTERNAL_ERROR); // dstImage is not set yet.
+    AVIF_ASSERT_OR_RETURN(dstWidth >= srcImage->width, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(dstHeight >= srcImage->height, AVIF_RESULT_INTERNAL_ERROR);
 
     // Copy all fields but do not allocate the planes.
     AVIF_CHECKRES(avifImageCopy(dstImage, srcImage, (avifPlanesFlag)0));
@@ -1229,9 +1229,9 @@ static avifResult avifValidateGrid(uint32_t gridCols,
     const avifImage * bottomRightCell = cellImages[cellCount - 1];
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     if (validateGainMap) {
-        AVIF_CHECKERR(firstCell->gainMap && firstCell->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(firstCell->gainMap && firstCell->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
         firstCell = firstCell->gainMap->image;
-        AVIF_CHECKERR(bottomRightCell->gainMap && bottomRightCell->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(bottomRightCell->gainMap && bottomRightCell->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
         bottomRightCell = bottomRightCell->gainMap->image;
     }
 #endif
@@ -1243,7 +1243,7 @@ static avifResult avifValidateGrid(uint32_t gridCols,
         const avifImage * cellImage = cellImages[cellIndex];
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         if (validateGainMap) {
-            AVIF_CHECKERR(cellImage->gainMap && cellImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(cellImage->gainMap && cellImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
             cellImage = cellImage->gainMap->image;
         }
 #endif
@@ -1517,12 +1517,12 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             uint16_t alphaItemID;
             AVIF_CHECKRES(avifEncoderAddImageItems(encoder, gridCols, gridRows, gridWidth, gridHeight, AVIF_ITEM_ALPHA, &alphaItemID));
             avifEncoderItem * alphaItem = avifEncoderDataFindItemByID(encoder->data, alphaItemID);
-            AVIF_CHECKERR(alphaItem, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(alphaItem, AVIF_RESULT_INTERNAL_ERROR);
             alphaItem->irefType = "auxl";
             alphaItem->irefToID = colorItemID;
             if (encoder->data->imageMetadata->alphaPremultiplied) {
                 avifEncoderItem * colorItem = avifEncoderDataFindItemByID(encoder->data, colorItemID);
-                AVIF_CHECKERR(colorItem, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(colorItem, AVIF_RESULT_INTERNAL_ERROR);
                 colorItem->irefType = "prem";
                 colorItem->irefToID = alphaItemID;
             }
@@ -1560,17 +1560,17 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             AVIF_CHECKRES(
                 avifEncoderAddImageItems(encoder, gridCols, gridRows, gainMapGridWidth, gainMapGridHeight, AVIF_ITEM_GAIN_MAP, &gainMapItemID));
             avifEncoderItem * gainMapItem = avifEncoderDataFindItemByID(encoder->data, gainMapItemID);
-            AVIF_CHECKERR(gainMapItem, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(gainMapItem, AVIF_RESULT_INTERNAL_ERROR);
             gainMapItem->hiddenImage = AVIF_TRUE;
 
             // Set the color item and gain map item's dimgFromID value to point to the tone mapped item.
             // The color item shall be first, and the gain map second. avifEncoderFinish() writes the
             // dimg item references in item id order, so as long as colorItemID < gainMapItemID, the order
             // will be correct.
-            AVIF_CHECKERR(colorItemID < gainMapItemID, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(colorItemID < gainMapItemID, AVIF_RESULT_INTERNAL_ERROR);
             avifEncoderItem * colorItem = avifEncoderDataFindItemByID(encoder->data, colorItemID);
-            AVIF_CHECKERR(colorItem, AVIF_RESULT_INTERNAL_ERROR);
-            AVIF_CHECKERR(colorItem->dimgFromID == 0, AVIF_RESULT_INTERNAL_ERROR); // Our internal API only allows one dimg value per item.
+            AVIF_ASSERT_OR_RETURN(colorItem, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(colorItem->dimgFromID == 0, AVIF_RESULT_INTERNAL_ERROR); // Our internal API only allows one dimg value per item.
             colorItem->dimgFromID = toneMappedItemID;
             gainMapItem->dimgFromID = toneMappedItemID;
         }
@@ -1630,7 +1630,7 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         //     }
         // Check whether it is safe to cast width and height to uint16_t. The maximum width and
         // height of an AV1 frame are 65536, which just exceeds uint16_t.
-        AVIF_CHECKERR(encoder->data->items.count > 0, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(encoder->data->items.count > 0, AVIF_RESULT_INTERNAL_ERROR);
         const avifImage * imageMetadata = encoder->data->imageMetadata;
         AVIF_CHECKERR(imageMetadata->width <= 65535 && imageMetadata->height <= 65535, AVIF_RESULT_INVALID_ARGUMENT);
     }
@@ -1645,9 +1645,9 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             const avifImage * firstCellImage = firstCell;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
             if (item->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                AVIF_CHECKERR(cellImage->gainMap && cellImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(cellImage->gainMap && cellImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
                 cellImage = cellImage->gainMap->image;
-                AVIF_CHECKERR(firstCell->gainMap && firstCell->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(firstCell->gainMap && firstCell->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
                 firstCellImage = firstCell->gainMap->image;
             }
 #endif
@@ -1792,7 +1792,7 @@ static avifResult avifEncoderWriteMediaDataBox(avifEncoder * encoder,
             if ((encoder->extraLayerCount > 0) && (item->encodeOutput->samples.count > 0)) {
                 // Interleave - Pick out AV1 items and interleave them later.
                 // We always interleave all AV1 items for layered images.
-                AVIF_CHECKERR(item->encodeOutput->samples.count == item->mdatFixups.count, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(item->encodeOutput->samples.count == item->mdatFixups.count, AVIF_RESULT_INTERNAL_ERROR);
 
                 avifEncoderItemReference * ref = (item->itemCategory == AVIF_ITEM_ALPHA) ? avifArrayPush(layeredAlphaItems)
                                                                                          : avifArrayPush(layeredColorItems);
@@ -1893,7 +1893,7 @@ static avifResult avifEncoderWriteMediaDataBox(avifEncoder * encoder,
             ++layerIndex;
         } while (hasMoreSample);
 
-        AVIF_CHECKERR(layerIndex <= AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(layerIndex <= AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_INTERNAL_ERROR);
     }
     avifRWStreamFinishBox(s, mdat);
     return AVIF_RESULT_OK;
@@ -1952,7 +1952,7 @@ static avifResult avifImageWriteExtendedMeta(const avifImage * imageMetadata, av
                                                    ((imageMetadata->transformFlags & AVIF_TRANSFORM_IROT) ? 1 : 0) +
                                                    ((imageMetadata->transformFlags & AVIF_TRANSFORM_IMIR) ? 1 : 0);
             const uint8_t ipmaCount = numNonEssentialProperties + numEssentialProperties;
-            AVIF_CHECKERR(ipmaCount >= 1, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(ipmaCount >= 1, AVIF_RESULT_INTERNAL_ERROR);
 
             // Only add properties to the primary item.
             AVIF_CHECKRES(avifRWStreamWriteU32(stream, 1)); // unsigned int(32) entry_count;
@@ -2062,15 +2062,15 @@ static avifResult avifEncoderWriteCondensedImageBox(avifEncoder * encoder, avifR
         avifEncoderItem * item = &encoder->data->items.item[itemIndex];
         if (item->id == encoder->data->primaryItemID) {
             colorItem = item;
-            AVIF_CHECKERR(colorItem->encodeOutput->samples.count == 1, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(colorItem->encodeOutput->samples.count == 1, AVIF_RESULT_INTERNAL_ERROR);
         } else if (item->itemCategory == AVIF_ITEM_ALPHA && item->irefToID == encoder->data->primaryItemID) {
-            AVIF_CHECKERR(!alphaItem, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(!alphaItem, AVIF_RESULT_INTERNAL_ERROR);
             alphaItem = item;
-            AVIF_CHECKERR(alphaItem->encodeOutput->samples.count == 1, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(alphaItem->encodeOutput->samples.count == 1, AVIF_RESULT_INTERNAL_ERROR);
         }
     }
 
-    AVIF_CHECKERR(colorItem, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(colorItem, AVIF_RESULT_INTERNAL_ERROR);
     const avifRWData * colorData = &colorItem->encodeOutput->samples.sample[0].data;
     const avifRWData * alphaData = alphaItem ? &alphaItem->encodeOutput->samples.sample[0].data : NULL;
 
@@ -2134,7 +2134,7 @@ static avifResult avifEncoderWriteCondensedImageBox(avifEncoder * encoder, avifR
                                                    // unsigned int(32) infe_type;
                                                    // unsigned int(32) codec_config_type;
     AVIF_CHECKRES(avifRWStreamWriteVarInt(s, 4));  // varint main_item_codec_config_size;
-    AVIF_CHECKERR(colorData->size >= 1, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(colorData->size >= 1, AVIF_RESULT_INTERNAL_ERROR);
     AVIF_CHECKRES(avifRWStreamWriteVarInt(s, (uint32_t)colorData->size - 1)); // varint main_item_data_size_minus_one;
 
     AVIF_CHECKRES(avifRWStreamWriteBits(s, alphaItem ? 1 : 0, 1)); // unsigned int(1) has_alpha;
@@ -2241,7 +2241,7 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
         if (isToneMappedImage) {
             itemMetadata = altImageMetadata;
         } else if (item->itemCategory == AVIF_ITEM_GAIN_MAP) {
-            AVIF_CHECKERR(itemMetadata->gainMap && itemMetadata->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(itemMetadata->gainMap && itemMetadata->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
             itemMetadata = itemMetadata->gainMap->image;
         }
 #else
@@ -2749,7 +2749,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             durationInTimescales = AVIF_INDEFINITE_DURATION64;
         } else {
             uint64_t loopCount = encoder->repetitionCount + 1;
-            AVIF_CHECKERR(framesDurationInTimescales != 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(framesDurationInTimescales != 0, AVIF_RESULT_INTERNAL_ERROR);
             if (loopCount > UINT64_MAX / framesDurationInTimescales) {
                 // The multiplication will overflow uint64_t.
                 return AVIF_RESULT_INVALID_ARGUMENT;

--- a/src/write.c
+++ b/src/write.c
@@ -1025,7 +1025,7 @@ static avifResult avifEncoderDataCreateXMPItem(avifEncoderData * data, const avi
 static avifResult avifImageCopyAndPad(avifImage * const dstImage, const avifImage * srcImage, uint32_t dstWidth, uint32_t dstHeight)
 {
     AVIF_CHECKERR(dstImage, AVIF_RESULT_INTERNAL_ERROR);
-    AVIF_CHECKERR(dstImage->width || dstImage->height, AVIF_RESULT_INTERNAL_ERROR); // dstImage is not set yet.
+    AVIF_CHECKERR(!dstImage->width && !dstImage->height, AVIF_RESULT_INTERNAL_ERROR); // dstImage is not set yet.
     AVIF_CHECKERR(dstWidth >= srcImage->width, AVIF_RESULT_INTERNAL_ERROR);
     AVIF_CHECKERR(dstHeight >= srcImage->height, AVIF_RESULT_INTERNAL_ERROR);
 

--- a/src/write.c
+++ b/src/write.c
@@ -2485,17 +2485,17 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
 
     avifBoxMarker ftyp;
     AVIF_CHECKRES(avifRWStreamWriteBox(&s, "ftyp", AVIF_BOX_SIZE_TBD, &ftyp));
-    AVIF_CHECKRES(avifRWStreamWriteChars(&s, majorBrand, 4)); // unsigned int(32) major_brand;
-    AVIF_CHECKRES(avifRWStreamWriteU32(&s, minorVersion));    // unsigned int(32) minor_version;
-    AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avif", 4));     // unsigned int(32) compatible_brands[];
-    if (useAvioBrand) {                                       //
-        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avio", 4)); // ... compatible_brands[]
-    } //
-    if (isSequence) {                                         //
-        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avis", 4)); // ... compatible_brands[]
-        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "msf1", 4)); // ... compatible_brands[]
-        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "iso8", 4)); // ... compatible_brands[]
-    } //
+    AVIF_CHECKRES(avifRWStreamWriteChars(&s, majorBrand, 4));              // unsigned int(32) major_brand;
+    AVIF_CHECKRES(avifRWStreamWriteU32(&s, minorVersion));                 // unsigned int(32) minor_version;
+    AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avif", 4));                  // unsigned int(32) compatible_brands[];
+    if (useAvioBrand) {                                                    //
+        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avio", 4));              // ... compatible_brands[]
+    }                                                                      //
+    if (isSequence) {                                                      //
+        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avis", 4));              // ... compatible_brands[]
+        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "msf1", 4));              // ... compatible_brands[]
+        AVIF_CHECKRES(avifRWStreamWriteChars(&s, "iso8", 4));              // ... compatible_brands[]
+    }                                                                      //
     AVIF_CHECKRES(avifRWStreamWriteChars(&s, "mif1", 4));                  // ... compatible_brands[]
     AVIF_CHECKRES(avifRWStreamWriteChars(&s, "miaf", 4));                  // ... compatible_brands[]
     if ((imageMetadata->depth == 8) || (imageMetadata->depth == 10)) {     //

--- a/src/write.c
+++ b/src/write.c
@@ -425,7 +425,7 @@ static avifResult avifItemPropertyDedupFinish(avifItemPropertyDedup * dedup, avi
             !memcmp(&outputStream->raw->data[property->offset], dedup->buffer.data, newPropertySize)) {
             // We've already written this exact property, reuse it
             propertyIndex = property->index;
-            AVIF_ASSERT_OR_RETURN(propertyIndex != 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(propertyIndex != 0);
             break;
         }
     }
@@ -639,7 +639,7 @@ static avifResult avifEncoderWriteColorProperties(avifRWStream * outputStream,
     // of an already stored property.
     avifRWStream * dedupStream = outputStream;
     if (dedup) {
-        AVIF_ASSERT_OR_RETURN(ipma, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(ipma);
 
         // Use the dedup's temporary stream for box writes.
         dedupStream = &dedup->s;
@@ -821,7 +821,7 @@ static avifResult avifEncoderWriteTrackMetaBox(avifEncoder * encoder, avifRWStre
             continue;
         }
 
-        AVIF_ASSERT_OR_RETURN(!item->hiddenImage, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(!item->hiddenImage);
         avifBoxMarker infe;
         AVIF_CHECKRES(avifRWStreamWriteFullBox(s, "infe", AVIF_BOX_SIZE_TBD, 2, 0, &infe));
         AVIF_CHECKRES(avifRWStreamWriteU16(s, item->id));                             // unsigned int(16) item_ID;
@@ -1024,10 +1024,10 @@ static avifResult avifEncoderDataCreateXMPItem(avifEncoderData * data, const avi
 // Same as avifImageCopy() but pads the dstImage with border pixel values to reach dstWidth and dstHeight.
 static avifResult avifImageCopyAndPad(avifImage * const dstImage, const avifImage * srcImage, uint32_t dstWidth, uint32_t dstHeight)
 {
-    AVIF_ASSERT_OR_RETURN(dstImage, AVIF_RESULT_INTERNAL_ERROR);
-    AVIF_ASSERT_OR_RETURN(!dstImage->width && !dstImage->height, AVIF_RESULT_INTERNAL_ERROR); // dstImage is not set yet.
-    AVIF_ASSERT_OR_RETURN(dstWidth >= srcImage->width, AVIF_RESULT_INTERNAL_ERROR);
-    AVIF_ASSERT_OR_RETURN(dstHeight >= srcImage->height, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(dstImage);
+    AVIF_ASSERT_OR_RETURN(!dstImage->width && !dstImage->height); // dstImage is not set yet.
+    AVIF_ASSERT_OR_RETURN(dstWidth >= srcImage->width);
+    AVIF_ASSERT_OR_RETURN(dstHeight >= srcImage->height);
 
     // Copy all fields but do not allocate the planes.
     AVIF_CHECKRES(avifImageCopy(dstImage, srcImage, (avifPlanesFlag)0));
@@ -1229,9 +1229,9 @@ static avifResult avifValidateGrid(uint32_t gridCols,
     const avifImage * bottomRightCell = cellImages[cellCount - 1];
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     if (validateGainMap) {
-        AVIF_ASSERT_OR_RETURN(firstCell->gainMap && firstCell->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(firstCell->gainMap && firstCell->gainMap->image);
         firstCell = firstCell->gainMap->image;
-        AVIF_ASSERT_OR_RETURN(bottomRightCell->gainMap && bottomRightCell->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(bottomRightCell->gainMap && bottomRightCell->gainMap->image);
         bottomRightCell = bottomRightCell->gainMap->image;
     }
 #endif
@@ -1243,7 +1243,7 @@ static avifResult avifValidateGrid(uint32_t gridCols,
         const avifImage * cellImage = cellImages[cellIndex];
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         if (validateGainMap) {
-            AVIF_ASSERT_OR_RETURN(cellImage->gainMap && cellImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(cellImage->gainMap && cellImage->gainMap->image);
             cellImage = cellImage->gainMap->image;
         }
 #endif
@@ -1517,12 +1517,12 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             uint16_t alphaItemID;
             AVIF_CHECKRES(avifEncoderAddImageItems(encoder, gridCols, gridRows, gridWidth, gridHeight, AVIF_ITEM_ALPHA, &alphaItemID));
             avifEncoderItem * alphaItem = avifEncoderDataFindItemByID(encoder->data, alphaItemID);
-            AVIF_ASSERT_OR_RETURN(alphaItem, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(alphaItem);
             alphaItem->irefType = "auxl";
             alphaItem->irefToID = colorItemID;
             if (encoder->data->imageMetadata->alphaPremultiplied) {
                 avifEncoderItem * colorItem = avifEncoderDataFindItemByID(encoder->data, colorItemID);
-                AVIF_ASSERT_OR_RETURN(colorItem, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(colorItem);
                 colorItem->irefType = "prem";
                 colorItem->irefToID = alphaItemID;
             }
@@ -1560,17 +1560,17 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             AVIF_CHECKRES(
                 avifEncoderAddImageItems(encoder, gridCols, gridRows, gainMapGridWidth, gainMapGridHeight, AVIF_ITEM_GAIN_MAP, &gainMapItemID));
             avifEncoderItem * gainMapItem = avifEncoderDataFindItemByID(encoder->data, gainMapItemID);
-            AVIF_ASSERT_OR_RETURN(gainMapItem, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(gainMapItem);
             gainMapItem->hiddenImage = AVIF_TRUE;
 
             // Set the color item and gain map item's dimgFromID value to point to the tone mapped item.
             // The color item shall be first, and the gain map second. avifEncoderFinish() writes the
             // dimg item references in item id order, so as long as colorItemID < gainMapItemID, the order
             // will be correct.
-            AVIF_ASSERT_OR_RETURN(colorItemID < gainMapItemID, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(colorItemID < gainMapItemID);
             avifEncoderItem * colorItem = avifEncoderDataFindItemByID(encoder->data, colorItemID);
-            AVIF_ASSERT_OR_RETURN(colorItem, AVIF_RESULT_INTERNAL_ERROR);
-            AVIF_ASSERT_OR_RETURN(colorItem->dimgFromID == 0, AVIF_RESULT_INTERNAL_ERROR); // Our internal API only allows one dimg value per item.
+            AVIF_ASSERT_OR_RETURN(colorItem);
+            AVIF_ASSERT_OR_RETURN(colorItem->dimgFromID == 0); // Our internal API only allows one dimg value per item.
             colorItem->dimgFromID = toneMappedItemID;
             gainMapItem->dimgFromID = toneMappedItemID;
         }
@@ -1630,7 +1630,7 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         //     }
         // Check whether it is safe to cast width and height to uint16_t. The maximum width and
         // height of an AV1 frame are 65536, which just exceeds uint16_t.
-        AVIF_ASSERT_OR_RETURN(encoder->data->items.count > 0, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(encoder->data->items.count > 0);
         const avifImage * imageMetadata = encoder->data->imageMetadata;
         AVIF_CHECKERR(imageMetadata->width <= 65535 && imageMetadata->height <= 65535, AVIF_RESULT_INVALID_ARGUMENT);
     }
@@ -1645,9 +1645,9 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             const avifImage * firstCellImage = firstCell;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
             if (item->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                AVIF_ASSERT_OR_RETURN(cellImage->gainMap && cellImage->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(cellImage->gainMap && cellImage->gainMap->image);
                 cellImage = cellImage->gainMap->image;
-                AVIF_ASSERT_OR_RETURN(firstCell->gainMap && firstCell->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(firstCell->gainMap && firstCell->gainMap->image);
                 firstCellImage = firstCell->gainMap->image;
             }
 #endif
@@ -1792,7 +1792,7 @@ static avifResult avifEncoderWriteMediaDataBox(avifEncoder * encoder,
             if ((encoder->extraLayerCount > 0) && (item->encodeOutput->samples.count > 0)) {
                 // Interleave - Pick out AV1 items and interleave them later.
                 // We always interleave all AV1 items for layered images.
-                AVIF_ASSERT_OR_RETURN(item->encodeOutput->samples.count == item->mdatFixups.count, AVIF_RESULT_INTERNAL_ERROR);
+                AVIF_ASSERT_OR_RETURN(item->encodeOutput->samples.count == item->mdatFixups.count);
 
                 avifEncoderItemReference * ref = (item->itemCategory == AVIF_ITEM_ALPHA) ? avifArrayPush(layeredAlphaItems)
                                                                                          : avifArrayPush(layeredColorItems);
@@ -1893,7 +1893,7 @@ static avifResult avifEncoderWriteMediaDataBox(avifEncoder * encoder,
             ++layerIndex;
         } while (hasMoreSample);
 
-        AVIF_ASSERT_OR_RETURN(layerIndex <= AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_INTERNAL_ERROR);
+        AVIF_ASSERT_OR_RETURN(layerIndex <= AVIF_MAX_AV1_LAYER_COUNT);
     }
     avifRWStreamFinishBox(s, mdat);
     return AVIF_RESULT_OK;
@@ -1952,7 +1952,7 @@ static avifResult avifImageWriteExtendedMeta(const avifImage * imageMetadata, av
                                                    ((imageMetadata->transformFlags & AVIF_TRANSFORM_IROT) ? 1 : 0) +
                                                    ((imageMetadata->transformFlags & AVIF_TRANSFORM_IMIR) ? 1 : 0);
             const uint8_t ipmaCount = numNonEssentialProperties + numEssentialProperties;
-            AVIF_ASSERT_OR_RETURN(ipmaCount >= 1, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(ipmaCount >= 1);
 
             // Only add properties to the primary item.
             AVIF_CHECKRES(avifRWStreamWriteU32(stream, 1)); // unsigned int(32) entry_count;
@@ -2062,15 +2062,15 @@ static avifResult avifEncoderWriteCondensedImageBox(avifEncoder * encoder, avifR
         avifEncoderItem * item = &encoder->data->items.item[itemIndex];
         if (item->id == encoder->data->primaryItemID) {
             colorItem = item;
-            AVIF_ASSERT_OR_RETURN(colorItem->encodeOutput->samples.count == 1, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(colorItem->encodeOutput->samples.count == 1);
         } else if (item->itemCategory == AVIF_ITEM_ALPHA && item->irefToID == encoder->data->primaryItemID) {
-            AVIF_ASSERT_OR_RETURN(!alphaItem, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(!alphaItem);
             alphaItem = item;
-            AVIF_ASSERT_OR_RETURN(alphaItem->encodeOutput->samples.count == 1, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(alphaItem->encodeOutput->samples.count == 1);
         }
     }
 
-    AVIF_ASSERT_OR_RETURN(colorItem, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(colorItem);
     const avifRWData * colorData = &colorItem->encodeOutput->samples.sample[0].data;
     const avifRWData * alphaData = alphaItem ? &alphaItem->encodeOutput->samples.sample[0].data : NULL;
 
@@ -2134,7 +2134,7 @@ static avifResult avifEncoderWriteCondensedImageBox(avifEncoder * encoder, avifR
                                                    // unsigned int(32) infe_type;
                                                    // unsigned int(32) codec_config_type;
     AVIF_CHECKRES(avifRWStreamWriteVarInt(s, 4));  // varint main_item_codec_config_size;
-    AVIF_ASSERT_OR_RETURN(colorData->size >= 1, AVIF_RESULT_INTERNAL_ERROR);
+    AVIF_ASSERT_OR_RETURN(colorData->size >= 1);
     AVIF_CHECKRES(avifRWStreamWriteVarInt(s, (uint32_t)colorData->size - 1)); // varint main_item_data_size_minus_one;
 
     AVIF_CHECKRES(avifRWStreamWriteBits(s, alphaItem ? 1 : 0, 1)); // unsigned int(1) has_alpha;
@@ -2241,7 +2241,7 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
         if (isToneMappedImage) {
             itemMetadata = altImageMetadata;
         } else if (item->itemCategory == AVIF_ITEM_GAIN_MAP) {
-            AVIF_ASSERT_OR_RETURN(itemMetadata->gainMap && itemMetadata->gainMap->image, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(itemMetadata->gainMap && itemMetadata->gainMap->image);
             itemMetadata = itemMetadata->gainMap->image;
         }
 #else
@@ -2749,7 +2749,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             durationInTimescales = AVIF_INDEFINITE_DURATION64;
         } else {
             uint64_t loopCount = encoder->repetitionCount + 1;
-            AVIF_ASSERT_OR_RETURN(framesDurationInTimescales != 0, AVIF_RESULT_INTERNAL_ERROR);
+            AVIF_ASSERT_OR_RETURN(framesDurationInTimescales != 0);
             if (loopCount > UINT64_MAX / framesDurationInTimescales) {
                 // The multiplication will overflow uint64_t.
                 return AVIF_RESULT_INVALID_ARGUMENT;

--- a/src/write.c
+++ b/src/write.c
@@ -425,7 +425,7 @@ static avifResult avifItemPropertyDedupFinish(avifItemPropertyDedup * dedup, avi
             !memcmp(&outputStream->raw->data[property->offset], dedup->buffer.data, newPropertySize)) {
             // We've already written this exact property, reuse it
             propertyIndex = property->index;
-            assert(propertyIndex != 0);
+            AVIF_ASSERT(propertyIndex != 0, AVIF_RESULT_UNKNOWN_ERROR);
             break;
         }
     }
@@ -639,7 +639,7 @@ static avifResult avifEncoderWriteColorProperties(avifRWStream * outputStream,
     // of an already stored property.
     avifRWStream * dedupStream = outputStream;
     if (dedup) {
-        assert(ipma);
+        AVIF_ASSERT(ipma, AVIF_RESULT_UNKNOWN_ERROR);
 
         // Use the dedup's temporary stream for box writes.
         dedupStream = &dedup->s;
@@ -821,7 +821,7 @@ static avifResult avifEncoderWriteTrackMetaBox(avifEncoder * encoder, avifRWStre
             continue;
         }
 
-        assert(!item->hiddenImage);
+        AVIF_ASSERT(!item->hiddenImage, AVIF_RESULT_UNKNOWN_ERROR);
         avifBoxMarker infe;
         AVIF_CHECKRES(avifRWStreamWriteFullBox(s, "infe", AVIF_BOX_SIZE_TBD, 2, 0, &infe));
         AVIF_CHECKRES(avifRWStreamWriteU16(s, item->id));                             // unsigned int(16) item_ID;
@@ -1025,6 +1025,9 @@ static avifResult avifEncoderDataCreateXMPItem(avifEncoderData * data, const avi
 // Returns NULL if a memory allocation failed.
 static avifImage * avifImageCopyAndPad(const avifImage * srcImage, uint32_t dstWidth, uint32_t dstHeight)
 {
+    AVIF_ASSERT(dstWidth >= srcImage->width, NULL);
+    AVIF_ASSERT(dstHeight >= srcImage->height, NULL);
+
     avifImage * dstImage = avifImageCreateEmpty();
     if (!dstImage) {
         return NULL;
@@ -1034,8 +1037,6 @@ static avifImage * avifImageCopyAndPad(const avifImage * srcImage, uint32_t dstW
         avifImageDestroy(dstImage);
         return NULL;
     }
-    assert(dstWidth >= srcImage->width);
-    assert(dstHeight >= srcImage->height);
     dstImage->width = dstWidth;
     dstImage->height = dstHeight;
 
@@ -1242,9 +1243,9 @@ static avifResult avifValidateGrid(uint32_t gridCols,
     const avifImage * bottomRightCell = cellImages[cellCount - 1];
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     if (validateGainMap) {
-        assert(firstCell->gainMap && firstCell->gainMap->image);
+        AVIF_ASSERT(firstCell->gainMap && firstCell->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
         firstCell = firstCell->gainMap->image;
-        assert(bottomRightCell->gainMap && bottomRightCell->gainMap->image);
+        AVIF_ASSERT(bottomRightCell->gainMap && bottomRightCell->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
         bottomRightCell = bottomRightCell->gainMap->image;
     }
 #endif
@@ -1256,7 +1257,7 @@ static avifResult avifValidateGrid(uint32_t gridCols,
         const avifImage * cellImage = cellImages[cellIndex];
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
         if (validateGainMap) {
-            assert(cellImage->gainMap && cellImage->gainMap->image);
+            AVIF_ASSERT(cellImage->gainMap && cellImage->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
             cellImage = cellImage->gainMap->image;
         }
 #endif
@@ -1530,12 +1531,12 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             uint16_t alphaItemID;
             AVIF_CHECKRES(avifEncoderAddImageItems(encoder, gridCols, gridRows, gridWidth, gridHeight, AVIF_ITEM_ALPHA, &alphaItemID));
             avifEncoderItem * alphaItem = avifEncoderDataFindItemByID(encoder->data, alphaItemID);
-            assert(alphaItem);
+            AVIF_ASSERT(alphaItem, AVIF_RESULT_UNKNOWN_ERROR);
             alphaItem->irefType = "auxl";
             alphaItem->irefToID = colorItemID;
             if (encoder->data->imageMetadata->alphaPremultiplied) {
                 avifEncoderItem * colorItem = avifEncoderDataFindItemByID(encoder->data, colorItemID);
-                assert(colorItem);
+                AVIF_ASSERT(colorItem, AVIF_RESULT_UNKNOWN_ERROR);
                 colorItem->irefType = "prem";
                 colorItem->irefToID = alphaItemID;
             }
@@ -1573,17 +1574,17 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             AVIF_CHECKRES(
                 avifEncoderAddImageItems(encoder, gridCols, gridRows, gainMapGridWidth, gainMapGridHeight, AVIF_ITEM_GAIN_MAP, &gainMapItemID));
             avifEncoderItem * gainMapItem = avifEncoderDataFindItemByID(encoder->data, gainMapItemID);
-            assert(gainMapItem);
+            AVIF_ASSERT(gainMapItem, AVIF_RESULT_UNKNOWN_ERROR);
             gainMapItem->hiddenImage = AVIF_TRUE;
 
             // Set the color item and gain map item's dimgFromID value to point to the tone mapped item.
             // The color item shall be first, and the gain map second. avifEncoderFinish() writes the
             // dimg item references in item id order, so as long as colorItemID < gainMapItemID, the order
             // will be correct.
-            assert(colorItemID < gainMapItemID);
+            AVIF_ASSERT(colorItemID < gainMapItemID, AVIF_RESULT_UNKNOWN_ERROR);
             avifEncoderItem * colorItem = avifEncoderDataFindItemByID(encoder->data, colorItemID);
-            assert(colorItem);
-            assert(colorItem->dimgFromID == 0); // Our internal API only allows one dimg value per item.
+            AVIF_ASSERT(colorItem, AVIF_RESULT_UNKNOWN_ERROR);
+            AVIF_ASSERT(colorItem->dimgFromID == 0, AVIF_RESULT_UNKNOWN_ERROR); // Our internal API only allows one dimg value per item.
             colorItem->dimgFromID = toneMappedItemID;
             gainMapItem->dimgFromID = toneMappedItemID;
         }
@@ -1643,11 +1644,9 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         //     }
         // Check whether it is safe to cast width and height to uint16_t. The maximum width and
         // height of an AV1 frame are 65536, which just exceeds uint16_t.
-        assert(encoder->data->items.count > 0);
+        AVIF_ASSERT(encoder->data->items.count > 0, AVIF_RESULT_UNKNOWN_ERROR);
         const avifImage * imageMetadata = encoder->data->imageMetadata;
-        if ((imageMetadata->width > 65535) || (imageMetadata->height > 65535)) {
-            return AVIF_RESULT_INVALID_ARGUMENT;
-        }
+        AVIF_CHECKERR(imageMetadata->width <= 65535 && imageMetadata->height <= 65535, AVIF_RESULT_INVALID_ARGUMENT);
     }
 
     // -----------------------------------------------------------------------
@@ -1660,9 +1659,9 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             const avifImage * firstCellImage = firstCell;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
             if (item->itemCategory == AVIF_ITEM_GAIN_MAP) {
-                assert(cellImage->gainMap && cellImage->gainMap->image);
+                AVIF_ASSERT(cellImage->gainMap && cellImage->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
                 cellImage = cellImage->gainMap->image;
-                assert(firstCell->gainMap && firstCell->gainMap->image);
+                AVIF_ASSERT(firstCell->gainMap && firstCell->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
                 firstCellImage = firstCell->gainMap->image;
             }
 #endif
@@ -1804,7 +1803,7 @@ static avifResult avifEncoderWriteMediaDataBox(avifEncoder * encoder,
             if ((encoder->extraLayerCount > 0) && (item->encodeOutput->samples.count > 0)) {
                 // Interleave - Pick out AV1 items and interleave them later.
                 // We always interleave all AV1 items for layered images.
-                assert(item->encodeOutput->samples.count == item->mdatFixups.count);
+                AVIF_ASSERT(item->encodeOutput->samples.count == item->mdatFixups.count, AVIF_RESULT_UNKNOWN_ERROR);
 
                 avifEncoderItemReference * ref = (item->itemCategory == AVIF_ITEM_ALPHA) ? avifArrayPush(layeredAlphaItems)
                                                                                          : avifArrayPush(layeredColorItems);
@@ -1905,7 +1904,7 @@ static avifResult avifEncoderWriteMediaDataBox(avifEncoder * encoder,
             ++layerIndex;
         } while (hasMoreSample);
 
-        assert(layerIndex <= AVIF_MAX_AV1_LAYER_COUNT);
+        AVIF_ASSERT(layerIndex <= AVIF_MAX_AV1_LAYER_COUNT, AVIF_RESULT_UNKNOWN_ERROR);
     }
     avifRWStreamFinishBox(s, mdat);
     return AVIF_RESULT_OK;
@@ -1964,7 +1963,7 @@ static avifResult avifImageWriteExtendedMeta(const avifImage * imageMetadata, av
                                                    ((imageMetadata->transformFlags & AVIF_TRANSFORM_IROT) ? 1 : 0) +
                                                    ((imageMetadata->transformFlags & AVIF_TRANSFORM_IMIR) ? 1 : 0);
             const uint8_t ipmaCount = numNonEssentialProperties + numEssentialProperties;
-            assert(ipmaCount >= 1);
+            AVIF_ASSERT(ipmaCount >= 1, AVIF_RESULT_UNKNOWN_ERROR);
 
             // Only add properties to the primary item.
             AVIF_CHECKRES(avifRWStreamWriteU32(stream, 1)); // unsigned int(32) entry_count;
@@ -2074,15 +2073,15 @@ static avifResult avifEncoderWriteCondensedImageBox(avifEncoder * encoder, avifR
         avifEncoderItem * item = &encoder->data->items.item[itemIndex];
         if (item->id == encoder->data->primaryItemID) {
             colorItem = item;
-            assert(colorItem->encodeOutput->samples.count == 1);
+            AVIF_ASSERT(colorItem->encodeOutput->samples.count == 1, AVIF_RESULT_UNKNOWN_ERROR);
         } else if (item->itemCategory == AVIF_ITEM_ALPHA && item->irefToID == encoder->data->primaryItemID) {
-            assert(!alphaItem);
+            AVIF_ASSERT(!alphaItem, AVIF_RESULT_UNKNOWN_ERROR);
             alphaItem = item;
-            assert(alphaItem->encodeOutput->samples.count == 1);
+            AVIF_ASSERT(alphaItem->encodeOutput->samples.count == 1, AVIF_RESULT_UNKNOWN_ERROR);
         }
     }
 
-    assert(colorItem);
+    AVIF_ASSERT(colorItem, AVIF_RESULT_UNKNOWN_ERROR);
     const avifRWData * colorData = &colorItem->encodeOutput->samples.sample[0].data;
     const avifRWData * alphaData = alphaItem ? &alphaItem->encodeOutput->samples.sample[0].data : NULL;
 
@@ -2146,7 +2145,7 @@ static avifResult avifEncoderWriteCondensedImageBox(avifEncoder * encoder, avifR
                                                    // unsigned int(32) infe_type;
                                                    // unsigned int(32) codec_config_type;
     AVIF_CHECKRES(avifRWStreamWriteVarInt(s, 4));  // varint main_item_codec_config_size;
-    assert(colorData->size >= 1);
+    AVIF_ASSERT(colorData->size >= 1, AVIF_RESULT_UNKNOWN_ERROR);
     AVIF_CHECKRES(avifRWStreamWriteVarInt(s, (uint32_t)colorData->size - 1)); // varint main_item_data_size_minus_one;
 
     AVIF_CHECKRES(avifRWStreamWriteBits(s, alphaItem ? 1 : 0, 1)); // unsigned int(1) has_alpha;
@@ -2253,7 +2252,7 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
         if (isToneMappedImage) {
             itemMetadata = altImageMetadata;
         } else if (item->itemCategory == AVIF_ITEM_GAIN_MAP) {
-            assert(itemMetadata->gainMap && itemMetadata->gainMap->image);
+            AVIF_ASSERT(itemMetadata->gainMap && itemMetadata->gainMap->image, AVIF_RESULT_UNKNOWN_ERROR);
             itemMetadata = itemMetadata->gainMap->image;
         }
 #else
@@ -2761,7 +2760,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
             durationInTimescales = AVIF_INDEFINITE_DURATION64;
         } else {
             uint64_t loopCount = encoder->repetitionCount + 1;
-            assert(framesDurationInTimescales != 0);
+            AVIF_ASSERT(framesDurationInTimescales != 0, AVIF_RESULT_UNKNOWN_ERROR);
             if (loopCount > UINT64_MAX / framesDurationInTimescales) {
                 // The multiplication will overflow uint64_t.
                 return AVIF_RESULT_INVALID_ARGUMENT;

--- a/tests/gtest/aviflosslesstest.cc
+++ b/tests/gtest/aviflosslesstest.cc
@@ -23,10 +23,11 @@ TEST(BasicTest, EncodeDecodeMatrixCoefficients) {
 
     for (auto matrix_coefficient : {
 #if defined(AVIF_ENABLE_EXPERIMENTAL_YCGCO_R)
-           AVIF_MATRIX_COEFFICIENTS_YCGCO_RE, AVIF_MATRIX_COEFFICIENTS_YCGCO_RO,
+             AVIF_MATRIX_COEFFICIENTS_YCGCO_RE,
+             AVIF_MATRIX_COEFFICIENTS_YCGCO_RO,
 #endif
-               AVIF_MATRIX_COEFFICIENTS_IDENTITY, AVIF_MATRIX_COEFFICIENTS_YCGCO
-         }) {
+             AVIF_MATRIX_COEFFICIENTS_IDENTITY,
+             AVIF_MATRIX_COEFFICIENTS_YCGCO}) {
       // Read a ground truth image but ask for certain matrix coefficients.
       ImagePtr image(avifImageCreateEmpty());
       ASSERT_NE(image, nullptr);

--- a/tests/gtest/aviflosslesstest.cc
+++ b/tests/gtest/aviflosslesstest.cc
@@ -23,11 +23,10 @@ TEST(BasicTest, EncodeDecodeMatrixCoefficients) {
 
     for (auto matrix_coefficient : {
 #if defined(AVIF_ENABLE_EXPERIMENTAL_YCGCO_R)
-             AVIF_MATRIX_COEFFICIENTS_YCGCO_RE,
-             AVIF_MATRIX_COEFFICIENTS_YCGCO_RO,
+           AVIF_MATRIX_COEFFICIENTS_YCGCO_RE, AVIF_MATRIX_COEFFICIENTS_YCGCO_RO,
 #endif
-             AVIF_MATRIX_COEFFICIENTS_IDENTITY,
-             AVIF_MATRIX_COEFFICIENTS_YCGCO}) {
+               AVIF_MATRIX_COEFFICIENTS_IDENTITY, AVIF_MATRIX_COEFFICIENTS_YCGCO
+         }) {
       // Read a ground truth image but ask for certain matrix coefficients.
       ImagePtr image(avifImageCreateEmpty());
       ASSERT_NE(image, nullptr);


### PR DESCRIPTION
This is a general proposal, there are variants:
- Use `AVIF_CHECKERR()` directly instead of introducing `AVIF_ASSERT()`
- Introduce `AVIF_RESULT_ASSERTION_FAILED` instead of using `AVIF_RESULT_UNKNOWN_ERROR`

What do you think? If you agree with this initiative, it can be applied to more files in `src/`.

Example of why this PR is useful: `AVIF_ASSERT(itemID != 0);` in `avifMetaFindOrCreateItem()` could have sped the security investigation around https://github.com/AOMediaCodec/libavif/pull/1922 up.