### PR TITLE
Bump clang-format check to clang-format-16

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: RafikFarhad/clang-format-github-action@4a04d8e72a661766278abf214ed995bf6bdf0b8f # v3.2.0
+      - uses: RafikFarhad/clang-format-github-action@873e2c426db342189305bc04213fe55cb701fd91 # v4
         with:
           style: file
           sources: "apps/*.c,apps/**/*.h,apps/**/*.c,apps/**/*.cc,examples/*.c,include/avif/*.h,src/*.c,tests/*.c,tests/**/*.h,tests/**/*.cc"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ libavif is written in C99.
 ### Formatting
 
 Use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to format the C
-sources from the top-level folder:
+sources from the top-level folder (`clang-format-16` preferred):
 
 ```sh
 clang-format -style=file -i \


### PR DESCRIPTION
Tested with "Debian clang-format version 16.0.6" locally (output of clang-format-16 --version).

Bumped upstream in https://github.com/RafikFarhad/clang-format-github-action/pull/11.