### PR TITLE
Fix ci-android-emulator-tests

### DIFF
--- a/.github/workflows/ci-android-emulator-tests.yml
+++ b/.github/workflows/ci-android-emulator-tests.yml
@@ -25,13 +25,7 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Download and Setup the Android NDK
-        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # v1.5.0
-        id: setup-ndk
-        with:
-          # r25c is the same as 25.2.9519653.
-          ndk-version: r25c
-          add-to-path: false
+      - uses: gradle/gradle-build-action@v3
       - uses: ./.github/actions/setup-linux
         with:
           codec-aom: 'LOCAL'
@@ -40,17 +34,13 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
-          java-version: '11'
-          distribution: 'zulu'
+          java-version: '17'
+          distribution: 'temurin'
       - name: Run Instrumented Tests on the Emulator
         uses: reactivecircus/android-emulator-runner@77986be26589807b8ebab3fde7bbf5c60dabec32 # v2.31.0
         with:
           working-directory: android_jni
-          api-level: 30
+          api-level: 29
           force-avd-creation: false
-          # This is the same version of cmake that is found in build.gradle.
-          # This will be used to build libavif and the JNI bindings.
-          cmake: 3.22.1
-          ndk: 25.2.9519653
           arch: x86_64
           script: ./gradlew cAT

--- a/.github/workflows/ci-android-emulator-tests.yml
+++ b/.github/workflows/ci-android-emulator-tests.yml
@@ -5,6 +5,7 @@ on:
       - 'android_jni/**'
   pull_request:
     paths:
+      - '.github/workflows/ci-android-emulator-tests.yml'
       - 'android_jni/**'
 
 permissions:
@@ -17,7 +18,7 @@ concurrency:
 
 jobs:
   build-and-run-android-jni-tests:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
ci-android-emulator-tests actually ran on macOS but with the arm64 only architecture and the emulation happening, it is easier to stick to x86 and therefore linux.