### PR TITLE
Fix EncoderPtr to DecoderPtr in fuzztest_helpers

### DIFF
--- a/tests/gtest/avif_fuzztest_helpers.h
+++ b/tests/gtest/avif_fuzztest_helpers.h
@@ -159,7 +159,7 @@ inline auto ArbitraryBaseAvifDecoder() {
 }
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-// Generator for an arbitrary EncoderPtr with base options and gain map
+// Generator for an arbitrary DecoderPtr with base options and gain map
 // options fuzzed, with the exception of 'ignoreColorAndAlpha' (because it would
 // break most tests' assumptions).
 inline auto ArbitraryAvifDecoderWithGainMapOptions() {


### PR DESCRIPTION
Similar to https://github.com/AOMediaCodec/libavif/pull/2019.