### PR TITLE
Switch macos-13 to macos-latest

### DIFF
--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
         libyuv: [OFF, LOCAL]
         include:
           - runs-on: ubuntu-latest

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
         build-type: [Release, Debug]
         include:
           - runs-on: ubuntu-latest


### PR DESCRIPTION
macos-latest now is macos-14, cf
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories