### PR TITLE
Fix Clang's -Wformat warnings

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2877,7 +2877,7 @@ static avifResult avifParseItemReferenceBox(avifMeta * meta, const uint8_t * raw
             if (item->hasDimgFrom) {
                 // ISO/IEC 23008-12 (HEIF) 6.6.1: The number of SingleItemTypeReferenceBoxes with the box type 'dimg'
                 // and with the same value of from_item_ID shall not be greater than 1.
-                avifDiagnosticsPrintf(diag, "Box[iinf] contains duplicate boxes of type 'dimg' with the same from_item_ID value %d", fromID);
+                avifDiagnosticsPrintf(diag, "Box[iinf] contains duplicate boxes of type 'dimg' with the same from_item_ID value %u", fromID);
                 return AVIF_RESULT_BMFF_PARSE_FAILED;
             }
             item->hasDimgFrom = AVIF_TRUE;
@@ -3385,7 +3385,7 @@ static avifBool avifParseEditListBox(avifTrack * track, const uint8_t * raw, siz
     uint32_t entryCount;
     AVIF_CHECK(avifROStreamReadU32(&s, &entryCount)); // unsigned int(32) entry_count;
     if (entryCount != 1) {
-        avifDiagnosticsPrintf(diag, "Box[elst] contains an entry_count != 1 [%d]", entryCount);
+        avifDiagnosticsPrintf(diag, "Box[elst] contains an entry_count != 1 [%u]", entryCount);
         return AVIF_FALSE;
     }
 
@@ -5367,7 +5367,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                     continue;
                 }
                 if (avifDecoderItemShouldBeSkipped(inputImageItem)) {
-                    avifDiagnosticsPrintf(data->diag, "Box[sato] input item %d is not a supported image type", inputImageItem->id);
+                    avifDiagnosticsPrintf(data->diag, "Box[sato] input item %u is not a supported image type", inputImageItem->id);
                     return AVIF_RESULT_DECODE_SAMPLE_TRANSFORM_FAILED;
                 }
                 // Input image item order is important because input image items are indexed according to this order.

--- a/src/write.c
+++ b/src/write.c
@@ -1005,7 +1005,7 @@ static avifResult avifEncoderWriteSampleTransformPayload(avifEncoder * encoder, 
     const avifResult result = avifEncoderWriteSampleTransformTokens(&s, &expression);
     avifArrayDestroy(&expression);
     if (result != AVIF_RESULT_OK) {
-        avifDiagnosticsPrintf(&encoder->diag, "Failed to write sample transform metadata for recipe %d", encoder->sampleTransformRecipe);
+        avifDiagnosticsPrintf(&encoder->diag, "Failed to write sample transform metadata for recipe %d", (int)encoder->sampleTransformRecipe);
         return result;
     }
 
@@ -1467,7 +1467,7 @@ static avifResult avifValidateGrid(uint32_t gridCols,
         const uint32_t expectedCellHeight = (cellIndex < (cellCount - gridCols)) ? tileHeight : bottomRightCell->height;
         if ((cellImage->width != expectedCellWidth) || (cellImage->height != expectedCellHeight)) {
             avifDiagnosticsPrintf(diag,
-                                  "%s cell %d has invalid dimensions: expected %dx%d found %dx%d",
+                                  "%s cell %u has invalid dimensions: expected %ux%u found %ux%u",
                                   validateGainMap ? "gain map" : "image",
                                   cellIndex,
                                   expectedCellWidth,
@@ -1498,7 +1498,7 @@ static avifResult avifValidateGrid(uint32_t gridCols,
 
     if ((bottomRightCell->width > tileWidth) || (bottomRightCell->height > tileHeight)) {
         avifDiagnosticsPrintf(diag,
-                              "the last %s cell can be smaller but not larger than the other cells which are %dx%d, found %dx%d",
+                              "the last %s cell can be smaller but not larger than the other cells which are %ux%u, found %ux%u",
                               validateGainMap ? "gain map" : "image",
                               tileWidth,
                               tileHeight,


### PR DESCRIPTION
Use the %u format specifier with uint32_t arguments.

Cast an enum type to int and use the %d format specifier with it. The underlying type of an enum type is implementation-defined. GCC uses unsigned int whenever possible, whereas MSVC always uses int. So there is no portable format specifier for an enum type. Since all enum constants have the int type (this is not implementation-defined), it is safe to cast an enum type to int and use the %d format specifier with it.