### PR TITLE
GetSeedDataDirs: allow TEST_DATA_DIRS to be -D defined

### DIFF
--- a/tests/gtest/avif_fuzztest_helpers.cc
+++ b/tests/gtest/avif_fuzztest_helpers.cc
@@ -187,11 +187,13 @@ class Environment : public ::testing::Environment {
 
 //------------------------------------------------------------------------------
 
+#ifdef TEST_DATA_DIRS
 // Helper macros to ensure TEST_DATA_DIRS is a quoted string.
-// NOTE: TEST_DATA_DIRS MUST NOT be a quoted string before stringification
+// NOTE: TEST_DATA_DIRS must NOT be a quoted string before stringification
 // otherwise it will be quoted twice, resulting in the use of an incorrect path.
 #define AVIF_TO_STRING(S) #S
 #define AVIF_STRINGIFY(S) AVIF_TO_STRING(S)
+#endif
 
 std::vector<std::string> GetSeedDataDirs() {
   const char* var = std::getenv("TEST_DATA_DIRS");

--- a/tests/gtest/avif_fuzztest_helpers.cc
+++ b/tests/gtest/avif_fuzztest_helpers.cc
@@ -187,9 +187,20 @@ class Environment : public ::testing::Environment {
 
 //------------------------------------------------------------------------------
 
+// Helper macros to ensure TEST_DATA_DIRS is a quoted string.
+// NOTE: TEST_DATA_DIRS MUST NOT be a quoted string before stringification
+// otherwise it will be quoted twice, resulting in the use of an incorrect path.
+#define AVIF_TO_STRING(S) #S
+#define AVIF_STRINGIFY(S) AVIF_TO_STRING(S)
+
 std::vector<std::string> GetSeedDataDirs() {
   const char* var = std::getenv("TEST_DATA_DIRS");
   std::vector<std::string> res;
+#ifdef TEST_DATA_DIRS
+  if (var == nullptr) {
+    var = AVIF_STRINGIFY(TEST_DATA_DIRS);
+  }
+#endif
   if (var == nullptr || *var == 0) return res;
   const char* var_start = var;
   while (true) {
@@ -202,6 +213,9 @@ std::vector<std::string> GetSeedDataDirs() {
   }
   return res;
 }
+
+#undef AVIF_STRINGIFY
+#undef AVIF_TO_STRING
 
 std::vector<std::string> GetTestImagesContents(
     size_t max_file_size, const std::vector<avifAppFileFormat>& image_formats) {


### PR DESCRIPTION
This allows build/test environments to set the path if they are unable
influence the environment. This is based on the implementations in
libvpx and libaom.

Bug: https://crbug.com/329464135