### PR TITLE
In sed scripts, match a dot "." with "\."

### DIFF
--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -54,13 +54,13 @@ if [ "$SANITIZER" == "memory" ]
 then
   export DAV1D_EXTRA_FLAGS="${DAV1D_EXTRA_FLAGS} -Denable_asm=false"
 fi
-sed -i 's/meson setup \(.*\) ../meson setup \1 '"${DAV1D_EXTRA_FLAGS}"' ../g' ./ext/dav1d.cmd
+sed -i 's/meson setup \(.*\) \.\./meson setup \1 '"${DAV1D_EXTRA_FLAGS}"' ../g' ./ext/dav1d.cmd
 
 # Build libaom with sanitizer flags.
 # Adds extra flags: -DAOM_TARGET_CPU=generic for msan.
 if [ "$SANITIZER" == "memory" ]
 then
-  sed -i 's/cmake \(.*\) ../cmake \1 -DAOM_TARGET_CPU=generic ../g' ./ext/aom.cmd
+  sed -i 's/cmake \(.*\) \.\./cmake \1 -DAOM_TARGET_CPU=generic ../g' ./ext/aom.cmd
 fi
 
 # Prepare remaining dependencies.


### PR DESCRIPTION
Otherwise, "." matches any character.