### PR TITLE
Rely on CMake to build the build folder.

### DIFF
--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -73,9 +73,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
         -DAVIF_CODEC_RAV1E=LOCAL -DAVIF_CODEC_SVT=LOCAL

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        cmake .. -G Ninja -S ./ -B build
+        cmake -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
         -DAVIF_CODEC_RAV1E=LOCAL -DAVIF_CODEC_SVT=LOCAL

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        cmake .. -G Ninja -S ./ -B build
+        cmake -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_LIBYUV=LOCAL
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -54,9 +54,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_LIBYUV=LOCAL
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -66,9 +66,7 @@ jobs:
       run: convert --version
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON
         -DAVIF_CODEC_DAV1D=ON -DAVIF_LOCAL_DAV1D=ON

--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -57,9 +57,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=SYSTEM
         -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_AOM_ENCODE=ON

--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        cmake .. -G Ninja -S ./ -B build
+        cmake -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=SYSTEM
         -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_AOM_ENCODE=ON
@@ -65,7 +65,7 @@ jobs:
         -DAVIF_LIBSHARPYUV=LOCAL -DAVIF_LIBYUV=SYSTEM
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_GTEST=LOCAL
-        -DAVIF_BUILD_GDK_PIXBUF=ON -DCMAKE_INSTALL_PREFIX=./install
+        -DAVIF_BUILD_GDK_PIXBUF=ON
         -DAVIF_ENABLE_WERROR=ON
     - name: Build libavif (ninja)
       working-directory: ./build

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -64,14 +64,14 @@ jobs:
       # so build it locally instead.
     - name: Prepare libavif (cmake)
       run: >
-        cmake .. -G Ninja -S ./ -B build
+        cmake -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
         -DAVIF_CODEC_AOM=SYSTEM
         -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_AOM_ENCODE=ON
         -DAVIF_CODEC_DAV1D=SYSTEM
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_GTEST=LOCAL
-        -DAVIF_BUILD_GDK_PIXBUF=ON -DCMAKE_INSTALL_PREFIX=./install
+        -DAVIF_BUILD_GDK_PIXBUF=ON -DCMAKE_INSTALL_PREFIX=./build/install
         -DAVIF_ENABLE_WERROR=ON ${{ env.CMAKE_AVIF_FLAGS }}
     - name: Build libavif (ninja)
       working-directory: ./build
@@ -100,9 +100,7 @@ jobs:
         cmake . -DCMAKE_PREFIX_PATH=../install
     - name: Prepare libavif with [[nodiscard]] (cmake)
       run: >
-        mkdir build_nodiscard && cd build_nodiscard
-
-        cmake .. -G Ninja
+        cmake -G Ninja -S ./ -B build_nodiscard
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
         -DAVIF_CODEC_AOM=SYSTEM
         -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_AOM_ENCODE=ON
@@ -111,7 +109,6 @@ jobs:
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_GTEST=LOCAL
         -DAVIF_BUILD_GDK_PIXBUF=ON  ${{ env.CMAKE_AVIF_FLAGS }}
-        -DCMAKE_INSTALL_PREFIX=./install
     - name: Build libavif with [[nodiscard]] (ninja)
       working-directory: ./build_nodiscard
       run: ninja

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -64,9 +64,7 @@ jobs:
       # so build it locally instead.
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
         -DAVIF_CODEC_AOM=SYSTEM
         -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_AOM_ENCODE=ON

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -62,9 +62,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
         -DAVIF_LIBYUV=${{ matrix.libyuv }}

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        cmake .. -G Ninja -S ./ -B build
+        cmake -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
         -DAVIF_LIBYUV=${{ matrix.libyuv }}

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        cmake .. -G Ninja -S ./ -B build
+        cmake -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AVM=LOCAL
         -DAVIF_CODEC_DAV1D=${{ matrix.also-enable-av1-codecs }}

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -66,9 +66,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AVM=LOCAL
         -DAVIF_CODEC_DAV1D=${{ matrix.also-enable-av1-codecs }}

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -82,7 +82,7 @@ jobs:
       run: convert --version
     - name: Prepare libavif (cmake)
       run: >
-        cmake .. -G Ninja -S ./ -B build
+        cmake -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
         -DAVIF_CODEC_RAV1E=LOCAL -DAVIF_CODEC_SVT=LOCAL

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -82,9 +82,7 @@ jobs:
       run: convert --version
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
         -DAVIF_CODEC_RAV1E=LOCAL -DAVIF_CODEC_SVT=LOCAL

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -70,9 +70,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_AOM_ENCODE=ON
         -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_DAV1D=LOCAL

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        cmake .. -G Ninja -S ./ -B build
+        cmake -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_AOM_ENCODE=ON
         -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_DAV1D=LOCAL

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        cmake .. -G Ninja -S ./ -B build
+        cmake -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
         -DAVIF_CODEC_RAV1E=LOCAL -DAVIF_CODEC_SVT=LOCAL

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -91,9 +91,7 @@ jobs:
 
     - name: Prepare libavif (cmake)
       run: >
-        mkdir build && cd build
-
-        cmake .. -G Ninja
+        cmake .. -G Ninja -S ./ -B build
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
         -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
         -DAVIF_CODEC_RAV1E=LOCAL -DAVIF_CODEC_SVT=LOCAL


### PR DESCRIPTION
This is useful in case the build folder already exists due to caching. "mkdir -p" could be used on Unix (not Windows) but it is easier to use a common command.