### PR TITLE
Move gainmap function definitions to gainmap.c

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -1163,29 +1163,3 @@ void avifCodecVersions(char outBuffer[256])
         append(&writePos, &remainingLen, availableCodecs[i].version());
     }
 }
-
-#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-avifGainMap * avifGainMapCreate(void)
-{
-    avifGainMap * gainMap = (avifGainMap *)avifAlloc(sizeof(avifGainMap));
-    if (!gainMap) {
-        return NULL;
-    }
-    memset(gainMap, 0, sizeof(avifGainMap));
-    gainMap->altColorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
-    gainMap->altTransferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
-    gainMap->altMatrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
-    gainMap->altYUVRange = AVIF_RANGE_FULL;
-    gainMap->metadata.useBaseColorSpace = AVIF_TRUE;
-    return gainMap;
-}
-
-void avifGainMapDestroy(avifGainMap * gainMap)
-{
-    if (gainMap->image) {
-        avifImageDestroy(gainMap->image);
-    }
-    avifRWDataFree(&gainMap->altICC);
-    avifFree(gainMap);
-}
-#endif // AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -9,6 +9,30 @@
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
 
+avifGainMap * avifGainMapCreate(void)
+{
+    avifGainMap * gainMap = (avifGainMap *)avifAlloc(sizeof(avifGainMap));
+    if (!gainMap) {
+        return NULL;
+    }
+    memset(gainMap, 0, sizeof(avifGainMap));
+    gainMap->altColorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
+    gainMap->altTransferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
+    gainMap->altMatrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
+    gainMap->altYUVRange = AVIF_RANGE_FULL;
+    gainMap->metadata.useBaseColorSpace = AVIF_TRUE;
+    return gainMap;
+}
+
+void avifGainMapDestroy(avifGainMap * gainMap)
+{
+    if (gainMap->image) {
+        avifImageDestroy(gainMap->image);
+    }
+    avifRWDataFree(&gainMap->altICC);
+    avifFree(gainMap);
+}
+
 avifBool avifGainMapMetadataDoubleToFractions(avifGainMapMetadata * dst, const avifGainMapMetadataDouble * src)
 {
     AVIF_CHECK(dst != NULL && src != NULL);


### PR DESCRIPTION
Move two gainmap function definitions (avifGainMapCreate and avifGainMapDestroy).

This is a good change on its own, but the reason I wanted to move them is to work around a strange unresolved symbol linker error on Windows if I enable -DBUILD_SHARED_LIBS=ON in ci-windows-installed.yml:

  avif_apps_internal.lib(avifjpeg.c.obj) : error LNK2019: unresolved
  external symbol __imp_avifGainMapMetadataDoubleToFractions referenced
  in function avifJPEGParseGainMapXMPProperties

  tests\avif16bittest.exe : fatal error LNK1120: 1 unresolved externals

See https://github.com/AOMediaCodec/libavif/actions/runs/10046011390.

I have debugged this for a long time but haven't found what is wrong. I also cannot reproduce this unresolved symbol linker error locally.