### PR TITLE
Do not define AVIF_ENABLE_NODISCARD for avif.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,16 @@ include(FetchContent)
 include(FindPkgConfig)
 include(AvifExternalProjectUtils)
 
+option(AVIF_ENABLE_NODISCARD "Add [[nodiscard]] to some functions. CMake must be at least 3.21 to request C23." OFF)
+
 # Set C99 as the default
-set(CMAKE_C_STANDARD 99)
+if(AVIF_ENABLE_NODISCARD AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.21.0)
+    # [[nodiscard]] requires C23. The supported value 23 for CMAKE_C_STANDARD
+    # was added in CMake version 3.21.
+    set(CMAKE_C_STANDARD 23)
+else()
+    set(CMAKE_C_STANDARD 99)
+endif()
 
 # SOVERSION scheme: MAJOR.MINOR.PATCH
 #   If there was an incompatible interface change:
@@ -52,7 +60,6 @@ set(LIBRARY_SOVERSION ${LIBRARY_VERSION_MAJOR})
 option(BUILD_SHARED_LIBS "Build shared avif library" ON)
 
 option(AVIF_ENABLE_WERROR "Treat all compiler warnings as errors" OFF)
-option(AVIF_ENABLE_NODISCARD "Add [[nodiscard]] to some functions. CMake must be at least 3.21 to force C23" OFF)
 
 option(AVIF_ENABLE_EXPERIMENTAL_YCGCO_R "Enable experimental YCgCo-R matrix code" OFF)
 option(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP
@@ -334,22 +341,6 @@ endif()
 
 target_link_libraries(avif_obj PRIVATE avif_enable_warnings)
 
-if(AVIF_ENABLE_NODISCARD)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.21.0)
-        set(CMAKE_C_STANDARD 23)
-        set_property(TARGET avif_obj PROPERTY C_STANDARD 23)
-    else()
-        unset(CMAKE_C_STANDARD)
-        set_property(TARGET avif_obj PROPERTY C_STANDARD)
-        if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
-            target_compile_options(avif_obj PUBLIC $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:C>:-std=gnu2x>>)
-        elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
-            target_compile_options(avif_obj PUBLIC $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:C>:/std:clatest>>)
-        endif()
-    endif()
-    target_compile_definitions(avif_obj PUBLIC $<BUILD_INTERFACE:AVIF_ENABLE_NODISCARD=1>)
-endif()
-
 if(AVIF_ENABLE_COVERAGE)
     if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
         message(STATUS "libavif: Enabling coverage for Clang")
@@ -592,6 +583,7 @@ if(AVIF_LIB_USE_CXX OR (AVIF_BUILD_APPS AND AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP) O
 )
     enable_language(CXX)
     if(AVIF_ENABLE_NODISCARD)
+        # [[nodiscard]] requires C++17.
         set(CMAKE_CXX_STANDARD 17)
     else()
         set(CMAKE_CXX_STANDARD 14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,16 @@ include(FetchContent)
 include(FindPkgConfig)
 include(AvifExternalProjectUtils)
 
-option(AVIF_ENABLE_NODISCARD "Add [[nodiscard]] to some functions. CMake must be at least 3.21 to request C23." OFF)
+option(AVIF_ENABLE_NODISCARD "Add [[nodiscard]] to some functions. CMake must be at least 3.21 to force C23." OFF)
 
 # Set C99 as the default
-if(AVIF_ENABLE_NODISCARD AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.21.0)
-    # [[nodiscard]] requires C23. The supported value 23 for CMAKE_C_STANDARD
-    # was added in CMake version 3.21.
+if(AVIF_ENABLE_NODISCARD)
+    # [[nodiscard]] requires C23.
+    if(CMAKE_VERSION VERSION_LESS 3.21.0)
+        message(FATAL_ERROR "CMake must be at least 3.21 to force C23, bailing out")
+    endif()
     set(CMAKE_C_STANDARD 23)
+    set(CMAKE_C_STANDARD_REQUIRED ON)
 else()
     set(CMAKE_C_STANDARD 99)
 endif()
@@ -585,6 +588,7 @@ if(AVIF_LIB_USE_CXX OR (AVIF_BUILD_APPS AND AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP) O
     if(AVIF_ENABLE_NODISCARD)
         # [[nodiscard]] requires C++17.
         set(CMAKE_CXX_STANDARD 17)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
     else()
         set(CMAKE_CXX_STANDARD 14)
     endif()

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -48,8 +48,7 @@ extern "C" {
 #define AVIF_API
 #endif // defined(AVIF_DLL)
 
-#if defined(AVIF_ENABLE_NODISCARD) || (defined(__cplusplus) && __cplusplus >= 201703L) || \
-    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
 #define AVIF_NODISCARD [[nodiscard]]
 #else
 // Starting with 3.9, clang allows defining the warn_unused_result attribute for enums.

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -48,7 +48,14 @@ extern "C" {
 #define AVIF_API
 #endif // defined(AVIF_DLL)
 
-#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+// [[nodiscard]] requires C++17 and C23.
+//
+// If the -std=c2x or -std=gnu2x option is specified, __STDC_VERSION__ is
+//   * 202000L in GCC 13.2.0, Clang 16.0.6, and Apple Clang 15.0.0; or
+//   * 202311L in Clang 19.0.0git.
+// If the /std:clatest option is specified, __STDC_VERSION__ is
+//   * 202312L in Microsoft Visual Studio 17.10.5.
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202000L)
 #define AVIF_NODISCARD [[nodiscard]]
 #else
 // Starting with 3.9, clang allows defining the warn_unused_result attribute for enums.


### PR DESCRIPTION
```
Make the AVIF_ENABLE_NODISCARD cmake option require C23 so that avif.h
can define the AVIF_NODISCARD macro as [[nodiscard]] without checking
the AVIF_ENABLE_NODISCARD macro. This requires changing avif.h to test
__STDC_VERSION__ >= 202000L, which is the value of __STDC_VERSION__ in
recent versions of GCC and Clang when -std=c2x or -std=gnu2x is
specified.

In general avif.h should only test compiler predefined macros. The only
exception is AVIF_DLL (ignoring the experimental feature macros.)

Fix https://github.com/AOMediaCodec/libavif/issues/2352.
```