### PR TITLE
Enable compiler warnings in fuzztest targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,10 @@ option(AVIF_ENABLE_GTEST
 option(AVIF_ENABLE_FUZZTEST "Build avif fuzztest targets. Requires Google FuzzTest. Has no effect unless AVIF_BUILD_TESTS is ON."
        OFF
 )
-option(AVIF_LOCAL_FUZZTEST
-       "Build the Google FuzzTest framework by providing your own copy of the repo in ext/fuzztest (see Local Builds in README)"
-       OFF
+option(
+    AVIF_LOCAL_FUZZTEST
+    "Build the Google FuzzTest framework by providing your own copy of the repo in ext/fuzztest (see Local Builds in README). CMake must be at least 3.25."
+    OFF
 )
 
 # Whether the libavif library uses c++ indirectly (e.g. through linking to libyuv).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -198,10 +198,12 @@ if(AVIF_ENABLE_FUZZTEST)
         #   FUZZTEST_REPLAY=/path/to/repro_file.test
         # and running one of the targets below.
         # See https://github.com/google/fuzztest/blob/main/doc/quickstart-cmake.md
-        # Note: The SYSTEM argument for add_subdirectory() is new in CMake
-        # version 3.25. There are compiler warnings in FuzzTest headers. Add
-        # the ext/fuzztest subdirectory with the SYSTEM directory property so
-        # that warnings in its headers are suppressed.
+        # Note: There are compiler warnings in the FuzzTest headers. Add the
+        # ext/fuzztest subdirectory with the SYSTEM directory property set to
+        # true so that warnings in its headers are suppressed.
+        if(CMAKE_VERSION VERSION_LESS 3.25.0)
+            message(FATAL_ERROR "CMake must be at least 3.25 to pass the SYSTEM argument to add_subdirectory(), bailing out")
+        endif()
         add_subdirectory(${AVIF_SOURCE_DIR}/ext/fuzztest ${AVIF_SOURCE_DIR}/ext/fuzztest/build.libavif EXCLUDE_FROM_ALL SYSTEM)
     else()
         message(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -184,10 +184,7 @@ if(AVIF_ENABLE_FUZZTEST)
     macro(add_avif_fuzztest TEST_NAME)
         add_executable(${TEST_NAME} gtest/${TEST_NAME}.cc gtest/avif_fuzztest_helpers.cc ${ARGN})
         # FuzzTest bundles GoogleTest so no need to link to gtest librairies.
-        # NOTE: FuzzTest and Abseil headers have compiler warnings (mostly
-        # -Wsign-compare and some -Wunused-parameter and -Wshorten-64-to-32),
-        # so we don't enable compiler warnings on the fuzztest targets.
-        target_link_libraries(${TEST_NAME} PRIVATE aviftest_helpers_internal)
+        target_link_libraries(${TEST_NAME} PRIVATE aviftest_helpers_internal avif_enable_warnings)
         link_fuzztest(${TEST_NAME})
         add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
         set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "TEST_DATA_DIRS=${CMAKE_CURRENT_SOURCE_DIR}/data/")
@@ -201,7 +198,11 @@ if(AVIF_ENABLE_FUZZTEST)
         #   FUZZTEST_REPLAY=/path/to/repro_file.test
         # and running one of the targets below.
         # See https://github.com/google/fuzztest/blob/main/doc/quickstart-cmake.md
-        add_subdirectory(${AVIF_SOURCE_DIR}/ext/fuzztest ${AVIF_SOURCE_DIR}/ext/fuzztest/build.libavif EXCLUDE_FROM_ALL)
+        # Note: The SYSTEM argument for add_subdirectory() is new in CMake
+        # version 3.25. There are compiler warnings in FuzzTest headers. Add
+        # the ext/fuzztest subdirectory with the SYSTEM directory property so
+        # that warnings in its headers are suppressed.
+        add_subdirectory(${AVIF_SOURCE_DIR}/ext/fuzztest ${AVIF_SOURCE_DIR}/ext/fuzztest/build.libavif EXCLUDE_FROM_ALL SYSTEM)
     else()
         message(
             FATAL_ERROR


### PR DESCRIPTION
Pass the SYSTEM argument to add_subdirectory(ext/fuzztest) to treat 
FuzzTest headers as system headers. This suppresses compiler warnings in
FuzzTest headers.

Fix https://github.com/AOMediaCodec/libavif/issues/2350.