### PR TITLE
android_jni: Support 16kb page size

### DIFF
--- a/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
+++ b/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
@@ -39,4 +39,5 @@ set(CPU_FEATURES_DIR "${ANDROID_NDK}/sources/android/cpufeatures")
 include_directories(${CPU_FEATURES_DIR})
 add_library(cpufeatures STATIC "${CPU_FEATURES_DIR}/cpu-features.c")
 
+target_link_options(avif_android PRIVATE "-Wl,-z,max-page-size=16384")
 target_link_libraries(avif_android jnigraphics avif log cpufeatures)


### PR DESCRIPTION
Add -Wl,-z,max-page-size=16384 linker flag when building the JNI
wrapper to support newly added 16kb page size on Android.

https://developer.android.com/guide/practices/page-sizes#cmake

Fixes issue #2464
