### PR TITLE
Replace recent-cmake action variable with oldest-cmake

### DIFF
--- a/.github/actions/setup-common/action.yml
+++ b/.github/actions/setup-common/action.yml
@@ -10,7 +10,7 @@ inputs:
   codec-rav1e:
     description: 'Can take the values: OFF, LOCAL, SYSTEM'
     default: 'OFF'
-  recent-cmake:
+  oldest-cmake:
     description: 'Can take the values: true, false. Only useful on Linux'
     default: 'false'
 runs:
@@ -20,19 +20,12 @@ runs:
       uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.x'
-    - name: Set up CMake < 3.21
-      if: ${{ runner.os == 'Linux' && inputs.recent-cmake == 'false' }}
+    - name: Set up CMake 3.13
+      if: ${{ runner.os == 'Linux' && inputs.oldest-cmake == 'true' }}
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
       with:
         # Use the minimum required version of cmake.
         cmake-version: '3.13.x'
-    - name: Set up CMake >= 3.25
-      if: ${{ runner.os == 'Linux' && inputs.recent-cmake == 'true' }}
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
-      with:
-        # Need cmake 3.21 to set CMAKE_C_STANDARD to 23 for [[nodiscard]].
-        # Need cmake 3.25 for fuzztest
-        cmake-version: '3.25.x'
     - name: Print CMake version
       run: cmake --version
       shell: bash

--- a/.github/actions/setup-common/action.yml
+++ b/.github/actions/setup-common/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Can take the values: OFF, LOCAL, SYSTEM'
     default: 'OFF'
   oldest-cmake:
-    description: 'Can take the values: true, false. Only useful on Linux'
+    description: 'Can take the values: true, false. Only useful on Linux to force using the minimum required CMake'
     default: 'false'
 runs:
   using: "composite"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -25,7 +25,7 @@ inputs:
   libyuv:
     description: 'Can take the values: OFF, LOCAL, SYSTEM'
     default: 'OFF'
-  recent-cmake:
+  oldest-cmake:
     description: 'Can take the values: true, false'
     default: 'false'
 outputs:
@@ -80,7 +80,7 @@ runs:
         codec-aom: ${{ inputs.codec-aom }}
         codec-dav1d: ${{ inputs.codec-dav1d }}
         codec-rav1e: ${{ inputs.codec-rav1e }}
-        recent-cmake: ${{ inputs.recent-cmake }}
+        oldest-cmake: ${{ inputs.oldest-cmake }}
     - uses: ./.github/actions/cache
       id: cache
       with:

--- a/.github/workflows/ci-android-emulator-tests.yml
+++ b/.github/workflows/ci-android-emulator-tests.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           codec-dav1d: 'LOCAL'
           libyuv: 'LOCAL'
+          oldest-cmake: true
       - name: Setup JDK
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:

--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           codec-aom: 'LOCAL'
           codec-dav1d: 'LOCAL'
-          recent-cmake: 'true'
       - name: Setup JDK
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -43,7 +43,6 @@ jobs:
         codec-rav1e: 'LOCAL'
         gcc-version: ${{ matrix.gcc }}
         libyuv: 'LOCAL'
-        recent-cmake: 'true'
 
     - name: Prepare libavif (cmake)
       run: >

--- a/.github/workflows/ci-fuzztest.yml
+++ b/.github/workflows/ci-fuzztest.yml
@@ -35,7 +35,6 @@ jobs:
         codec-dav1d: 'LOCAL'
         libxml2: 'LOCAL'
         libyuv: ${{ matrix.libyuv }}
-        recent-cmake: 'true'
     - name: Build fuzztest
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext

--- a/.github/workflows/ci-linux-golden-tests.yml
+++ b/.github/workflows/ci-linux-golden-tests.yml
@@ -35,7 +35,6 @@ jobs:
         gcc-version: ${{ matrix.gcc }}
         libxml2: 'LOCAL'
         libyuv: 'LOCAL'
-        recent-cmake: 'true'
     - name: Build mp4box
       if: steps.setup.outputs.ext-cache-hit != 'true'
       working-directory: ./ext

