### PR TITLE
Fix avifEncoderWriteExtendedColorProperties comment

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -620,7 +620,7 @@ static avifResult avifEncoderWriteNclxProperty(avifRWStream * dedupStream,
     return AVIF_RESULT_OK;
 }
 
-// Subset of avifEncoderWriteColorProperties() for the properties clli, pasp, clap, irot, imir.
+// Subset of avifEncoderWriteColorProperties() for the properties pasp, clap, irot, imir.
 // Also used by the extended_meta field of the MinimizedImageBox if AVIF_ENABLE_EXPERIMENTAL_MINI is
 // defined.
 static avifResult avifEncoderWriteExtendedColorProperties(avifRWStream * dedupStream,


### PR DESCRIPTION
When avifEncoderWriteExtendedColorProperties() was added in commit fa1139531, it did write the clli property. But the writing of clli was moved to the new avifEncoderWriteHDRProperties() function in commit 50a541469.