### PR TITLE
Work around the bug that aom.pc always has -lm

### DIFF
--- a/cmake/Modules/LocalAom.cmake
+++ b/cmake/Modules/LocalAom.cmake
@@ -38,6 +38,11 @@ if(EXISTS "${LIB_FILENAME}")
     set(_AOM_PC_LIBRARIES "${_AOM_STATIC_LIBRARIES}")
     # remove "aom" so we only have library dependencies
     list(REMOVE_ITEM _AOM_PC_LIBRARIES "aom")
+    # Work around crbug.com/aomedia/356153293: aom.pc has -lm in the
+    # Libs.private field on all platforms, whether libm or m.lib exists or not.
+    if(WIN32 OR APPLE)
+        list(REMOVE_ITEM _AOM_PC_LIBRARIES "m")
+    endif()
 
     # Add absolute paths to libraries
     foreach(_lib ${_AOM_PC_LIBRARIES})


### PR DESCRIPTION
Fix an issue introduced in
https://github.com/AOMediaCodec/libavif/pull/2304 when libaom is built locally in the ext/ directory. See
https://github.com/AOMediaCodec/libavif/pull/2304#pullrequestreview-2203255217 for more information.

Related to https://github.com/AOMediaCodec/libavif/issues/2274.