### PR TITLE
Do not use env:NUMBER_OF_PROCESSORS for MinGW

### DIFF
--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -82,4 +82,4 @@ jobs:
       run: ninja
     - name: Run AVIF Tests
       working-directory: ./build
-      run: ctest -j $Env:NUMBER_OF_PROCESSORS --output-on-failure
+      run: ctest -j --output-on-failure


### PR DESCRIPTION
Since CMake 3.29 (which is on MingW), we can omit the parameter. https://cmake.org/cmake/help/latest/manual/ctest.1.html "Otherwise, if the value is omitted, parallelism is limited by the number of processors, or 2, whichever is larger."