### PR TITLE
Make it easier to build android_jni

### DIFF
--- a/android_jni/README.md
+++ b/android_jni/README.md
@@ -24,7 +24,7 @@ $ git clone https://github.com/AOMediaCodec/libavif.git
 $ cd libavif
 ```
 
-Step 2 - Set the SDK and NDK paths in environment variables.
+Step 2 - Set the SDK and NDK paths in environment variables. (Recommended Android NDK revision: r25c)
 
 ```
 $ export ANDROID_SDK_ROOT="/path/to/android/sdk"

--- a/android_jni/avifandroidjni/build.gradle
+++ b/android_jni/avifandroidjni/build.gradle
@@ -4,12 +4,12 @@ plugins {
 
 android {
     namespace 'org.aomedia.avif.android'
-    compileSdk 30
+    compileSdk 31
     ndkVersion "25.2.9519653"
 
     defaultConfig {
         minSdk 21
-        targetSdk 30
+        targetSdk 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
+++ b/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
@@ -35,7 +35,8 @@ add_library("avif_android" SHARED "libavif_jni.cc")
 
 # Import the cpu-features module to compute the number of threads used for
 # decoding.
-include(AndroidNdkModules)
-android_ndk_import_module_cpufeatures()
+set(CPU_FEATURES_DIR "${ANDROID_NDK}/sources/android/cpufeatures")
+include_directories(${CPU_FEATURES_DIR})
+add_library(cpufeatures STATIC "${CPU_FEATURES_DIR}/cpu-features.c")
 
 target_link_libraries(avif_android jnigraphics avif log cpufeatures)


### PR DESCRIPTION
This PR sets the `targetSdk` and `compileSdk` to `31`, alongside with fixing the `cpufeatures` library on the CMake file for Android builds, to fix the build errors. The PR has also added a recommended NDK revison, as `r26` and above is causing an `i686-linux-android19-clang not found` error from the `ext/dav1d_android.sh` buildscript because support for Android API 19 and 20 was removed.