### PR TITLE
Build libyuv with fuzzer flags

### DIFF
--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -36,17 +36,6 @@
 #     avif_fuzztest_enc_dec_incr@EncodeDecodeAvifFuzzTest.EncodeDecodeGridValid \
 #     --sanitizer address
 
-# Reset compile flags to build libyuv without fuzzer flags.
-export ORIG_CFLAGS="$CFLAGS"
-export ORIG_CXXFLAGS="$CXXFLAGS"
-export CFLAGS=""
-export CXXFLAGS=""
-
-cd ext && bash libyuv.cmd && cd ..
-
-export CFLAGS=$ORIG_CFLAGS
-export CXXFLAGS=$ORIG_CXXFLAGS
-
 # Build dav1d with sanitizer flags.
 # Adds extra flags: -Db_sanitize=$SANITIZER -Db_lundef=false, and -Denable_asm=false for msan
 export DAV1D_EXTRA_FLAGS="-Db_sanitize=$SANITIZER -Db_lundef=false"
@@ -63,9 +52,9 @@ then
   sed -i 's/cmake \(.*\) ../cmake \1 -DAOM_TARGET_CPU=generic ../g' ./ext/aom.cmd
 fi
 
-# Prepare remaining dependencies.
+# Prepare dependencies.
 cd ext && bash aom.cmd && bash dav1d.cmd && bash fuzztest.cmd && bash libjpeg.cmd &&
-      bash libsharpyuv.cmd && bash zlibpng.cmd && cd ..
+      bash libsharpyuv.cmd && bash libyuv.cmd && bash zlibpng.cmd && cd ..
 
 # build libavif
 mkdir build


### PR DESCRIPTION
This fixes false positive MSan use-of-uninitialized-value warnings when libyuv functions are involved.

With this change, all dependencies are built with fuzzer flags.

BUG=oss-fuzz:66845
BUG=oss-fuzz:66846