### PR TITLE
avifgainmaputil: Fix MSVC warnings C4244 on enum

### DIFF
--- a/apps/avifgainmaputil/swapbase_command.cc
+++ b/apps/avifgainmaputil/swapbase_command.cc
@@ -38,8 +38,9 @@ avifResult ChangeBase(const avifImage& image, int depth,
       AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED) {
     // Default to PQ for HDR and sRGB for SDR if unspecified.
     const avifTransferCharacteristics transfer_characteristics =
-        tone_mapping_to_sdr ? AVIF_TRANSFER_CHARACTERISTICS_SRGB
-                            : AVIF_TRANSFER_CHARACTERISTICS_PQ;
+        static_cast<avifTransferCharacteristics>(
+            tone_mapping_to_sdr ? AVIF_TRANSFER_CHARACTERISTICS_SRGB
+                                : AVIF_TRANSFER_CHARACTERISTICS_PQ);
     swapped->transferCharacteristics = transfer_characteristics;
   }
 

--- a/apps/avifgainmaputil/tonemap_command.cc
+++ b/apps/avifgainmaputil/tonemap_command.cc
@@ -129,9 +129,9 @@ avifResult TonemapCommand::Run() {
   }
   if (cicp.transfer_characteristics ==
       AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED) {
-    cicp.transfer_characteristics = tone_mapping_to_hdr
-                                        ? AVIF_TRANSFER_CHARACTERISTICS_PQ
-                                        : AVIF_TRANSFER_CHARACTERISTICS_SRGB;
+    cicp.transfer_characteristics = static_cast<avifTransferCharacteristics>(
+        tone_mapping_to_hdr ? AVIF_TRANSFER_CHARACTERISTICS_PQ
+                            : AVIF_TRANSFER_CHARACTERISTICS_SRGB);
   }
 
   // Determine output depth.


### PR DESCRIPTION
Cast enum constants AVIF_TRANSFER_CHARACTERISTICS_* of an unnamed enum type to avifTransferCharacteristics (an typedef of uint16_t) to fix MSVC warnings like the following:

  D:\a\libavif\libavif\apps\avifgainmaputil\tonemap_command.cc(132):
  warning C4244: '=': conversion from
  '<unnamed-enum-AVIF_TRANSFER_CHARACTERISTICS_UNKNOWN>' to
  'avifTransferCharacteristics', possible loss of data