### PR TITLE
Work around a bug in the windows-latest os image

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -55,6 +55,14 @@ jobs:
       env:
         CC: clang-cl
         CXX: clang-cl
+    - name: Build libgav1
+      if: steps.setup.outputs.ext-cache-hit != 'true'
+      working-directory: ./ext
+      run: ./libgav1.cmd
+      # Work around a bug in the windows-latest os image. See
+      # https://github.com/actions/runner-images/issues/10004#issuecomment-2153445161.
+      env:
+        CXXFLAGS: -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
     - name: Build libyuv
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext

--- a/ext/libgav1.cmd
+++ b/ext/libgav1.cmd
@@ -8,7 +8,7 @@
 : # If you're running this on Windows, be sure you've already run this (from your VC2019 install dir):
 : #     "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 
-# When updating the libgav1 version, make the same change to libgav1_android.sh.
+: # When updating the libgav1 version, make the same change to libgav1_android.sh.
 git clone -b v0.19.0 --depth 1 https://chromium.googlesource.com/codecs/libgav1
 
 cd libgav1


### PR DESCRIPTION
The bug causes access violation in avifcodectest when libgav1 is used. The error message is:
  error: SEH exception with code 0xc0000005 thrown in the test body.