### PR TITLE
avifpng.c: Print avif->width, avif->height with %u

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -457,7 +457,7 @@ avifBool avifPNGRead(const char * inputFilename,
         goto cleanup;
     }
     if (avif->width > imageSizeLimit / avif->height) {
-        fprintf(stderr, "Too big PNG dimensions (%d x %d > %u px): %s\n", avif->width, avif->height, imageSizeLimit, inputFilename);
+        fprintf(stderr, "Too big PNG dimensions (%u x %u > %u px): %s\n", avif->width, avif->height, imageSizeLimit, inputFilename);
         goto cleanup;
     }
 


### PR DESCRIPTION
avif->width and avif->height are of the uint32_t type, so print them with the %u format specifier.