### PR TITLE
Remove check that the meta box is zero when searching for a tmap.

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -4091,7 +4091,6 @@ static avifResult avifParse(avifDecoder * decoder)
     avifDecoderData * data = decoder->data;
     avifBool ftypSeen = AVIF_FALSE;
     avifBool metaSeen = AVIF_FALSE;
-    avifBool metaIsSizeZero = AVIF_FALSE;
     avifBool moovSeen = AVIF_FALSE;
     avifBool needsMeta = AVIF_FALSE;
     avifBool needsMoov = AVIF_FALSE;
@@ -4140,7 +4139,6 @@ static avifResult avifParse(avifDecoder * decoder)
         } else if (!memcmp(header.type, "meta", 4)) {
             isMeta = AVIF_TRUE;
             isNonSkippableVariableLengthBox = AVIF_TRUE;
-            metaIsSizeZero = header.isSizeZeroBox;
         } else if (!memcmp(header.type, "moov", 4)) {
             isMoov = AVIF_TRUE;
             isNonSkippableVariableLengthBox = AVIF_TRUE;
@@ -4277,9 +4275,6 @@ static avifResult avifParse(avifDecoder * decoder)
 #if defined(AVIF_ENABLE_EXPERIMENTAL_MINI)
         sawEverythingNeeded = sawEverythingNeeded && (!needsMini || miniSeen);
 #endif
-#if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
-        sawEverythingNeeded = sawEverythingNeeded && (!needsTmap || tmapSeen);
-#endif
         if (sawEverythingNeeded) {
             return AVIF_RESULT_OK;
         }
@@ -4292,10 +4287,8 @@ static avifResult avifParse(avifDecoder * decoder)
     }
 #if defined(AVIF_ENABLE_EXPERIMENTAL_GAIN_MAP)
     if (needsTmap && !tmapSeen) {
-        return metaIsSizeZero ? AVIF_RESULT_TRUNCATED_DATA : AVIF_RESULT_BMFF_PARSE_FAILED;
+        return AVIF_RESULT_BMFF_PARSE_FAILED;
     }
-#else
-    (void)metaIsSizeZero;
 #endif
 #if defined(AVIF_ENABLE_EXPERIMENTAL_MINI)
     if (needsMini && !miniSeen) {


### PR DESCRIPTION
Unless I'm misunderstanding something, whether the meta box has size zero or not, it's read in one go. So if the meta box has been seen, all of it has been seen. The only case where it could be read partially is if the provided sizeHint value is too small, but then the parsing code still assumes it has read the whole box.
If the whole box is not available yet, the reading function is supposed to return AVIF_RESULT_WAITING_ON_IO.