### PR TITLE
Do not include stdint.h if inttypes.h is included

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -7,7 +7,6 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <math.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -5,7 +5,6 @@
 
 #include <assert.h>
 #include <inttypes.h>
-#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -4,7 +4,6 @@
 #include "avif/avif.h"
 
 #include <inttypes.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
inttypes.h is documented to include stdint.h, so we can depend on that.

https://en.wikibooks.org/wiki/C_Programming/inttypes.h
https://cplusplus.com/reference/cinttypes/
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/inttypes.h.html