### PR TITLE
read.c: Return BMFF_PARSE_FAILED on unknown top level size 0 box

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3998,7 +3998,7 @@ static avifResult avifParse(avifDecoder * decoder)
         } else if (header.size == 0) {
             // An unknown top level box with size 0 was found. If we reach here it means we haven't completed parsing successfully
             // since there are no further boxes left.
-            return AVIF_RESULT_TRUNCATED_DATA;
+            return AVIF_RESULT_BMFF_PARSE_FAILED;
         }
         parseOffset += header.size;
 

--- a/tests/gtest/avifsize0test.cc
+++ b/tests/gtest/avifsize0test.cc
@@ -109,7 +109,7 @@ TEST(AvifDecodeTest, UnknownTopLevelBoxSize0) {
   ASSERT_EQ(
       avifDecoderSetIOMemory(decoder.get(), avif_edited.data, avif_edited.size),
       AVIF_RESULT_OK);
-  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_TRUNCATED_DATA);
+  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_BMFF_PARSE_FAILED);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Do not return TRUNCATED_DATA In that case since all the other
similar error paths in that function return BMFF_PARSE_FAILED.

Also, in some cases TRUNCATED_DATA could be considered a
recoverable error but in this case it is not.
