### PR TITLE
Windows: change leading / to - in RAV1E_LIBRARIES

### DIFF
--- a/cmake/Modules/LocalRav1e.cmake
+++ b/cmake/Modules/LocalRav1e.cmake
@@ -99,6 +99,10 @@ else()
 
     set(RAV1E_LIBRARIES ${Rust_CARGO_TARGET_LINK_NATIVE_LIBS})
     if(WIN32)
+        # If an item starts with "/" (e.g., "/defaultlib:msvcrt"), change the
+        # leading "/" to "-" so that the target_link_libraries() call below
+        # will treat the item as a linker flag.
+        list(TRANSFORM RAV1E_LIBRARIES REPLACE "^/" "-")
         # Remove msvcrt from RAV1E_LIBRARIES since it's linked by default
         list(REMOVE_ITEM RAV1E_LIBRARIES "msvcrt.lib" "-lmsvcrt")
     endif()


### PR DESCRIPTION
Fix the ci-windows.yml error in the "Build libavif (ninja)" step:
  ninja: error: '/defaultlib:msvcrt', needed by
  'avif_example_decode_memory.exe', missing and no known rule to make it

RAV1E_LIBRARIES is passed to target_link_libraries(). Item names starting with -, but not -l or -framework, are treated by target_link_libraries() as linker flags. On Windows, linker flags may start with / (e.g., /defaultlib:msvcrt), so we need to change / to - before passing the linker flags to target_link_libraries(). Otherwise target_link_libraries() will incorrectly treat those linker flags as libraries.