### PR TITLE
ci: Run on push only in the `main` branch

### DIFF
--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -1,5 +1,9 @@
 name: CI Android JNI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -7,6 +7,8 @@
 name: CI Disable GTest
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths:
       - '.github/workflows/ci-disable-gtest.yml'

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -3,7 +3,11 @@
 # which can be downloaded from GitHub'S UI or with 'gh run download'.
 
 name: CI Linux Golden Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -1,6 +1,8 @@
 name: CI Unix Static For AVIF_LOCAL
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths:
       - '.github/workflows/ci-linux-static-old-local.yml'

--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -2,7 +2,11 @@
 # with an additional build configuration (using installed deps and dav1d).
 
 name: CI MinGW
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -2,7 +2,11 @@
 # with an additional build configuration (using installed deps and dav1d).
 
 name: CI Unix Shared Installed
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -4,7 +4,11 @@
 #   * Does not build rav1e, SVT-AV1 nor libgav1.
 
 name: CI Unix Shared Local
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -1,6 +1,8 @@
 name: CI Unix Static AV2
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths:
       - '.github/workflows/ci-unix-static-av2.yml'

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -1,6 +1,8 @@
 name: CI Unix Static Sanitized
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths:
       - '.github/workflows/ci-unix-static-sanitized.yml'

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -1,6 +1,8 @@
 name: CI Unix Static
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths:
       - '.github/workflows/ci-unix-static.yml'

--- a/.github/workflows/ci-windows-installed.yml
+++ b/.github/workflows/ci-windows-installed.yml
@@ -5,7 +5,11 @@
 #   * TODO: use proper installations of libgav1, libsharpyuv and SVT once released.
 
 name: CI Windows Installed
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -13,6 +13,8 @@
 name: CI Windows
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths:
       - '.github/workflows/ci-windows.yml'

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,6 +1,8 @@
 name: CI Fuzz
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths:
       - '.github/workflows/cifuzz.yml'

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,9 @@
 name: CI Format Check
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
This avoids excessive CI runs when pushing changes to other
branches on forks.
