### PR TITLE
Rename imageSizeLimit to sizeLimit in avifJPEGRead

### DIFF
--- a/apps/shared/avifjpeg.h
+++ b/apps/shared/avifjpeg.h
@@ -11,7 +11,8 @@ extern "C" {
 #endif
 
 // Decodes the jpeg file at path 'inputFilename' into 'avif'.
-// At most imageSizeLimit pixels will be read or an error returned.
+// At most sizeLimit pixels will be read or an error returned. At most sizeLimit
+// bytes of Exif or XMP metadata will be read or an error returned.
 // 'ignoreGainMap' is only relevant for jpeg files that have a gain map
 // and only if AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION is ON
 // (requires AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP and libxml2). Otherwise
@@ -25,7 +26,7 @@ avifBool avifJPEGRead(const char * inputFilename,
                       avifBool ignoreExif,
                       avifBool ignoreXMP,
                       avifBool ignoreGainMap,
-                      uint32_t imageSizeLimit);
+                      uint32_t sizeLimit);
 avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int jpegQuality, avifChromaUpsampling chromaUpsampling);
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_JPEG_GAIN_MAP_CONVERSION)

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -321,6 +321,7 @@ avifAppFileFormat avifReadImage(const char * filename,
             *outDepth = image->depth;
         }
     } else if (format == AVIF_APP_FILE_FORMAT_JPEG) {
+        // imageSizeLimit is also used to limit Exif and XMP metadata here.
         if (!avifJPEGRead(filename, image, requestedFormat, requestedDepth, chromaDownsampling, ignoreColorProfile, ignoreExif, ignoreXMP, ignoreGainMap, imageSizeLimit)) {
             return AVIF_APP_FILE_FORMAT_UNKNOWN;
         }


### PR DESCRIPTION
Also add the `((uint64_t)standardXMPSize + totalExtendedXMPSize) > SIZE_MAX` check back in case `sizeLimit` changes.