### PR TITLE
Run clang-format-check.yml on pull_request

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,5 @@
 name: CI Format Check
-on: [push]
+on: [push, pull_request]
 
 permissions:
   contents: read


### PR DESCRIPTION
It is inconvenient to report a formatting error after a pull request has been merged.