### PR TITLE
Use runner.os in artifact archive name

### DIFF
--- a/.github/workflows/ci-unix-artifacts.yml
+++ b/.github/workflows/ci-unix-artifacts.yml
@@ -49,7 +49,7 @@ jobs:
         uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
         with:
           type: zip
-          filename: ${{ matrix.os }}-artifacts.zip
+          filename: ${{ runner.os }}-artifacts.zip
           directory: build
           path: |
             avifenc
@@ -61,13 +61,13 @@ jobs:
         with:
           # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: build/${{ matrix.os }}-artifacts.zip
-          asset_name: ${{ matrix.os }}-artifacts.zip
+          asset_path: build/${{ runner.os }}-artifacts.zip
+          asset_name: ${{ runner.os }}-artifacts.zip
           asset_content_type: application/zip
 
     # Use the following instead of the above to test this workflow outside of a release event.
     # - name: Upload artifacts
     #   uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
     #   with:
-    #     name: ${{ matrix.os }}-artifacts.zip
-    #     path: build/${{ matrix.os }}-artifacts.zip
+    #     name: ${{ runner.os }}-artifacts.zip
+    #     path: build/${{ runner.os }}-artifacts.zip


### PR DESCRIPTION
"Linux-artifacts.zip" and "macOS-artifacts.zip" should be prettier than "ubuntu-latest-artifacts.zip" and "macos-latest-artifacts.zip".

See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context.