### PR TITLE
 Fix "No known features for CXX compiler" CMake error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,14 +122,28 @@ set_local_or_system_option(
     "GTEST" OFF
     "Build the GoogleTest framework by providing your own copy of the repo in ext/googletest (see Local Builds in README)"
 )
+option(AVIF_BUILD_APPS "Build avif apps." OFF)
+option(AVIF_BUILD_TESTS "Build avif tests." OFF)
 option(AVIF_LOCAL_FUZZTEST
        "Build the Google FuzzTest framework by providing your own copy of the repo in ext/fuzztest (see Local Builds in README)"
        OFF
 )
-
 option(
     AVIF_ENABLE_COMPLIANCE_WARDEN
     "Check all avifEncoderFinish() output for AVIF specification compliance. Depends on gpac/ComplianceWarden which can be added with ext/compliance_warden.sh"
+    OFF
+)
+option(
+    AVIF_ENABLE_GOLDEN_TESTS
+    "Build tests that compare encoding outputs to golden files. Needs AVIF_BUILD_APPS=ON, and depends on MP4box which can be built with ext/mp4box.sh"
+    OFF
+)
+option(AVIF_ENABLE_GTEST
+       "Build avif C++ tests, which depend on GoogleTest. Requires GoogleTest. Has no effect unless AVIF_BUILD_TESTS is ON." ON
+)
+option(
+    AVIF_ENABLE_FUZZTEST
+    "Build avif fuzztest targets. Requires Google FuzzTest. Has no effect unless AVIF_BUILD_TESTS is ON."
     OFF
 )
 
@@ -646,22 +660,6 @@ endif()
 if(NOT SKIP_INSTALL_ALL)
     include(GNUInstallDirs)
 endif()
-
-option(AVIF_BUILD_APPS "Build avif apps." OFF)
-option(AVIF_BUILD_TESTS "Build avif tests." OFF)
-option(
-    AVIF_ENABLE_GOLDEN_TESTS
-    "Build tests that compare encoding outputs to golden files. Needs AVIF_BUILD_APPS=ON, and depends on MP4box which can be built with ext/mp4box.sh"
-    OFF
-)
-option(AVIF_ENABLE_GTEST
-       "Build avif C++ tests, which depend on GoogleTest. Requires GoogleTest. Has no effect unless AVIF_BUILD_TESTS is ON." ON
-)
-option(
-    AVIF_ENABLE_FUZZTEST
-    "Build avif fuzztest targets. Requires Google FuzzTest. Has no effect unless AVIF_BUILD_TESTS and AVIF_ENABLE_GTEST are ON."
-    OFF
-)
 
 if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST)))
     if(AVIF_ZLIBPNG STREQUAL "OFF")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,10 +124,6 @@ set_local_or_system_option(
 )
 option(AVIF_BUILD_APPS "Build avif apps." OFF)
 option(AVIF_BUILD_TESTS "Build avif tests." OFF)
