### PR TITLE
Fix -Wextra-semi-stmt

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -829,7 +829,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             int layerCount = encoder->extraLayerCount + 1;
             if (aom_codec_control(&codec->internal->encoder, AOME_SET_NUMBER_SPATIAL_LAYERS, layerCount) != AOM_CODEC_OK) {
                 return AVIF_RESULT_UNKNOWN_ERROR;
-            };
+            }
         }
         if (aomCpuUsed != -1) {
             if (aom_codec_control(&codec->internal->encoder, AOME_SET_CPUUSED, aomCpuUsed) != AOM_CODEC_OK) {

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -710,7 +710,7 @@ static avifResult avmCodecEncodeImage(avifCodec * codec,
             int layerCount = encoder->extraLayerCount + 1;
             if (aom_codec_control(&codec->internal->encoder, AOME_SET_NUMBER_SPATIAL_LAYERS, layerCount) != AOM_CODEC_OK) {
                 return AVIF_RESULT_UNKNOWN_ERROR;
-            };
+            }
         }
         if (aomCpuUsed != -1) {
             if (aom_codec_control(&codec->internal->encoder, AOME_SET_CPUUSED, aomCpuUsed) != AOM_CODEC_OK) {


### PR DESCRIPTION
`empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Werror,-Wextra-semi-stmt]`

We noticed this in our libsdl fork. Applies to v1.0.x branch as is, as well.
