### PR TITLE
fix: correct SVT-AV1 defaults to avoid crash

### DIFF
--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -152,6 +152,12 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
         }
         svt_config->qp = quantizer;
 
+        // Set gop constraint rc to 0, otherwise encoder won't run
+        svt_config->gop_constraint_rc = 0;
+
+        // Set target socket to -1 (both sockets)
+        svt_config->target_socket = -1;
+
         if (tileRowsLog2 != 0) {
             svt_config->tile_rows = tileRowsLog2;
         }


### PR DESCRIPTION
Occaisonally, I have observed SVT-AV1 builds on Linux crash due to these two options not being configured properly for CRF encoding. This should fix that issue.