### PR TITLE
Test the predefined macro _WIN32 instead of WIN32

### DIFF
--- a/tests/gtest/avif_fuzztest_helpers.cc
+++ b/tests/gtest/avif_fuzztest_helpers.cc
@@ -200,10 +200,10 @@ class Environment : public ::testing::Environment {
   Environment(const char* name, const char* value)
       : name_(name), value_(value) {}
   void SetUp() override {
-#ifdef WIN32
+#ifdef _WIN32
     _putenv_s(name_, value_);  // Defined in stdlib.h.
 #else
-    setenv(name_, value_, /*__replace=*/1);
+    setenv(name_, value_, /*overwrite=*/1);
 #endif
   }
 


### PR DESCRIPTION
Also correct the parameter name comment for the last parameter of setenv().