### PR TITLE
Remove forced address sanitizer flags.

### DIFF
--- a/ext/fuzztest.cmd
+++ b/ext/fuzztest.cmd
@@ -12,6 +12,8 @@ cd fuzztest
 : # There is no tagged release as of 2024/01/26. Pick the earliest commit that fixes the
 : # undefined reference to LLVMFuzzerRunDriver when building ubsan tests.
 git checkout a53a2083e7df08749ea26b5960c05a9bffa186c2
+sed -i 's/-fsanitize=address//g' ./cmake/FuzzTestFlagSetup.cmake
+sed -i 's/-DADDRESS_SANITIZER//g' ./cmake/FuzzTestFlagSetup.cmake
 
 : # fuzztest is built by the main CMake project through add_subdirectory as recommended at:
 : # https://github.com/google/fuzztest/blob/main/doc/quickstart-cmake.md


### PR DESCRIPTION
This is a bug on the fuzztest CMake that will be fixed in parallel.
This get the check_build to work for ubsan:
```
python3 infra/helper.py check_build --sanitizer undefined libavif
```