### PR TITLE
Add support for all profiles of SVT-AV1

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -113,7 +113,10 @@ typedef int avifBool;
 
 #define AVIF_SPEED_DEFAULT -1
 #define AVIF_SPEED_SLOWEST 0
-#define AVIF_SPEED_FASTEST 10
+
+// Libaom and Rav1e fastest speed setting is 10, while SVT-AV1 fastest profile is 13.
+#define AVIF_SPEED_LIBAOM_RAV1E_FASTEST 10
+#define AVIF_SPEED_FASTEST 13
 
 // This value is used to indicate that an animated AVIF file has to be repeated infinitely.
 #define AVIF_REPETITION_COUNT_INFINITE -1

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -160,7 +160,8 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
         }
         if (encoder->speed != AVIF_SPEED_DEFAULT) {
 #if SVT_AV1_CHECK_VERSION(0, 9, 0)
-            svt_config->enc_mode = (int8_t)encoder->speed;
+            int speed = AVIF_CLAMP(encoder->speed, 0, AVIF_SPEED_FASTEST);
+            svt_config->enc_mode = (int8_t)speed;
 #else
             int speed = AVIF_CLAMP(encoder->speed, 0, 8);
             svt_config->enc_mode = (int8_t)speed;

--- a/tests/gtest/avif16bittest.cc
+++ b/tests/gtest/avif16bittest.cc
@@ -42,7 +42,7 @@ TEST_P(SampleTransformTest, Avif16bit) {
 
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   encoder->quality = quality;
   encoder->qualityAlpha = quality;
   encoder->sampleTransformRecipe = recipe;

--- a/tests/gtest/avif_fuzztest_helpers.h
+++ b/tests/gtest/avif_fuzztest_helpers.h
@@ -187,7 +187,7 @@ inline auto ArbitraryAvifEncoder() {
   const auto tile_cols_log2 = fuzztest::InRange(0, 6);
   // Fuzz only a small range of 'speed' values to avoid slowing down the fuzzer
   // too much. The main goal is to fuzz libavif, not the underlying AV1 encoder.
-  const auto speed = fuzztest::InRange(6, AVIF_SPEED_FASTEST);
+  const auto speed = fuzztest::InRange(6, AVIF_SPEED_LIBAOM_RAV1E_FASTEST);
   return fuzztest::Map(CreateAvifEncoder, codec_choice, max_threads,
                        min_quantizer, max_quantizer, min_quantizer_alpha,
                        max_quantizer_alpha, tile_rows_log2, tile_cols_log2,

--- a/tests/gtest/avifallocationtest.cc
+++ b/tests/gtest/avifallocationtest.cc
@@ -137,7 +137,7 @@ void TestEncoding(uint32_t width, uint32_t height, uint32_t depth,
   // Try to encode.
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   testutil::AvifRwData encoded_avif;
   ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encoded_avif),
             expected_result);

--- a/tests/gtest/avifchangesettingtest.cc
+++ b/tests/gtest/avifchangesettingtest.cc
@@ -29,7 +29,7 @@ void TestEncodeDecode(avifCodecChoice codec,
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
   encoder->codecChoice = codec;
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   encoder->timescale = 1;
 
   for (const auto& option : init_cs_options) {
@@ -134,7 +134,7 @@ TEST(ChangeSettingTest, UnchangeableSetting) {
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
   encoder->codecChoice = AVIF_CODEC_CHOICE_AOM;
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   encoder->timescale = 1;
   ASSERT_EQ(encoder->repetitionCount, AVIF_REPETITION_COUNT_INFINITE);
   encoder->minQuantizer = 63;
@@ -178,7 +178,7 @@ TEST(ChangeSettingTest, UnchangeableImageColorRange) {
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
   encoder->codecChoice = AVIF_CODEC_CHOICE_AOM;
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   encoder->timescale = 1;
   ASSERT_EQ(encoder->repetitionCount, AVIF_REPETITION_COUNT_INFINITE);
   encoder->quality = AVIF_QUALITY_WORST;
@@ -215,7 +215,7 @@ TEST(ChangeSettingTest, UnchangeableImageChromaSamplePosition) {
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
   encoder->codecChoice = AVIF_CODEC_CHOICE_AOM;
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   encoder->timescale = 1;
   ASSERT_EQ(encoder->repetitionCount, AVIF_REPETITION_COUNT_INFINITE);
   encoder->quality = AVIF_QUALITY_WORST;

--- a/tests/gtest/avifgridapitest.cc
+++ b/tests/gtest/avifgridapitest.cc
@@ -37,7 +37,7 @@ avifResult EncodeDecodeGrid(const std::vector<std::vector<Cell>>& cell_rows,
   if (!encoder) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   encoder->quality = AVIF_QUALITY_LOSSLESS;
   encoder->qualityAlpha = AVIF_QUALITY_LOSSLESS;
   // cell_image_ptrs exists only to match the libavif API.
@@ -239,7 +239,7 @@ TEST(GridApiTest, SameMatrixCoefficients) {
 
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   const avifImage* cell_image_ptrs[2] = {cell_0.get(), cell_1.get()};
   ASSERT_EQ(
       avifEncoderAddImageGrid(encoder.get(), /*gridCols=*/2, /*gridRows=*/1,
@@ -268,7 +268,7 @@ TEST(GridApiTest, DifferentMatrixCoefficients) {
 
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   // Encoding should fail.
   const avifImage* cell_image_ptrs[2] = {cell_0.get(), cell_1.get()};
   ASSERT_EQ(

--- a/tests/gtest/avifincrtest_helpers.cc
+++ b/tests/gtest/avifincrtest_helpers.cc
@@ -231,7 +231,7 @@ void EncodeAsGrid(const avifImage& image, uint32_t grid_cols,
 
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   // Just here to match libavif API.
   std::vector<avifImage*> cell_image_ptrs(cell_images.size());
   for (size_t i = 0; i < cell_images.size(); ++i) {

--- a/tests/gtest/avifiostatstest.cc
+++ b/tests/gtest/avifiostatstest.cc
@@ -31,7 +31,7 @@ bool GetIoStatsFromEncode(avifIOStats& encoder_io_stats, int quality,
 
   EncoderPtr encoder(avifEncoderCreate());
   AVIF_CHECK(encoder != nullptr);
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   encoder->quality = quality;
   encoder->qualityAlpha = qualityAlpha;
   for (int frame = 0; frame < num_frames; ++frame) {

--- a/tests/gtest/aviflosslesstest.cc
+++ b/tests/gtest/aviflosslesstest.cc
@@ -54,7 +54,7 @@ TEST(BasicTest, EncodeDecodeMatrixCoefficients) {
       // Encode.
       EncoderPtr encoder(avifEncoderCreate());
       ASSERT_NE(encoder, nullptr);
-      encoder->speed = AVIF_SPEED_FASTEST;
+      encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
       encoder->quality = AVIF_QUALITY_LOSSLESS;
       encoder->qualityAlpha = AVIF_QUALITY_LOSSLESS;
       testutil::AvifRwData encoded;

--- a/tests/gtest/avifmetadatatest.cc
+++ b/tests/gtest/avifmetadatatest.cc
@@ -73,7 +73,7 @@ TEST_P(AvifMetadataTest, EncodeDecode) {
   // Encode.
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   testutil::AvifRwData encoded_avif;
   ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encoded_avif),
             AVIF_RESULT_OK);
@@ -228,7 +228,7 @@ TEST(MetadataTest, ExifButDefaultIrotImir) {
             avifTransformFlags{AVIF_TRANSFORM_NONE});
 
   const testutil::AvifRwData encoded =
-      testutil::Encode(image.get(), AVIF_SPEED_FASTEST);
+      testutil::Encode(image.get(), AVIF_SPEED_LIBAOM_RAV1E_FASTEST);
   const ImagePtr decoded = testutil::Decode(encoded.data, encoded.size);
   ASSERT_NE(decoded, nullptr);
 
@@ -251,7 +251,7 @@ TEST(MetadataTest, ExifOrientation) {
   EXPECT_EQ(image->imir.axis, 0u);
 
   const testutil::AvifRwData encoded =
-      testutil::Encode(image.get(), AVIF_SPEED_FASTEST);
+      testutil::Encode(image.get(), AVIF_SPEED_LIBAOM_RAV1E_FASTEST);
   const ImagePtr decoded = testutil::Decode(encoded.data, encoded.size);
   ASSERT_NE(decoded, nullptr);
 
@@ -296,7 +296,7 @@ TEST(MetadataTest, ExifOrientationAndForcedImir) {
   image->imir.axis = 1;
 
   const testutil::AvifRwData encoded =
-      testutil::Encode(image.get(), AVIF_SPEED_FASTEST);
+      testutil::Encode(image.get(), AVIF_SPEED_LIBAOM_RAV1E_FASTEST);
   const ImagePtr decoded = testutil::Decode(encoded.data, encoded.size);
   ASSERT_NE(decoded, nullptr);
 

--- a/tests/gtest/avifminitest.cc
+++ b/tests/gtest/avifminitest.cc
@@ -69,7 +69,7 @@ TEST_P(AvifMinimizedImageBoxTest, SimpleOpaque) {
   testutil::AvifRwData encoded_mini;
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
-  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->speed = AVIF_SPEED_LIBAOM_RAV1E_FASTEST;
   encoder->headerFormat = AVIF_HEADER_REDUCED;
   ASSERT_EQ(avifEncoderWrite(encoder.get(), image.get(), &encoded_mini),
             AVIF_RESULT_OK);


### PR DESCRIPTION
SVT-AV1 profiles (speed) can be set from 0 to 13, while libaom and Rav1e speed settings range is 0-10. This CL adds support to set the speed paramter up to 13.