### PR TITLE
Properly check for cache hits.

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -4,6 +4,9 @@ inputs:
   use-rust:
     description: 'Whether rust is used'
     default: false
+outputs:
+  ext-cache-hit:
+    value: ${{ steps.cache-ext.outputs.cache-hit }}
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
     - uses: seanmiddleditch/gha-setup-ninja@8b297075da4cd2a5f1fd21fe011b499edf06e9d2 # v4
     - name: Build mp4box
-      if: ${{ !steps.cache-ext.outputs.cache-hit }}
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: bash -e mp4box.sh
 

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
     - uses: seanmiddleditch/gha-setup-ninja@8b297075da4cd2a5f1fd21fe011b499edf06e9d2 # v4
     - name: Build mp4box
-      if: steps.cache.ext-cache-hit != 'true'
+      if: steps.cache.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: bash -e mp4box.sh
 

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -37,6 +37,7 @@ jobs:
         sudo apt update
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev
     - uses: ./.github/actions/cache
+      id: cache
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
       with:
@@ -47,7 +48,7 @@ jobs:
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
     - uses: seanmiddleditch/gha-setup-ninja@8b297075da4cd2a5f1fd21fe011b499edf06e9d2 # v4
     - name: Build mp4box
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache.ext-cache-hit != 'true'
       working-directory: ./ext
       run: bash -e mp4box.sh
 

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
     - uses: seanmiddleditch/gha-setup-ninja@8b297075da4cd2a5f1fd21fe011b499edf06e9d2 # v4
     - name: Build mp4box
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: ${{ !steps.cache-ext.outputs.cache-hit }}
       working-directory: ./ext
       run: bash -e mp4box.sh
 

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -41,21 +41,21 @@ jobs:
         run: brew install aom dav1d imagemagick libpng
       - uses: ./.github/actions/cache
       - name: Build aom
-        if: ${{ !steps.cache-ext.outputs.cache-hit }}
+        if: steps.cache-ext.outputs.cache-hit != 'true'
         working-directory: ./ext
         run: >
           sed -i -e 's/cmake -G Ninja \(.*\) \.\./cmake -G Ninja \1 -DSANITIZE=${{ matrix.sanitizer }} ../g' aom.cmd
 
           ./aom.cmd
       - name: Build dav1d
-        if: ${{ !steps.cache-ext.outputs.cache-hit }}
+        if: steps.cache-ext.outputs.cache-hit != 'true'
         working-directory: ./ext
         run: >
           sed -i -e 's/meson setup \(.*\) \.\./meson setup \1 -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false ../g' dav1d.cmd
 
           ./dav1d.cmd
       - name: Build libyuv
-        if: ${{ !steps.cache-ext.outputs.cache-hit }}
+        if: steps.cache-ext.outputs.cache-hit != 'true'
         working-directory: ./ext
         run: ./libyuv.cmd
         env:
@@ -63,7 +63,7 @@ jobs:
           CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
           LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
       - name: Build libsharpyuv
-        if: ${{ !steps.cache-ext.outputs.cache-hit }}
+        if: steps.cache-ext.outputs.cache-hit != 'true'
         working-directory: ./ext
         run: ./libsharpyuv.cmd
         env:
@@ -71,7 +71,7 @@ jobs:
           CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
           LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
       - name: Build GoogleTest
-        if: ${{ !steps.cache-ext.outputs.cache-hit }}
+        if: steps.cache-ext.outputs.cache-hit != 'true'
         working-directory: ./ext
         # Note: "apt install googletest" is sometimes insufficient for find_package(GTest) so build in ext/ instead.
         run: bash -e googletest.cmd

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -40,22 +40,23 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install aom dav1d imagemagick libpng
       - uses: ./.github/actions/cache
+        id: cache
       - name: Build aom
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: steps.cache.ext-cache-hit != 'true'
         working-directory: ./ext
         run: >
           sed -i -e 's/cmake -G Ninja \(.*\) \.\./cmake -G Ninja \1 -DSANITIZE=${{ matrix.sanitizer }} ../g' aom.cmd
 
           ./aom.cmd
       - name: Build dav1d
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: steps.cache.ext-cache-hit != 'true'
         working-directory: ./ext
         run: >
           sed -i -e 's/meson setup \(.*\) \.\./meson setup \1 -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false ../g' dav1d.cmd
 
           ./dav1d.cmd
       - name: Build libyuv
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: steps.cache.ext-cache-hit != 'true'
         working-directory: ./ext
         run: ./libyuv.cmd
         env:
@@ -63,7 +64,7 @@ jobs:
           CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
           LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
       - name: Build libsharpyuv
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: steps.cache.ext-cache-hit != 'true'
         working-directory: ./ext
         run: ./libsharpyuv.cmd
         env:
