### PR TITLE
Free reference when data is incomplete.

### DIFF
--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -99,10 +99,9 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
 
         int res = dav1d_get_picture(codec->internal->dav1dContext, &nextFrame);
         if (res == DAV1D_ERR(EAGAIN)) {
+            // No new data can be sent so stop here.
             if (dav1dData.data) {
-                // send more data
                 dav1d_data_unref(&dav1dData);
-                continue;
             }
             return AVIF_FALSE;
         } else if (res < 0) {

--- a/src/codec_dav1d.c
+++ b/src/codec_dav1d.c
@@ -101,6 +101,7 @@ static avifBool dav1dCodecGetNextImage(struct avifCodec * codec,
         if (res == DAV1D_ERR(EAGAIN)) {
             if (dav1dData.data) {
                 // send more data
+                dav1d_data_unref(&dav1dData);
                 continue;
             }
             return AVIF_FALSE;


### PR DESCRIPTION
That can be problematic if we decode 1 YUV tile, 2 alpha tiles and we are back to decoding 1 YUV tile.

This fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66313