### PR TITLE
avifMetaDestroy: check meta pointer before accessing

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -761,7 +761,7 @@ static avifMeta * avifMetaCreate()
 static void avifMetaDestroy(avifMeta * meta)
 {
     if (meta == NULL) {
-      return;
+        return;
     }
 
     for (uint32_t i = 0; i < meta->items.count; ++i) {

--- a/src/read.c
+++ b/src/read.c
@@ -760,7 +760,10 @@ static avifMeta * avifMetaCreate()
 
 static void avifMetaDestroy(avifMeta * meta)
 {
-    if (meta == NULL) return;
+    if (meta == NULL) {
+      return;
+    }
+
     for (uint32_t i = 0; i < meta->items.count; ++i) {
         avifDecoderItem * item = meta->items.item[i];
         avifArrayDestroy(&item->properties);

--- a/src/read.c
+++ b/src/read.c
@@ -760,10 +760,6 @@ static avifMeta * avifMetaCreate()
 
 static void avifMetaDestroy(avifMeta * meta)
 {
-    if (meta == NULL) {
-        return;
-    }
-
     for (uint32_t i = 0; i < meta->items.count; ++i) {
         avifDecoderItem * item = meta->items.item[i];
         avifArrayDestroy(&item->properties);
@@ -997,7 +993,9 @@ static void avifDecoderDataClearTiles(avifDecoderData * data)
 
 static void avifDecoderDataDestroy(avifDecoderData * data)
 {
-    avifMetaDestroy(data->meta);
+    if (data->meta) {
+        avifMetaDestroy(data->meta);
+    }
     for (uint32_t i = 0; i < data->tracks.count; ++i) {
         avifTrack * track = &data->tracks.track[i];
         if (track->sampleTable) {

--- a/src/read.c
+++ b/src/read.c
@@ -760,6 +760,7 @@ static avifMeta * avifMetaCreate()
 
 static void avifMetaDestroy(avifMeta * meta)
 {
+    if (meta == NULL) return;
     for (uint32_t i = 0; i < meta->items.count; ++i) {
         avifDecoderItem * item = meta->items.item[i];
         avifArrayDestroy(&item->properties);


### PR DESCRIPTION
fixes a NULL dereference should avifMetaCreate() fail and
avifDecoderDataDestroy() is called to clean up.

Found by Nallocfuzz (https://github.com/catenacyber/nallocfuzz).
