### PR TITLE
Run cifuzz.yml on pull requests for CMakeLists.txt

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/cifuzz.yml'
+      - '**CMakeLists.txt'
       - 'cmake/**'
       - 'ext/**'
       - 'tests/gtest/**'


### PR DESCRIPTION
All the other CI workflows that run on pull requests for 'cmake/**' also run on pull requests for '**CMakeLists.txt'. So cifuzz.yml is the only exception.