### PR TITLE
Check FuzzTest WithSize() actual size

### DIFF
--- a/tests/gtest/avif_fuzztest_enc_dec_anim.cc
+++ b/tests/gtest/avif_fuzztest_enc_dec_anim.cc
@@ -25,6 +25,9 @@ struct FrameOptions {
 void EncodeDecodeAnimation(std::vector<ImagePtr> frames,
                            const std::vector<FrameOptions>& frame_options,
                            EncoderPtr encoder, DecoderPtr decoder) {
+  // Make sure WithSize() works.
+  ASSERT_EQ(frame_options.size(), kMaxNumFrames);
+
   ASSERT_NE(encoder, nullptr);
   ASSERT_NE(decoder, nullptr);
   ImagePtr decoded_image(avifImageCreateEmpty());

--- a/tests/gtest/avif_fuzztest_helpers.cc
+++ b/tests/gtest/avif_fuzztest_helpers.cc
@@ -58,6 +58,9 @@ ImagePtr CreateAvifImage(size_t width, size_t height, int depth,
 ImagePtr CreateAvifImage8b(size_t width, size_t height,
                            avifPixelFormat pixel_format, bool has_alpha,
                            const std::vector<uint8_t>& samples) {
+  // Make sure WithSize() works.
+  assert(samples.size() == GetNumSamples(/*num_frames=*/1, width, height,
+                                         pixel_format, has_alpha));
   return CreateAvifImage(width, height, 8, pixel_format, has_alpha,
                          samples.data());
 }
@@ -65,6 +68,9 @@ ImagePtr CreateAvifImage8b(size_t width, size_t height,
 ImagePtr CreateAvifImage16b(size_t width, size_t height, int depth,
                             avifPixelFormat pixel_format, bool has_alpha,
                             const std::vector<uint16_t>& samples) {
+  // Make sure WithSize() works.
+  assert(samples.size() == GetNumSamples(/*num_frames=*/1, width, height,
+                                         pixel_format, has_alpha));
   return CreateAvifImage(width, height, depth, pixel_format, has_alpha,
                          reinterpret_cast<const uint8_t*>(samples.data()));
 }
@@ -74,6 +80,9 @@ std::vector<ImagePtr> CreateAvifAnim8b(size_t num_frames, size_t width,
                                        avifPixelFormat pixel_format,
                                        bool has_alpha,
                                        const std::vector<uint8_t>& samples) {
+  // Make sure WithSize() works.
+  assert(samples.size() ==
+         GetNumSamples(num_frames, width, height, pixel_format, has_alpha));
   std::vector<ImagePtr> frames;
   frames.reserve(num_frames);
   const uint8_t* frame_samples = samples.data();
@@ -91,6 +100,9 @@ std::vector<ImagePtr> CreateAvifAnim16b(size_t num_frames, size_t width,
                                         avifPixelFormat pixel_format,
                                         bool has_alpha,
                                         const std::vector<uint16_t>& samples) {
+  // Make sure WithSize() works.
+  assert(samples.size() ==
+         GetNumSamples(num_frames, width, height, pixel_format, has_alpha));
   std::vector<ImagePtr> frames;
   frames.reserve(num_frames);
   const uint16_t* frame_samples = samples.data();


### PR DESCRIPTION
Because of the recent false positive possibly attributed to FuzzTest domains not respecting constraints.

Can be reverted when no longer useful.