### PR TITLE
android ci: Run on ubuntu-latest

### DIFF
--- a/.github/workflows/ci-android-emulator-tests.yml
+++ b/.github/workflows/ci-android-emulator-tests.yml
@@ -1,10 +1,14 @@
 name: CI Android Emulator Tests
 on:
   push:
+    branches:
+      - main
     paths:
+      - '.github/workflows/ci-android-emulator-tests.yml'
       - 'android_jni/**'
   pull_request:
     paths:
+      - '.github/workflows/ci-android-emulator-tests.yml'
       - 'android_jni/**'
 
 permissions:
@@ -17,13 +21,20 @@ concurrency:
 
 jobs:
   build-and-run-android-jni-tests:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
 
     steps:
       - name: Checkout the repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      # This is needed for faster emulators. See:
+      # https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Download and Setup the Android NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # v1.5.0
         id: setup-ndk
@@ -33,23 +44,19 @@ jobs:
           add-to-path: false
       - uses: ./.github/actions/setup-linux
         with:
-          codec-aom: 'LOCAL'
           codec-dav1d: 'LOCAL'
-          recent-cmake: 'true'
+          libyuv: 'LOCAL'
       - name: Setup JDK
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
-          java-version: '11'
-          distribution: 'zulu'
+          java-version: '17'
+          distribution: 'temurin'
       - name: Run Instrumented Tests on the Emulator
         uses: reactivecircus/android-emulator-runner@77986be26589807b8ebab3fde7bbf5c60dabec32 # v2.31.0
         with:
           working-directory: android_jni
-          api-level: 30
+          api-level: 31
           force-avd-creation: false
-          # This is the same version of cmake that is found in build.gradle.
-          # This will be used to build libavif and the JNI bindings.
-          cmake: 3.22.1
           ndk: 25.2.9519653
           arch: x86_64
           script: ./gradlew cAT


### PR DESCRIPTION
With the recent changes to mac, android emulation is faster on
ubuntu runners with x86_64.

See: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
