### PR TITLE
Add note about buffer copy in avifDecoderRead()

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -5589,6 +5589,8 @@ avifResult avifDecoderRead(avifDecoder * decoder, avifImage * image)
     if (result != AVIF_RESULT_OK) {
         return result;
     }
+    // If decoder->image owns its planes, their ownership could be transferred here instead of copied,
+    // unless the user reuses the decoder instance, which is unknown yet.
     return avifImageCopy(image, decoder->image, AVIF_PLANES_ALL);
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -5589,8 +5589,12 @@ avifResult avifDecoderRead(avifDecoder * decoder, avifImage * image)
     if (result != AVIF_RESULT_OK) {
         return result;
     }
-    // If decoder->image owns its planes, their ownership could be transferred here instead of copied,
-    // unless the user reuses the decoder instance, which is unknown yet.
+    // If decoder->image->imageOwnsYUVPlanes and the decoder instance is not used after this call,
+    // the ownership of the samples in decoder->image could be transferred here instead of copied.
+    // However most codec_*.c implementations allocate the output buffer themselves and return a
+    // view, unless some postprocessing is applied (container-level grid reconstruction for
+    // example), so the first condition rarely holds.
+    // The second condition does not hold either: it is not required by the documentation in avif.h.
     return avifImageCopy(image, decoder->image, AVIF_PLANES_ALL);
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -5589,8 +5589,8 @@ avifResult avifDecoderRead(avifDecoder * decoder, avifImage * image)
     if (result != AVIF_RESULT_OK) {
         return result;
     }
-    // If decoder->image->imageOwnsYUVPlanes and the decoder instance is not used after this call,
-    // the ownership of the samples in decoder->image could be transferred here instead of copied.
+    // If decoder->image->imageOwnsYUVPlanes is true and decoder->image is not used after this call,
+    // the ownership of the planes in decoder->image could be transferred here instead of copied.
     // However most codec_*.c implementations allocate the output buffer themselves and return a
     // view, unless some postprocessing is applied (container-level grid reconstruction for
     // example), so the first condition rarely holds.


### PR DESCRIPTION
I think tiles are allocated by libavif and the buffers lent to the codecs.  
If not used afterwards, they could be moved instead of copied.

More of a question than a change request. Could be a `TODO: investigate`.