### PR TITLE
obu: Handle size == 0 in avifBitsInit

### DIFF
--- a/src/obu.c
+++ b/src/obu.c
@@ -66,7 +66,7 @@ static void avifBitsInit(avifBits * const bits, const uint8_t * const data, cons
     bits->bitsLeft = 0;
     bits->state = 0;
     bits->error = 0;
-    bits->eof = 0;
+    bits->eof = (size == 0);
 }
 
 static void avifBitsRefill(avifBits * const bits, const uint32_t n)


### PR DESCRIPTION
If size == 0, eof has to be set to 1 in avifBitsInit for the
rest of the code to work as intended. Otherwise the first byte
is read unconditionally which is incorrect.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68568
