### PR TITLE
avifenc: make alpha quality be the same as the color quality by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The changes are relative to the previous release, unless the baseline is specifi
   flags. `-q` or `--qcolor` and `--qalpha` should be used instead.
 * For dependencies, the deprecated way of setting AVIF_LOCAL_* to ON is
   removed. Dependency options can now only be set to OFF/LOCAL/SYSTEM.
+* Change the default quality for alpha to be the same as the quality for color.
 
 ## [1.1.1] - 2024-07-30
 

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -130,17 +130,17 @@ pushd ${TMP_DIR}
   # The default quality is 60. The default alpha quality is 100 (lossless).
   "${AVIFENC}" -s 10 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[60 " "${OUT_MSG}"
-  grep " alpha quality \[100 " "${OUT_MSG}"
+  grep " alpha quality \[60 " "${OUT_MSG}"
   "${AVIFENC}" -s 10 -q 85 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[85 " "${OUT_MSG}"
-  grep " alpha quality \[100 " "${OUT_MSG}"
+  grep " alpha quality \[85 " "${OUT_MSG}"
   # The average of 15 and 25 is 20. Quantizer 20 maps to quality 68.
   "${AVIFENC}" -s 10 --min 15 --max 25 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[68 " "${OUT_MSG}"
-  grep " alpha quality \[100 " "${OUT_MSG}"
+  grep " alpha quality \[68 " "${OUT_MSG}"
   "${AVIFENC}" -s 10 -q 65 --min 15 --max 25 "${INPUT_Y4M}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[65 " "${OUT_MSG}"
-  grep " alpha quality \[100 " "${OUT_MSG}"
+  grep " alpha quality \[65 " "${OUT_MSG}"
 popd
 
 exit 0

--- a/tests/test_cmd_animation.sh
+++ b/tests/test_cmd_animation.sh
@@ -52,6 +52,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Looks for a string (NOT a regex) in a string.
+# findstr needle haystack
+findstr() {
+  if ! echo "${2}" | grep -F "${1}"; then
+    echo "ERROR: String '${1}' not found"
+    return 1
+  fi
+}
+
 pushd ${TMP_DIR}
   # Lossy test.
   "${AVIFENC}" -s 8 "${INPUT_Y4M_0}" "${INPUT_Y4M_1}" -o "${ENCODED_FILE}"
@@ -73,11 +82,26 @@ pushd ${TMP_DIR}
   "${AVIFENC}" -s 8 -q 60 "${INPUT_Y4M_0}" "${INPUT_Y4M_1}" -o "${ENCODED_FILE}"
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}"
   Q60_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
-  "${AVIFENC}" -s 8 -q 60 "${INPUT_Y4M_0}" -q:u 100 "${INPUT_Y4M_1}" -o "${ENCODED_FILE}"
+  out=$("${AVIFENC}" -s 8 -q 60 "${INPUT_Y4M_0}" -q:u 100 "${INPUT_Y4M_1}" -o "${ENCODED_FILE}")
+  findstr "Encoding frame 0 [1/25 ts] color quality [60 (Medium)], alpha quality [60 (Medium)]" "${out}"
+  findstr "Encoding frame 1 [1/25 ts] color quality [100 (Lossless)], alpha quality [100 (Lossless)]" "${out}"
   "${AVIFDEC}" "${ENCODED_FILE}" "${DECODED_FILE}"
   Q60_Q100_FILE_SIZE=$(wc -c < "${ENCODED_FILE}")
   [[ ${Q60_FILE_SIZE} -lt ${Q60_Q100_FILE_SIZE} ]] || exit 1
 
+  # Test updating of q and qalpha. Alpha quality defaults to the same as color quality
+  # until the first time it's explicitly set.
+  out=$("${AVIFENC}" -s 8 -q 70 "${INPUT_Y4M_0}" -q:u 20 "${INPUT_Y4M_1}" --qalpha:u 10 "${INPUT_Y4M_0}" -q:u 30 "${INPUT_Y4M_1}" -o "${ENCODED_FILE}")
+  findstr "Encoding frame 0 [1/25 ts] color quality [70 (Medium)], alpha quality [70 (Medium)]" "${out}"
+  findstr "Encoding frame 1 [1/25 ts] color quality [20 (Low)], alpha quality [20 (Low)]" "${out}"
+  findstr "Encoding frame 2 [1/25 ts] color quality [20 (Low)], alpha quality [10 (Low)]" "${out}"
+  findstr "Encoding frame 3 [1/25 ts] color quality [30 (Low)], alpha quality [10 (Low)]" "${out}"
+  out=$("${AVIFENC}" -s 8 --qalpha 50 -q 70 "${INPUT_Y4M_0}" -q:u 20 "${INPUT_Y4M_1}" -o "${ENCODED_FILE}")
+  findstr "Encoding frame 0 [1/25 ts] color quality [70 (Medium)], alpha quality [50 (Medium)]" "${out}"
+  findstr "Encoding frame 1 [1/25 ts] color quality [20 (Low)], alpha quality [50 (Medium)]" "${out}"
+  out=$("${AVIFENC}" -s 8 "${INPUT_Y4M_0}" "${INPUT_Y4M_1}" -o "${ENCODED_FILE}")
+  findstr "Encoding frame 0 [1/25 ts] color quality [60 (Medium)], alpha quality [60 (Medium)]" "${out}"
+  findstr "Encoding frame 1 [1/25 ts] color quality [60 (Medium)], alpha quality [60 (Medium)]" "${out}"
 popd
 
 exit 0

--- a/tests/test_cmd_avm.sh
+++ b/tests/test_cmd_avm.sh
@@ -86,17 +86,17 @@ pushd ${TMP_DIR}
   # The default quality is 60. The default alpha quality is 100 (lossless).
   "${AVIFENC}" -c avm -s 10 "${INPUT_PNG}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[60 " "${OUT_MSG}"
-  grep " alpha quality \[100 " "${OUT_MSG}"
+  grep " alpha quality \[60 " "${OUT_MSG}"
   "${AVIFENC}" -c avm -s 10 -q 85 "${INPUT_PNG}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[85 " "${OUT_MSG}"
-  grep " alpha quality \[100 " "${OUT_MSG}"
+  grep " alpha quality \[85 " "${OUT_MSG}"
   # The average of 15 and 25 is 20. Quantizer 20 maps to quality 68.
   "${AVIFENC}" -c avm -s 10 --min 15 --max 25 "${INPUT_PNG}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[68 " "${OUT_MSG}"
-  grep " alpha quality \[100 " "${OUT_MSG}"
+  grep " alpha quality \[68 " "${OUT_MSG}"
   "${AVIFENC}" -c avm -s 10 -q 65 --min 15 --max 25 "${INPUT_PNG}" "${ENCODED_FILE}" > "${OUT_MSG}"
   grep " color quality \[65 " "${OUT_MSG}"
-  grep " alpha quality \[100 " "${OUT_MSG}"
+  grep " alpha quality \[65 " "${OUT_MSG}"
 popd
 
 exit 0


### PR DESCRIPTION
If only the color quality is set, alpha quality is automatically set to the same value.

The old behavior was alpha quality set to 100 (lossless) but this generates very large file and is not needed in most cases.