@@ -71,7 +72,7 @@ jobs:
           CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
           LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
       - name: Build GoogleTest
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: steps.cache.ext-cache-hit != 'true'
         working-directory: ./ext
         # Note: "apt install googletest" is sometimes insufficient for find_package(GTest) so build in ext/ instead.
         run: bash -e googletest.cmd

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -42,21 +42,21 @@ jobs:
       - uses: ./.github/actions/cache
         id: cache
       - name: Build aom
-        if: steps.cache.ext-cache-hit != 'true'
+        if: steps.cache.outputs.ext-cache-hit != 'true'
         working-directory: ./ext
         run: >
           sed -i -e 's/cmake -G Ninja \(.*\) \.\./cmake -G Ninja \1 -DSANITIZE=${{ matrix.sanitizer }} ../g' aom.cmd
 
           ./aom.cmd
       - name: Build dav1d
-        if: steps.cache.ext-cache-hit != 'true'
+        if: steps.cache.outputs.ext-cache-hit != 'true'
         working-directory: ./ext
         run: >
           sed -i -e 's/meson setup \(.*\) \.\./meson setup \1 -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false ../g' dav1d.cmd
 
           ./dav1d.cmd
       - name: Build libyuv
-        if: steps.cache.ext-cache-hit != 'true'
+        if: steps.cache.outputs.ext-cache-hit != 'true'
         working-directory: ./ext
         run: ./libyuv.cmd
         env:
@@ -64,7 +64,7 @@ jobs:
           CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
           LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
       - name: Build libsharpyuv
-        if: steps.cache.ext-cache-hit != 'true'
+        if: steps.cache.outputs.ext-cache-hit != 'true'
         working-directory: ./ext
         run: ./libsharpyuv.cmd
         env:
@@ -72,7 +72,7 @@ jobs:
           CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
           LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
       - name: Build GoogleTest
-        if: steps.cache.ext-cache-hit != 'true'
+        if: steps.cache.outputs.ext-cache-hit != 'true'
         working-directory: ./ext
         # Note: "apt install googletest" is sometimes insufficient for find_package(GTest) so build in ext/ instead.
         run: bash -e googletest.cmd

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -41,21 +41,21 @@ jobs:
         run: brew install aom dav1d imagemagick libpng
       - uses: ./.github/actions/cache
       - name: Build aom
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: ${{ !steps.cache-ext.outputs.cache-hit }}
         working-directory: ./ext
         run: >
           sed -i -e 's/cmake -G Ninja \(.*\) \.\./cmake -G Ninja \1 -DSANITIZE=${{ matrix.sanitizer }} ../g' aom.cmd
 
           ./aom.cmd
       - name: Build dav1d
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: ${{ !steps.cache-ext.outputs.cache-hit }}
         working-directory: ./ext
         run: >
           sed -i -e 's/meson setup \(.*\) \.\./meson setup \1 -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false ../g' dav1d.cmd
 
           ./dav1d.cmd
       - name: Build libyuv
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: ${{ !steps.cache-ext.outputs.cache-hit }}
         working-directory: ./ext
         run: ./libyuv.cmd
         env:
@@ -63,7 +63,7 @@ jobs:
           CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
           LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
       - name: Build libsharpyuv
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: ${{ !steps.cache-ext.outputs.cache-hit }}
         working-directory: ./ext
         run: ./libsharpyuv.cmd
         env:
@@ -71,7 +71,7 @@ jobs:
           CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
           LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
       - name: Build GoogleTest
-        if: steps.cache-ext.outputs.cache-hit != 'true'
+        if: ${{ !steps.cache-ext.outputs.cache-hit }}
         working-directory: ./ext
         # Note: "apt install googletest" is sometimes insufficient for find_package(GTest) so build in ext/ instead.
         run: bash -e googletest.cmd

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@8b297075da4cd2a5f1fd21fe011b499edf06e9d2 # v4
     - run: pip install meson
     - name: Build aom
-      if: steps.cache.ext-cache-hit != 'true'
+      if: steps.cache.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./aom.cmd
       # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
@@ -39,11 +39,11 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build dav1d
-      if: steps.cache.ext-cache-hit != 'true'
+      if: steps.cache.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./dav1d.cmd
     - name: Build libyuv
-      if: steps.cache.ext-cache-hit != 'true'
+      if: steps.cache.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the
@@ -52,15 +52,15 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build libsharpyuv
-      if: steps.cache.ext-cache-hit != 'true'
+      if: steps.cache.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./libsharpyuv.cmd
     - name: Build libjpeg
-      if: steps.cache.ext-cache-hit != 'true'
+      if: steps.cache.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./libjpeg.cmd
     - name: Build zlib and libpng
-      if: steps.cache.ext-cache-hit != 'true'
+      if: steps.cache.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./zlibpng.cmd
 

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@8b297075da4cd2a5f1fd21fe011b499edf06e9d2 # v4
     - run: pip install meson
     - name: Build aom