--- a/.github/workflows/ci-linux-static-old-local.yml
+++ b/.github/workflows/ci-linux-static-old-local.yml
@@ -38,7 +38,6 @@ jobs:
         gcc-version: ${{ matrix.gcc }}
         libxml2: 'LOCAL'
         libyuv: 'LOCAL'
-        recent-cmake: 'true'
     - name: Prepare libavif (cmake)
       run: >
         cmake .. -G Ninja -S . -B build

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -14,15 +14,19 @@ concurrency:
 
 jobs:
   build-shared-installed:
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-latest]
+        oldest-cmake: [false, true]
         include:
-          - runs-on: ubuntu-24.04
+          - os: ubuntu-24.04
             compiler: gcc
             gcc: 14
+        exclude:
+          - os: macos-latest
+            oldest-cmake: true
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -34,8 +38,7 @@ jobs:
         gcc-version: ${{ matrix.gcc }}
         gtest: 'SYSTEM'
         libyuv: 'SYSTEM'
-        # Need cmake 3.21 to force C23 for [[nodiscard]].
-        recent-cmake: 'true'
+        oldest-cmake: ${{ matrix.oldest-cmake }}
     - uses: ./.github/actions/setup-macos
       if: runner.os == 'macOS'
       with:
@@ -84,6 +87,8 @@ jobs:
 
         cmake . -DCMAKE_PREFIX_PATH=../install
     - name: Prepare libavif with [[nodiscard]] (cmake)
+      # CMake 3.21 is needed to force C23 for [[nodiscard]].
+      if: runner.oldest-cmake == 'false'
       run: >
         cmake -G Ninja -S . -B build_nodiscard
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
@@ -95,5 +100,6 @@ jobs:
         -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_GTEST=LOCAL
         -DAVIF_BUILD_GDK_PIXBUF=ON  ${{ env.CMAKE_AVIF_FLAGS }}
     - name: Build libavif with [[nodiscard]] (ninja)
+      if: runner.oldest-cmake == 'false'
       working-directory: ./build_nodiscard
       run: ninja

--- a/.github/workflows/ci-unix-shared-installed.yml
+++ b/.github/workflows/ci-unix-shared-installed.yml
@@ -16,14 +16,19 @@ jobs:
   build-shared-installed:
     strategy:
       fail-fast: false
+      # Generate the configurations:
+      # Ubuntu with gcc 14 with oldest-cmake set to true or false
+      # OSX with default gcc and CMake (oldest-cmake is unused on OSX)
       matrix:
         os: [ubuntu-24.04, macos-latest]
         oldest-cmake: [false, true]
         include:
+          # Add a gcc version on Ubuntu only
           - os: ubuntu-24.04
             compiler: gcc
             gcc: 14
         exclude:
+          # Do not use the oldest CMake on OSX
           - os: macos-latest
             oldest-cmake: true
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -39,7 +39,6 @@ jobs:
         gcc-version: ${{ matrix.gcc }}
         libxml2: 'LOCAL'
         libyuv: ${{ matrix.libyuv }}
-        recent-cmake: 'true'
     - uses: ./.github/actions/setup-macos
       if: runner.os == 'macOS'
       with:

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -38,7 +38,6 @@ jobs:
         extra-cache-key: ${{ matrix.also-enable-av1-codecs }}
         gcc-version: ${{ matrix.gcc }}
         libyuv: 'LOCAL'
-        recent-cmake: 'true'
 
     - name: Prepare libavif (cmake)
       run: >

--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -33,7 +33,6 @@ jobs:
           codec-aom: 'LOCAL'
           codec-dav1d: 'LOCAL'
           libyuv: 'LOCAL'
-          recent-cmake: 'true'
           extra-cache-key: ${{ matrix.sanitizer }}
       - uses: ./.github/actions/setup-macos
         if: runner.os == 'macOS'

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -40,7 +40,6 @@ jobs:
         gcc-version: ${{ matrix.gcc }}
         libxml2: 'LOCAL'
         libyuv: 'LOCAL'
-        recent-cmake: 'true'
     - uses: ./.github/actions/setup-macos
       if: runner.os == 'macOS'
       with:


### PR DESCRIPTION
All tests actually use a recent CMake.
A new test in ci-unix-shared-installed.yml is added to test for the oldest supported CMake (3.13).
This fixes https://github.com/AOMediaCodec/libavif/issues/2363