### PR TITLE
libjpeg: Pass -DWITH_CRT_DLL=ON to cmake

### DIFF
--- a/cmake/Modules/LocalJpeg.cmake
+++ b/cmake/Modules/LocalJpeg.cmake
@@ -22,6 +22,13 @@ else()
 
     set(JPEG_INSTALL_DIR "${prefix}/libjpeg-install")
 
+    # Set WITH_CRT_DLL to ON to compile libjpeg-turbo with /MD (use the DLL
+    # version of the run-time library) instead of /MT (use the static version
+    # of the run-time library) on Windows. On non-Windows platform, this causes
+    # a CMake warning, which is safe to ignore:
+    #   Manually-specified variables were not used by the project:
+    #
+    #     WITH_CRT_DLL
     ExternalProject_Add(
         libjpeg
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/libjpeg
@@ -40,6 +47,7 @@ else()
                    -DENABLE_STATIC=ON
                    -DCMAKE_BUILD_TYPE=Release
                    -DWITH_TURBOJPEG=OFF
+                   -DWITH_CRT_DLL=ON
         BUILD_BYPRODUCTS "${LIB_FILENAME}"
         INSTALL_COMMAND ""
     )

--- a/ext/libjpeg.cmd
+++ b/ext/libjpeg.cmd
@@ -6,5 +6,12 @@
 
 git clone -b 3.0.3 --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo.git
 
-cmake -S libjpeg-turbo -B libjpeg-turbo/build.libavif -G Ninja -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DWITH_TURBOJPEG=OFF
+# Set WITH_CRT_DLL to ON to compile libjpeg-turbo with /MD (use the DLL
+# version of the run-time library) instead of /MT (use the static version
+# of the run-time library) on Windows. On non-Windows platform, this causes
+# a CMake warning, which is safe to ignore:
+#   Manually-specified variables were not used by the project:
+#
+#     WITH_CRT_DLL
+cmake -S libjpeg-turbo -B libjpeg-turbo/build.libavif -G Ninja -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DCMAKE_BUILD_TYPE=Release -DWITH_TURBOJPEG=OFF -DWITH_CRT_DLL=ON
 cmake --build libjpeg-turbo/build.libavif --parallel


### PR DESCRIPTION
On Windows, add
  target_link_options(avifenc PRIVATE /WX)
to CMakeLists.txt to treat linker warnings as errors. This pull request fixes the following linker warning:
  warning LNK4098: defaultlib 'LIBCMT' conflicts with use of other libs;
  use /NODEFAULTLIB:library

Adding /NODEFAULTLIB:LIBCMT to the target_link_options() call, as the warning message suggests, is another way to fix the linker warning.

For more info on the WITH_CRT_DLL cmake option, see https://github.com/libjpeg-turbo/libjpeg-turbo/issues/573.