### PR TITLE
Pass avifStrictFlags type to BitFlagCombinationOf

### DIFF
--- a/tests/gtest/avif_fuzztest_helpers.h
+++ b/tests/gtest/avif_fuzztest_helpers.h
@@ -153,9 +153,9 @@ inline auto ArbitraryBaseAvifDecoder() {
       /*image_dimension_limit=*/fuzztest::Just(kMaxDimension),
       /*image_count_limit=*/fuzztest::Just(10),
       /*strict_flags=*/
-      fuzztest::BitFlagCombinationOf({AVIF_STRICT_PIXI_REQUIRED,
-                                      AVIF_STRICT_CLAP_VALID,
-                                      AVIF_STRICT_ALPHA_ISPE_REQUIRED}));
+      fuzztest::BitFlagCombinationOf<avifStrictFlags>(
+          {AVIF_STRICT_PIXI_REQUIRED, AVIF_STRICT_CLAP_VALID,
+           AVIF_STRICT_ALPHA_ISPE_REQUIRED}));
 }
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)


### PR DESCRIPTION
If the type parameter is omitted, the fuzztest::BitFlagCombinationOf template infers the avifStrictFlag enum type from
AVIF_STRICT_PIXI_REQUIRED, AVIF_STRICT_CLAP_VALID, and AVIF_STRICT_ALPHA_ISPE_REQUIRED. The type of the combination of these bit flags should be avifStrictFlags (note the 's' at the end).

BUG=oss-fuzz:66414