### PR TITLE
Rename avifSampleTransformExpressionIsValid() arg

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -202,7 +202,7 @@ typedef struct avifSampleTransformToken
 } avifSampleTransformToken;
 
 AVIF_ARRAY_DECLARE(avifSampleTransformExpression, avifSampleTransformToken, tokens);
-avifBool avifSampleTransformExpressionIsValid(const avifSampleTransformExpression * expression, uint32_t numInputImageItems);
+avifBool avifSampleTransformExpressionIsValid(const avifSampleTransformExpression * tokens, uint32_t numInputImageItems);
 avifBool avifSampleTransformExpressionIsEquivalentTo(const avifSampleTransformExpression * a, const avifSampleTransformExpression * b);
 
 avifResult avifSampleTransformRecipeToExpression(avifSampleTransformRecipe recipe, avifSampleTransformExpression * expression);

--- a/tests/gtest/avifsampletransformtest.cc
+++ b/tests/gtest/avifsampletransformtest.cc
@@ -144,16 +144,6 @@ struct Op {
 
 class SampleTransformOperationTest : public testing::TestWithParam<Op> {};
 
-ImagePtr OneByOne(uint32_t depth) {
-  ImagePtr image(avifImageCreate(/*width=*/1, /*height=*/1, depth,
-                                 AVIF_PIXEL_FORMAT_YUV444));
-  if (image.get() != nullptr &&
-      avifImageAllocatePlanes(image.get(), AVIF_PLANES_YUV) == AVIF_RESULT_OK) {
-    return image;
-  }
-  return nullptr;
-}
-
 TEST_P(SampleTransformOperationTest, Apply) {
   AvifExpression expression;
   // Postfix notation.


### PR DESCRIPTION
Also remove unused function in avifsampletransformtest.