### PR TITLE
Link aviftest/avifyuv with C++ compiler if libyuv

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ macro(register_test_for_coverage TEST_NAME)
 endmacro()
 
 add_executable(aviftest aviftest.c)
-if(AVIF_CODEC_LIBGAV1_ENABLED)
+if(AVIF_CODEC_LIBGAV1_ENABLED OR AVIF_LIBYUV_ENABLED)
     set_target_properties(aviftest PROPERTIES LINKER_LANGUAGE "CXX")
 endif()
 target_link_libraries(aviftest avif)
@@ -31,7 +31,7 @@ add_test(NAME aviftest COMMAND aviftest ${CMAKE_CURRENT_SOURCE_DIR}/data)
 register_test_for_coverage(aviftest ${CMAKE_CURRENT_SOURCE_DIR}/data/)
 
 add_executable(avifyuv avifyuv.c)
-if(AVIF_CODEC_LIBGAV1_ENABLED)
+if(AVIF_CODEC_LIBGAV1_ENABLED OR AVIF_LIBYUV_ENABLED)
     set_target_properties(avifyuv PROPERTIES LINKER_LANGUAGE "CXX")
 endif()
 


### PR DESCRIPTION
libyuv is a C++ library. If libyuv is used, especially as a static library, we need to link a C program such as aviftest.c and avifyuv.c with libyuv using the C++ compiler.

This addresses the issue described in
https://github.com/google/oss-fuzz/issues/713.