### PR TITLE
Fix .github/workflows/ci-windows-artifacts.yml

### DIFF
--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -6,7 +6,7 @@ on:
     types: [created]
 
 permissions:
-  contents: [read, write]
+  contents: write
 
 jobs:
   build-static:


### PR DESCRIPTION
`write` implies `read`, see https://github.com/orgs/community/discussions/26655.

If this workflow works, this patch should also be applied to the `main` branch.