### PR TITLE
Move the project() call earlier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ if(POLICY CMP0135)
     cmake_policy(SET CMP0135 NEW) # valid for DOWNLOAD_EXTRACT_TIMESTAMP option in CMake 3.24 and later
 endif()
 
+project(libavif LANGUAGES C VERSION 1.1.0)
+
 # The root directory of the avif source
 set(AVIF_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
@@ -24,8 +26,6 @@ include(ExternalProject)
 include(FetchContent)
 include(FindPkgConfig)
 include(AvifExternalProjectUtils)
-
-project(libavif LANGUAGES C VERSION 1.1.0)
 
 # Set C99 as the default
 set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
Call project() after the cmake_minimum_required() and cmake_policy() calls, but before everything else.

Fix the following warning message from
.github/workflows/ci-windows-installed.yml:

  -- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
  Hint: The project() command has not yet been called.  It sets up
  system-specific search paths.