### PR TITLE
Remove standalone clang from PATH

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -48,7 +48,10 @@ jobs:
     - name: Build aom
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
-      run: ./aom.cmd
+      run: |
+        # Remove standalone clang from PATH.
+        $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\LLVM\bin' }) -join ';'
+        ./aom.cmd
       # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
       # AVX-512 instructions to be emitted in non-AVX-512 code. See
       # https://github.com/AOMediaCodec/libavif/issues/2033#issuecomment-1960062751.
@@ -66,7 +69,10 @@ jobs:
     - name: Build libyuv
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
-      run: ./libyuv.cmd
+      run: |
+        # Remove standalone clang from PATH.
+        $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\LLVM\bin' }) -join ';'
+        ./libyuv.cmd
       # Use clang-cl to build libyuv. The assembly code in libyuv is written in the
       # GCC inline assembly format. Visual C++ doesn't support GCC inline assembly.
       env:


### PR DESCRIPTION
Use the clang in Visual Studio. Recommended in
https://github.com/actions/runner-images/issues/10001#issuecomment-2150541007.