### PR TITLE
avifstreamtest.cc: Remove three unused variables

### DIFF
--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -14,11 +14,6 @@
 namespace avif {
 namespace {
 
-// Taken from stream.c.
-static const int VARINT_DEPTH_0 = 7;
-static const int VARINT_DEPTH_1 = 3;
-static const int VARINT_DEPTH_2 = 18;
-
 //------------------------------------------------------------------------------
 
 TEST(StreamTest, Roundtrip) {


### PR DESCRIPTION
Fix Clang -Wunused-const-variable warnings on 'VARINT_DEPTH_0', 'VARINT_DEPTH_1', and 'VARINT_DEPTH_2'.