### PR TITLE
Allow odd clap dimensions and offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ The changes are relative to the previous release, unless the baseline is specifi
 * For dependencies, the deprecated way of setting AVIF_LOCAL_* to ON is
   removed. Dependency options can now only be set to OFF/LOCAL/SYSTEM.
 * Change the default quality for alpha to be the same as the quality for color.
+* Allow decoding subsampled images with odd Clean Aperture dimensions or offsets.
+* Deprecate avifCropRectConvertCleanApertureBox(). Replace it with
+  avifCropRectFromCleanApertureBox().
 
 ## [1.1.1] - 2024-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,9 @@ The changes are relative to the previous release, unless the baseline is specifi
   removed. Dependency options can now only be set to OFF/LOCAL/SYSTEM.
 * Change the default quality for alpha to be the same as the quality for color.
 * Allow decoding subsampled images with odd Clean Aperture dimensions or offsets.
-* Deprecate avifCropRectConvertCleanApertureBox(). Replace it with
-  avifCropRectFromCleanApertureBox().
+* Deprecate avifCropRectConvertCleanApertureBox() and
+  avifCleanApertureBoxConvertCropRect(). Replace them with
+  avifCropRectFromCleanApertureBox() and avifCleanApertureBoxFromCropRect().
 
 ## [1.1.1] - 2024-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Deprecate avifCropRectConvertCleanApertureBox() and
   avifCleanApertureBoxConvertCropRect(). Replace them with
   avifCropRectFromCleanApertureBox() and avifCleanApertureBoxFromCropRect().
+* Add avifCropRectRequiresUpsampling().
 
 ## [1.1.1] - 2024-07-30
 

