### PR TITLE
Add missing CHANGELOG.md entries (#1977)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * AVIF_ENABLE_WERROR is set to OFF by default.
+* Fix wrong alpha plane deallocation when decoded tile pixel format does not
+  match reconstructed output image pixel format.
+* Fix identical chunk skipping optimization when writing animation data.
+* Fix ID selection for artificial grid alpha item when decoding a grid of tiles
+  which each have an associated auxiliary alpha image item.
 
 ## [1.0.3] - 2023-12-03
 


### PR DESCRIPTION
for
https://github.com/AOMediaCodec/libavif/pull/1962
https://github.com/AOMediaCodec/libavif/pull/1966
https://github.com/AOMediaCodec/libavif/pull/1974

Cherry-pick of dcc0a15