### PR TITLE
Add AVIF_CHROMA_SAMPLE_POSITION_RESERVED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Add avifdec --icc flag to override the output color profile.
 * Add experimental API for reading and writing 16-bit AVIF files behind the
   compilation flag AVIF_ENABLE_EXPERIMENTAL_SAMPLE_TRANSFORM.
+* Add AVIF_CHROMA_SAMPLE_POSITION_RESERVED to avifChromaSamplePosition enum.
 
 ### Changed since 1.0.0
 * Update aom.cmd: v3.9.0

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -297,7 +297,8 @@ typedef enum avifChromaSamplePosition
 {
     AVIF_CHROMA_SAMPLE_POSITION_UNKNOWN = 0,
     AVIF_CHROMA_SAMPLE_POSITION_VERTICAL = 1,
-    AVIF_CHROMA_SAMPLE_POSITION_COLOCATED = 2
+    AVIF_CHROMA_SAMPLE_POSITION_COLOCATED = 2,
+    AVIF_CHROMA_SAMPLE_POSITION_RESERVED = 3
 } avifChromaSamplePosition;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Value 3 is allowed and considered to be reserved according to the
AV1 spec.