### PR TITLE
Add lsel (layer selection) property to progressive images.

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -2892,7 +2892,6 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
 
         if (item->extraLayerCount > 0) {
             // Layered Image Indexing Property
-
             avifItemPropertyDedupStart(dedup);
             avifBoxMarker a1lx;
             AVIF_CHECKRES(avifRWStreamWriteBox(&dedup->s, "a1lx", AVIF_BOX_SIZE_TBD, &a1lx));
@@ -2921,6 +2920,19 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
             }
             avifRWStreamFinishBox(&dedup->s, a1lx);
             AVIF_CHECKRES(avifItemPropertyDedupFinish(dedup, s, &item->ipma, AVIF_FALSE));
+
+            avifItemPropertyDedupStart(dedup);
+            avifBoxMarker lsel;
+            AVIF_CHECKRES(avifRWStreamWriteBox(&dedup->s, "lsel", AVIF_BOX_SIZE_TBD, &lsel));
+            // Layer Selection Property
+            // Section 2.3.1 of of AV1 Image File Format specification v1.1.0:
+            // The value 0xFFFF is reserved for a special meaning. If a lsel property is associated with an AV1
+            // Image Item but its layer_id value is set to 0xFFFF, the renderer is free to render either only
+            // the output image of the highest spatial layer, or to render all output images of all the intermediate
+            // layers and the highest spatial layer, resulting in a form of progressive decoding.
+            AVIF_CHECKRES(avifRWStreamWriteU16(&dedup->s, 0xFFFF));
+            avifRWStreamFinishBox(&dedup->s, lsel);
+            AVIF_CHECKRES(avifItemPropertyDedupFinish(dedup, s, &item->ipma, AVIF_TRUE));
         }
     }
     return AVIF_RESULT_OK;

--- a/src/write.c
+++ b/src/write.c
@@ -2925,7 +2925,7 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
             avifBoxMarker lsel;
             AVIF_CHECKRES(avifRWStreamWriteBox(&dedup->s, "lsel", AVIF_BOX_SIZE_TBD, &lsel));
             // Layer Selection Property
-            // Section 2.3.1 of of AV1 Image File Format specification v1.1.0:
+            // Section 2.3.1 of AV1 Image File Format specification v1.1.0:
             // The value 0xFFFF is reserved for a special meaning. If a lsel property is associated with an AV1
             // Image Item but its layer_id value is set to 0xFFFF, the renderer is free to render either only
             // the output image of the highest spatial layer, or to render all output images of all the intermediate

--- a/tests/data/goldens/circle-trns-after-plte_progressive.avif.xml
+++ b/tests/data/goldens/circle-trns-after-plte_progressive.avif.xml
@@ -49,7 +49,7 @@
 </AV1ConfigurationBox>
 <ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="1" transfer_characteristics="13" matrix_coefficients="6" full_range_flag="1">
 </ColourInformationBox>
-<AV1LayeredImageIndexingPropertyBox Size="15" Type="a1lx" Specification="avif" Container="ipco" large_size="0" layer_size0="206" layer_size1="0" layer_size2="0">
+<AV1LayeredImageIndexingPropertyBox Size="15" Type="a1lx" Specification="avif" Container="ipco" large_size="0" layer_size0="REDACTED" layer_size1="0" layer_size2="0">
 </AV1LayeredImageIndexingPropertyBox>
 <UnknownBox Size="10" Type="lsel" Specification="unknown" Container="unknown" data="0xFFFF" >
 </UnknownBox>
@@ -62,7 +62,7 @@
 </AV1ConfigurationBox>
 <AuxiliaryTypePropertyBox Size="56" Type="auxC" Version="0" Flags="0" Specification="iff" Container="ipco" aux_type="urn:mpeg:mpegB:cicp:systems:auxiliary:alpha" aux_subtype="">
 </AuxiliaryTypePropertyBox>
-<AV1LayeredImageIndexingPropertyBox Size="15" Type="a1lx" Specification="avif" Container="ipco" large_size="0" layer_size0="664" layer_size1="0" layer_size2="0">
+<AV1LayeredImageIndexingPropertyBox Size="15" Type="a1lx" Specification="avif" Container="ipco" large_size="0" layer_size0="REDACTED" layer_size1="0" layer_size2="0">
 </AV1LayeredImageIndexingPropertyBox>
 </ItemPropertyContainerBox>
 <ItemPropertyAssociationBox Size="34" Type="ipma" Version="0" Flags="0" Specification="iff" Container="iprp" entry_count="2">

