### PR TITLE
Revert workaround for bug in windows-latest image

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -45,14 +45,6 @@ jobs:
         codec-dav1d: 'LOCAL'
         codec-rav1e: 'LOCAL'
 
-    - name: Build libgav1
-      if: steps.setup.outputs.ext-cache-hit != 'true'
-      working-directory: ./ext
-      run: ./libgav1.cmd
-      # Work around a bug in the windows-latest os image. See
-      # https://github.com/actions/runner-images/issues/10004#issuecomment-2153445161.
-      env:
-        CXXFLAGS: -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
     - name: Build libyuv
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext


### PR DESCRIPTION
The bug has been fixed in the windows-2022 runner image version 20240610.1.0.