-option(AVIF_LOCAL_FUZZTEST
-       "Build the Google FuzzTest framework by providing your own copy of the repo in ext/fuzztest (see Local Builds in README)"
-       OFF
-)
 option(
     AVIF_ENABLE_COMPLIANCE_WARDEN
     "Check all avifEncoderFinish() output for AVIF specification compliance. Depends on gpac/ComplianceWarden which can be added with ext/compliance_warden.sh"
@@ -135,16 +131,18 @@ option(
 )
 option(
     AVIF_ENABLE_GOLDEN_TESTS
-    "Build tests that compare encoding outputs to golden files. Needs AVIF_BUILD_APPS=ON, and depends on MP4box which can be built with ext/mp4box.sh"
+    "Build tests that compare encoding outputs to golden files. Needs AVIF_BUILD_APPS=ON and AVIF_BUILD_TESTS=ON, and depends on MP4box which can be built with ext/mp4box.sh"
     OFF
 )
 option(AVIF_ENABLE_GTEST
        "Build avif C++ tests, which depend on GoogleTest. Requires GoogleTest. Has no effect unless AVIF_BUILD_TESTS is ON." ON
 )
-option(
-    AVIF_ENABLE_FUZZTEST
-    "Build avif fuzztest targets. Requires Google FuzzTest. Has no effect unless AVIF_BUILD_TESTS is ON."
-    OFF
+option(AVIF_ENABLE_FUZZTEST "Build avif fuzztest targets. Requires Google FuzzTest. Has no effect unless AVIF_BUILD_TESTS is ON."
+       OFF
+)
+option(AVIF_LOCAL_FUZZTEST
+       "Build the Google FuzzTest framework by providing your own copy of the repo in ext/fuzztest (see Local Builds in README)"
+       OFF
 )
 
 # Whether the libavif library uses c++ indirectly (e.g. through linking to libyuv).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ if(AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST OR AVIF_BUILD_APPS)
     target_link_libraries(aviftest_helpers_internal avif_apps_internal avif_internal)
 endif()
 
-if(CMAKE_CXX_COMPILER_VERSION)
+if(CMAKE_CXX_COMPILER_LOADED)
     # Fuzz target without any fuzzing engine dependency. For easy reproduction of oss-fuzz issues.
     add_executable(repro_avif_decode_fuzzer oss-fuzz/avif_decode_fuzzer.cc oss-fuzz/repro_fuzz.cc)
     set_target_properties(repro_avif_decode_fuzzer PROPERTIES LINKER_LANGUAGE "CXX")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ if(AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST OR AVIF_BUILD_APPS)
     target_link_libraries(aviftest_helpers_internal avif_apps_internal avif_internal)
 endif()
 
-if(AVIF_ENABLE_FUZZTEST)
+if(AVIF_LIB_USE_CXX)
     # TODO(vrabaud): merge with oss-fuzz.
     # Fuzz target without any fuzzing engine dependency. For easy reproduction of oss-fuzz issues.
     add_executable(repro_avif_decode_fuzzer oss-fuzz/avif_decode_fuzzer.cc oss-fuzz/repro_fuzz.cc)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,14 +47,17 @@ if(AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST OR AVIF_BUILD_APPS)
     target_link_libraries(aviftest_helpers_internal avif_apps_internal avif_internal)
 endif()
 
-# Fuzz target without any fuzzing engine dependency. For easy reproduction of oss-fuzz issues.
-add_executable(repro_avif_decode_fuzzer oss-fuzz/avif_decode_fuzzer.cc oss-fuzz/repro_fuzz.cc)
-set_target_properties(repro_avif_decode_fuzzer PROPERTIES LINKER_LANGUAGE "CXX")
-target_link_libraries(repro_avif_decode_fuzzer avif)
-# The test below exists for coverage and as a usage example: repro_avif_decode_fuzzer [reproducer file path]
-add_test(NAME repro_avif_decode_fuzzer COMMAND repro_avif_decode_fuzzer
-                                               ${CMAKE_CURRENT_SOURCE_DIR}/data/color_grid_alpha_nogrid.avif
-)
+if(AVIF_ENABLE_FUZZTEST)
+    # TODO(vrabaud): merge with oss-fuzz.
+    # Fuzz target without any fuzzing engine dependency. For easy reproduction of oss-fuzz issues.
+    add_executable(repro_avif_decode_fuzzer oss-fuzz/avif_decode_fuzzer.cc oss-fuzz/repro_fuzz.cc)
+    set_target_properties(repro_avif_decode_fuzzer PROPERTIES LINKER_LANGUAGE "CXX")
+    target_link_libraries(repro_avif_decode_fuzzer avif)
+    # The test below exists for coverage and as a usage example: repro_avif_decode_fuzzer [reproducer file path]
+    add_test(NAME repro_avif_decode_fuzzer COMMAND repro_avif_decode_fuzzer
+                                                   ${CMAKE_CURRENT_SOURCE_DIR}/data/color_grid_alpha_nogrid.avif
+    )
+endif()
 
 ################################################################################
 # GoogleTest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,8 +47,7 @@ if(AVIF_ENABLE_FUZZTEST OR AVIF_ENABLE_GTEST OR AVIF_BUILD_APPS)
     target_link_libraries(aviftest_helpers_internal avif_apps_internal avif_internal)
 endif()
 
-if(AVIF_LIB_USE_CXX)
-    # TODO(vrabaud): merge with oss-fuzz.
+if(CMAKE_CXX_COMPILER_VERSION)
     # Fuzz target without any fuzzing engine dependency. For easy reproduction of oss-fuzz issues.
     add_executable(repro_avif_decode_fuzzer oss-fuzz/avif_decode_fuzzer.cc oss-fuzz/repro_fuzz.cc)
     set_target_properties(repro_avif_decode_fuzzer PROPERTIES LINKER_LANGUAGE "CXX")


### PR DESCRIPTION
 Fix "No known features for CXX compiler" CMake error
    
- move relevant options at the top. AVIF_ENABLE_GTEST defaults
   to ON so it should be defined/set before it is checked
- update AVIF_ENABLE_FUZZTEST doc string to fix https://github.com/AOMediaCodec/libavif/issues/2314
- isolate repro_avif_decode_fuzzer build with CMAKE_CXX_COMPILER_LOADED

This fixes https://github.com/AOMediaCodec/libavif/issues/2300