### PR TITLE
github ci: use default profile for actions-rs

### DIFF
--- a/.github/actions/setup-common/action.yml
+++ b/.github/actions/setup-common/action.yml
@@ -38,6 +38,4 @@ runs:
       if: ${{ inputs.codec-rav1e == 'LOCAL' }}
       uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
-        profile: minimal
         toolchain: stable
-        override: true


### PR DESCRIPTION
Do not explicitly specify the profile and override for
actions-rs. Only specify the toolchain.

This fixes some CI failures caused when building rav1e.
