### PR TITLE
android_jni: Allow loading dav1d as a separate shared object

### DIFF
--- a/android_jni/avifandroidjni/src/main/java/org/aomedia/avif/android/AvifDecoder.java
+++ b/android_jni/avifandroidjni/src/main/java/org/aomedia/avif/android/AvifDecoder.java
@@ -37,6 +37,12 @@ import java.nio.ByteBuffer;
 @SuppressWarnings("CatchAndPrintStackTrace")
 public class AvifDecoder {
   static {
+    // If dav1d is built as a separate shared object, try loading that first.
+    try {
+      System.loadLibrary("dav1d");
+    } catch (UnsatisfiedLinkError exception) {
+      // This is not an error. Do nothing.
+    }
     try {
       System.loadLibrary("avif_android");
     } catch (UnsatisfiedLinkError exception) {


### PR DESCRIPTION
Try loading libdav1d.so as a separate shared object. This allows
apps to share dav1d between video and AVIF decoding without having
to bundle it within libavif_android.so to reduce the APK size.
