### PR TITLE
Clean YCgCo-R a bit.

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -361,7 +361,7 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                             yuvBlock[bI][bJ].v = 0.5f * (rgbPixel[0] - rgbPixel[2]);
 #if defined(AVIF_ENABLE_EXPERIMENTAL_YCGCO_R)
                         } else if (state.yuv.mode == AVIF_REFORMAT_MODE_YCGCO_RE || state.yuv.mode == AVIF_REFORMAT_MODE_YCGCO_RO) {
-                            // Formulas from JVET-U0093.
+                            // Formulas 58,59,60,61 from https://www.itu.int/rec/T-REC-H.273-202407-P
                             const int R = (int)avifRoundf(AVIF_CLAMP(rgbPixel[0] * rgbMaxChannelF, 0.0f, rgbMaxChannelF));
                             const int G = (int)avifRoundf(AVIF_CLAMP(rgbPixel[1] * rgbMaxChannelF, 0.0f, rgbMaxChannelF));
                             const int B = (int)avifRoundf(AVIF_CLAMP(rgbPixel[2] * rgbMaxChannelF, 0.0f, rgbMaxChannelF));
@@ -771,6 +771,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
                     R = t + Cr;
 #if defined(AVIF_ENABLE_EXPERIMENTAL_YCGCO_R)
                 } else if (state->yuv.mode == AVIF_REFORMAT_MODE_YCGCO_RE || state->yuv.mode == AVIF_REFORMAT_MODE_YCGCO_RO) {
+                    // YCgCoRe/YCgCoRo: Formulas 62,63,64,65 from https://www.itu.int/rec/T-REC-H.273-202407-P
                     const int YY = unormY;
                     const int Cg = (int)avifRoundf(Cb * yuvMaxChannel);
                     const int Co = (int)avifRoundf(Cr * yuvMaxChannel);

--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -366,11 +366,10 @@ TEST(RGBToYUVTest, AllMatrixCoefficients) {
                      AVIF_MATRIX_COEFFICIENTS_SMPTE240,
                      AVIF_MATRIX_COEFFICIENTS_YCGCO,
                      AVIF_MATRIX_COEFFICIENTS_BT2020_NCL,
-                     AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL
+                     AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL,
 #if defined(AVIF_ENABLE_EXPERIMENTAL_YCGCO_R)
-                     ,
                      AVIF_MATRIX_COEFFICIENTS_YCGCO_RE,
-                     AVIF_MATRIX_COEFFICIENTS_YCGCO_RO
+                     AVIF_MATRIX_COEFFICIENTS_YCGCO_RO,
 #endif
                  // These are unsupported. See avifPrepareReformatState().
                  // AVIF_MATRIX_COEFFICIENTS_BT2020_CL


### PR DESCRIPTION
- update references
- add tests

This is to simplify https://github.com/AOMediaCodec/libavif/pull/2078.

It is possible the P in the URL is for `pre-published`: we might need to update it once fully published.