-      if: ${{ !steps.cache-ext.outputs.cache-hit }}
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./aom.cmd
       # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
@@ -38,11 +38,11 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build dav1d
-      if: ${{ !steps.cache-ext.outputs.cache-hit }}
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./dav1d.cmd
     - name: Build libyuv
-      if: ${{ !steps.cache-ext.outputs.cache-hit }}
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the
@@ -51,15 +51,15 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build libsharpyuv
-      if: ${{ !steps.cache-ext.outputs.cache-hit }}
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./libsharpyuv.cmd
     - name: Build libjpeg
-      if: ${{ !steps.cache-ext.outputs.cache-hit }}
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./libjpeg.cmd
     - name: Build zlib and libpng
-      if: ${{ !steps.cache-ext.outputs.cache-hit }}
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./zlibpng.cmd
 

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@8b297075da4cd2a5f1fd21fe011b499edf06e9d2 # v4
     - run: pip install meson
     - name: Build aom
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: ${{ !steps.cache-ext.outputs.cache-hit }}
       working-directory: ./ext
       run: ./aom.cmd
       # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
@@ -38,11 +38,11 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build dav1d
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: ${{ !steps.cache-ext.outputs.cache-hit }}
       working-directory: ./ext
       run: ./dav1d.cmd
     - name: Build libyuv
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: ${{ !steps.cache-ext.outputs.cache-hit }}
       working-directory: ./ext
       run: ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the
@@ -51,15 +51,15 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build libsharpyuv
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: ${{ !steps.cache-ext.outputs.cache-hit }}
       working-directory: ./ext
       run: ./libsharpyuv.cmd
     - name: Build libjpeg
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: ${{ !steps.cache-ext.outputs.cache-hit }}
       working-directory: ./ext
       run: ./libjpeg.cmd
     - name: Build zlib and libpng
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: ${{ !steps.cache-ext.outputs.cache-hit }}
       working-directory: ./ext
       run: ./zlibpng.cmd
 

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -22,13 +22,14 @@ jobs:
       if: runner.os == 'Windows'
       uses: egor-tensin/vs-shell@9a932a62d05192eae18ca370155cf877eecc2202 # v2.1
     - uses: ./.github/actions/cache
+      id: cache
     - name: Print cmake version
       run: cmake --version
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
     - uses: seanmiddleditch/gha-setup-ninja@8b297075da4cd2a5f1fd21fe011b499edf06e9d2 # v4
     - run: pip install meson
     - name: Build aom
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./aom.cmd
       # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
@@ -38,11 +39,11 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build dav1d
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./dav1d.cmd
     - name: Build libyuv
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the
@@ -51,15 +52,15 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build libsharpyuv
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./libsharpyuv.cmd
     - name: Build libjpeg
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./libjpeg.cmd
     - name: Build zlib and libpng
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./zlibpng.cmd
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Print ImageMagick version
       run: magick --version
     - name: Build aom
-      if: ${{ !steps.cache-ext.outputs.cache-hit }}
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./aom.cmd
       # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
@@ -70,7 +70,7 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build libyuv
-      if: ${{ !steps.cache-ext.outputs.cache-hit }}
+      if: steps.cache-ext.outputs.cache-hit != 'true'
       working-directory: ./ext
       run: ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Print ImageMagick version
       run: magick --version
     - name: Build aom
-      if: steps.cache.ext-cache-hit != 'true'
+      if: steps.cache.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./aom.cmd
       # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
@@ -71,7 +71,7 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build libyuv
-      if: steps.cache.ext-cache-hit != 'true'
+      if: steps.cache.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Print ImageMagick version
       run: magick --version
     - name: Build aom
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: ${{ !steps.cache-ext.outputs.cache-hit }}
       working-directory: ./ext
       run: ./aom.cmd
       # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
@@ -70,7 +70,7 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build libyuv
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: ${{ !steps.cache-ext.outputs.cache-hit }}
       working-directory: ./ext
       run: ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -50,6 +50,7 @@ jobs:
         toolchain: stable
         override: true
     - uses: ./.github/actions/cache
+      id: cache
       with:
         use-rust: true
     - name: Print cmake version
@@ -60,7 +61,7 @@ jobs:
     - name: Print ImageMagick version
       run: magick --version
     - name: Build aom
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./aom.cmd
       # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
@@ -70,7 +71,7 @@ jobs:
         CC: clang-cl
         CXX: clang-cl
     - name: Build libyuv
-      if: steps.cache-ext.outputs.cache-hit != 'true'
+      if: steps.cache.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the


### PR DESCRIPTION
`steps.cache-ext.outputs.cache-hit != 'true'` is actually always true because `steps.cache-ext.outputs.cache-hit` does not exist anymore, as the step `cache-hit` is now hidden in the cache action. The `cache-hit` information has to be sent back from the cache action.