### PR TITLE
Remove unneeded uint32_t casts

### DIFF
--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -55,7 +55,7 @@ static avifBool avifJPEGCopyPixels(avifImage * avif, uint32_t sizeLimit, struct 
 
     avif->width = cinfo->image_width;
     avif->height = cinfo->image_height;
-    if ((uint32_t)avif->width > sizeLimit / (uint32_t)avif->height) {
+    if (avif->width > sizeLimit / avif->height) {
         return AVIF_FALSE;
     }
 

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -456,7 +456,7 @@ avifBool avifPNGRead(const char * inputFilename,
         fprintf(stderr, "png_get_channels() should return 3 or 4 but returns %d.\n", numChannels);
         goto cleanup;
     }
-    if ((uint32_t)avif->width > imageSizeLimit / (uint32_t)avif->height) {
+    if (avif->width > imageSizeLimit / avif->height) {
         fprintf(stderr, "Too big PNG dimensions (%d x %d > %u px): %s\n", avif->width, avif->height, imageSizeLimit, inputFilename);
         goto cleanup;
     }


### PR DESCRIPTION
avif->width and avif->height are of the uint32_t type, so it is not necessary to cast them to uint32_t.