### PR TITLE
Fix off-by-one error in a comment

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -1815,8 +1815,8 @@ static avifResult avifEncoderWriteMediaDataBox(avifEncoder * encoder,
 
             size_t chunkOffset = 0;
 
-            // Deduplication - See if an identical chunk to this has already been written
-            // Doing it when item->encodeOutput->samples.count > 0 would require contiguous memory.
+            // Deduplication - See if an identical chunk to this has already been written.
+            // Doing it when item->encodeOutput->samples.count > 1 would require contiguous memory.
             if (item->encodeOutput->samples.count == 1) {
                 avifEncodeSample * sample = &item->encodeOutput->samples.sample[0];
                 chunkOffset = avifEncoderFindExistingChunk(s, mdatStartOffset, sample->data.data, sample->data.size);


### PR DESCRIPTION
The deduplication code in avifEncoderWriteMediaDataBox() handles item->encodeOutput->samples.count == 1 and
item->encodeOutput->samples.count == 0, so the unhandled case should be item->encodeOutput->samples.count > 1, not
item->encodeOutput->samples.count > 0.