### PR TITLE
Add an "Upgrade clang" step

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -45,6 +45,8 @@ jobs:
         codec-dav1d: 'LOCAL'
         codec-rav1e: 'LOCAL'
 
+    - name: Upgrade clang
+      run: choco upgrade llvm
     - name: Build aom
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext


### PR DESCRIPTION
In the current windows-latest (windows-2022) image, the installed Clang is version 16, but the Visual Studio STL requires Clang version 17 or later. The "Upgrade clang" workaround is recommended in https://github.com/actions/runner-images/issues/10001#issuecomment-2153764664.