### PR TITLE
Add option parsing for rav1e and SVT-AV1.

### DIFF
--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -88,11 +88,6 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
     RaFrame * rav1eFrame = NULL;
 
     if (!codec->internal->rav1eContext) {
-        if (codec->csOptions->count > 0) {
-            // None are currently supported!
-            return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
-        }
-
         const avifBool supports400 = rav1eSupports400();
         RaPixelRange rav1eRange;
         if (alpha) {
@@ -180,6 +175,13 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
             // "key_frame_interval" is the maximum interval between two keyframes.
             if (rav1e_config_parse_int(rav1eConfig, "key_frame_interval", encoder->keyframeInterval) == -1) {
                 goto cleanup;
+            }
+        }
+        for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
+            avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
+            if (rav1e_config_parse(rav1eConfig, entry->key, entry->value) < 0) {
+                avifDiagnosticsPrintf(codec->diag, "Invalid value for %s: %s.", entry->key, entry->value);
+                return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
             }
         }
 

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -181,7 +181,8 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
             avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
             if (rav1e_config_parse(rav1eConfig, entry->key, entry->value) < 0) {
                 avifDiagnosticsPrintf(codec->diag, "Invalid value for %s: %s.", entry->key, entry->value);
-                return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
+                result = AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
+                goto cleanup;
             }
         }
 

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -197,7 +197,6 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
 #else
         if (codec->csOptions->count > 0) {
             avifDiagnosticsPrintf(codec->diag, "SVT-AV1 does not support setting options");
-            // None are currently supported!
             result = AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
             goto cleanup;
         }

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -190,14 +190,16 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
             avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
             if (svt_av1_enc_parse_parameter(svt_config, entry->key, entry->value) < 0) {
                 avifDiagnosticsPrintf(codec->diag, "Invalid value for %s: %s.", entry->key, entry->value);
-                return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
+                result = AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
+                goto cleanup;
             }
         }
 #else
         if (codec->csOptions->count > 0) {
             avifDiagnosticsPrintf(codec->diag, "SVT-AV1 does not support setting options");
             // None are currently supported!
-            return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
+            result = AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
+            goto cleanup;
         }
 #endif
 

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -185,6 +185,22 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
             svt_config->intra_period_length = encoder->keyframeInterval - 1;
         }
 
+#if SVT_AV1_CHECK_VERSION(0, 9, 1)
+        for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
+            avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
+            if (svt_av1_enc_parse_parameter(svt_config, entry->key, entry->value) < 0) {
+                avifDiagnosticsPrintf(codec->diag, "Invalid value for %s: %s.", entry->key, entry->value);
+                return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
+            }
+        }
+#else
+        if (codec->csOptions->count > 0) {
+            avifDiagnosticsPrintf(codec->diag, "SVT-AV1 does not support setting options");
+            // None are currently supported!
+            return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
+        }
+#endif
+
         res = svt_av1_enc_set_parameter(codec->internal->svt_encoder, svt_config);
         if (res == EB_ErrorBadParameter) {
             goto cleanup;

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -66,6 +66,16 @@ cleanup() {
 trap cleanup EXIT
 
 pushd ${TMP_DIR}
+  # Test options.
+  echo "Testing options"
+  for pair in aom,end-usage,cbr avm,end-usage,cbr rav1e,tiles,1 svt,film-grain,0; do
+    IFS=','; set -- $pair
+    if "${AVIFENC}" --help | grep $1' \['; then
+      "${AVIFENC}" -s 10 -q 85 -c $1 -a foo=1 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}" && exit 1
+      "${AVIFENC}" -s 10 -q 85 -c $1 -a $2=$3 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
+    fi
+  done
+
   # Lossy test. The decoded pixels should be different from the original image.
   echo "Testing basic lossy"
   "${AVIFENC}" -s 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}"


### PR DESCRIPTION
This fixes https://github.com/AOMediaCodec/libavif/issues/2108

Documenting the options seems tedious: rav1e has like 15 (cf usr/include/rav1e/rav1e.h), SVT-AV1, a lot more: https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Source/Lib/Encoder/Globals/EbEncSettings.c?ref_type=heads#L1925)