### PR TITLE
read.c: Use header size when parsing VisualSampleEntry

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3259,8 +3259,12 @@ static avifResult avifParseSampleDescriptionBox(avifSampleTable * sampleTable,
             return AVIF_RESULT_OUT_OF_MEMORY;
         }
         memcpy(description->format, sampleEntryHeader.type, sizeof(description->format));
-        size_t remainingBytes = avifROStreamRemainingBytes(&s);
-        if ((avifGetCodecType(description->format) != AVIF_CODEC_TYPE_UNKNOWN) && (remainingBytes > VISUALSAMPLEENTRY_SIZE)) {
+        size_t remainingBytes = sampleEntryHeader.size;
+        if ((avifGetCodecType(description->format) != AVIF_CODEC_TYPE_UNKNOWN)) {
+            if (remainingBytes < VISUALSAMPLEENTRY_SIZE) {
+                avifDiagnosticsPrintf(diag, "Not enough bytes to parse VisualSampleEntry");
+                return AVIF_RESULT_BMFF_PARSE_FAILED;
+            }
             AVIF_CHECKRES(avifParseItemPropertyContainerBox(&description->properties,
                                                             rawOffset + avifROStreamOffset(&s) + VISUALSAMPLEENTRY_SIZE,
                                                             avifROStreamCurrent(&s) + VISUALSAMPLEENTRY_SIZE,


### PR DESCRIPTION
The current code uses avifROStreamRemainingBytes which is not
correct. We are inside a for loop where each loop is a box with
a fixed header size. So within each loop, we should not parse
more than that loop's header size.

Also return an error if there aren't enough bytes to parse
VisualSampleEntry.
