### PR TITLE
Declare ScalePlane_16() in libyuv/scale.h

### DIFF
--- a/third_party/libyuv/include/libyuv/scale.h
+++ b/third_party/libyuv/include/libyuv/scale.h
@@ -31,6 +31,16 @@ int ScalePlane(const uint8_t* src,
                int dst_height,
                enum FilterMode filtering);
 
+int ScalePlane_16(const uint16_t* src,
+                  int src_stride,
+                  int src_width,
+                  int src_height,
+                  uint16_t* dst,
+                  int dst_stride,
+                  int dst_width,
+                  int dst_height,
+                  enum FilterMode filtering);
+
 int ScalePlane_12(const uint16_t* src,
                   int src_stride,
                   int src_width,


### PR DESCRIPTION
Fix the -Wmissing-prototypes warning. We could also fix the warning by marking ScalePlane_16() as file static. I chose to declare it in libyuv/scale.h to match the upstream code more closely.