### PR TITLE
Switch macos-13 to macos-latest in CI

### DIFF
--- a/.github/workflows/ci-unix-shared-local.yml
+++ b/.github/workflows/ci-unix-shared-local.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13]
+        os: [ubuntu-24.04, macos-latest]
         libyuv: [OFF, LOCAL]
         include:
           - runs-on: ubuntu-24.04

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13]
+        os: [ubuntu-24.04, macos-latest]
         build-type: [Release, Debug]
         include:
           - runs-on: ubuntu-24.04

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Check static link bundling
         run: |
           ${{ env.CC }} -o avifenc  -I./apps/shared -I./third_party/iccjpeg -I./include apps/avifenc.c \
+            -I/opt/homebrew/include/ -L/opt/homebrew/lib \
             apps/shared/*.c third_party/iccjpeg/iccjpeg.c build/libavif.a \
             -lpng -ljpeg -lz -lm -ldl -lstdc++
 


### PR DESCRIPTION
The CI on macos-13 has been slower to trigger, probably due to it being phased out (macos-15 is out now).