### PR TITLE
Remove -Db_lundef=false from DAV1D_EXTRA_FLAGS

### DIFF
--- a/tests/oss-fuzz/build.sh
+++ b/tests/oss-fuzz/build.sh
@@ -37,10 +37,10 @@
 #     --sanitizer address
 
 # Build dav1d with sanitizer flags.
-# Adds extra flags: -Db_sanitize=$SANITIZER -Db_lundef=false, and -Denable_asm=false for msan
+# Adds extra flags: -Db_sanitize=$SANITIZER, and -Denable_asm=false for msan
 if [ "$SANITIZER" != "coverage" ] && [ "$SANITIZER" != "introspector" ]
 then
-  export DAV1D_EXTRA_FLAGS="-Db_sanitize=$SANITIZER -Db_lundef=false"
+  export DAV1D_EXTRA_FLAGS="-Db_sanitize=$SANITIZER"
 fi
 if [ "$SANITIZER" == "memory" ]
 then


### PR DESCRIPTION
The -Db_lundef=false flag does not seem necessary if we use the compilers specified in the oss-fuzz environment as the linkers.

This pull request depends on
https://github.com/AOMediaCodec/libavif/pull/2028.