### PR TITLE
Handle unknown top level boxes with size == 0

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3995,6 +3995,10 @@ static avifResult avifParse(avifDecoder * decoder)
             }
         } else if (header.size > (UINT64_MAX - parseOffset)) {
             return AVIF_RESULT_BMFF_PARSE_FAILED;
+        } else if (header.size == 0) {
+            // An unknown top level box with size 0 was found. If we reach here it means we haven't completed parsing successfully
+            // since there are no futher boxes left.
+            return AVIF_RESULT_TRUNCATED_DATA;
         }
         parseOffset += header.size;
 


### PR DESCRIPTION
In avifParse() right now we skip over unknown top level boxes with
size == 0 incorrectly.

The correct behavior is to simply fail on them because if we reach
that point it means that:
1) there are no more boxes left to parse (since the current unknown
   box goes on until the end of stream).
2) we haven't found all the necessary boxes for the parsing to be
   considered a succeess (either ftyp or moov or meta was not yet
   seen).
