### PR TITLE
Fix empty CMAKE_CXX_FLAGS_RELEASE if libaom local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changes are relative to the previous release, unless the baseline is specifi
 
 ### Changed since 1.1.1
 * avifenc: Allow large images to be encoded.
+* Fix empty CMAKE_CXX_FLAGS_RELEASE if -DAVIF_CODEC_AOM=LOCAL -DAVIF_LIBYUV=OFF
+  is specified. https://github.com/AOMediaCodec/libavif/issues/2365.
 
 ## [1.1.1] - 2024-07-30
 

--- a/cmake/Modules/LocalAom.cmake
+++ b/cmake/Modules/LocalAom.cmake
@@ -143,9 +143,11 @@ else()
         endif()
         avif_set_aom_compile_options(aom ${_aom_config})
 
+        # Restore the variables.
         foreach(_config_setting CMAKE_C_FLAGS CMAKE_CXX_FLAGS CMAKE_EXE_LINKER_FLAGS)
             foreach(_config_type DEBUG RELEASE MINSIZEREL RELWITHDEBINFO)
-                set(${_config_setting}_${_config_type} ${${_config_setting}_${_config_type}_ORIG} CACHE STRING "" FORCE)
+                unset(${_config_setting}_${_config_type} CACHE)
+                set(${_config_setting}_${_config_type} ${${_config_setting}_${_config_type}_ORIG})
                 unset(${_config_setting}_${_config_type}_ORIG)
             endforeach()
         endforeach()


### PR DESCRIPTION
Fix empty CMAKE_CXX_FLAGS_RELEASE if libaom is built locally using FetchContent and AVIF_LIBYUV is OFF.

libaom sets CMAKE_CXX_FLAGS_RELEASE and other flags as CACHE variables. To undo the changes libaom makes, unset the variables as cache variables so that they can be reset to their original values as normal variables.

Fix https://github.com/AOMediaCodec/libavif/issues/2365.