### PR TITLE
Further cleanup in avifParseSampleDescriptionBox()

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3259,7 +3259,7 @@ static avifResult avifParseSampleDescriptionBox(avifSampleTable * sampleTable,
             return AVIF_RESULT_OUT_OF_MEMORY;
         }
         memcpy(description->format, sampleEntryHeader.type, sizeof(description->format));
-        size_t sampleEntryBytes = sampleEntryHeader.size;
+        const size_t sampleEntryBytes = sampleEntryHeader.size;
         if (avifGetCodecType(description->format) != AVIF_CODEC_TYPE_UNKNOWN) {
             if (sampleEntryBytes < VISUALSAMPLEENTRY_SIZE) {
                 avifDiagnosticsPrintf(diag, "Not enough bytes to parse VisualSampleEntry");

--- a/src/read.c
+++ b/src/read.c
@@ -3259,20 +3259,20 @@ static avifResult avifParseSampleDescriptionBox(avifSampleTable * sampleTable,
             return AVIF_RESULT_OUT_OF_MEMORY;
         }
         memcpy(description->format, sampleEntryHeader.type, sizeof(description->format));
-        size_t remainingBytes = sampleEntryHeader.size;
-        if ((avifGetCodecType(description->format) != AVIF_CODEC_TYPE_UNKNOWN)) {
-            if (remainingBytes < VISUALSAMPLEENTRY_SIZE) {
+        size_t sampleEntryBytes = sampleEntryHeader.size;
+        if (avifGetCodecType(description->format) != AVIF_CODEC_TYPE_UNKNOWN) {
+            if (sampleEntryBytes < VISUALSAMPLEENTRY_SIZE) {
                 avifDiagnosticsPrintf(diag, "Not enough bytes to parse VisualSampleEntry");
                 return AVIF_RESULT_BMFF_PARSE_FAILED;
             }
             AVIF_CHECKRES(avifParseItemPropertyContainerBox(&description->properties,
                                                             rawOffset + avifROStreamOffset(&s) + VISUALSAMPLEENTRY_SIZE,
                                                             avifROStreamCurrent(&s) + VISUALSAMPLEENTRY_SIZE,
-                                                            remainingBytes - VISUALSAMPLEENTRY_SIZE,
+                                                            sampleEntryBytes - VISUALSAMPLEENTRY_SIZE,
                                                             diag));
         }
 
-        AVIF_CHECKERR(avifROStreamSkip(&s, sampleEntryHeader.size), AVIF_RESULT_BMFF_PARSE_FAILED);
+        AVIF_CHECKERR(avifROStreamSkip(&s, sampleEntryBytes), AVIF_RESULT_BMFF_PARSE_FAILED);
     }
     return AVIF_RESULT_OK;
 }


### PR DESCRIPTION
Rename the `remainingBytes` variable as `sampleEntryBytes`. The `remainingBytes` name made sense when the variable stored the return value of avifROStreamRemainingBytes(&s). The variable now stores the value of sampleEntryHeader.size, so the name `sampleEntryBytes` is more appropriate.

Remove an extraneous pair of parentheses around a conditional expression.

Replace an instance of sampleEntryHeader.size with `sampleEntryBytes`.