### PR TITLE
Get ubsan fuzztest test to build.

### DIFF
--- a/ext/fuzztest.cmd
+++ b/ext/fuzztest.cmd
@@ -9,7 +9,8 @@
 
 git clone https://github.com/google/fuzztest.git
 cd fuzztest
-: # There is no tagged release as of 2024/01/26. Pick the earliest commit that contains a needed bug fix.
+: # There is no tagged release as of 2024/01/26. Pick the earliest commit that fixes the
+: # undefined reference to LLVMFuzzerRunDriver when building ubsan tests.
 git checkout a53a2083e7df08749ea26b5960c05a9bffa186c2
 
 : # fuzztest is built by the main CMake project through add_subdirectory as recommended at:

--- a/ext/fuzztest.cmd
+++ b/ext/fuzztest.cmd
@@ -9,8 +9,8 @@
 
 git clone https://github.com/google/fuzztest.git
 cd fuzztest
-: # There is no tagged release as of 2024/01/22. Pick the earliest commit that contains a needed bug fix.
-git checkout 8f82f46e14cc2484ddecf6d55e46243923f9a036
+: # There is no tagged release as of 2024/01/26. Pick the earliest commit that contains a needed bug fix.
+git checkout a53a2083e7df08749ea26b5960c05a9bffa186c2
 
 : # fuzztest is built by the main CMake project through add_subdirectory as recommended at:
 : # https://github.com/google/fuzztest/blob/main/doc/quickstart-cmake.md

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -199,6 +199,7 @@ if(AVIF_ENABLE_FUZZTEST)
                 "fuzztest: Installed FuzzTest is not supported, please set AVIF_LOCAL_FUZZTEST=ON or AVIF_ENABLE_FUZZTEST=OFF"
         )
     endif()
+    fuzztest_setup_fuzzing_flags()
 
     add_avif_fuzztest(avif_fuzztest_dec)
     add_avif_fuzztest(avif_fuzztest_dec_incr gtest/avifincrtest_helpers.cc)

--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -42,7 +42,8 @@ export ORIG_CXXFLAGS="$CXXFLAGS"
 export CFLAGS=""
 export CXXFLAGS=""
 
-# fuzz flags are problematic with meson (hence no dav1d) and no point in fuzzing fuzztest.
+# Use normal flags for projects built outside of libavif (e.g. dav1d with meson is
+# problematic with sanitizer flags)
 cd ext && bash dav1d.cmd && bash libsharpyuv.cmd && bash libyuv.cmd && cd ..
 
 export CFLAGS=$ORIG_CFLAGS

--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -43,14 +43,13 @@ export CFLAGS=""
 export CXXFLAGS=""
 
 # fuzz flags are problematic with meson (hence no dav1d) and no point in fuzzing fuzztest.
-cd ext && bash dav1d.cmd && bash fuzztest.cmd && cd ..
+cd ext && bash dav1d.cmd && bash libsharpyuv.cmd && bash libyuv.cmd && cd ..
 
 export CFLAGS=$ORIG_CFLAGS
 export CXXFLAGS=$ORIG_CXXFLAGS
 
 # build dependencies
-cd ext && bash aom.cmd && bash libjpeg.cmd && bash libsharpyuv.cmd && \
-      bash libyuv.cmd && bash zlibpng.cmd && cd ..
+cd ext && bash aom.cmd && bash fuzztest.cmd && bash libjpeg.cmd && bash zlibpng.cmd && cd ..
 
 # build libavif
 mkdir build

--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -36,21 +36,21 @@
 #     avif_fuzztest_enc_dec_incr@EncodeDecodeAvifFuzzTest.EncodeDecodeGridValid \
 #     --sanitizer address
 
-# Reset compile flags to build some deps without fuzzer flags.
+# Reset compile flags to build dav1d without fuzzer flags. The meson build system
+# is problematic with sanitizer flags.
 export ORIG_CFLAGS="$CFLAGS"
 export ORIG_CXXFLAGS="$CXXFLAGS"
 export CFLAGS=""
 export CXXFLAGS=""
 
-# Use normal flags for projects built outside of libavif (e.g. dav1d with meson is
-# problematic with sanitizer flags)
-cd ext && bash dav1d.cmd && bash libsharpyuv.cmd && bash libyuv.cmd && cd ..
+cd ext && bash dav1d.cmd && cd ..
 
 export CFLAGS=$ORIG_CFLAGS
 export CXXFLAGS=$ORIG_CXXFLAGS
 
-# build dependencies
-cd ext && bash aom.cmd && bash fuzztest.cmd && bash libjpeg.cmd && bash zlibpng.cmd && cd ..
+# Prepare remaining dependencies.
+cd ext && bash aom.cmd && bash fuzztest.cmd && bash libjpeg.cmd && bash libsharpyuv.cmd &&
+      bash libyuv.cmd && bash zlibpng.cmd && cd ..
 
 # build libavif
 mkdir build


### PR DESCRIPTION
- add missing flags that would trigger undefined reference to asan
- update fuzztest to not get an undefined reference to LLVMFuzzerRunDriver
- use normal flags for projects built outside of libavif (dav1d with meson is problematic with sanitizer flags so let's minimize risks)