### PR TITLE
Deprecate min/max quantizer fields/flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Remove AVIF_ENABLE_GTEST CMake option. It's now implied by
   AVIF_GTEST=LOCAL/SYSTEM.
 * Add 'avifgainmaputil' command line tool to installed apps.
+* Deprecate `avifEncoder`'s `minQuantizer`, `maxQuantizer`, `minQuantizerAlpha`,
+  and `maxQuantizerAlpha` fields. `quality` and `qualityAlpha` should be used
+  instead. Deprecate `avifenc`'s `--min`, `--max`, `--minalpha` and `--maxalpha`
+  flags. `-q` or `--qcolor` and `--qalpha` should be used instead.
 
 ## [1.1.1] - 2024-07-30
 

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -268,8 +268,8 @@ static void syntaxLong(void)
     printf("    --tilerowslog2 R                  : Set log2 of number of tile rows (0-6, default: 0)\n");
     printf("    --tilecolslog2 C                  : Set log2 of number of tile columns (0-6, default: 0)\n");
     printf("    --autotiling                      : Set --tilerowslog2 and --tilecolslog2 automatically\n");
-    printf("    --max QP                          : Deprecated, use -q [0-100] instead\n");
     printf("    --min QP                          : Deprecated, use -q [0-100] instead\n");
