### PR TITLE
Revert "Move gainmap function definitions to gainmap.c"

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -1163,3 +1163,29 @@ void avifCodecVersions(char outBuffer[256])
         append(&writePos, &remainingLen, availableCodecs[i].version());
     }
 }
+
+#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
+avifGainMap * avifGainMapCreate(void)
+{
+    avifGainMap * gainMap = (avifGainMap *)avifAlloc(sizeof(avifGainMap));
+    if (!gainMap) {
+        return NULL;
+    }
+    memset(gainMap, 0, sizeof(avifGainMap));
+    gainMap->altColorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
+    gainMap->altTransferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
+    gainMap->altMatrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
+    gainMap->altYUVRange = AVIF_RANGE_FULL;
+    gainMap->metadata.useBaseColorSpace = AVIF_TRUE;
+    return gainMap;
+}
+
+void avifGainMapDestroy(avifGainMap * gainMap)
+{
+    if (gainMap->image) {
+        avifImageDestroy(gainMap->image);
+    }
+    avifRWDataFree(&gainMap->altICC);
+    avifFree(gainMap);
+}
+#endif // AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -9,30 +9,6 @@
 
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
 
-avifGainMap * avifGainMapCreate(void)
-{
-    avifGainMap * gainMap = (avifGainMap *)avifAlloc(sizeof(avifGainMap));
-    if (!gainMap) {
-        return NULL;
-    }
-    memset(gainMap, 0, sizeof(avifGainMap));
-    gainMap->altColorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
-    gainMap->altTransferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
-    gainMap->altMatrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
-    gainMap->altYUVRange = AVIF_RANGE_FULL;
-    gainMap->metadata.useBaseColorSpace = AVIF_TRUE;
-    return gainMap;
-}
-
-void avifGainMapDestroy(avifGainMap * gainMap)
-{
-    if (gainMap->image) {
-        avifImageDestroy(gainMap->image);
-    }
-    avifRWDataFree(&gainMap->altICC);
-    avifFree(gainMap);
-}
-
 avifBool avifGainMapMetadataDoubleToFractions(avifGainMapMetadata * dst, const avifGainMapMetadataDouble * src)
 {
     AVIF_CHECK(dst != NULL && src != NULL);


### PR DESCRIPTION
This reverts commit 4a4ff640088063fdf0d33164f6aa380777492f5a.

The code that was originally in src/gainmap.c is not used by Chrome. With this commit, Chrome will need to include src/gainmap.c, which in turn requires src/colrconvert.c.

Let's try again to figure out the reason for the strange unresolved symbol linker error in a shared library build on Windows, and fix it properly.