### PR TITLE
Revert "Fix avif_fuzztest_enc_dec_anim for AVIF_ADD_IMAGE_FLAG_SINGLE…

### DIFF
--- a/tests/gtest/avif_fuzztest_enc_dec_anim.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_anim.cc
@@ -35,26 +35,10 @@ void EncodeDecodeAnimation(ImagePtr frame,
   int total_duration = 0;
 
   // Encode.
-  for (size_t i = 0; i < frame_options.size(); ++i) {
-    const FrameOptions& options = frame_options[i];
+  for (const FrameOptions& options : frame_options) {
     total_duration += options.duration;
     const avifResult result = avifEncoderAddImage(
         encoder.get(), frame.get(), options.duration, options.flags);
-    // AVIF_ADD_IMAGE_FLAG_SINGLE can only be used on one image.
-    if ((frame_options[0].flags & AVIF_ADD_IMAGE_FLAG_SINGLE) && i > 0) {
-      ASSERT_EQ(result, AVIF_RESULT_ENCODE_COLOR_FAILED)
-          << avifResultToString(result) << " " << encoder->diag.error;
-      return;
-    }
-    // AVIF_ADD_IMAGE_FLAG_SINGLE can only be used on the first image.
-    // It also cannot be set for layered images.
-    if ((options.flags & AVIF_ADD_IMAGE_FLAG_SINGLE) &&
-        (i > 0 || encoder->extraLayerCount > 0)) {
-      ASSERT_EQ(result, AVIF_RESULT_INVALID_ARGUMENT)
-          << avifResultToString(result) << " " << encoder->diag.error;
-      return;
-    }
-
     ASSERT_EQ(result, AVIF_RESULT_OK)
         << avifResultToString(result) << " " << encoder->diag.error;
   }


### PR DESCRIPTION
… (#1940)"

This reverts commit 57408733672485966cc37a07217d7ea2f52a14d7.

Now that we are using a fuzztest version with the bit flag fix, let's trust it.