### PR TITLE
Do not compile libaom with clang-cl on Windows

### DIFF
--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -28,12 +28,6 @@ jobs:
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext
       run: ./aom.cmd
-      # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
-      # AVX-512 instructions to be emitted in non-AVX-512 code. See
-      # https://github.com/AOMediaCodec/libavif/issues/2033#issuecomment-1960062751.
-      env:
-        CC: clang-cl
-        CXX: clang-cl
     - name: Build dav1d
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -45,16 +45,6 @@ jobs:
         codec-dav1d: 'LOCAL'
         codec-rav1e: 'LOCAL'
 
-    - name: Build aom
-      if: steps.setup.outputs.ext-cache-hit != 'true'
-      working-directory: ./ext
-      run: ./aom.cmd
-      # Visual Studio 2022 has an issue starting at 17.8.0 which might cause
-      # AVX-512 instructions to be emitted in non-AVX-512 code. See
-      # https://github.com/AOMediaCodec/libavif/issues/2033#issuecomment-1960062751.
-      env:
-        CC: clang-cl
-        CXX: clang-cl
     - name: Build libgav1
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext


### PR DESCRIPTION
The Visual Studio 2022 bug has been fixed. Remove the workaround added in commit 877a2742671849dd393f9b54cd39328c63c6ee4e.