### PR TITLE
Fix avifParseItemLocationBox() itemReferenceIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ The changes are relative to the previous release, unless the baseline is specifi
   (https://crbug.com/oss-fuzz/65657).
 * ext/libjpeg.cmd now pulls libjpeg-turbo instead of libjpeg and AVIF_JPEG=LOCAL
   now expects the library dependency in ext/libjpeg-turbo/build.libavif.
+* Fix 'iloc' box parsing bugs that may have wrongly accepted, rejected or parsed
+  some files with rare values of offset_size, length_size, base_offset_size and 
+  index_size.
 
 ## [1.0.4] - 2024-02-08
 


### PR DESCRIPTION
Revert bug introduced with StreamReadBits(): https://github.com/AOMediaCodec/libavif/pull/1506/files#diff-d4b71621e3fb7422ad72c18339089f9626a0c48a95d4b71483bb18351bcd58c4
Read item_reference_index even if construction_method!=2 to be accurate with the ISOBMFF specification.