### PR TITLE
Remove gainmap backward direction

### DIFF
--- a/apps/avifgainmaputil/printmetadata_command.cc
+++ b/apps/avifgainmaputil/printmetadata_command.cc
@@ -91,8 +91,6 @@ avifResult PrintMetadataCommand::Run() {
   std::cout << " * " << std::left << std::setw(w) << "Gain Map Gamma: "
             << FormatFractions(metadata.gainMapGammaN, metadata.gainMapGammaD)
             << "\n";
-  std::cout << " * " << std::left << std::setw(w) << "Backward Direction: "
-            << (metadata.backwardDirection ? "True" : "False") << "\n";
   std::cout << " * " << std::left << std::setw(w) << "Use Base Color Space: "
             << (metadata.useBaseColorSpace ? "True" : "False") << "\n";
 

--- a/apps/avifgainmaputil/swapbase_command.cc
+++ b/apps/avifgainmaputil/swapbase_command.cc
@@ -98,7 +98,6 @@ avifResult ChangeBase(const avifImage& image, int depth,
 
   // Swap base and alternate in the gain map metadata.
   avifGainMapMetadata& metadata = swapped->gainMap->metadata;
-  metadata.backwardDirection = !metadata.backwardDirection;
   metadata.useBaseColorSpace = !metadata.useBaseColorSpace;
   std::swap(metadata.baseHdrHeadroomN, metadata.alternateHdrHeadroomN);
   std::swap(metadata.baseHdrHeadroomD, metadata.alternateHdrHeadroomD);

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -601,7 +601,6 @@ static avifBool avifJPEGParseGainMapXMPProperties(const xmlNode * rootNode, avif
 
     avifGainMapMetadataDouble metadataDouble;
     // Set default values from Adobe's spec.
-    metadataDouble.backwardDirection = AVIF_FALSE;
     metadataDouble.baseHdrHeadroom = 0.0;
     metadataDouble.alternateHdrHeadroom = 1.0;
     for (int i = 0; i < 3; ++i) {
@@ -637,13 +636,11 @@ static avifBool avifJPEGParseGainMapXMPProperties(const xmlNode * rootNode, avif
     const char * baseRenditionIsHDR;
     if (avifJPEGFindGainMapProperty(descNode, "BaseRenditionIsHDR", /*maxValues=*/1, &baseRenditionIsHDR, &numValues)) {
         if (!strcmp(baseRenditionIsHDR, "True")) {
-            metadataDouble.backwardDirection = AVIF_TRUE;
             SwapDoubles(&metadataDouble.baseHdrHeadroom, &metadataDouble.alternateHdrHeadroom);
             for (int c = 0; c < 3; ++c) {
                 SwapDoubles(&metadataDouble.baseOffset[c], &metadataDouble.alternateOffset[c]);
             }
         } else if (!strcmp(baseRenditionIsHDR, "False")) {
-            metadataDouble.backwardDirection = AVIF_FALSE;
         } else {
             return AVIF_FALSE; // Unexpected value.
         }

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -630,16 +630,13 @@ typedef struct avifGainMapMetadata
     //
     // If 'H' is the display's current log2-encoded HDR capacity (HDR to SDR ratio),
     // then the weight 'w' to apply the gain map is computed as follows:
-    // f = clamp((H - hdrCapacityMin) /
-    //           (hdrCapacityMax - hdrCapacityMin), 0, 1);
-    // w = backwardDirection ? f * -1 : f;
+    // f = clamp((H - baseHdrHeadroom) /
+    //           (alternateHdrHeadroom - baseHdrHeadroom), 0, 1);
+    // w = sign(alternateHdrHeadroom - baseHdrHeadroom) * f
     uint32_t baseHdrHeadroomN;
     uint32_t baseHdrHeadroomD;
     uint32_t alternateHdrHeadroomN;
     uint32_t alternateHdrHeadroomD;
-
-    // True if the gain map should be applied in reverse, see weight formula above.
-    avifBool backwardDirection;
 
     // True if tone mapping should be performed in the color space of the
     // base image. If false, the color space of the alternate image should
@@ -702,7 +699,6 @@ typedef struct avifGainMapMetadataDouble
     double alternateOffset[3];
     double baseHdrHeadroom;
     double alternateHdrHeadroom;
-    avifBool backwardDirection;
     avifBool useBaseColorSpace;
 } avifGainMapMetadataDouble;
 

--- a/src/read.c
+++ b/src/read.c
@@ -1973,7 +1973,6 @@ static avifBool avifParseToneMappedImageBox(avifGainMapMetadata * metadata, cons
     uint8_t channelCount = (flags & 1) * 2 + 1;
     AVIF_ASSERT_OR_RETURN(channelCount == 1 || channelCount == 3);
     metadata->useBaseColorSpace = (flags & 2) != 0;
-    metadata->backwardDirection = (flags & 4) != 0;
     const avifBool useCommonDenominator = (flags & 8) != 0;
 
     if (useCommonDenominator) {

--- a/src/write.c
+++ b/src/write.c
@@ -919,9 +919,6 @@ static avifBool avifWriteToneMappedImagePayload(avifRWData * data, const avifGai
     if (metadata->useBaseColorSpace) {
         flags |= 2;
     }
-    if (metadata->backwardDirection) {
-        flags |= 4;
-    }
     const uint32_t denom = metadata->baseHdrHeadroomD;
     avifBool useCommonDenominator = metadata->baseHdrHeadroomD == denom && metadata->alternateHdrHeadroomD == denom;
     for (int c = 0; c < channelCount; ++c) {
@@ -1609,8 +1606,7 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             }
             const avifGainMapMetadata * firstMetadata = &firstGainMap->metadata;
             const avifGainMapMetadata * cellMetadata = &cellGainMap->metadata;
-            if (cellMetadata->backwardDirection != firstMetadata->backwardDirection ||
-                cellMetadata->baseHdrHeadroomN != firstMetadata->baseHdrHeadroomN ||
+            if (cellMetadata->baseHdrHeadroomN != firstMetadata->baseHdrHeadroomN ||
                 cellMetadata->baseHdrHeadroomD != firstMetadata->baseHdrHeadroomD ||
                 cellMetadata->alternateHdrHeadroomN != firstMetadata->alternateHdrHeadroomN ||
                 cellMetadata->alternateHdrHeadroomD != firstMetadata->alternateHdrHeadroomD) {

--- a/tests/gtest/avif_fuzztest_enc_dec_experimental.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_experimental.cc
@@ -21,10 +21,6 @@ namespace {
 
 void CheckGainMapMetadataMatches(const avifGainMapMetadata& actual,
                                  const avifGainMapMetadata& expected) {
-  // 'expecteed' is the source struct which has arbitrary data and booleans
-  // values can contain any value, but the decoded ('actual') struct should
-  // be 0 or 1.
-  EXPECT_EQ(actual.backwardDirection, expected.backwardDirection ? 1 : 0);
   EXPECT_EQ(actual.baseHdrHeadroomN, expected.baseHdrHeadroomN);
   EXPECT_EQ(actual.baseHdrHeadroomD, expected.baseHdrHeadroomD);
   EXPECT_EQ(actual.alternateHdrHeadroomN, expected.alternateHdrHeadroomN);

--- a/tests/gtest/avifjpeggainmaptest.cc
+++ b/tests/gtest/avifjpeggainmaptest.cc
@@ -67,7 +67,6 @@ void CheckGainMapMetadata(
   EXPECT_NEAR(
       static_cast<double>(m.alternateHdrHeadroomN) / m.alternateHdrHeadroomD,
       alternate_hdr_headroom, kEpsilon);
-  EXPECT_EQ(m.backwardDirection, backward_direction);
 }
 
 TEST(JpegTest, ReadJpegWithGainMap) {


### PR DESCRIPTION
This did not end up in the ISO 21496-1 specification.