### PR TITLE
avifRWStreamWriteBits: Check `v` for valid range

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -732,7 +732,7 @@ avifResult avifRWStreamWriteU32(avifRWStream * stream, uint32_t v);
 avifResult avifRWStreamWriteU64(avifRWStream * stream, uint64_t v);
 avifResult avifRWStreamWriteZeros(avifRWStream * stream, size_t byteCount);
 // The following functions can write non-aligned bits.
-avifResult avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCount);
+AVIF_NODISCARD avifResult avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCount);
 avifResult avifRWStreamWriteVarInt(avifRWStream * stream, uint32_t v);
 
 // This is to make it clear that the box size is currently unknown, and will be determined later (with a call to avifRWStreamFinishBox)

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -732,7 +732,7 @@ avifResult avifRWStreamWriteU32(avifRWStream * stream, uint32_t v);
 avifResult avifRWStreamWriteU64(avifRWStream * stream, uint64_t v);
 avifResult avifRWStreamWriteZeros(avifRWStream * stream, size_t byteCount);
 // The following functions can write non-aligned bits.
-AVIF_NODISCARD avifResult avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCount);
+avifResult avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCount);
 avifResult avifRWStreamWriteVarInt(avifRWStream * stream, uint32_t v);
 
 // This is to make it clear that the box size is currently unknown, and will be determined later (with a call to avifRWStreamFinishBox)

--- a/src/stream.c
+++ b/src/stream.c
@@ -479,7 +479,9 @@ avifResult avifRWStreamWriteZeros(avifRWStream * stream, size_t byteCount)
 
 avifResult avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCount)
 {
-    assert(((uint64_t)v >> bitCount) == 0); // (uint32_t >> 32 is undefined behavior)
+    if (bitCount < 32 && (v >> bitCount) != 0) {
+        return AVIF_RESULT_INVALID_ARGUMENT;
+    }
     while (bitCount) {
         if (stream->numUsedBitsInPartialByte == 0) {
             AVIF_CHECKRES(makeRoom(stream, 1)); // Book a new partial byte in the stream.

--- a/src/stream.c
+++ b/src/stream.c
@@ -479,9 +479,7 @@ avifResult avifRWStreamWriteZeros(avifRWStream * stream, size_t byteCount)
 
 avifResult avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCount)
 {
-    if (bitCount < 32 && (v >> bitCount) != 0) {
-        return AVIF_RESULT_INVALID_ARGUMENT;
-    }
+    AVIF_CHECKERR(bitCount >= 32 || (v >> bitCount) == 0, AVIF_RESULT_INVALID_ARGUMENT);
     while (bitCount) {
         if (stream->numUsedBitsInPartialByte == 0) {
             AVIF_CHECKRES(makeRoom(stream, 1)); // Book a new partial byte in the stream.

--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -203,6 +203,15 @@ TEST(StreamTest, Roundtrip) {
   EXPECT_FALSE(avifROStreamSkip(&ro_stream, /*byteCount=*/1));
 }
 
+TEST(StreamTest, WriteBitsLimit) {
+  testutil::AvifRwData rw_data;
+  avifRWStream rw_stream;
+  avifRWStreamStart(&rw_stream, &rw_data);
+  EXPECT_EQ(avifRWStreamWriteBits(&rw_stream, 7, 3), AVIF_RESULT_OK);
+  EXPECT_EQ(avifRWStreamWriteBits(&rw_stream, 8, 3),
+            AVIF_RESULT_INVALID_ARGUMENT);
+}
+
 //------------------------------------------------------------------------------
 // Variable length integer implementation
 


### PR DESCRIPTION
Make sure the input parameter `v` can be represented in `bitCount` bits. This was checked by an assertion. Replace the assertion by an error return.