### PR TITLE
Do not test #if AVIF_CODEC_AVM_ENABLED in C code

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3636,7 +3636,7 @@ static avifResult avifParseMetaBoxV1(avifROStream * s, avifMeta * meta, uint64_t
     if (hasExplicitCodecTypes) {
         AVIF_CHECKERR(avifROStreamRead(s, infeType, 4), AVIF_RESULT_BMFF_PARSE_FAILED);        // bit(32) infe_type;
         AVIF_CHECKERR(avifROStreamRead(s, codecConfigType, 4), AVIF_RESULT_BMFF_PARSE_FAILED); // bit(32) codec_config_type;
-#if AVIF_CODEC_AVM_ENABLED
+#if defined(AVIF_CODEC_AVM)
         if (!memcmp(infeType, "av02", 4) && !memcmp(codecConfigType, "av2C", 4)) {
             return AVIF_RESULT_NOT_IMPLEMENTED;
         }


### PR DESCRIPTION
AVIF_CODEC_AVM_ENABLED is a cmake variable, whereas AVIF_CODEC_AVM is a C preprocessor macro. In C code, test #if defined(AVIF_CODEC_AVM) instead of #if AVIF_CODEC_AVM_ENABLED.