### PR TITLE
Bump fuzztest

### DIFF
--- a/ext/fuzztest.cmd
+++ b/ext/fuzztest.cmd
@@ -9,14 +9,16 @@
 
 git clone https://github.com/google/fuzztest.git
 cd fuzztest
-: # There is no tagged release as of 2024/04/12. Pick the latest commit that works.
-git checkout a40caf40aaf621dd0e04f9d8b47d1153fd2682d2
+: # There is no tagged release as of 2024/06/17. Pick the latest commit that works.
+git checkout ce454aced15f7dc2cc96aeae969a6204b563b4c9
 : # Fixes for https://github.com/google/fuzztest/issues/1124
 sed -i 's/-fsanitize=address//g' ./cmake/FuzzTestFlagSetup.cmake
 sed -i 's/-DADDRESS_SANITIZER//g' ./cmake/FuzzTestFlagSetup.cmake
 : # Fixes for https://github.com/google/fuzztest/issues/1125
 sed -i 's/if (IsEnginePlaceholderInput(data)) return;/if (data.size() == 0) return;/g' ./fuzztest/internal/compatibility_mode.cc
 sed -i 's/set(GTEST_HAS_ABSL ON)/set(GTEST_HAS_ABSL OFF)/g' ./cmake/BuildDependencies.cmake
+: # Fixes https://github.com/google/fuzztest/issues/1192
+git revert --no-commit ed6f817771702bf7823b73498d0e1914475f2313
 
 : # fuzztest is built by the main CMake project through add_subdirectory as recommended at:
 : # https://github.com/google/fuzztest/blob/main/doc/quickstart-cmake.md


### PR DESCRIPTION
This seems to fix the oss-fuzz build pinned at an old builder: https://github.com/AOMediaCodec/libavif/issues/2207