### PR TITLE
read.c: Declare alphaCategory as avifItemCategory

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -5377,7 +5377,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                               AVIF_RESULT_NOT_IMPLEMENTED);
                 avifItemCategory * category = &data->sampleTransformInputImageItems[data->sampleTransformNumInputImageItems];
                 avifBool foundItem = AVIF_FALSE;
-                uint32_t alphaCategory = AVIF_ITEM_CATEGORY_COUNT;
+                avifItemCategory alphaCategory = AVIF_ITEM_CATEGORY_COUNT;
                 for (int c = AVIF_ITEM_COLOR; c < AVIF_ITEM_CATEGORY_COUNT; ++c) {
                     if (mainItems[c] && inputImageItem->id == mainItems[c]->id) {
                         *category = c;
@@ -5391,7 +5391,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                     AVIF_CHECKERR(numExtraInputImageItems < AVIF_SAMPLE_TRANSFORM_MAX_NUM_EXTRA_INPUT_IMAGE_ITEMS,
                                   AVIF_RESULT_NOT_IMPLEMENTED);
                     *category = (avifItemCategory)(AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_COLOR + numExtraInputImageItems);
-                    alphaCategory = AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_ALPHA + numExtraInputImageItems;
+                    alphaCategory = (avifItemCategory)(AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_ALPHA + numExtraInputImageItems);
                     mainItems[*category] = inputImageItem;
                     ++numExtraInputImageItems;
 


### PR DESCRIPTION
This way *category and alphaCategory have the same type, and code that uses them looks consistent.