### PR TITLE
Revert "android_jni: Allow loading dav1d as a separate shared object"

### DIFF
--- a/android_jni/avifandroidjni/src/main/java/org/aomedia/avif/android/AvifDecoder.java
+++ b/android_jni/avifandroidjni/src/main/java/org/aomedia/avif/android/AvifDecoder.java
@@ -37,12 +37,6 @@ import java.nio.ByteBuffer;
 @SuppressWarnings("CatchAndPrintStackTrace")
 public class AvifDecoder {
   static {
-    // If dav1d is built as a separate shared object, try loading that first.
-    try {
-      System.loadLibrary("dav1d");
-    } catch (UnsatisfiedLinkError exception) {
-      // This is not an error. Do nothing.
-    }
     try {
       System.loadLibrary("avif_android");
     } catch (UnsatisfiedLinkError exception) {


### PR DESCRIPTION
This reverts commit cdddec07209243c8398717ba3e701ac79ad6d6f4.

This change was a bit premature and not necessary.
