### PR TITLE
Pass -f to rm in cleanup handlers

### DIFF
--- a/tests/test_cmd_animation.sh
+++ b/tests/test_cmd_animation.sh
@@ -47,7 +47,7 @@ ERROR_MSG="avif_test_cmd_animation_error_msg.txt"
 
 cleanup() {
   pushd ${TMP_DIR}
-    rm -- "${ENCODED_FILE}" "${DECODED_FILE}" "${ERROR_MSG}"
+    rm -f -- "${ENCODED_FILE}" "${DECODED_FILE}" "${ERROR_MSG}"
   popd
 }
 trap cleanup EXIT

--- a/tests/test_cmd_grid.sh
+++ b/tests/test_cmd_grid.sh
@@ -54,9 +54,9 @@ DECODED_FILE_7x5="avif_test_cmd_grid_7x5_decoded.png"
 # Cleanup
 cleanup() {
   pushd ${TMP_DIR}
-    rm -- "${ENCODED_FILE}" "${DECODED_FILE}" \
-          "${ENCODED_FILE_2x2}" "${DECODED_FILE_2x2}" \
-          "${ENCODED_FILE_7x5}" "${DECODED_FILE_7x5}"
+    rm -f -- "${ENCODED_FILE}" "${DECODED_FILE}" \
+             "${ENCODED_FILE_2x2}" "${DECODED_FILE_2x2}" \
+             "${ENCODED_FILE_7x5}" "${DECODED_FILE_7x5}"
   popd
 }
 trap cleanup EXIT

--- a/tests/test_cmd_icc_profile.sh
+++ b/tests/test_cmd_icc_profile.sh
@@ -55,7 +55,7 @@ CORRECTED_FILE="avif_test_cmd_icc_profile_corrected.png"
 # Cleanup
 cleanup() {
   pushd ${TMP_DIR}
-    rm -- "${ENCODED_FILE}" "${DECODED_FILE}" "${CORRECTED_FILE}"
+    rm -f -- "${ENCODED_FILE}" "${DECODED_FILE}" "${CORRECTED_FILE}"
   popd
 }
 trap cleanup EXIT

--- a/tests/test_cmd_lossless.sh
+++ b/tests/test_cmd_lossless.sh
@@ -52,7 +52,7 @@ DECODED_FILE_LOSSLESS="avif_test_cmd_lossless_decoded_lossless.png"
 # Cleanup
 cleanup() {
   pushd ${TMP_DIR}
-    rm -- "${ENCODED_FILE}" "${DECODED_FILE}" "${DECODED_FILE_LOSSLESS}"
+    rm -f -- "${ENCODED_FILE}" "${DECODED_FILE}" "${DECODED_FILE_LOSSLESS}"
   popd
 }
 trap cleanup EXIT

--- a/tests/test_cmd_metadata.sh
+++ b/tests/test_cmd_metadata.sh
@@ -54,8 +54,9 @@ DECODED_FILE_CHANGED_ICC="avif_test_cmd_metadata_decoded_changed_icc.png"
 # Cleanup
 cleanup() {
   pushd ${TMP_DIR}
-    rm -- "${ENCODED_FILE}" "${ENCODED_FILE_NO_METADATA}" "${ENCODED_FILE_MORE_METADATA}" \
-          "${DECODED_FILE}" "${DECODED_FILE_CHANGED_ICC}"
+    rm -f -- "${ENCODED_FILE}" "${ENCODED_FILE_NO_METADATA}" \
+             "${ENCODED_FILE_MORE_METADATA}" \
+             "${DECODED_FILE}" "${DECODED_FILE_CHANGED_ICC}"
   popd
 }
 trap cleanup EXIT

--- a/tests/test_cmd_targetsize.sh
+++ b/tests/test_cmd_targetsize.sh
@@ -49,7 +49,8 @@ DECODED_BIGGEST_FILE="avif_test_cmd_targetsize_decoded_biggest.png"
 # Cleanup
 cleanup() {
   pushd ${TMP_DIR}
-    rm -- "${ENCODED_FILE}" "${DECODED_SMALLEST_FILE}" "${DECODED_BIGGEST_FILE}"
+    rm -f -- "${ENCODED_FILE}" "${DECODED_SMALLEST_FILE}" \
+             "${DECODED_BIGGEST_FILE}"
   popd
 }
 trap cleanup EXIT


### PR DESCRIPTION
When a test fails, some of the files the cleanup handler needs to remove may not have been created, so pass -f to rm to ignore nonexistent files.