### PR TITLE
Test bitCount == 0 in avifROStreamSkipBits()

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -153,7 +153,7 @@ avifBool avifROStreamSkipBits(avifROStream * stream, size_t bitCount)
         const size_t padding = AVIF_MIN(8 - stream->numUsedBitsInPartialByte, bitCount);
         stream->numUsedBitsInPartialByte = (stream->numUsedBitsInPartialByte + padding) % 8;
         bitCount -= padding;
-        if (stream->numUsedBitsInPartialByte != 0) {
+        if (bitCount == 0) {
             return AVIF_TRUE;
         }
     }


### PR DESCRIPTION
Testing bitCount == 0 is easier to understand and avoids unnecessary work if stream->numUsedBitsInPartialByte == 0 and bitCount == 0.

Suggested by Yannis Guyon.

Bug: b:376733153