### PR TITLE
Print unprintable item->type in diagnostic message

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -4,6 +4,7 @@
 #include "avif/internal.h"
 
 #include <assert.h>
+#include <ctype.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <math.h>
@@ -1421,7 +1422,22 @@ static avifResult avifDecoderGenerateImageGridTiles(avifDecoder * decoder, avifI
         // as errors.
         const avifCodecType tileCodecType = avifGetCodecType(item->type);
         if (tileCodecType == AVIF_CODEC_TYPE_UNKNOWN) {
-            avifDiagnosticsPrintf(&decoder->diag, "Tile item ID %u has an unknown item type '%.4s'", item->id, (const char *)item->type);
+            char type[4];
+            for (int j = 0; j < 4; j++) {
+                if (isprint((unsigned char)item->type[j])) {
+                    type[j] = item->type[j];
+                } else {
+                    type[j] = '.';
+                }
+            }
+            avifDiagnosticsPrintf(&decoder->diag,
+                                  "Tile item ID %u has an unknown item type '%.4s' (%02x%02x %02x%02x)",
+                                  item->id,
+                                  type,
+                                  item->type[0],
+                                  item->type[1],
+                                  item->type[2],
+                                  item->type[3]);
             return AVIF_RESULT_INVALID_IMAGE_GRID;
         }
 

--- a/src/read.c
+++ b/src/read.c
@@ -1431,7 +1431,7 @@ static avifResult avifDecoderGenerateImageGridTiles(avifDecoder * decoder, avifI
                 }
             }
             avifDiagnosticsPrintf(&decoder->diag,
-                                  "Tile item ID %u has an unknown item type '%.4s' (%02x%02x %02x%02x)",
+                                  "Tile item ID %u has an unknown item type '%.4s' (%02x%02x%02x%02x)",
                                   item->id,
                                   type,
                                   item->type[0],


### PR DESCRIPTION
In avifDecoderGenerateImageGridTiles(), replace unprintable characters in item->type with '.' and also print the hex values of item->type in parentheses.

For example, if item->type is four NUL characters ('\0'), avifdec prints the following diagnostic message:

Before:
  Diagnostics:
   * Tile item ID 5 has an unknown item type ''

After:
  Diagnostics:
   * Tile item ID 5 has an unknown item type '....' (0000 0000)