### PR TITLE
avifgainmaputil: Fix MSVC type conversion warnings

### DIFF
--- a/apps/avifgainmaputil/combine_command.cc
+++ b/apps/avifgainmaputil/combine_command.cc
@@ -98,10 +98,13 @@ avifResult CombineCommand::Run() {
   }
 
   const int downscaling = std::max<int>(1, arg_downscaling_);
-  const uint32_t gain_map_width = std::max<uint32_t>(
-      std::round((float)base_image->width / downscaling), 1u);
-  const uint32_t gain_map_height = std::max<uint32_t>(
-      std::round((float)base_image->height / downscaling), 1u);
+  const uint32_t gain_map_width = std::max(
+      static_cast<uint32_t>(std::round((float)base_image->width / downscaling)),
+      1u);
+  const uint32_t gain_map_height =
+      std::max(static_cast<uint32_t>(
+                   std::round((float)base_image->height / downscaling)),
+               1u);
   std::cout << "Creating a gain map of size " << gain_map_width << " x "
             << gain_map_height << "\n";
 

--- a/apps/avifgainmaputil/combine_command.cc
+++ b/apps/avifgainmaputil/combine_command.cc
@@ -97,8 +97,8 @@ avifResult CombineCommand::Run() {
         arg_alternate_cicp_.value().matrix_coefficients;
   }
 
-  const int downscaling = std::max<int>(1, arg_downscaling_);
-  const int rounding = downscaling / 2;
+  const uint32_t downscaling = std::max<int>(1, arg_downscaling_);
+  const uint32_t rounding = downscaling / 2;
   const uint32_t gain_map_width =
       std::max((base_image->width + rounding) / downscaling, 1u);
   const uint32_t gain_map_height =

--- a/apps/avifgainmaputil/combine_command.cc
+++ b/apps/avifgainmaputil/combine_command.cc
@@ -98,13 +98,11 @@ avifResult CombineCommand::Run() {
   }
 
   const int downscaling = std::max<int>(1, arg_downscaling_);
-  const uint32_t gain_map_width = std::max(
-      static_cast<uint32_t>(std::round((float)base_image->width / downscaling)),
-      1u);
+  const int rounding = downscaling / 2;
+  const uint32_t gain_map_width =
+      std::max((base_image->width + rounding) / downscaling, 1u);
   const uint32_t gain_map_height =
-      std::max(static_cast<uint32_t>(
-                   std::round((float)base_image->height / downscaling)),
-               1u);
+      std::max((base_image->height + rounding) / downscaling, 1u);
   std::cout << "Creating a gain map of size " << gain_map_width << " x "
             << gain_map_height << "\n";
 

--- a/apps/avifgainmaputil/swapbase_command.cc
+++ b/apps/avifgainmaputil/swapbase_command.cc
@@ -23,7 +23,7 @@ avifResult ChangeBase(const avifImage& image, int depth,
   swapped->yuvFormat = yuvFormat;
 
   const float headroom =
-      static_cast<double>(image.gainMap->metadata.alternateHdrHeadroomN) /
+      static_cast<float>(image.gainMap->metadata.alternateHdrHeadroomN) /
       image.gainMap->metadata.alternateHdrHeadroomD;
   const bool tone_mapping_to_sdr = (headroom == 0.0f);
 

--- a/apps/avifgainmaputil/tonemap_command.cc
+++ b/apps/avifgainmaputil/tonemap_command.cc
@@ -52,7 +52,7 @@ avifResult TonemapCommand::Run() {
   avifContentLightLevelInformationBox clli_box = {};
   bool clli_set = false;
   if (arg_clli_str_.value().size() > 0) {
-    std::vector<uint32_t> clli;
+    std::vector<uint16_t> clli;
     if (!ParseList(arg_clli_str_, ',', 2, &clli)) {
       std::cerr << "Invalid clli values, expected format: maxCLL,maxPALL where "
                    "both maxCLL and maxPALL are positive integers, got: "


### PR DESCRIPTION
Fix MSVC C4244 warnings on type conversions, possible loss of data.