### PR TITLE
Same size limit in read_image fuzzer as dec_incr

### DIFF
--- a/tests/gtest/avif_fuzztest_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_dec_incr.cc
@@ -61,11 +61,11 @@ void DecodeIncr(const std::string& arbitrary_bytes, bool is_persistent,
   DecoderPtr decoder(avifDecoderCreate());
   ASSERT_NE(decoder.get(), nullptr);
   avifDecoderSetIO(decoder.get(), &io);
-  // OSS-Fuzz limits the allocated memory to 2560 MB.
+  // OSS-Fuzz limits the allocated memory to 2560 MB. Consider 16-bit samples.
   // avifDecoderParse returns AVIF_RESULT_NOT_IMPLEMENTED if kImageSizeLimit is
   // bigger than AVIF_DEFAULT_IMAGE_SIZE_LIMIT.
   constexpr uint32_t kImageSizeLimit =
-      2560u * 512 * 512 / AVIF_MAX_AV1_LAYER_COUNT / sizeof(uint16_t);
+      2560u * 1024 * 1024 / AVIF_MAX_AV1_LAYER_COUNT / sizeof(uint16_t) / 4;
   static_assert(kImageSizeLimit <= AVIF_DEFAULT_IMAGE_SIZE_LIMIT,
                 "Too big an image size limit");
   decoder->imageSizeLimit = kImageSizeLimit;

--- a/tests/gtest/avif_fuzztest_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_dec_incr.cc
@@ -64,11 +64,11 @@ void DecodeIncr(const std::string& arbitrary_bytes, bool is_persistent,
   // OSS-Fuzz limits the allocated memory to 2560 MB.
   constexpr uint32_t kMaxMem = 2560u * 1024 * 1024;
   // Consider at most four planes of 16-bit samples.
-  constexpr uint32_t kMaxSampleMem =
+  constexpr uint32_t kMaxImageSize =
       kMaxMem / (AVIF_PLANE_COUNT_YUV + 1) / sizeof(uint16_t);
   // Reduce the limit further to include pixel buffer copies and other memory
   // allocations.
-  constexpr uint32_t kImageSizeLimit = kMaxSampleMem / 4;
+  constexpr uint32_t kImageSizeLimit = kMaxImageSize / 4;
   // avifDecoderParse returns AVIF_RESULT_NOT_IMPLEMENTED if kImageSizeLimit is
   // bigger than AVIF_DEFAULT_IMAGE_SIZE_LIMIT.
   static_assert(kImageSizeLimit <= AVIF_DEFAULT_IMAGE_SIZE_LIMIT,

--- a/tests/gtest/avif_fuzztest_read_image.cc
+++ b/tests/gtest/avif_fuzztest_read_image.cc
@@ -61,8 +61,10 @@ void ReadImageFile(const std::string& arbitrary_bytes,
   avif_image->matrixCoefficients = matrix_coefficients;
 
   // OSS-Fuzz limits the allocated memory to 2560 MB. Consider 16-bit samples.
+  // Reduce the limit further to include pixel buffer copies and other memory
+  // allocations.
   constexpr uint32_t kImageSizeLimit =
-      2560u * 1024 * 1024 / AVIF_MAX_AV1_LAYER_COUNT / sizeof(uint16_t);
+      2560u * 1024 * 1024 / AVIF_MAX_AV1_LAYER_COUNT / sizeof(uint16_t) / 4;
   // SharpYUV is computationally expensive. Avoid timeouts.
   const uint32_t imageSizeLimit =
       (chroma_downsampling == AVIF_CHROMA_DOWNSAMPLING_SHARP_YUV &&

--- a/tests/gtest/avif_fuzztest_read_image.cc
+++ b/tests/gtest/avif_fuzztest_read_image.cc
@@ -63,11 +63,11 @@ void ReadImageFile(const std::string& arbitrary_bytes,
   // OSS-Fuzz limits the allocated memory to 2560 MB.
   constexpr uint32_t kMaxMem = 2560u * 1024 * 1024;
   // Consider at most four planes of 16-bit samples.
-  constexpr uint32_t kMaxSampleMem =
+  constexpr uint32_t kMaxImageSize =
       kMaxMem / (AVIF_PLANE_COUNT_YUV + 1) / sizeof(uint16_t);
   // Reduce the limit further to include pixel buffer copies and other memory
   // allocations.
-  constexpr uint32_t kImageSizeLimit = kMaxSampleMem / 4;
+  constexpr uint32_t kImageSizeLimit = kMaxImageSize / 4;
   // SharpYUV is computationally expensive. Avoid timeouts.
   const uint32_t imageSizeLimit =
       (chroma_downsampling == AVIF_CHROMA_DOWNSAMPLING_SHARP_YUV &&


### PR DESCRIPTION
BUG=[oss-fuzz:66494](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66494)