### PR TITLE
Actually use a local fuzztest repo and bump its version.

### DIFF
--- a/ext/fuzztest.cmd
+++ b/ext/fuzztest.cmd
@@ -9,8 +9,8 @@
 
 git clone https://github.com/google/fuzztest.git
 cd fuzztest
-: # There is no tagged release as of 2023/09/18. Pick the last commit.
-git checkout b5500afbac873c884e1e021ea019ad943434df7d
+: # There is no tagged release as of 2024/01/22. Pick the earliest commit that contains a needed bug fix.
+git checkout 8f82f46e14cc2484ddecf6d55e46243923f9a036
 
 : # fuzztest is built by the main CMake project through add_subdirectory as recommended at:
 : # https://github.com/google/fuzztest/blob/main/doc/quickstart-cmake.md

--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -36,14 +36,12 @@
 #     avif_fuzztest_enc_dec_incr@EncodeDecodeAvifFuzzTest.EncodeDecodeGridValid \
 #     --sanitizer address
 
-ln -s $SRC/fuzztest $SRC/libavif/ext/fuzztest
-
 # Add asan as a dependency by default to fix builds.
 export CXXFLAGS="${CXXFLAGS} -fsanitize=address"
 export CFLAGS="${CFLAGS} -fsanitize=address"
 
 # build dependencies
-cd ext && bash aom.cmd && bash dav1d.cmd && bash libjpeg.cmd && \
+cd ext && bash aom.cmd && bash dav1d.cmd && bash fuzztest.cmd && bash libjpeg.cmd && \
       bash libsharpyuv.cmd && bash libyuv.cmd && bash zlibpng.cmd && cd ..
 
 # build libavif


### PR DESCRIPTION
This is after discussion at:
https://github.com/google/oss-fuzz/issues/11528