### PR TITLE
ext/dav1d.cmd: Add -Db_lundef=false to comments

### DIFF
--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ext
-        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}-releasedeps-v2
+        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}-releasedeps
     - name: Print cmake version
       run: cmake --version
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ext
-        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}-alldeps-v2
+        key: ${{ runner.os }}-${{ hashFiles('ext/*.cmd') }}-alldeps
     - name: Print cmake version
       run: cmake --version
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1

--- a/ext/dav1d.cmd
+++ b/ext/dav1d.cmd
@@ -16,8 +16,9 @@ mkdir build
 cd build
 
 : # macOS might require: -Dc_args=-fno-stack-check
-: # Build with asan: -Db_sanitize=address
-: # Build with ubsan: -Db_sanitize=undefined
+: # Build with asan: -Db_sanitize=address -Db_lundef=false
+: # Build with msan: -Db_sanitize=memory -Db_lundef=false -Denable_asm=false
+: # Build with ubsan: -Db_sanitize=undefined -Db_lundef=false
 meson setup --default-library=static --buildtype release -Denable_tools=false -Denable_tests=false ..
 ninja
 cd ../..


### PR DESCRIPTION
The need to use -Db_lundef=false with the sanitizers in Clang is documented in the following pages:
https://clang.llvm.org/docs/AddressSanitizer.html#usage
https://clang.llvm.org/docs/MemorySanitizer.html#usage

If -Db_sanitize=<sanitizer> is used without -Db_lundef=false and the compiler is Clang, meson emits a warning message like this:
  ../tests/meson.build:31: WARNING: Trying to use address sanitizer on
  Clang with b_lundef.
  This will probably not work.
  Try setting b_lundef to false instead.

Note: The change to ext/dav1d.cmd allows us to remove the "-v2" suffix (added in https://github.com/AOMediaCodec/libavif/pull/2034) from the cache file names.