### PR TITLE
Improve error message for missing 'SYSTEM' dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,14 @@ macro(check_avif_option _VAR)
             if(${_VAR} STREQUAL "LOCAL")
                 include(${_LOCAL_INCLUDE})
             elseif(${_VAR} STREQUAL "SYSTEM")
-                find_package(${_AVIF_OPTION_PKG_NAME} REQUIRED)
+                # QUIET instead of REQUIRED in order to use a custom error message below.
+                find_package(${_AVIF_OPTION_PKG_NAME} QUIET)
+                if(NOT ${_AVIF_OPTION_PKG_NAME}_FOUND)
+                    message(
+                        FATAL_ERROR
+                            "Cannot find ${_AVIF_OPTION_PKG_NAME}. Make sure it's installed on the system, or pass -D${_VAR}=LOCAL (to fetch and build it locally) or -D${_VAR}=OFF (to disable it)"
+                    )
+                endif()
             endif()
         endif()
     endif()


### PR DESCRIPTION
Before:

```
$ cmake .
...
-- Checking for module 'libyuv'
--   Package 'libyuv', required by 'virtual:world', not found
CMake Error at /usr/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find libyuv (missing: LIBYUV_LIBRARY LIBYUV_LIBRARIES
  LIBYUV_INCLUDE_DIR) (found version "")
Call Stack (most recent call first):
  /usr/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  cmake/Modules/Findlibyuv.cmake:52 (find_package_handle_standard_args)
  CMakeLists.txt:216 (find_package)
  CMakeLists.txt:235 (check_avif_option)
```

After:

```
$ cmake .
...
-- Checking for module 'libyuv'
--   Package 'libyuv', required by 'virtual:world', not found
CMake Error at CMakeLists.txt:219 (message):
  Cannot find libyuv.  Make sure it's installed on the system, or pass
  -DAVIF_LIBYUV=LOCAL (to fetch and built it locally) or -DAVIF_LIBYUV=OFF
  (to disable it)
Call Stack (most recent call first):
  CMakeLists.txt:242 (check_avif_option)
```