+    printf("    --max QP                          : Deprecated, use -q [0-100] instead\n");
     printf("    --minalpha QP                     : Deprecated, use --qalpha [0-100] instead\n");
     printf("    --maxalpha QP                     : Deprecated, use --qalpha [0-100] instead\n");
     printf("    --scaling-mode N[/D]              : EXPERIMENTAL: Set frame (layer) scaling mode as given fraction. If omitted, D default to 1. (Default: 1/1)\n");

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -2081,7 +2081,7 @@ int main(int argc, char * argv[])
             }
             if (fileSettings->minQuantizer.set && fileSettings->maxQuantizer.set) {
                 fprintf(stderr,
-                        "WARNING: --min and --max are deprecated, please used --q [0-100] instead. "
+                        "WARNING: --min and --max are deprecated, please use --q [0-100] instead. "
                         "--min %d --max %d is equivalent to -q %d\n",
                         fileSettings->minQuantizer.value,
                         fileSettings->maxQuantizer.value,
@@ -2089,7 +2089,7 @@ int main(int argc, char * argv[])
             }
             if (fileSettings->minQuantizerAlpha.set && fileSettings->maxQuantizerAlpha.set) {
                 fprintf(stderr,
-                        "WARNING: --minalpha maxalpha --maxalpha are deprecated, please used --qalpha [0-100] instead. "
+                        "WARNING: --minalpha and --maxalpha are deprecated, please use --qalpha [0-100] instead. "
                         "--minalpha %d --maxalpha %d is equivalent to --qalpha %d\n",
                         fileSettings->minQuantizerAlpha.value,
                         fileSettings->maxQuantizerAlpha.value,

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -268,22 +268,10 @@ static void syntaxLong(void)
     printf("    --tilerowslog2 R                  : Set log2 of number of tile rows (0-6, default: 0)\n");
     printf("    --tilecolslog2 C                  : Set log2 of number of tile columns (0-6, default: 0)\n");
     printf("    --autotiling                      : Set --tilerowslog2 and --tilecolslog2 automatically\n");
-    printf("    --min QP                          : Set min quantizer for color (%d-%d, where %d is lossless)\n",
-           AVIF_QUANTIZER_BEST_QUALITY,
-           AVIF_QUANTIZER_WORST_QUALITY,
-           AVIF_QUANTIZER_LOSSLESS);
-    printf("    --max QP                          : Set max quantizer for color (%d-%d, where %d is lossless)\n",
-           AVIF_QUANTIZER_BEST_QUALITY,
-           AVIF_QUANTIZER_WORST_QUALITY,
-           AVIF_QUANTIZER_LOSSLESS);
-    printf("    --minalpha QP                     : Set min quantizer for alpha (%d-%d, where %d is lossless)\n",
-           AVIF_QUANTIZER_BEST_QUALITY,
-           AVIF_QUANTIZER_WORST_QUALITY,
-           AVIF_QUANTIZER_LOSSLESS);
-    printf("    --maxalpha QP                     : Set max quantizer for alpha (%d-%d, where %d is lossless)\n",
-           AVIF_QUANTIZER_BEST_QUALITY,
-           AVIF_QUANTIZER_WORST_QUALITY,
-           AVIF_QUANTIZER_LOSSLESS);
+    printf("    --max QP                          : Deprecated, use -q [0-100] instead\n");
+    printf("    --min QP                          : Deprecated, use -q [0-100] instead\n");
+    printf("    --minalpha QP                     : Deprecated, use --qalpha [0-100] instead\n");
+    printf("    --maxalpha QP                     : Deprecated, use --qalpha [0-100] instead\n");
     printf("    --scaling-mode N[/D]              : EXPERIMENTAL: Set frame (layer) scaling mode as given fraction. If omitted, D default to 1. (Default: 1/1)\n");
     printf("    --duration D                      : Set frame durations (in timescales) to D; default 1. This option always apply to following inputs with or without suffix.\n");
     printf("    -a,--advanced KEY[=VALUE]         : Pass an advanced, codec-specific key/value string pair directly to the codec. avifenc will warn on any not used by the codec.\n");
@@ -1360,6 +1348,12 @@ static avifBool avifEncodeImages(avifSettings * settings,
     return AVIF_TRUE;
 }
 
+static int quantizerToQuality(int minQuantizer, int maxQuantizer)
+{
+    const int quantizer = (minQuantizer + maxQuantizer) / 2;
+    return (int)(100 - (100 * quantizer - 50) / 63.0);
+}
+
 int main(int argc, char * argv[])
 {
     if (argc < 2) {
@@ -2084,6 +2078,22 @@ int main(int argc, char * argv[])
                         "ERROR: --minalpha and --maxalpha must be either both specified or both unspecified for input %s.\n",
                         file->filename);
                 goto cleanup;
+            }
+            if (fileSettings->minQuantizer.set && fileSettings->maxQuantizer.set) {
+                fprintf(stderr,
+                        "WARNING: --min and --max are deprecated, please used --q [0-100] instead. "
+                        "--min %d --max %d is equivalent to -q %d\n",
+                        fileSettings->minQuantizer.value,
+                        fileSettings->maxQuantizer.value,
+                        quantizerToQuality(fileSettings->minQuantizer.value, fileSettings->maxQuantizer.value));
+            }
+            if (fileSettings->minQuantizerAlpha.set && fileSettings->maxQuantizerAlpha.set) {
+                fprintf(stderr,
+                        "WARNING: --minalpha maxalpha --maxalpha are deprecated, please used --qalpha [0-100] instead. "
+                        "--minalpha %d --maxalpha %d is equivalent to --qalpha %d\n",
+                        fileSettings->minQuantizerAlpha.value,
+                        fileSettings->maxQuantizerAlpha.value,
+                        quantizerToQuality(fileSettings->minQuantizerAlpha.value, fileSettings->maxQuantizerAlpha.value));
             }
 
             if (!fileSettings->autoTiling.set) {

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1456,13 +1456,6 @@ typedef struct avifScalingMode
 // * If (maxThreads < 2), multithreading is disabled
 //   * NOTE: Please see the "Understanding maxThreads" comment block above
 // * Quality range: [AVIF_QUALITY_WORST - AVIF_QUALITY_BEST]
-// * Quantizer range: [AVIF_QUANTIZER_BEST_QUALITY - AVIF_QUANTIZER_WORST_QUALITY]
-// * In older versions of libavif, the avifEncoder struct doesn't have the quality and qualityAlpha
-//   fields. For backward compatibility, if the quality field is not set, the default value of
-//   quality is based on the average of minQuantizer and maxQuantizer. Similarly the default value
-//   of qualityAlpha is based on the average of minQuantizerAlpha and maxQuantizerAlpha. New code
-//   should set quality and qualityAlpha and leave minQuantizer, maxQuantizer, minQuantizerAlpha,
-//   and maxQuantizerAlpha initialized to their default values.
 // * To enable tiling, set tileRowsLog2 > 0 and/or tileColsLog2 > 0.
 //   Tiling values range [0-6], where the value indicates a request for 2^n tiles in that dimension.
 //   If autoTiling is set to AVIF_TRUE, libavif ignores tileRowsLog2 and tileColsLog2 and
@@ -1495,10 +1488,10 @@ typedef struct avifEncoder
     // changeable encoder settings
     int quality;
     int qualityAlpha;
-    int minQuantizer;
-    int maxQuantizer;
-    int minQuantizerAlpha;
-    int maxQuantizerAlpha;
+    int minQuantizer;      // Deprecated, use `quality` instead.
+    int maxQuantizer;      // Deprecated, use `quality` instead.
+    int minQuantizerAlpha; // Deprecated, use `qualityAlpha` instead.
+    int maxQuantizerAlpha; // Deprecated, use `qualityAlpha` instead.
     int tileRowsLog2;
     int tileColsLog2;
     avifBool autoTiling;


### PR DESCRIPTION
They are still supported but no longer documented and quality fields are recommended instead.
avifenc prints a warning when they are used.