### PR TITLE
Fix Clang's -Wmissing-field-initializers warnings

### DIFF
--- a/tests/gtest/avif_fuzztest_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_dec_incr.cc
@@ -56,7 +56,9 @@ void DecodeIncr(const std::string& arbitrary_bytes, bool is_persistent,
 
   DecoderInput data = {reinterpret_cast<const uint8_t*>(arbitrary_bytes.data()),
                        arbitrary_bytes.size(), 0};
-  avifIO io = {.read = AvifIoRead,
+  avifIO io = {.destroy = nullptr,
+               .read = AvifIoRead,
+               .write = nullptr,
                .sizeHint = arbitrary_bytes.size(),
                .persistent = AVIF_TRUE,
                .data = &data};


### PR DESCRIPTION
Fix -Wmissing-field-initializers warnings in avif_fuzztest_dec_incr.cc.