### PR TITLE
Support compiling with clang-cl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The changes are relative to the previous release, unless the baseline is specifi
   disabled for non-native builds.
 * Fix CMake config shared library leaks
   https://github.com/AOMediaCodec/libavif/issues/2264.
+* Fix clang-cl compilation.
 
 ## [1.1.0] - 2024-07-11
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,40 +261,53 @@ endif()
 
 # Enable all warnings
 include(CheckCCompilerFlag)
-if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+if(MSVC)
+    message(STATUS "libavif: Enabling warnings for MSVC")
+    target_compile_options(
+        avif_obj
+        PUBLIC $<BUILD_INTERFACE:
+               /W4 # For clang-cl, /W4 enables -Wall and -Wextra
+               /wd4324 # Disable: structure was padded due to alignment specifier
+               /wd4996 # Disable: potentially unsafe stdlib methods
+               >
+    )
+    # clang-cl documentation says:
+    #   /execution-charset:<value>
+    #                           Runtime encoding, supports only UTF-8
+    #   ...
+    #   /source-charset:<value> Source encoding, supports only UTF-8
+    # So we don't need to pass /source-charset:utf-8 to clang-cl, and we cannot pass /execution-charset:us-ascii to clang-cl.
+    if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+        target_compile_options(
+            avif_obj
+            PUBLIC $<BUILD_INTERFACE:
+                   # This tells MSVC to read source code as UTF-8 and assume console can only use ASCII (minimal safe).
+                   # libavif uses ANSI API to print to console, which is not portable between systems using different
+                   # languages and results in mojibake unless we only use codes shared by every code page: ASCII.
+                   # A C4556 warning will be generated on violation.
+                   # Commonly used /utf-8 flag assumes UTF-8 for both source and console, which is usually not the case.
+                   # Warnings can be suppressed but there will still be random characters printed to the console.
+                   /source-charset:utf-8
+                   /execution-charset:us-ascii
+                   >
+        )
+    endif()
+elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
     message(STATUS "libavif: Enabling warnings for Clang")
     target_compile_options(avif_obj PUBLIC $<BUILD_INTERFACE:-Wall -Wextra -Wshorten-64-to-32>)
 elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
     message(STATUS "libavif: Enabling warnings for GCC")
     target_compile_options(avif_obj PUBLIC $<BUILD_INTERFACE:-Wall -Wextra>)
-elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
-    message(STATUS "libavif: Enabling warnings for MSVC")
-    target_compile_options(
-        avif_obj
-        PUBLIC $<BUILD_INTERFACE:
-               /W4
-               /wd4324 # Disable: structure was padded due to alignment specifier
-               /wd4996 # Disable: potentially unsafe stdlib methods
-               # This tells MSVC to read source code as UTF-8 and assume console can only use ASCII (minimal safe).
-               # libavif uses ANSI API to print to console, which is not portable between systems using different
-               # languages and results in mojibake unless we only use codes shared by every code page: ASCII.
-               # A C4556 warning will be generated on violation.
-               # Commonly used /utf-8 flag assumes UTF-8 for both source and console, which is usually not the case.
-               # Warnings can be suppressed but there will still be random characters printed to the console.
-               /source-charset:utf-8
-               /execution-charset:us-ascii
-               >
-    )
 else()
     message(FATAL_ERROR "libavif: Unknown compiler, bailing out")
 endif()
 
 if(AVIF_ENABLE_WERROR)
     # Warnings as errors
-    if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
-        target_compile_options(avif_obj PUBLIC $<BUILD_INTERFACE:-Werror>)
-    elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+    if(MSVC)
         target_compile_options(avif_obj PUBLIC $<BUILD_INTERFACE:/WX>)
+    elseif(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
+        target_compile_options(avif_obj PUBLIC $<BUILD_INTERFACE:-Werror>)
     else()
         message(FATAL_ERROR "libavif: Unknown compiler, bailing out")
     endif()
@@ -324,6 +337,13 @@ if(AVIF_ENABLE_COVERAGE)
         message(WARNING "libavif: Ignoring request for coverage (AVIF_ENABLE_COVERAGE); only clang is currently supported.")
         set(AVIF_ENABLE_COVERAGE OFF)
     endif()
+endif()
+
+if(MSVC)
+    # Disable deprecation warnings about POSIX function names such as setmode (replaced by the ISO C and C++ conformant name _setmode).
+    add_compile_definitions(_CRT_NONSTDC_NO_WARNINGS)
+    # Disable deprecation warnings about less secure CRT functions such as fopen (replaced by fopen_s).
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 
 if(AVIF_ENABLE_EXPERIMENTAL_YCGCO_R)


### PR DESCRIPTION
Instead of testing
    CMAKE_C_COMPILER_ID MATCHES "MSVC"
test the cmake variable MSVC.

Exclude /source-charset:utf-8 /execution-charset:us-ascii from clang-cl because clang-cl does not support /execution-charset:us-ascii and /source-charset:utf-8 is the only /source-charset option clang-cl supports.

Define _CRT_NONSTDC_NO_WARNINGS and _CRT_SECURE_NO_WARNINGS to disable deprecation warnings about POSIX function names and less secure functions in Microsoft CRT. I don't know why genuine MSVC doesn't warn about these functions.