### PR TITLE
Omit the apps/avifgainmaputil/ include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,7 +739,6 @@ if(AVIF_BUILD_APPS)
         endif()
     endif()
     set_target_properties(avifgainmaputil PROPERTIES LINKER_LANGUAGE "CXX")
-    target_include_directories(avifgainmaputil PRIVATE apps/avifgainmaputil/)
     target_link_libraries(avifgainmaputil libargparse avif_apps avif avif_enable_warnings)
 
     if(NOT SKIP_INSTALL_APPS AND NOT SKIP_INSTALL_ALL)


### PR DESCRIPTION
All the C compilers I have worked with automatically search for headers in the same directory where the source file resides. So it is redundant to add that directory to target_include_directories().