### PR TITLE
Add code coverage CI.

### DIFF
--- a/.github/workflows/ci-linux-coverage.yml
+++ b/.github/workflows/ci-linux-coverage.yml
@@ -1,0 +1,62 @@
+# Workflow that builds libabvif with aom and dav1d, runs tests and generates coverage report.
+
+name: CI Linux Code Coverage
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build-shared-run-golden-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04]
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-linux
+        id: setup
+        with:
+          codec-aom: "LOCAL"
+          codec-dav1d: "LOCAL"
+          libxml2: "LOCAL"
+
+      - name: Install LLVM
+        run:  sudo apt install -y llvm
+
+      - name: Prepare libavif (cmake)
+        run: >
+          cmake -G Ninja -S . -B build
+          -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
+          -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
+          -DAVIF_LIBSHARPYUV=LOCAL -DAVIF_LIBXML2=LOCAL
+          -DAVIF_LIBYUV=OFF
+          -DAVIF_BUILD_EXAMPLES=ON -DAVIF_BUILD_APPS=ON
+          -DAVIF_BUILD_TESTS=ON -DAVIF_GTEST=LOCAL
+          -DAVIF_ENABLE_EXPERIMENTAL_YCGCO_R=ON
+          -DAVIF_ENABLE_EXPERIMENTAL_MINI=ON
+          -DAVIF_ENABLE_EXPERIMENTAL_SAMPLE_TRANSFORM=ON
+          -DAVIF_ENABLE_WERROR=ON -DAVIF_ENABLE_COVERAGE=ON
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      - name: Build libavif (ninja)
+        working-directory: ./build
+        run: ninja
+      - name: Run AVIF coverage
+        working-directory: ./build
+        run: ninja avif_coverage
+
+      # See https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
+      - name: Archive coverage output
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        with:
+          name: coverage-output
+          path:  |
+            ./build/tests/coverage/*
+            ./build/tests/coverage/**/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,6 +346,11 @@ endif()
 
 target_link_libraries(avif_obj PRIVATE avif_enable_warnings)
 
+option(
+    AVIF_ENABLE_COVERAGE
+    "Enable code coverage. Requires LLVM and clang as compiler. Has no effect unless AVIF_BUILD_TESTS is ON. Use the 'avif_coverage' target to generate a coverage report."
+    OFF
+)
 if(AVIF_ENABLE_COVERAGE)
     if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
         message(STATUS "libavif: Enabling coverage for Clang")

--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ and can be built by enabling `AVIF_BUILD_TESTS` and setting `AVIF_GTEST` to
 Additionally, fuzzing tests require [fuzztest](https://github.com/google/fuzztest),
 see also fuzzing test instructions in `ext/oss-fuzz/README.md`.
 
+Code coverage is available by enabling `AVIF_ENABLE_COVERAGE` then building
+the `avif_coverage` target, e.g. `make avif_coverage -j`. It requires
+compiling with clang (`-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`)
+and LLVM must be installed on the system.
+
 ### Build Command Lines {#build-command-lines}
 
 The following instructions can be used to build the libavif library and the


### PR DESCRIPTION
Add a cmake option.
Document in readme.

After this is merged I will delete the seriously outdated instructions in the wiki https://github.com/AOMediaCodec/libavif/wiki/Coverage