### PR TITLE
Use CMake's compiler when checking for static link bundling

### DIFF
--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -61,7 +61,7 @@ jobs:
         run: ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure
       - name: Check static link bundling
         run: |
-          cc -o avifenc  -I./apps/shared -I./third_party/iccjpeg -I./include apps/avifenc.c \
+          $CC -o avifenc  -I./apps/shared -I./third_party/iccjpeg -I./include apps/avifenc.c \
             apps/shared/*.c third_party/iccjpeg/iccjpeg.c build/libavif.a \
             -lpng -ljpeg -lz -lm -ldl -lstdc++
 

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -71,7 +71,7 @@ jobs:
         run: ctest -j $(getconf _NPROCESSORS_ONLN) --output-on-failure
       - name: Check static link bundling
         run: |
-          cc -o avifenc  -I./apps/shared -I./third_party/iccjpeg -I./include apps/avifenc.c \
+          $CC -o avifenc  -I./apps/shared -I./third_party/iccjpeg -I./include apps/avifenc.c \
             apps/shared/*.c third_party/iccjpeg/iccjpeg.c build/libavif.a \
             -lpng -ljpeg -lz -lm -ldl -lstdc++
 


### PR DESCRIPTION
This should fix issues seen in https://github.com/AOMediaCodec/libavif/pull/2557