### PR TITLE
Add brew update step in setup-macos CI workflow

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -19,6 +19,9 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Update package manager references
+      run: brew update
+      shell: bash
     - name: Install non-library dependencies
       run: brew install imagemagick
       shell: bash


### PR DESCRIPTION
Solution found at
https://discuss.circleci.com/t/homebrew-error-the-brew-link-step-did-not-complete-successfully-trying-to-install-ffmpeg/39727