### PR TITLE
Build libyuv without sanitizer flags.

### DIFF
--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -43,14 +43,14 @@ export ORIG_CXXFLAGS="$CXXFLAGS"
 export CFLAGS=""
 export CXXFLAGS=""
 
-cd ext && bash dav1d.cmd && cd ..
+cd ext && bash dav1d.cmd && bash libyuv.cmd && cd ..
 
 export CFLAGS=$ORIG_CFLAGS
 export CXXFLAGS=$ORIG_CXXFLAGS
 
 # Prepare remaining dependencies.
 cd ext && bash aom.cmd && bash fuzztest.cmd && bash libjpeg.cmd && bash libsharpyuv.cmd &&
-      bash libyuv.cmd && bash zlibpng.cmd && cd ..
+      bash zlibpng.cmd && cd ..
 
 # build libavif
 mkdir build


### PR DESCRIPTION
This is actually needed to build fuzztest tests with ubsan. This is most likely due to the fact that it is not CMake and that flags are not propagated.