### PR TITLE
Fix an incorrect file name in tests/data/README.md

### DIFF
--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -551,9 +551,9 @@ by running `./tests/avifgainmaptest --gtest_filter=GainMapTest.CreateGainMapImag
 Contains a gain map with the `minimum_version` field set to 99 in the tmap box.
 `version` and `writer_version` are 0.
 
-### File [unsupported_gainmap_version.avif](unsupported_gainmap_version.avif)
+### File [unsupported_gainmap_writer_version_with_extra_bytes.avif](unsupported_gainmap_writer_version_with_extra_bytes.avif)
 
-![](unsupported_gainmap_version.avif)
+![](unsupported_gainmap_writer_version_with_extra_bytes.avif)
 
 License: [same as libavif](https://github.com/AOMediaCodec/libavif/blob/main/LICENSE)
 
@@ -574,7 +574,7 @@ Source: generated with a modified libavif at https://github.com/maryla-uc/libavi
 by running `./tests/avifgainmaptest --gtest_filter=GainMapTest.CreateGainMapImages ../tests/data/` 
 
 Contains a gain map with some extra unexpected bytes at the end of the gain map metadata.
-Contains `version`, `minimum_version` and `writer_version` are 0.
+`version`, `minimum_version` and `writer_version` are 0.
 
 ### File [seine_hdr_srgb.avif](seine_hdr_srgb.avif)
 


### PR DESCRIPTION
The second instance of unsupported_gainmap_version.avif is apparently a copy-and-paste error. It has an unsupported writer_version (99). It should be unsupported_gainmap_writer_version_with_extra_bytes.avif.