### PR TITLE
Use common code for caching

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -1,14 +1,14 @@
 name: 'Cache for all OSes'
 description: 'Needs to be called before any call to ext/.cmd|sh or cmake'
 inputs:
-  codec-rav1e:
-    description: 'Can take the values: OFF, LOCAL, SYSTEM'
-    default: 'OFF'
+  use-rust:
+    description: 'Whether rust is used'
+    default: false
 runs:
   using: "composite"
   steps:
     - name: Cache cargo registry
-      if: ${{ inputs.codec-rav1e == 'LOCAL' }}
+      if: ${{ inputs.use-rust }}
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       continue-on-error: true
       with:

--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -1,0 +1,27 @@
+name: 'Cache for all OSes'
+description: 'Needs to be called before any call to ext/.cmd|sh or cmake'
+inputs:
+  codec-rav1e:
+    description: 'Can take the values: OFF, LOCAL, SYSTEM'
+    default: 'OFF'
+runs:
+  using: "composite"
+  steps:
+    - name: Cache cargo registry
+      if: ${{ inputs.codec-rav1e == 'LOCAL' }}
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      continue-on-error: true
+      with:
+        path: ~/.cargo/registry/cache
+        key: cargo-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('CMakeLists.txt', 'cmake/Modules/Findrav1e.cmake', 'cmake/Modules/LocalRav1e.cmake', 'ext/rav1e.cmd') }}-${{ github.job }}
+    - name: Cache external dependencies in ext
+      id: cache-ext
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: ext
+        key: ext-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/*', 'ext/*.cmd', 'ext/*.sh') }}-${{ github.job }}
+    - name: Cache external dependencies in build/_deps
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: build/_deps
+        key: deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/*', 'CMakeLists.txt', 'cmake/Modules/*') }}-${{ github.job }}

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -51,12 +51,9 @@ jobs:
       run: |
         sudo apt update
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: ./.github/actions/cache
       with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-disable-gtest-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}
+        codec-rav1e: 'LOCAL'
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
       with:
@@ -78,15 +75,6 @@ jobs:
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=OFF
         -DAVIF_ENABLE_WERROR=ON
-    - name: Cache cargo registry
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry/cache
-        key: cargo-registry-${{ runner.os }}-${{ hashFiles('ext/rav1e/Cargo.lock') }}-disable-gtest
-        restore-keys: |
-          cargo-registry-${{ runner.os }}-${{ hashFiles('ext/rav1e/Cargo.lock') }}-
-          cargo-registry-${{ runner.os }}-
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -53,7 +53,7 @@ jobs:
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev
     - uses: ./.github/actions/cache
       with:
-        codec-rav1e: 'LOCAL'
+        use-rust: true
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
       with:

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -36,12 +36,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-golden-tests-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}
+    - uses: ./.github/actions/cache
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
       with:

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -44,12 +44,9 @@ jobs:
       run: |
         sudo apt update
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: ./.github/actions/cache
       with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-linux-static-old-local-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}
+        codec-rav1e: 'LOCAL'
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
       with:
@@ -78,15 +75,6 @@ jobs:
         -DAVIF_ENABLE_EXPERIMENTAL_GAIN_MAP=ON
         -DAVIF_ENABLE_EXPERIMENTAL_MINI=ON
         -DAVIF_ENABLE_WERROR=ON
-    - name: Cache cargo registry
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry/cache
-        key: cargo-registry-${{ runner.os }}-${{ hashFiles('ext/rav1e/Cargo.lock') }}-unix-static
-        restore-keys: |
-          cargo-registry-${{ runner.os }}-${{ hashFiles('ext/rav1e/Cargo.lock') }}-
-          cargo-registry-${{ runner.os }}-
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -46,7 +46,7 @@ jobs:
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev
     - uses: ./.github/actions/cache
       with:
-        codec-rav1e: 'LOCAL'
+        use-rust: true
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
       with:

--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -46,12 +46,7 @@ jobs:
           libyuv:p
           ninja:p
           zlib:p
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-mingw-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}
+    - uses: ./.github/actions/cache
     - name: Print cmake version
       run: cmake --version
 

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -33,12 +33,7 @@ jobs:
       # TODO(yguyon): Install libyuv (not available with brew).
       if: runner.os == 'macOS'
       run: echo "CMAKE_AVIF_FLAGS=\"-DAVIF_LIBYUV=OFF\""  >> $GITHUB_ENV
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-unix-shared-installed-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}
+    - uses: ./.github/actions/cache
     - name: Setup cmake
       if: runner.os == 'Linux'
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -45,12 +45,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: brew install imagemagick
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-${{ matrix.libyuv }}-unix-shared-local-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}
+    - uses: ./.github/actions/cache
     - name: Setup cmake
       if: runner.os == 'Linux'
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -47,7 +47,7 @@ jobs:
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev 
     - uses: ./.github/actions/cache
       with:
-        codec-rav1e: 'LOCAL'
+        use-rust: true
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
       with:

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -45,12 +45,9 @@ jobs:
       run: |
         sudo apt update
         sudo apt install imagemagick libjpeg-turbo8-dev libpng-dev 
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: ./.github/actions/cache
       with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-${{ matrix.also-enable-av1-codec }}-unix-static-av2-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}
+        codec-rav1e: 'LOCAL'
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
       with:
@@ -75,15 +72,6 @@ jobs:
         -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_GTEST=LOCAL
         -DAVIF_ENABLE_WERROR=ON
-    - name: Cache cargo registry
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry/cache
-        key: cargo-registry-${{ runner.os }}-${{ hashFiles('ext/rav1e/Cargo.lock') }}-unix-static-av2
-        restore-keys: |
-          cargo-registry-${{ runner.os }}-${{ hashFiles('ext/rav1e/Cargo.lock') }}-
-          cargo-registry-${{ runner.os }}-
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -39,12 +39,7 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install aom dav1d imagemagick libpng
-      - name: Cache external dependencies
-        id: cache-ext
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: ext, build/_deps
-          key: ${{ runner.os }}-${{ matrix.sanitizer }}-unix-static-sanitized-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}
+      - uses: ./.github/actions/cache
       - name: Build aom
         if: steps.cache-ext.outputs.cache-hit != 'true'
         working-directory: ./ext

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -50,12 +50,9 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: brew install imagemagick
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: ./.github/actions/cache
       with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-${{ matrix.build-type }}-unix-static-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}
+        codec-rav1e: 'LOCAL'
     - name: Setup cmake
       if: runner.os == 'Linux'
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
@@ -69,6 +66,7 @@ jobs:
     - run: pip install meson
     - name: Print ImageMagick version
       run: convert --version
+
     - name: Prepare libavif (cmake)
       run: >
         cmake -G Ninja -S ./ -B build
@@ -84,15 +82,6 @@ jobs:
         -DAVIF_ENABLE_EXPERIMENTAL_MINI=ON
         -DAVIF_ENABLE_EXPERIMENTAL_SAMPLE_TRANSFORM=ON
         -DAVIF_ENABLE_WERROR=ON
-    - name: Cache cargo registry
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry/cache
-        key: cargo-registry-${{ runner.os }}-${{ hashFiles('ext/rav1e/Cargo.lock') }}-unix-static
-        restore-keys: |
-          cargo-registry-${{ runner.os }}-${{ hashFiles('ext/rav1e/Cargo.lock') }}-
-          cargo-registry-${{ runner.os }}-
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -52,7 +52,7 @@ jobs:
       run: brew install imagemagick
     - uses: ./.github/actions/cache
       with:
-        codec-rav1e: 'LOCAL'
+        use-rust: true
     - name: Setup cmake
       if: runner.os == 'Linux'
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -21,12 +21,7 @@ jobs:
     - name: Setup Visual Studio shell
       if: runner.os == 'Windows'
       uses: egor-tensin/vs-shell@9a932a62d05192eae18ca370155cf877eecc2202 # v2.1
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}-releasedeps
+    - uses: ./.github/actions/cache
     - name: Print cmake version
       run: cmake --version
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -51,7 +51,7 @@ jobs:
         override: true
     - uses: ./.github/actions/cache
       with:
-        codec-rav1e: 'LOCAL'
+        use-rust: true
     - name: Print cmake version
       run: cmake --version
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -49,13 +49,9 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
-
-    - name: Cache external dependencies
-      id: cache-ext
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: ./.github/actions/cache
       with:
-        path: ext, build/_deps
-        key: ${{ runner.os }}-${{ hashFiles('cmake/Modules/*', 'ext/*.cmd', 'ext/*.sh') }}-alldeps
+        codec-rav1e: 'LOCAL'
     - name: Print cmake version
       run: cmake --version
     - uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
@@ -99,14 +95,6 @@ jobs:
         -DAVIF_ENABLE_EXPERIMENTAL_MINI=ON
         -DAVIF_ENABLE_EXPERIMENTAL_SAMPLE_TRANSFORM=ON
         -DAVIF_ENABLE_WERROR=ON
-    - name: Cache cargo registry
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry/cache
-        key: cargo-registry-${{ runner.os }}-${{ hashFiles('ext/rav1e/Cargo.lock') }}-
-        restore-keys: |
-          cargo-registry-${{ runner.os }}-
     - name: Build libavif (ninja)
       working-directory: ./build
       run: ninja


### PR DESCRIPTION
Also fixes:
- the cargo cache needs to be called before CMake
- the cargo cache hash needs to depend on existing file (otheriwse the value is just the empty string which creates invalid cache hits)
- the cache can be split between ext./ and build/_deps to trigger its refresh less often
- the hash keys need to take the architecture into account (as macOS can have multiple architecures)