--- a/tests/data/goldens/circle-trns-after-plte_progressive.avif.xml
+++ b/tests/data/goldens/circle-trns-after-plte_progressive.avif.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ISOBaseMediaFileTrace>
+<!--MP4Box dump trace-->
+<IsoMediaFile xmlns="urn:mpeg:isobmff:schema:file:2016" Name="circle-trns-after-plte_progressive.avif">
+<FileTypeBox Size="32" Type="ftyp" Specification="p12" Container="file otyp" MajorBrand="avif" MinorVersion="0">
+<BrandEntry AlternateBrand="avif"/>
+<BrandEntry AlternateBrand="mif1"/>
+<BrandEntry AlternateBrand="miaf"/>
+<BrandEntry AlternateBrand="MA1A"/>
+</FileTypeBox>
+<MetaBox Size="450" Type="meta" Version="0" Flags="0" Specification="p12" Container="file moov trak moof traf udta" >
+<HandlerBox Size="33" Type="hdlr" Version="0" Flags="0" Specification="p12" Container="mdia meta minf" hdlrType="pict" Name="" reserved1="0" reserved2="data:application/octet-string,000000000000000000000000">
+</HandlerBox>
+<PrimaryItemBox Size="14" Type="pitm" Version="0" Flags="0" Specification="p12" Container="meta" item_ID="1">
+</PrimaryItemBox>
+<ItemLocationBox Size="60" Type="iloc" Version="0" Flags="0" Specification="p12" Container="meta" offset_size="4" length_size="4" base_offset_size="0" index_size="0">
+<ItemLocationEntry item_ID="1" data_reference_index="0" base_offset="0" construction_method="0">
+<ItemExtentEntry extent_offset="REDACTED" extent_length="REDACTED" extent_index="0" />
+<ItemExtentEntry extent_offset="REDACTED" extent_length="REDACTED" extent_index="0" />
+</ItemLocationEntry>
+<ItemLocationEntry item_ID="2" data_reference_index="0" base_offset="0" construction_method="0">
+<ItemExtentEntry extent_offset="REDACTED" extent_length="REDACTED" extent_index="0" />
+<ItemExtentEntry extent_offset="REDACTED" extent_length="REDACTED" extent_index="0" />
+</ItemLocationEntry>
+</ItemLocationBox>
+<ItemInfoBox Size="66" Type="iinf" Version="0" Flags="0" Specification="p12" Container="meta" >
+<ItemInfoEntryBox Size="26" Type="infe" Version="2" Flags="0" Specification="p12" Container="iinf" item_ID="1" item_protection_index="0" item_name="Color" content_type="(null)" content_encoding="(null)" item_type="av01">
+</ItemInfoEntryBox>
+<ItemInfoEntryBox Size="26" Type="infe" Version="2" Flags="0" Specification="p12" Container="iinf" item_ID="2" item_protection_index="0" item_name="Alpha" content_type="(null)" content_encoding="(null)" item_type="av01">
+</ItemInfoEntryBox>
+</ItemInfoBox>
+<ItemReferenceBox Size="26" Type="iref" Version="0" Flags="0" Specification="p12" Container="meta" >
+<ItemReferenceBox Size="14" Type="auxl" Specification="p12" Container="iref" from_item_id="2">
+<ItemReferenceBoxEntry ItemID="1"/>
+</ItemReferenceBox>
+</ItemReferenceBox>
+<ItemPropertiesBox Size="239" Type="iprp" Specification="iff" Container="meta" >
+<ItemPropertyContainerBox Size="197" Type="ipco" Specification="iff" Container="iprp" >
+<ImageSpatialExtentsPropertyBox Size="20" Type="ispe" Version="0" Flags="0" Specification="iff" Container="ipco" image_width="100" image_height="60">
+</ImageSpatialExtentsPropertyBox>
+<PixelInformationPropertyBox Size="16" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
+<BitPerChannel bits_per_channel="8"/>
+<BitPerChannel bits_per_channel="8"/>
+<BitPerChannel bits_per_channel="8"/>
+</PixelInformationPropertyBox>
+<AV1ConfigurationBox>
+<AV1Config version="1" profile="1" level_idx0="0" tier="0" high_bitdepth="0" twelve_bit="0" monochrome="0" chroma_subsampling_x="0" chroma_subsampling_y="0" chroma_sample_position="0" initial_presentation_delay="1" OBUs_count="0">
+</AV1Config>
+</AV1ConfigurationBox>
+<ColourInformationBox Size="19" Type="colr" Specification="iff" Container="video_sample_entry ipco encv resv" colour_type="nclx" colour_primaries="1" transfer_characteristics="13" matrix_coefficients="6" full_range_flag="1">
+</ColourInformationBox>
+<AV1LayeredImageIndexingPropertyBox Size="15" Type="a1lx" Specification="avif" Container="ipco" large_size="0" layer_size0="206" layer_size1="0" layer_size2="0">
+</AV1LayeredImageIndexingPropertyBox>
+<UnknownBox Size="10" Type="lsel" Specification="unknown" Container="unknown" data="0xFFFF" >
+</UnknownBox>
+<PixelInformationPropertyBox Size="14" Type="pixi" Version="0" Flags="0" Specification="iff" Container="ipco" >
+<BitPerChannel bits_per_channel="8"/>
+</PixelInformationPropertyBox>
+<AV1ConfigurationBox>
+<AV1Config version="1" profile="0" level_idx0="0" tier="0" high_bitdepth="0" twelve_bit="0" monochrome="1" chroma_subsampling_x="1" chroma_subsampling_y="1" chroma_sample_position="0" initial_presentation_delay="1" OBUs_count="0">
+</AV1Config>
+</AV1ConfigurationBox>
+<AuxiliaryTypePropertyBox Size="56" Type="auxC" Version="0" Flags="0" Specification="iff" Container="ipco" aux_type="urn:mpeg:mpegB:cicp:systems:auxiliary:alpha" aux_subtype="">
+</AuxiliaryTypePropertyBox>
+<AV1LayeredImageIndexingPropertyBox Size="15" Type="a1lx" Specification="avif" Container="ipco" large_size="0" layer_size0="664" layer_size1="0" layer_size2="0">
+</AV1LayeredImageIndexingPropertyBox>
+</ItemPropertyContainerBox>
+<ItemPropertyAssociationBox Size="34" Type="ipma" Version="0" Flags="0" Specification="iff" Container="iprp" entry_count="2">
+<AssociationEntry item_ID="1" association_count="6">
+<Property index="1" essential="0"/>
+<Property index="2" essential="0"/>
+<Property index="3" essential="1"/>
+<Property index="4" essential="0"/>
+<Property index="5" essential="0"/>
+<Property index="6" essential="1"/>
+</AssociationEntry>
+<AssociationEntry item_ID="2" association_count="6">
+<Property index="1" essential="0"/>
+<Property index="7" essential="0"/>
+<Property index="8" essential="1"/>
+<Property index="9" essential="0"/>
+<Property index="10" essential="0"/>
+<Property index="6" essential="1"/>
+</AssociationEntry>
+</ItemPropertyAssociationBox>
+</ItemPropertiesBox>
+</MetaBox>
+<MediaDataBox Size="REDACTED" Type="mdat" Specification="p12" Container="file" dataSize="REDACTED">
+</MediaDataBox>
+</IsoMediaFile>
+<Tracks>
+</Tracks>
+</ISOBaseMediaFileTrace>

