### PR TITLE
Disable JPEG finding in libyuv

### DIFF
--- a/cmake/Modules/LocalLibyuv.cmake
+++ b/cmake/Modules/LocalLibyuv.cmake
@@ -34,6 +34,7 @@ else()
         GIT_REPOSITORY "https://chromium.googlesource.com/libyuv/libyuv"
         BINARY_DIR "${LIBYUV_BINARY_DIR}"
         GIT_TAG "${AVIF_LOCAL_LIBYUV_TAG}"
+        PATCH_COMMAND sed -i.bak -e "s:find_package.*(.*JPEG.*)::" CMakeLists.txt
         UPDATE_COMMAND ""
     )
 


### PR DESCRIPTION
This is to prevent extra files in libyuv to be built and have a dependency order problem.