### PR TITLE
LocalGTest.cmake: set BUILD_GMOCK option to OFF

### DIFF
--- a/cmake/Modules/LocalGTest.cmake
+++ b/cmake/Modules/LocalGTest.cmake
@@ -39,7 +39,7 @@ else()
         GIT_SHALLOW ON
     )
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
+    set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
 
     avif_fetchcontent_populate_cmake(googletest)
 


### PR DESCRIPTION
ON was apparently a copy-and-paste error. This matches the -DBUILD_GMOCK=OFF -Dgtest_force_shared_crt=ON options in ext/googletest.cmd.