### PR TITLE
Rust fixes

### DIFF
--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -42,21 +42,12 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - name: Set up rust
+      uses: dtolnay/rust-toolchain@stable
     - name: Install dependencies
       run: |
         sudo apt update
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev
-    - name: Install cargo-c
-      env:
-        LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
-        CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
-      run: |
-        curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
     - name: Cache external dependencies
       id: cache-ext
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -44,6 +44,8 @@ jobs:
         python-version: '3.x'
     - name: Set up rust
       uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+      with:
+        toolchain: 1.80.0
     - name: Install dependencies
       run: |
         sudo apt update

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -42,10 +42,11 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - name: Set up rust
-      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
-        toolchain: 1.80.0
+        profile: minimal
+        toolchain: stable
+        override: true
     - name: Install dependencies
       run: |
         sudo apt update

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Set up rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
     - name: Install dependencies
       run: |
         sudo apt update

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Set up rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
     - name: Install dependencies (Linux)
       run: |
         sudo apt update

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -37,6 +37,8 @@ jobs:
         python-version: '3.x'
     - name: Set up rust
       uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+      with:
+        toolchain: 1.80.0
     - name: Install dependencies (Linux)
       run: |
         sudo apt update

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -35,21 +35,12 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - name: Set up rust
+      uses: dtolnay/rust-toolchain@stable
     - name: Install dependencies (Linux)
       run: |
         sudo apt update
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev
-    - name: Install cargo-c (linux)
-      env:
-        LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
-        CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
-      run: |
-        curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
     - name: Cache external dependencies
       id: cache-ext
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -35,10 +35,11 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - name: Set up rust
-      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
-        toolchain: 1.80.0
+        profile: minimal
+        toolchain: stable
+        override: true
     - name: Install dependencies (Linux)
       run: |
         sudo apt update

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Set up rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
     - name: Install dependencies
       run: |
         sudo apt update

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -36,21 +36,12 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - name: Set up rust
+      uses: dtolnay/rust-toolchain@stable
     - name: Install dependencies
       run: |
         sudo apt update
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev 
-    - name: Install cargo-c
-      env:
-        LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
-        CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
-      run: |
-        curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
     - name: Cache external dependencies
       id: cache-ext
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -38,6 +38,8 @@ jobs:
         python-version: '3.x'
     - name: Set up rust
       uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+      with:
+        toolchain: 1.80.0
     - name: Install dependencies
       run: |
         sudo apt update

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -36,10 +36,11 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - name: Set up rust
-      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
-        toolchain: 1.80.0
+        profile: minimal
+        toolchain: stable
+        override: true
     - name: Install dependencies
       run: |
         sudo apt update

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -37,11 +37,8 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - name: Set up rust
+      uses: dtolnay/rust-toolchain@stable
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'
       run: |
@@ -50,22 +47,6 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: brew install imagemagick
-    - name: Install cargo-c (linux)
-      if: runner.os == 'Linux'
-      env:
-        LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
-        CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
-      run: |
-        curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
-    - name: Install cargo-c (mac)
-      if: matrix.os == 'macos-latest'
-      env:
-        LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
-        CARGO_C_FILE: cargo-c-macos.zip
-      run: |
-        curl -sLo $CARGO_C_FILE $LINK/$CARGO_C_FILE
-        unzip -o $CARGO_C_FILE -d ~/.cargo/bin
-        rm $CARGO_C_FILE
     - name: Cache external dependencies
       id: cache-ext
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -37,10 +37,11 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - name: Set up rust
-      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
-        toolchain: 1.80.0
+        profile: minimal
+        toolchain: stable
+        override: true
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -39,6 +39,8 @@ jobs:
         python-version: '3.x'
     - name: Set up rust
       uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+      with:
+        toolchain: 1.80.0
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Set up rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -44,10 +44,11 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - name: Set up rust
-      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
-        toolchain: 1.80.0
+        profile: minimal
+        toolchain: stable
+        override: true
 
     - name: Cache external dependencies
       id: cache-ext

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -46,6 +46,8 @@ jobs:
         python-version: '3.x'
     - name: Set up rust
       uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
+      with:
+        toolchain: 1.80.0
 
     - name: Cache external dependencies
       id: cache-ext

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -44,11 +44,8 @@ jobs:
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - name: Set up rust
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Cache external dependencies
       id: cache-ext
@@ -56,12 +53,6 @@ jobs:
       with:
         path: ext, build/_deps
         key: ${{ runner.os }}-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}-alldeps
-    - name: Install cargo-c
-      run: |
-        $LINK = "https://github.com/lu-zero/cargo-c/releases/latest/download"
-        $CARGO_C_FILE = "cargo-c-windows-msvc"
-        curl -LO "$LINK/$CARGO_C_FILE.zip"
-        7z e -y "$CARGO_C_FILE.zip" -o"${env:USERPROFILE}\.cargo\bin"
     - name: Print cmake version
       run: cmake --version
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Set up rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a
 
     - name: Cache external dependencies
       id: cache-ext


### PR DESCRIPTION
- switch deprecated actions-rs/toolchain, cf https://github.com/actions-rs/toolchain/issues/216
- do not download cargo: it does not always work (e.g. macOS has several architectures but there is only one download), it is complex code, and we have a proper way to install it through CMake cf
https://github.com/AOMediaCodec/libavif/blob/c21943e1e07ced29a22d1a59b0c4748e00b84c67/cmake/Modules/LocalRav1e.cmake#L49