### PR TITLE
Fix size 0 handling in avifParse()

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -647,6 +647,11 @@ typedef size_t avifBoxMarker;
 
 typedef struct avifBoxHeader
 {
+    // If set to AVIF_TRUE, it means that the box goes on until the end of the
+    // stream. So, |size| must be set to the number of bytes left in the input
+    // stream. If set to AVIF_FALSE, |size| indicates the size of the box in
+    // bytes, excluding the box header.
+    avifBool isSizeZeroBox;
     // Size of the box in bytes, excluding the box header.
     size_t size;
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -278,6 +278,7 @@ avifBool avifROStreamReadBoxHeaderPartial(avifROStream * stream, avifBoxHeader *
         // Otherwise size could be set to avifROStreamRemainingBytes(stream) + (stream->offset - startOffset) right now.
 
         // Wait for avifIOReadFunc() to return AVIF_RESULT_OK.
+        header->isSizeZeroBox = AVIF_TRUE;
         header->size = 0;
         return AVIF_TRUE;
     }
@@ -286,6 +287,7 @@ avifBool avifROStreamReadBoxHeaderPartial(avifROStream * stream, avifBoxHeader *
         avifDiagnosticsPrintf(stream->diag, "%s: Header size overflow check failure", stream->diagContext);
         return AVIF_FALSE;
     }
+    header->isSizeZeroBox = AVIF_FALSE;
     header->size = (size_t)(size - bytesRead);
     return AVIF_TRUE;
 }


### PR DESCRIPTION
header.size in avifParse is not the raw value that is found in
the input stream. It is calculated in avifROStreamReadBoxHeaderPartial.

So when handling size == 0 in avifParse(), we cannot use header.size
since it may be 0 in legit cases (where the box itself is empty).

This PR adds a new member to avifBoxHeader which stores the actual
raw size found in the input stream and uses that in avifParse().

Also handle the isSizeZeroBox in avifPeekCompatibleFileType.