### PR TITLE
Switch from gcc 13 to gcc 12 in ubuntu-latest

### DIFF
--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -32,7 +32,7 @@ jobs:
         include:
           - runs-on: ubuntu-latest
             compiler: gcc
-            gcc: 13
+            gcc: 12
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - runs-on: ubuntu-latest
             compiler: gcc
-            gcc: 13
+            gcc: 12
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -26,7 +26,7 @@ jobs:
         include:
           - runs-on: ubuntu-latest
             compiler: gcc
-            gcc: 13
+            gcc: 12
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - runs-on: ubuntu-latest
             compiler: gcc
-            gcc: 13
+            gcc: 12
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - runs-on: ubuntu-latest
             compiler: gcc
-            gcc: 13
+            gcc: 12
 
     name: build-shared-local (${{ matrix.os }}, libyuv ${{ matrix.libyuv }})
 

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -26,7 +26,7 @@ jobs:
         include:
           - runs-on: ubuntu-latest
             compiler: gcc
-            gcc: 13
+            gcc: 12
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - runs-on: ubuntu-latest
             compiler: gcc
-            gcc: 13
+            gcc: 12
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4


### PR DESCRIPTION
gcc-13 was removed from the ubuntu-22.04 os image. See https://github.com/actions/runner-images/issues/8555#issuecomment-2115818597