### PR TITLE
Compile libaom and libyuv with clang-cl

### DIFF
--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ext
-        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}-releasedeps
+        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}-releasedeps-v2
     - name: Print cmake version
       run: cmake --version
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
@@ -38,6 +38,12 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./aom.cmd
+      # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
+      # AVX-512 instructions to be emitted in non-AVX-512 code. See
+      # https://github.com/AOMediaCodec/libavif/issues/2033#issuecomment-1960062751.
+      env:
+        CC: clang-cl
+        CXX: clang-cl
     - name: Build dav1d
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
@@ -45,19 +51,12 @@ jobs:
     - name: Build libyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
+      run: ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the
       # GCC inline assembly format. Visual C++ doesn't support GCC inline assembly.
-      # This is PowerShell syntax.
-      run: >
-        $Env:CC = 'clang-cl'
-
-        $Env:CXX = 'clang-cl'
-
-        ./libyuv.cmd
-
-        $Env:CC = ''
-
-        $Env:CXX = ''
+      env:
+        CC: clang-cl
+        CXX: clang-cl
     - name: Build libsharpyuv
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ext
-        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}-alldeps
+        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}-alldeps-v2
     - name: Print cmake version
       run: cmake --version
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
@@ -62,6 +62,12 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./aom.cmd
+      # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
+      # AVX-512 instructions to be emitted in non-AVX-512 code. See
+      # https://github.com/AOMediaCodec/libavif/issues/2033#issuecomment-1960062751.
+      env:
+        CC: clang-cl
+        CXX: clang-cl
     - name: Build dav1d
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
@@ -82,6 +88,11 @@ jobs:
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./libyuv.cmd
+      # Use clang-cl to build libyuv. The assembly code in libyuv is written in the
+      # GCC inline assembly format. Visual C++ doesn't support GCC inline assembly.
+      env:
+        CC: clang-cl
+        CXX: clang-cl
     - name: Build libjpeg
       if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext


### PR DESCRIPTION
The libaom change is temporary, until the Visual Studio 2022 bug is fixed.

The libyuv change is permanent.

Fix https://github.com/AOMediaCodec/libavif/issues/2033.