--- a/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
+++ b/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
@@ -85,12 +85,15 @@ bool CreateDecoderAndParse(AvifDecoderWrapper* const decoder,
   avifDiagnostics diag;
   // If the image does not have a valid 'clap' property, then we simply display
   // the whole image.
-  // TODO: Use avifCropRectFromCleanApertureBox() instead.
+  // TODO(vigneshv): Handle the case of avifCropRectRequiresUpsampling()
+  //                 returning true.
   if (!(decoder->decoder->image->transformFlags & AVIF_TRANSFORM_CLAP) ||
-      !avifCropRectConvertCleanApertureBox(
+      !avifCropRectFromCleanApertureBox(
           &decoder->crop, &decoder->decoder->image->clap,
           decoder->decoder->image->width, decoder->decoder->image->height,
-          decoder->decoder->image->yuvFormat, &diag)) {
+          &diag) ||
+      avifCropRectRequiresUpsampling(&decoder->crop,
+                                     decoder->decoder->image->yuvFormat)) {
     decoder->crop.width = decoder->decoder->image->width;
     decoder->crop.height = decoder->decoder->image->height;
     decoder->crop.x = 0;
@@ -415,9 +418,8 @@ FUNC(jstring, versionString) {
     libyuv_version[0] = '\0';
   }
   char version_string[512];
-  snprintf(version_string, sizeof(version_string),
-           "libavif: %s. Codecs: %s.%s", avifVersion(),
-           codec_versions, libyuv_version);
+  snprintf(version_string, sizeof(version_string), "libavif: %s. Codecs: %s.%s",
+           avifVersion(), codec_versions, libyuv_version);
   return env->NewStringUTF(version_string);
 }
 

--- a/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
+++ b/android_jni/avifandroidjni/src/main/jni/libavif_jni.cc
@@ -85,6 +85,7 @@ bool CreateDecoderAndParse(AvifDecoderWrapper* const decoder,
   avifDiagnostics diag;
   // If the image does not have a valid 'clap' property, then we simply display
   // the whole image.
+  // TODO: Use avifCropRectFromCleanApertureBox() instead.
   if (!(decoder->decoder->image->transformFlags & AVIF_TRANSFORM_CLAP) ||
       !avifCropRectConvertCleanApertureBox(
           &decoder->crop, &decoder->decoder->image->clap,

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -347,6 +347,24 @@ int main(int argc, char * argv[])
     printf("Image details:\n");
     avifImageDump(decoder->image, 0, 0, decoder->progressiveState);
 
+    if (decoder->image->transformFlags & AVIF_TRANSFORM_CLAP) {
+        avifCropRect cropRect;
+        if (avifCropRectFromCleanApertureBox(&cropRect,
+                                             &decoder->image->clap,
+                                             decoder->image->width,
+                                             decoder->image->height,
+                                             &decoder->diag)) {
+            if (cropRect.x != 0 || cropRect.y != 0 || cropRect.width != decoder->image->width ||
+                cropRect.height != decoder->image->height) {
+                // TODO: Implement, see https://github.com/AOMediaCodec/libavif/issues/2427
+                fprintf(stderr, "Warning: Clean Aperture values were ignored, the output image was NOT cropped\n");
+            }
+        } else {
+            // Should happen only if AVIF_STRICT_CLAP_VALID is disabled.
+            fprintf(stderr, "Warning: Invalid Clean Aperture values\n");
+        }
+    }
+
     if (ignoreICC && (decoder->image->icc.size > 0)) {
         printf("[--ignore-icc] Discarding ICC profile.\n");
         // This cannot fail.

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -349,17 +349,11 @@ int main(int argc, char * argv[])
 
     if (decoder->image->transformFlags & AVIF_TRANSFORM_CLAP) {
         avifCropRect cropRect;
-        if (avifCropRectFromCleanApertureBox(&cropRect,
-                                             &decoder->image->clap,
-                                             decoder->image->width,
-                                             decoder->image->height,
-                                             &decoder->diag)) {
-            if (cropRect.x != 0 || cropRect.y != 0 || cropRect.width != decoder->image->width ||
-                cropRect.height != decoder->image->height) {
-                // TODO: Implement, see https://github.com/AOMediaCodec/libavif/issues/2427
-                fprintf(stderr, "Warning: Clean Aperture values were ignored, the output image was NOT cropped\n");
-            }
-        } else {
+        if (!avifCropRectFromCleanApertureBox(&cropRect,
+                                              &decoder->image->clap,
+                                              decoder->image->width,
+                                              decoder->image->height,
+                                              &decoder->diag)) {
             // Should happen only if AVIF_STRICT_CLAP_VALID is disabled.
             fprintf(stderr, "Warning: Invalid Clean Aperture values\n");
         }

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -2316,9 +2316,10 @@ int main(int argc, char * argv[])
 
         // Validate clap
         avifCropRect cropRect;
+        avifBool upsampleBeforeCropping;
         avifDiagnostics diag;
         avifDiagnosticsClearError(&diag);
-        if (!avifCropRectConvertCleanApertureBox(&cropRect, &image->clap, image->width, image->height, image->yuvFormat, &diag)) {
+        if (!avifCropRectFromCleanApertureBox(&cropRect, &upsampleBeforeCropping, &image->clap, image->width, image->height, image->yuvFormat, &diag)) {
             fprintf(stderr,
                     "ERROR: Invalid clap: width:[%d / %d], height:[%d / %d], horizOff:[%d / %d], vertOff:[%d / %d] - %s\n",
                     (int32_t)image->clap.widthN,

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -388,7 +388,7 @@ static avifBool strpre(const char * str, const char * prefix)
     return strncmp(str, prefix, strlen(prefix)) == 0;
 }
 
-static avifBool convertCropToClap(uint32_t srcW, uint32_t srcH, avifPixelFormat yuvFormat, uint32_t clapValues[8])
+static avifBool convertCropToClap(uint32_t srcW, uint32_t srcH, uint32_t clapValues[8])
 {
     avifCleanApertureBox clap;
     avifCropRect cropRect;
@@ -399,13 +399,12 @@ static avifBool convertCropToClap(uint32_t srcW, uint32_t srcH, avifPixelFormat 
 
     avifDiagnostics diag;
     avifDiagnosticsClearError(&diag);
-    avifBool convertResult = avifCleanApertureBoxConvertCropRect(&clap, &cropRect, srcW, srcH, yuvFormat, &diag);
+    avifBool convertResult = avifCleanApertureBoxFromCropRect(&clap, &cropRect, srcW, srcH, &diag);
     if (!convertResult) {
         fprintf(stderr,
-                "ERROR: Impossible crop rect: imageSize:[%ux%u], pixelFormat:%s, cropRect:[%u,%u, %ux%u] - %s\n",
+                "ERROR: Impossible crop rect: imageSize:[%ux%u], cropRect:[%u,%u, %ux%u] - %s\n",
                 srcW,
                 srcH,
-                avifPixelFormatToString(yuvFormat),
                 cropRect.x,
                 cropRect.y,
                 cropRect.width,
@@ -2298,7 +2297,7 @@ int main(int argc, char * argv[])
         image->pasp.vSpacing = settings.paspValues[1];
     }
     if (cropConversionRequired) {
-        if (!convertCropToClap(image->width, image->height, image->yuvFormat, settings.clapValues)) {
+        if (!convertCropToClap(image->width, image->height, settings.clapValues)) {
             goto cleanup;
         }
         settings.clapValid = AVIF_TRUE;
@@ -2332,7 +2331,6 @@ int main(int argc, char * argv[])
                     diag.error);
             goto cleanup;
         }
-        // avifCropRectRequiresUpsampling() does not need to be called for clap validation.
     }
     if (irotAngle != 0xff) {
         image->transformFlags |= AVIF_TRANSFORM_IROT;

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -2316,10 +2316,9 @@ int main(int argc, char * argv[])
 
         // Validate clap
         avifCropRect cropRect;
-        avifBool upsampleBeforeCropping;
         avifDiagnostics diag;
         avifDiagnosticsClearError(&diag);
-        if (!avifCropRectFromCleanApertureBox(&cropRect, &upsampleBeforeCropping, &image->clap, image->width, image->height, image->yuvFormat, &diag)) {
+        if (!avifCropRectFromCleanApertureBox(&cropRect, &image->clap, image->width, image->height, &diag)) {
             fprintf(stderr,
                     "ERROR: Invalid clap: width:[%d / %d], height:[%d / %d], horizOff:[%d / %d], vertOff:[%d / %d] - %s\n",
                     (int32_t)image->clap.widthN,
@@ -2333,6 +2332,7 @@ int main(int argc, char * argv[])
                     diag.error);
             goto cleanup;
         }
+        // avifCropRectRequiresUpsampling() does not need to be called for clap validation.
     }
     if (irotAngle != 0xff) {
         image->transformFlags |= AVIF_TRANSFORM_IROT;

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -1300,7 +1300,7 @@ avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int 
     if (avif->transformFlags & AVIF_TRANSFORM_CLAP) {
         avifCropRect cropRect;
         avifDiagnostics diag;
-        if (avifCropRectConvertCleanApertureBox(&cropRect, &avif->clap, avif->width, avif->height, avif->yuvFormat, &diag) &&
+        if (avifCropRectFromCleanApertureBox(&cropRect, &avif->clap, avif->width, avif->height, &diag) &&
             (cropRect.x != 0 || cropRect.y != 0 || cropRect.width != avif->width || cropRect.height != avif->height)) {
             // TODO: https://github.com/AOMediaCodec/libavif/issues/2427 - Implement.
             fprintf(stderr,

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -731,7 +731,7 @@ avifBool avifPNGWrite(const char * outputFilename, const avifImage * avif, uint3
     if (avif->transformFlags & AVIF_TRANSFORM_CLAP) {
         avifCropRect cropRect;
         avifDiagnostics diag;
-        if (avifCropRectConvertCleanApertureBox(&cropRect, &avif->clap, avif->width, avif->height, avif->yuvFormat, &diag) &&
+        if (avifCropRectFromCleanApertureBox(&cropRect, &avif->clap, avif->width, avif->height, &diag) &&
             (cropRect.x != 0 || cropRect.y != 0 || cropRect.width != avif->width || cropRect.height != avif->height)) {
             // TODO: https://github.com/AOMediaCodec/libavif/issues/2427 - Implement.
             fprintf(stderr,

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -102,15 +102,14 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
             avifBool upsampleBeforeCropping;
             avifDiagnostics diag;
             avifDiagnosticsClearError(&diag);
-            avifBool validClap =
-                avifCropRectFromCleanApertureBox(&cropRect, &upsampleBeforeCropping, &avif->clap, avif->width, avif->height, avif->yuvFormat, &diag);
+            avifBool validClap = avifCropRectFromCleanApertureBox(&cropRect, &avif->clap, avif->width, avif->height, &diag);
             if (validClap) {
                 printf("      * Valid, derived crop rect: X: %d, Y: %d, W: %d, H: %d%s\n",
                        cropRect.x,
                        cropRect.y,
                        cropRect.width,
                        cropRect.height,
-                       upsampleBeforeCropping ? " (upsample before cropping)" : "");
+                       avifCropRectRequiresUpsampling(&cropRect, avif->yuvFormat) ? " (upsample before cropping)" : "");
             } else {
                 printf("      * Invalid: %s\n", diag.error);
             }

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -99,7 +99,6 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
             printf("\n");
 
             avifCropRect cropRect;
-            avifBool upsampleBeforeCropping;
             avifDiagnostics diag;
             avifDiagnosticsClearError(&diag);
             avifBool validClap = avifCropRectFromCleanApertureBox(&cropRect, &avif->clap, avif->width, avif->height, &diag);

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -99,16 +99,18 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
             printf("\n");
 
             avifCropRect cropRect;
+            avifBool upsampleBeforeCropping;
             avifDiagnostics diag;
             avifDiagnosticsClearError(&diag);
             avifBool validClap =
-                avifCropRectConvertCleanApertureBox(&cropRect, &avif->clap, avif->width, avif->height, avif->yuvFormat, &diag);
+                avifCropRectFromCleanApertureBox(&cropRect, &upsampleBeforeCropping, &avif->clap, avif->width, avif->height, avif->yuvFormat, &diag);
             if (validClap) {
-                printf("      * Valid, derived crop rect: X: %d, Y: %d, W: %d, H: %d\n",
+                printf("      * Valid, derived crop rect: X: %d, Y: %d, W: %d, H: %d%s\n",
                        cropRect.x,
                        cropRect.y,
                        cropRect.width,
-                       cropRect.height);
+                       cropRect.height,
+                       upsampleBeforeCropping ? " (upsample before cropping)" : "");
             } else {
                 printf("      * Invalid: %s\n", diag.error);
             }

--- a/apps/shared/y4m.c
+++ b/apps/shared/y4m.c
@@ -496,7 +496,7 @@ avifBool y4mWrite(const char * outputFilename, const avifImage * avif)
     if (avif->transformFlags & AVIF_TRANSFORM_CLAP) {
         avifCropRect cropRect;
         avifDiagnostics diag;
-        if (avifCropRectConvertCleanApertureBox(&cropRect, &avif->clap, avif->width, avif->height, avif->yuvFormat, &diag) &&
+        if (avifCropRectFromCleanApertureBox(&cropRect, &avif->clap, avif->width, avif->height, &diag) &&
             (cropRect.x != 0 || cropRect.y != 0 || cropRect.width != avif->width || cropRect.height != avif->height)) {
             // TODO: https://github.com/AOMediaCodec/libavif/issues/2427 - Implement.
             fprintf(stderr,

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -557,7 +557,8 @@ AVIF_NODISCARD AVIF_API avifBool avifCleanApertureBoxFromCropRect(avifCleanApert
                                                                   uint32_t imageH,
                                                                   avifDiagnostics * diag);
 // If this function returns true, the image must be upsampled from 4:2:0 or 4:2:2 to 4:4:4 before
-// Clean Aperture values are applied.
+// Clean Aperture values are applied. This can be done by converting the avifImage to RGB using
+// avifImageYUVToRGB() and only using the cropRect region of the avifRGBImage.
 AVIF_NODISCARD AVIF_API avifBool avifCropRectRequiresUpsampling(const avifCropRect * cropRect, avifPixelFormat yuvFormat);
 
 // Deprecated. Use avifCropRectFromCleanApertureBox() instead.
@@ -1309,6 +1310,10 @@ typedef struct avifDecoder
     // legal to call avifImageYUVToRGB() on this in between calls to avifDecoderNextImage(), but use
     // avifImageCopy() if you want to make a complete, permanent copy of this image's YUV content or
     // metadata.
+    //
+    // For each field among clap, irot and imir, if the corresponding avifTransformFlag is set, the
+    // transform must be applied before rendering or converting the image, or forwarded along as
+    // attached metadata.
     avifImage * image;
 
     // Counts and timing for the current image in an image sequence. Uninteresting for single image files.

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -544,14 +544,10 @@ typedef struct avifCropRect
 
 // These will return AVIF_FALSE if the resultant values violate any standards, and if so, the output
 // values are not guaranteed to be complete or correct and should not be used.
-// If upsampleBeforeCropping is true, the image must be upsampled from 4:2:0 or 4:2:2 to 4:4:4 before
-// Clean Aperture values are applied.
 AVIF_NODISCARD AVIF_API avifBool avifCropRectFromCleanApertureBox(avifCropRect * cropRect,
-                                                                  avifBool * upsampleBeforeCropping,
                                                                   const avifCleanApertureBox * clap,
                                                                   uint32_t imageW,
                                                                   uint32_t imageH,
-                                                                  avifPixelFormat yuvFormat,
                                                                   avifDiagnostics * diag);
 AVIF_NODISCARD AVIF_API avifBool avifCleanApertureBoxConvertCropRect(avifCleanApertureBox * clap,
                                                                      const avifCropRect * cropRect,
@@ -559,6 +555,9 @@ AVIF_NODISCARD AVIF_API avifBool avifCleanApertureBoxConvertCropRect(avifCleanAp
                                                                      uint32_t imageH,
                                                                      avifPixelFormat yuvFormat,
                                                                      avifDiagnostics * diag);
+// If this function returns true, the image must be upsampled from 4:2:0 or 4:2:2 to 4:4:4 before
+// Clean Aperture values are applied.
+AVIF_NODISCARD AVIF_API avifBool avifCropRectRequiresUpsampling(const avifCropRect * cropRect, avifPixelFormat yuvFormat);
 
 // Deprecated. Use avifCropRectFromCleanApertureBox() instead.
 AVIF_NODISCARD AVIF_API avifBool

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -486,8 +486,8 @@ typedef struct avifCleanApertureBox
     // 'clap' from ISO/IEC 14496-12:2022 12.1.4.3
     // Note that ISO/IEC 23000-22:2024 7.3.6.7 requires the decoded image to be upsampled to 4:4:4 before
     // clean aperture is applied if a clean aperture size or offset is odd in a subsampled dimension.
-    // However, AV1 supports odd dimensions with chroma subsampling in those directions, so mostly watch
-    // for offsets.
+    // However, AV1 supports odd dimensions with chroma subsampling in those directions, so only apply the
+    // requirements to offsets.
 
     // a fractional number which defines the width of the clean aperture image
     uint32_t widthN;

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -484,6 +484,8 @@ typedef struct avifPixelAspectRatioBox
 typedef struct avifCleanApertureBox
 {
     // 'clap' from ISO/IEC 14496-12:2022 12.1.4.3
+    // Note that ISO/IEC 23000-22:2024 7.3.6.7 requires the decoded image to be upsampled to 4:4:4 before
+    // clean aperture is applied if a clean aperture size or offset is odd in a subsampled dimension.
 
     // a fractional number which defines the width of the clean aperture image
     uint32_t widthN;
@@ -542,18 +544,25 @@ typedef struct avifCropRect
 
 // These will return AVIF_FALSE if the resultant values violate any standards, and if so, the output
 // values are not guaranteed to be complete or correct and should not be used.
-AVIF_NODISCARD AVIF_API avifBool avifCropRectConvertCleanApertureBox(avifCropRect * cropRect,
-                                                                     const avifCleanApertureBox * clap,
-                                                                     uint32_t imageW,
-                                                                     uint32_t imageH,
-                                                                     avifPixelFormat yuvFormat,
-                                                                     avifDiagnostics * diag);
+// If upsampleBeforeCropping is true, the image must be upsampled from 4:2:0 or 4:2:2 to 4:4:4 before
+// Clean Aperture values are applied.
+AVIF_NODISCARD AVIF_API avifBool avifCropRectFromCleanApertureBox(avifCropRect * cropRect,
+                                                                  avifBool * upsampleBeforeCropping,
+                                                                  const avifCleanApertureBox * clap,
+                                                                  uint32_t imageW,
+                                                                  uint32_t imageH,
+                                                                  avifPixelFormat yuvFormat,
+                                                                  avifDiagnostics * diag);
 AVIF_NODISCARD AVIF_API avifBool avifCleanApertureBoxConvertCropRect(avifCleanApertureBox * clap,
                                                                      const avifCropRect * cropRect,
                                                                      uint32_t imageW,
                                                                      uint32_t imageH,
                                                                      avifPixelFormat yuvFormat,
                                                                      avifDiagnostics * diag);
+
+// Deprecated. Use avifCropRectFromCleanApertureBox() instead.
+AVIF_NODISCARD AVIF_API avifBool
+avifCropRectConvertCleanApertureBox(avifCropRect *, const avifCleanApertureBox *, uint32_t, uint32_t, avifPixelFormat, avifDiagnostics *);
 
 // ---------------------------------------------------------------------------
 // avifContentLightLevelInformationBox
@@ -1124,7 +1133,7 @@ typedef enum avifStrictFlag
     AVIF_STRICT_PIXI_REQUIRED = (1 << 0),
 
     // This demands that the values surfaced in the clap box are valid, determined by attempting to
-    // convert the clap box to a crop rect using avifCropRectConvertCleanApertureBox(). If this
+    // convert the clap box to a crop rect using avifCropRectFromCleanApertureBox(). If this
     // function returns AVIF_FALSE and this strict flag is set, the decode will fail.
     AVIF_STRICT_CLAP_VALID = (1 << 1),
 

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -486,6 +486,8 @@ typedef struct avifCleanApertureBox
     // 'clap' from ISO/IEC 14496-12:2022 12.1.4.3
     // Note that ISO/IEC 23000-22:2024 7.3.6.7 requires the decoded image to be upsampled to 4:4:4 before
     // clean aperture is applied if a clean aperture size or offset is odd in a subsampled dimension.
+    // However, AV1 supports odd dimensions with chroma subsampling in those directions, so mostly watch
+    // for offsets.
 
     // a fractional number which defines the width of the clean aperture image
     uint32_t widthN;
@@ -549,12 +551,11 @@ AVIF_NODISCARD AVIF_API avifBool avifCropRectFromCleanApertureBox(avifCropRect *
                                                                   uint32_t imageW,
                                                                   uint32_t imageH,
                                                                   avifDiagnostics * diag);
-AVIF_NODISCARD AVIF_API avifBool avifCleanApertureBoxConvertCropRect(avifCleanApertureBox * clap,
-                                                                     const avifCropRect * cropRect,
-                                                                     uint32_t imageW,
-                                                                     uint32_t imageH,
-                                                                     avifPixelFormat yuvFormat,
-                                                                     avifDiagnostics * diag);
+AVIF_NODISCARD AVIF_API avifBool avifCleanApertureBoxFromCropRect(avifCleanApertureBox * clap,
+                                                                  const avifCropRect * cropRect,
+                                                                  uint32_t imageW,
+                                                                  uint32_t imageH,
+                                                                  avifDiagnostics * diag);
 // If this function returns true, the image must be upsampled from 4:2:0 or 4:2:2 to 4:4:4 before
 // Clean Aperture values are applied.
 AVIF_NODISCARD AVIF_API avifBool avifCropRectRequiresUpsampling(const avifCropRect * cropRect, avifPixelFormat yuvFormat);
@@ -562,6 +563,9 @@ AVIF_NODISCARD AVIF_API avifBool avifCropRectRequiresUpsampling(const avifCropRe
 // Deprecated. Use avifCropRectFromCleanApertureBox() instead.
 AVIF_NODISCARD AVIF_API avifBool
 avifCropRectConvertCleanApertureBox(avifCropRect *, const avifCleanApertureBox *, uint32_t, uint32_t, avifPixelFormat, avifDiagnostics *);
+// Deprecated. Use avifCleanApertureBoxFromCropRect() instead.
+AVIF_NODISCARD AVIF_API avifBool
+avifCleanApertureBoxConvertCropRect(avifCleanApertureBox *, const avifCropRect *, uint32_t, uint32_t, avifPixelFormat, avifDiagnostics *);
 
 // ---------------------------------------------------------------------------
 // avifContentLightLevelInformationBox

--- a/src/read.c
+++ b/src/read.c
@@ -1285,10 +1285,12 @@ static avifResult avifDecoderItemValidateProperties(const avifDecoderItem * item
             }
 
             avifCropRect cropRect;
+            avifBool upsampleBeforeCropping;
             const uint32_t imageW = ispeProp->u.ispe.width;
             const uint32_t imageH = ispeProp->u.ispe.height;
             const avifPixelFormat configFormat = avifCodecConfigurationBoxGetFormat(&configProp->u.av1C);
-            avifBool validClap = avifCropRectConvertCleanApertureBox(&cropRect, &clapProp->u.clap, imageW, imageH, configFormat, diag);
+            const avifBool validClap =
+                avifCropRectFromCleanApertureBox(&cropRect, &upsampleBeforeCropping, &clapProp->u.clap, imageW, imageH, configFormat, diag);
             if (!validClap) {
                 return AVIF_RESULT_BMFF_PARSE_FAILED;
             }

--- a/src/read.c
+++ b/src/read.c
@@ -1285,12 +1285,9 @@ static avifResult avifDecoderItemValidateProperties(const avifDecoderItem * item
             }
 
             avifCropRect cropRect;
-            avifBool upsampleBeforeCropping;
             const uint32_t imageW = ispeProp->u.ispe.width;
             const uint32_t imageH = ispeProp->u.ispe.height;
-            const avifPixelFormat configFormat = avifCodecConfigurationBoxGetFormat(&configProp->u.av1C);
-            const avifBool validClap =
-                avifCropRectFromCleanApertureBox(&cropRect, &upsampleBeforeCropping, &clapProp->u.clap, imageW, imageH, configFormat, diag);
+            const avifBool validClap = avifCropRectFromCleanApertureBox(&cropRect, &clapProp->u.clap, imageW, imageH, diag);
             if (!validClap) {
                 return AVIF_RESULT_BMFF_PARSE_FAILED;
             }

--- a/tests/gtest/avifclaptest.cc
+++ b/tests/gtest/avifclaptest.cc
@@ -82,14 +82,15 @@ using InvalidClapPropertyTest =
 INSTANTIATE_TEST_SUITE_P(Parameterized, InvalidClapPropertyTest,
                          ::testing::ValuesIn(kInvalidClapPropertyTestParams));
 
-// Negative tests for the avifCropRectConvertCleanApertureBox() function.
+// Negative tests for the avifCropRectFromCleanApertureBox() function.
 TEST_P(InvalidClapPropertyTest, ValidateClapProperty) {
   const InvalidClapPropertyParam& param = GetParam();
   avifCropRect crop_rect;
+  avifBool upsampleBeforeCropping;
   avifDiagnostics diag;
-  EXPECT_FALSE(avifCropRectConvertCleanApertureBox(&crop_rect, &param.clap,
-                                                   param.width, param.height,
-                                                   param.yuv_format, &diag));
+  EXPECT_FALSE(avifCropRectFromCleanApertureBox(
+      &crop_rect, &upsampleBeforeCropping, &param.clap, param.width,
+      param.height, param.yuv_format, &diag));
 }
 
 struct ValidClapPropertyParam {
@@ -99,6 +100,7 @@ struct ValidClapPropertyParam {
   avifCleanApertureBox clap;
 
   avifCropRect expected_crop_rect;
+  bool expected_upsample_before_cropping;
 };
 
 constexpr ValidClapPropertyParam kValidClapPropertyTestParams[] = {
@@ -110,7 +112,8 @@ constexpr ValidClapPropertyParam kValidClapPropertyTestParams[] = {
      160,
      AVIF_PIXEL_FORMAT_YUV420,
      {96, 1, 132, 1, 0, 1, 0, 1},
-     {12, 14, 96, 132}},
+     {12, 14, 96, 132},
+     false},
     // pcX = -30 + (120 - 1)/2 = 29.5
     // pcY = -40 + (160 - 1)/2 = 39.5
     // leftmost = 29.5 - (60 - 1)/2 = 0
@@ -120,7 +123,8 @@ constexpr ValidClapPropertyParam kValidClapPropertyTestParams[] = {
      AVIF_PIXEL_FORMAT_YUV420,
      {60, 1, 80, 1, static_cast<uint32_t>(-30), 1, static_cast<uint32_t>(-40),
       1},
-     {0, 0, 60, 80}},
+     {0, 0, 60, 80},
+     false},
     // pcX = -1/2 + (100 - 1)/2 = 49
     // pcY = -1/2 + (100 - 1)/2 = 49
     // leftmost = 49 - (99 - 1)/2 = 0
@@ -129,7 +133,18 @@ constexpr ValidClapPropertyParam kValidClapPropertyTestParams[] = {
      100,
      AVIF_PIXEL_FORMAT_YUV420,
      {99, 1, 99, 1, static_cast<uint32_t>(-1), 2, static_cast<uint32_t>(-1), 2},
-     {0, 0, 99, 99}},
+     {0, 0, 99, 99},
+     true},
+    // pcX = -1/2 + (100 - 1)/2 = 49
+    // pcY = -1/2 + (100 - 1)/2 = 49
+    // leftmost = 49 - (99 - 1)/2 = 0
+    // topmost = 49 - (99 - 1)/2 = 0
+    {100,
+     100,
+     AVIF_PIXEL_FORMAT_YUV420,
+     {99, 1, 99, 1, 1, 2, 1, 2},
+     {1, 1, 99, 99},
+     true},
 };
 
 using ValidClapPropertyTest = ::testing::TestWithParam<ValidClapPropertyParam>;
@@ -137,19 +152,27 @@ using ValidClapPropertyTest = ::testing::TestWithParam<ValidClapPropertyParam>;
 INSTANTIATE_TEST_SUITE_P(Parameterized, ValidClapPropertyTest,
                          ::testing::ValuesIn(kValidClapPropertyTestParams));
 
-// Positive tests for the avifCropRectConvertCleanApertureBox() function.
+// Positive tests for the avifCropRectFromCleanApertureBox() function.
 TEST_P(ValidClapPropertyTest, ValidateClapProperty) {
   const ValidClapPropertyParam& param = GetParam();
   avifCropRect crop_rect;
+  avifBool upsampleBeforeCropping;
   avifDiagnostics diag;
-  EXPECT_TRUE(avifCropRectConvertCleanApertureBox(&crop_rect, &param.clap,
-                                                  param.width, param.height,
-                                                  param.yuv_format, &diag))
+  EXPECT_TRUE(avifCropRectFromCleanApertureBox(
+      &crop_rect, &upsampleBeforeCropping, &param.clap, param.width,
+      param.height, param.yuv_format, &diag))
       << diag.error;
   EXPECT_EQ(crop_rect.x, param.expected_crop_rect.x);
   EXPECT_EQ(crop_rect.y, param.expected_crop_rect.y);
   EXPECT_EQ(crop_rect.width, param.expected_crop_rect.width);
   EXPECT_EQ(crop_rect.height, param.expected_crop_rect.height);
+  EXPECT_EQ(upsampleBeforeCropping, param.expected_upsample_before_cropping);
+
+  // Deprecated function coverage.
+  EXPECT_EQ(avifCropRectConvertCleanApertureBox(&crop_rect, &param.clap,
+                                                param.width, param.height,
+                                                param.yuv_format, &diag),
+            !upsampleBeforeCropping);
 }
 
 }  // namespace

--- a/tests/gtest/avifclaptest.cc
+++ b/tests/gtest/avifclaptest.cc
@@ -150,7 +150,7 @@ using ValidClapPropertyTest = ::testing::TestWithParam<ValidClapPropertyParam>;
 INSTANTIATE_TEST_SUITE_P(Parameterized, ValidClapPropertyTest,
                          ::testing::ValuesIn(kValidClapPropertyTestParams));
 
-// Positive tests for the avifCropRectFromCleanApertureBox() and 
+// Positive tests for the avifCropRectFromCleanApertureBox() and
 // avifCleanApertureBoxFromCropRect() functions.
 TEST_P(ValidClapPropertyTest, ValidateClapProperty) {
   const ValidClapPropertyParam& param = GetParam();


### PR DESCRIPTION
The constraint in MIAF was replaced by an upsampling step before cropping.

Notes:
- `avifdec` does not crop anything when decoding.
- the libavif API only outputs YUV samples along with a `clap` field in `avifImage`. It is the user's duty to upsample, hence the added output argument in `avifCropRectFromCleanApertureBox()`.

See https://github.com/AOMediaCodec/av1-avif/pull/202#issuecomment-2339926253.