### PR TITLE
Fix array initialCapacity of sato expression

### DIFF
--- a/src/sampletransform.c
+++ b/src/sampletransform.c
@@ -121,7 +121,7 @@ avifResult avifSampleTransformRecipeToExpression(avifSampleTransformRecipe recip
         // reference_count is two: one 12-bit input image and one 8-bit input image (because AV1 does not support 4-bit samples).
         //   (base_sample << 4) | (hidden_sample >> 4)
         // Note: base_sample is encoded losslessly. hidden_sample is encoded lossily or losslessly.
-        AVIF_CHECKERR(avifArrayCreate(expression, sizeof(avifSampleTransformToken), 5), AVIF_RESULT_OUT_OF_MEMORY);
+        AVIF_CHECKERR(avifArrayCreate(expression, sizeof(avifSampleTransformToken), 7), AVIF_RESULT_OUT_OF_MEMORY);
 
         {
             // The base image represents the 12 most significant bits of the reconstructed, bit-depth-extended output image.

--- a/src/write.c
+++ b/src/write.c
@@ -1315,7 +1315,7 @@ static avifResult avifImageApplyOperation(avifImage * result,
     const avifSampleTransformToken tokens[] = { { AVIF_SAMPLE_TRANSFORM_INPUT_IMAGE_ITEM_INDEX, 0, /*inputImageItemIndex=*/1 },
                                                 { AVIF_SAMPLE_TRANSFORM_CONSTANT, constant, 0 },
                                                 { op, 0, 0 } };
-    return avifImageApplyOperations(result, AVIF_SAMPLE_TRANSFORM_BIT_DEPTH_32, 3, tokens, 1, &inputImageItem, planes);
+    return avifImageApplyOperations(result, AVIF_SAMPLE_TRANSFORM_BIT_DEPTH_32, /*numTokens=*/3, tokens, /*numInputImageItems=*/1, &inputImageItem, planes);
 }
 
 static avifResult avifEncoderCreateBitDepthExtensionImage(const avifEncoder * encoder,

--- a/tests/gtest/avif16bittest.cc
+++ b/tests/gtest/avif16bittest.cc
@@ -85,9 +85,10 @@ TEST_P(SampleTransformTest, Avif16bit) {
        /*inputImageItemIndex=*/1},
       {AVIF_SAMPLE_TRANSFORM_CONSTANT, 1 << shift, 0},
       {AVIF_SAMPLE_TRANSFORM_DIVIDE, 0, 0}};
-  ASSERT_EQ(avifImageApplyOperations(image_no_sato.get(),
-                                     AVIF_SAMPLE_TRANSFORM_BIT_DEPTH_32, 3,
-                                     tokens, 1, &inputImage, AVIF_PLANES_ALL),
+  ASSERT_EQ(avifImageApplyOperations(
+                image_no_sato.get(), AVIF_SAMPLE_TRANSFORM_BIT_DEPTH_32,
+                /*numTokens=*/3, tokens, /*numInputImageItems=*/1, &inputImage,
+                AVIF_PLANES_ALL),
             AVIF_RESULT_OK);
   EXPECT_TRUE(testutil::AreImagesEqual(*image_no_sato, *decoded_no_sato));
 }


### PR DESCRIPTION
Also add arg hints at avifImageApplyOperations() call sites.