### PR TITLE
Fix static libs INTERFACE_INCLUDE_DIRECTORIES

### DIFF
--- a/cmake/Modules/merge_static_libs.cmake
+++ b/cmake/Modules/merge_static_libs.cmake
@@ -52,6 +52,11 @@ function(merge_static_libs target in_target)
     set(source_file ${CMAKE_CURRENT_BINARY_DIR}/${target}_depends.c)
     add_library(${target} STATIC ${source_file})
 
+    get_target_property(include_dirs ${in_target} INTERFACE_INCLUDE_DIRECTORIES)
+    if(include_dirs)
+        target_include_directories(${target} PUBLIC ${include_dirs})
+    endif()
+
     avif_collect_deps(${in_target} lib_deps)
 
     foreach(lib ${lib_deps})


### PR DESCRIPTION
Fix issue https://github.com/microsoft/vcpkg/issues/42112, error with `fatal error: 'avif/avif.h' file not found` that target `avif` (i.e. `avif_static`) lost `INTERFACE_INCLUDE_DIRECTORIES` for static build.

Let `merge_static_libs.cmake` copy `INTERFACE_INCLUDE_DIRECTORIES` too.