### PR TITLE
Don't compare gainMapF[0] with itself

### DIFF
--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -363,7 +363,7 @@ avifResult avifFindMinMaxWithoutOutliers(const float * gainMapF, int numPixels, 
 
     float min = gainMapF[0];
     float max = gainMapF[0];
-    for (int i = 0; i < numPixels; ++i) {
+    for (int i = 1; i < numPixels; ++i) {
         min = AVIF_MIN(min, gainMapF[i]);
         max = AVIF_MAX(max, gainMapF[i]);
     }


### PR DESCRIPTION
When finding the min and max values in the gainMapF array, don't compare gainMapF[0] with itself.