### PR TITLE
Fix avifROStreamSkipBits bug for incomplete byte

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -153,6 +153,9 @@ avifBool avifROStreamSkipBits(avifROStream * stream, size_t bitCount)
         const size_t padding = AVIF_MIN(8 - stream->numUsedBitsInPartialByte, bitCount);
         stream->numUsedBitsInPartialByte = (stream->numUsedBitsInPartialByte + padding) % 8;
         bitCount -= padding;
+        if (stream->numUsedBitsInPartialByte != 0) {
+            return AVIF_TRUE;
+        }
     }
     const size_t num_bytes = (bitCount + 7) / 8;
     AVIF_CHECK(avifROStreamSkip(stream, num_bytes));

--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -167,6 +167,32 @@ TEST(StreamTest, Roundtrip) {
   EXPECT_FALSE(avifROStreamSkip(&ro_stream, /*byteCount=*/1));
 }
 
+TEST(StreamTest, SkipBits) {
+  const uint8_t data[40] = {};
+  avifROData ro_data = {data, sizeof(data)};
+  avifDiagnostics diag;
+  avifDiagnosticsClearError(&diag);
+  avifROStream ro_stream;
+  avifROStreamStart(&ro_stream, &ro_data, &diag, "diagContext");
+
+  EXPECT_TRUE(avifROStreamSkip(&ro_stream, 32));
+  EXPECT_EQ(avifROStreamOffset(&ro_stream), 32);
+  EXPECT_EQ(ro_stream.numUsedBitsInPartialByte, 0);
+
+  uint32_t unused;
+  EXPECT_TRUE(avifROStreamReadBitsU32(&ro_stream, &unused, 5));
+  EXPECT_EQ(avifROStreamOffset(&ro_stream), 33);
+  EXPECT_EQ(ro_stream.numUsedBitsInPartialByte, 5);
+
+  EXPECT_TRUE(avifROStreamSkipBits(&ro_stream, 1));
+  EXPECT_EQ(avifROStreamOffset(&ro_stream), 33);
+  EXPECT_EQ(ro_stream.numUsedBitsInPartialByte, 6);
+
+  EXPECT_TRUE(avifROStreamSkipBits(&ro_stream, 2));
+  EXPECT_EQ(avifROStreamOffset(&ro_stream), 33);
+  EXPECT_EQ(ro_stream.numUsedBitsInPartialByte, 0);
+}
+
 TEST(StreamTest, WriteBitsLimit) {
   testutil::AvifRwData rw_data;
   avifRWStream rw_stream;


### PR DESCRIPTION
Fix a bug in avifROStreamSkipBits if
bitCount < 8 - stream->numUsedBitsInPartialByte.

Bug: b:376733153