--- a/tests/golden_test_common.sh
+++ b/tests/golden_test_common.sh
@@ -83,6 +83,7 @@ redact_xml() {
              -e 's/extent_length="[0-9]*"/extent_length="REDACTED"/g' \
              -e 's/dataSize="[0-9]*"/dataSize="REDACTED"/g' \
              -e 's/<MediaDataBox\(.*\) Size="[0-9]*"/<MediaDataBox\1 Size="REDACTED"/g' \
+             -e 's/layer_size0="[0-9]*"/layer_size0="REDACTED"/g' \
              "$f"
   # For animations.
   sed -i.bak -e 's/CreationTime="[0-9]*"/CreationTime="REDACTED"/g' \

--- a/tests/test_cmd_enc_boxes_golden.sh
+++ b/tests/test_cmd_enc_boxes_golden.sh
@@ -37,6 +37,9 @@ encode_test_files() {
     # Animation with only keyframes.
     "${AVIFENC}" -s 9 --keyframe 1 "${TESTDATA_DIR}/kodim03_yuv420_8bpc.y4m" \
       "${TESTDATA_DIR}/kodim23_yuv420_8bpc.y4m" -o "kodim03_23_animation_keyframes.avif"
+    
+    # Progressive.
+    "${AVIFENC}" -s 9 "${TESTDATA_DIR}/circle-trns-after-plte.png" --progressive -o "circle-trns-after-plte_progressive.avif"
 }
 
 export -f encode_test_files


### PR DESCRIPTION
My understanding from the discussions in https://github.com/AOMediaCodec/libavif/pull/939 and the AVIF specification is that libavif treats the absence of the 'lsel' property the same as 'lsel' being present with the value 0xFFFF, but this is done for backward compatibility only and encoders are supposed to add the 'lsel' property on layered images.