### PR TITLE
Clean ci-unix-static-sanitized.yml

### DIFF
--- a/.github/workflows/ci-unix-static-sanitized.yml
+++ b/.github/workflows/ci-unix-static-sanitized.yml
@@ -44,41 +44,37 @@ jobs:
       - id: cache-hit
         run: echo "hit=${{ (runner.os == 'Linux' && steps.setup_linux.outputs.ext-cache-hit == 'true') || (runner.os == 'macOS' && steps.setup_macos.outputs.ext-cache-hit == 'true') }}" >> "$GITHUB_OUTPUT"
 
+      - name: Set FLAGS for sanitizers
+        run: |
+          echo "CI_CFLAGS=-fsanitize=${{ matrix.sanitizer }}"  >> $GITHUB_ENV
+          echo "CI_CXXFLAGS=-fsanitize=${{ matrix.sanitizer }}"  >> $GITHUB_ENV
+          echo "CI_LDFLAGS=-fsanitize=${{ matrix.sanitizer }}"  >> $GITHUB_ENV
+          echo "CI_LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
       - name: Build aom
         if: ${{ steps.cache-hit.outputs.hit == 'false' }}
         working-directory: ./ext
-        run: >
+        run: |
           sed -i -e 's/cmake -G Ninja \(.*\) \.\./cmake -G Ninja \1 -DSANITIZE=${{ matrix.sanitizer }} ../g' aom.cmd
-
           ./aom.cmd
+        env:
+          CFLAGS: ${{ env.CI_CFLAGS }}
+          CXXFLAGS: ${{ env.CI_CXXFLAGS }}
+          LDFLAGS: ${{ env.CI_LDFLAGS }}
+      - name: Prepare dav1d
+        if: ${{ steps.cache-hit.outputs.hit == 'false' }}
+        working-directory: ./ext
+        run:
+          sed -i -e 's/meson setup \(.*\) \.\./meson setup \1 -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false ../g' dav1d.cmd
       - name: Build dav1d
         if: ${{ steps.cache-hit.outputs.hit == 'false' }}
         working-directory: ./ext
-        run: >
-          sed -i -e 's/meson setup \(.*\) \.\./meson setup \1 -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false ../g' dav1d.cmd
-
+        run:
           ./dav1d.cmd
-      - name: Build libyuv
-        if: ${{ steps.cache-hit.outputs.hit == 'false' }}
-        working-directory: ./ext
-        run: ./libyuv.cmd
         env:
-          CFLAGS: -fsanitize=${{ matrix.sanitizer }}
-          CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
-          LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
-      - name: Build libsharpyuv
-        if: ${{ steps.cache-hit.outputs.hit == 'false' }}
-        working-directory: ./ext
-        run: ./libsharpyuv.cmd
-        env:
-          CFLAGS: -fsanitize=${{ matrix.sanitizer }}
-          CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
-          LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
-      - name: Build GoogleTest
-        if: ${{ steps.cache-hit.outputs.hit == 'false' }}
-        working-directory: ./ext
-        # Note: "apt install googletest" is sometimes insufficient for find_package(GTest) so build in ext/ instead.
-        run: bash -e googletest.cmd
+          CFLAGS: ${{ env.CI_CFLAGS }}
+          CXXFLAGS: ${{ env.CI_CXXFLAGS }}
+          LDFLAGS: ${{ env.CI_LDFLAGS }}
 
       - name: Prepare libavif (cmake)
         run: >
@@ -89,9 +85,9 @@ jobs:
           -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
           -DAVIF_BUILD_TESTS=ON -DAVIF_ENABLE_GTEST=ON -DAVIF_GTEST=LOCAL
         env:
-          CFLAGS: -fsanitize=${{ matrix.sanitizer }}
-          CXXFLAGS: -fsanitize=${{ matrix.sanitizer }}
-          LDFLAGS: -fsanitize=${{ matrix.sanitizer }}
+          CFLAGS: ${{ env.CI_CFLAGS }}
+          CXXFLAGS: ${{ env.CI_CXXFLAGS }}
+          LDFLAGS: ${{ env.CI_LDFLAGS }}
       - name: Build libavif (ninja)
         working-directory: ./build
         run: ninja
@@ -101,3 +97,4 @@ jobs:
         env:
           ASAN_OPTIONS: allocator_may_return_null=1
           TSAN_OPTIONS: allocator_may_return_null=1
+          LD_LIBRARY_PATH: ${{ env.CI_LD_LIBRARY_PATH }}


### PR DESCRIPTION
- no need to build libyuv/libsharpyuv/gtest in ext: CMake does it
- the aom/dav1d commands were not executed because of > instead of |
- export env variables to the ext builds
- split the dav1d command in two for later msan integration