### PR TITLE
Limit the CI jobs running on pull_request.

### DIFF
--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -5,7 +5,13 @@
 #   * Disables gtest.
 
 name: CI Disable GTest
-on: [push, pull_request]
+on:
+  push
+  pull_request:
+    paths:
+      - '**CMakeLists.txt**'
+      - 'cmake/**'
+      - 'ext/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -6,7 +6,7 @@
 
 name: CI Disable GTest
 on:
-  push
+  push:
   pull_request:
     paths:
       - '**CMakeLists.txt'

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -9,7 +9,7 @@ on:
   push
   pull_request:
     paths:
-      - '**CMakeLists.txt**'
+      - '**CMakeLists.txt'
       - 'cmake/**'
       - 'ext/**'
 

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -1,8 +1,9 @@
 name: CI Unix Static For AVIF_LOCAL
+on:
   push
   pull_request:
     paths:
-      - '**CMakeLists.txt**'
+      - '**CMakeLists.txt'
       - 'cmake/**'
       - 'ext/**'
 

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -1,5 +1,10 @@
 name: CI Unix Static For AVIF_LOCAL
-on: [push, pull_request]
+  push
+  pull_request:
+    paths:
+      - '**CMakeLists.txt**'
+      - 'cmake/**'
+      - 'ext/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -1,6 +1,6 @@
 name: CI Unix Static For AVIF_LOCAL
 on:
-  push
+  push:
   pull_request:
     paths:
       - '**CMakeLists.txt'

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -1,5 +1,10 @@
 name: CI Unix Static AV2
-on: [push, pull_request]
+  push
+  pull_request:
+    paths:
+      - '**CMakeLists.txt**'
+      - 'cmake/**'
+      - 'ext/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -1,8 +1,9 @@
 name: CI Unix Static AV2
+on:
   push
   pull_request:
     paths:
-      - '**CMakeLists.txt**'
+      - '**CMakeLists.txt'
       - 'cmake/**'
       - 'ext/**'
 

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -1,6 +1,6 @@
 name: CI Unix Static AV2
 on:
-  push
+  push:
   pull_request:
     paths:
       - '**CMakeLists.txt'

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -1,8 +1,9 @@
 name: CI Unix Static Sanitized
+on:
   push
   pull_request:
     paths:
-      - '**CMakeLists.txt**'
+      - '**CMakeLists.txt'
       - 'cmake/**'
       - 'ext/**'
 

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -1,5 +1,10 @@
 name: CI Unix Static Sanitized
-on: [ push, pull_request ]
+  push
+  pull_request:
+    paths:
+      - '**CMakeLists.txt**'
+      - 'cmake/**'
+      - 'ext/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -1,6 +1,6 @@
 name: CI Unix Static Sanitized
 on:
-  push
+  push:
   pull_request:
     paths:
       - '**CMakeLists.txt'

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -1,6 +1,6 @@
 name: CI Unix Static
 on:
-  push
+  push:
   pull_request:
     paths:
       - '**CMakeLists.txt'

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -1,5 +1,10 @@
 name: CI Unix Static
-on: [push, pull_request]
+  push
+  pull_request:
+    paths:
+      - '**CMakeLists.txt**'
+      - 'cmake/**'
+      - 'ext/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -1,8 +1,9 @@
 name: CI Unix Static
+on:
   push
   pull_request:
     paths:
-      - '**CMakeLists.txt**'
+      - '**CMakeLists.txt'
       - 'cmake/**'
       - 'ext/**'
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -11,7 +11,12 @@
 #   * Builds with local zlib and libpng (-DAVIF_ZLIBPNG=LOCAL).
 
 name: CI Windows
-on: [push, pull_request]
+  push
+  pull_request:
+    paths:
+      - '**CMakeLists.txt**'
+      - 'cmake/**'
+      - 'ext/**'
 
 permissions:
   contents: read
@@ -22,7 +27,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build-static:
+  build-windows:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,7 +12,7 @@
 
 name: CI Windows
 on:
-  push
+  push:
   pull_request:
     paths:
       - '**CMakeLists.txt'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -11,10 +11,11 @@
 #   * Builds with local zlib and libpng (-DAVIF_ZLIBPNG=LOCAL).
 
 name: CI Windows
+on:
   push
   pull_request:
     paths:
-      - '**CMakeLists.txt**'
+      - '**CMakeLists.txt'
       - 'cmake/**'
       - 'ext/**'
 

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,6 @@
 name: CI Fuzz
 on:
+  push
   pull_request:
     paths:
       - 'cmake/**'

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,6 +1,6 @@
 name: CI Fuzz
 on:
-  push
+  push:
   pull_request:
     paths:
       - 'cmake/**'

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -4,8 +4,6 @@ on:
     paths:
       - 'cmake/**'
       - 'ext/**'
-      - 'include/**'
-      - 'src/**'
       - 'tests/gtest/**'
       - 'tests/oss-fuzz/**'
 


### PR DESCRIPTION
Only trigger the ones recompiling dependencies locally when ./ext or CMake is changed.
This effectively prunes all the jobs taking more than 5 minutes.