### PR TITLE
Fix Python conflict with homebrew

### DIFF
--- a/.github/actions/setup-common/action.yml
+++ b/.github/actions/setup-common/action.yml
@@ -38,10 +38,6 @@ runs:
     - name: Set up nasm
       if: ${{ inputs.codec-aom == 'LOCAL' || inputs.codec-dav1d == 'LOCAL' }}
       uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
-    - name: Set up meson
-      if: ${{ inputs.codec-dav1d == 'LOCAL' }}
-      run: pip install meson
-      shell: bash
     - name: Set up rust
       if: ${{ inputs.codec-rav1e == 'LOCAL' }}
       uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -61,6 +61,10 @@ runs:
       run:
         sudo apt install libyuv-dev
       shell: bash
+    - name: Set up meson
+      if: ${{ inputs.codec-dav1d == 'LOCAL' }}
+      run: pip install meson
+      shell: bash
 
     - uses: ./.github/actions/setup-common
       with:

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -63,7 +63,8 @@ runs:
       shell: bash
     - name: Set up meson
       if: ${{ inputs.codec-dav1d == 'LOCAL' }}
-      run: pip install meson
+      run:
+        sudo apt install meson
       shell: bash
 
     - uses: ./.github/actions/setup-common

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -19,6 +19,14 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # github actions overwrites brew's python. Force it to reassert itself, by running in a separate step.
+    # Borrowed from https://github.com/mesonbuild/meson/blob/master/.github/workflows/macos.yml#L87-L92
+    - name: unbreak python in github actions
+      run: |
+        find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+        sudo rm -rf /Library/Frameworks/Python.framework/
+        brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
+      shell: bash
     - name: Install non-library dependencies
       run: brew install imagemagick
       shell: bash

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -23,7 +23,10 @@ runs:
     # Borrowed from https://github.com/mesonbuild/meson/blob/master/.github/workflows/macos.yml#L87-L92
     - name: unbreak python in github actions
       run: |
-        find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+        find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/2to3*' \
+          -o -lname '*/Library/Frameworks/Python.framework/idle3*' \
+          -o -lname '*/Library/Frameworks/Python.framework/pydoc3*' \
+          -o -lname '*/Library/Frameworks/Python.framework/python3*' -delete
         sudo rm -rf /Library/Frameworks/Python.framework/
         brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
       shell: bash

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
     - name: Set up meson
       if: ${{ inputs.codec-dav1d == 'LOCAL' }}
-      run: pip3 install meson
+      run: brew install meson
       shell: bash
 
     - uses: ./.github/actions/setup-common

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -41,6 +41,10 @@ runs:
       if: ${{ inputs.codec-dav1d == 'SYSTEM' }}
       run: brew install dav1d
       shell: bash
+    - name: Set up meson
+      if: ${{ inputs.codec-dav1d == 'LOCAL' }}
+      run: pip3 install meson
+      shell: bash
 
     - uses: ./.github/actions/setup-common
       with:

--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -21,6 +21,10 @@ runs:
   steps:
     - name: Setup Visual Studio shell
       uses: egor-tensin/vs-shell@9a932a62d05192eae18ca370155cf877eecc2202 # v2.1
+    - name: Set up meson
+      if: ${{ inputs.codec-dav1d == 'LOCAL' }}
+      run: pip install meson
+      shell: bash
 
     - uses: ./.github/actions/setup-common
       with:

--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -21,10 +21,13 @@ runs:
   steps:
     - name: Setup Visual Studio shell
       uses: egor-tensin/vs-shell@9a932a62d05192eae18ca370155cf877eecc2202 # v2.1
-    - name: Set up meson
+    - name: vcpkg build
+      uses: johnwason/vcpkg-action@v6
       if: ${{ inputs.codec-dav1d == 'LOCAL' }}
-      run: pip install meson
-      shell: bash
+      id: vcpkg
+      with:
+        pkgs: vcpkg-tool-meson
+        triplet: x64-windows-release
 
     - uses: ./.github/actions/setup-common
       with:

--- a/.github/workflows/ci-android-emulator-tests.yml
+++ b/.github/workflows/ci-android-emulator-tests.yml
@@ -31,7 +31,7 @@ jobs:
           # r25c is the same as 25.2.9519653.
           ndk-version: r25c
           add-to-path: false
-      - uses: ./.github/actions/setup-common
+      - uses: ./.github/actions/setup-linux
         with:
           codec-aom: 'LOCAL'
           codec-dav1d: 'LOCAL'

--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -25,7 +25,7 @@ jobs:
           # r25c is the same as 25.2.9519653.
           ndk-version: r25c
           add-to-path: false
-      - uses: ./.github/actions/setup-common
+      - uses: ./.github/actions/setup-linux
         with:
           codec-aom: 'LOCAL'
           codec-dav1d: 'LOCAL'


### PR DESCRIPTION
- delete the Python symlinks before reinstalling Python through meson
- install meson using the proper package managers (as pip now requires running in a virtualenc on macOS) 
- use the setup-linux action on Android (because meson installation is now moved to setup-linux)