### PR TITLE
 Update man pages based on avifenc/dec's --help message.

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -30,12 +30,12 @@ static void syntax(void)
     printf("Options:\n");
     printf("    -h,--help         : Show syntax help\n");
     printf("    -V,--version      : Show the version number\n");
-    printf("    -j,--jobs J       : Number of jobs (worker threads). Use \"all\" to potentially use as many cores as possible (default: all)\n");
+    printf("    -j,--jobs J       : Number of jobs (worker threads), or 'all' to potentially use as many cores as possible. (Default: all)\n");
     printf("    -c,--codec C      : Codec to use (choose from versions list below)\n");
-    printf("    -d,--depth D      : Output depth [8,16]. (PNG only; For y4m, depth is retained, and JPEG is always 8bpc)\n");
-    printf("    -q,--quality Q    : Output quality [0-100]. (JPEG only, default: %d)\n", DEFAULT_JPEG_QUALITY);
-    printf("    --png-compress L  : PNG compression level (PNG only; 0-9, 0=none, 9=max). Defaults to libpng's builtin default.\n");
-    printf("    -u,--upsampling U : Chroma upsampling (for 420/422). automatic (default), fastest, best, nearest, or bilinear\n");
+    printf("    -d,--depth D      : Output depth, either 8 or 16. (PNG only; For y4m, depth is retained, and JPEG is always 8bpc)\n");
+    printf("    -q,--quality Q    : Output quality in 0..100. (JPEG only, default: %d)\n", DEFAULT_JPEG_QUALITY);
+    printf("    --png-compress L  : PNG compression level in 0..9 (PNG only; 0=none, 9=max). Defaults to libpng's builtin default\n");
+    printf("    -u,--upsampling U : Chroma upsampling (for 420/422). One of 'automatic' (default), 'fastest', 'best', 'nearest', or 'bilinear'\n");
     printf("    -r,--raw-color    : Output raw RGB values instead of multiplying by alpha when saving to opaque formats\n");
     printf("                        (JPEG only; not applicable to y4m)\n");
     printf("    --index I         : When decoding an image sequence or progressive image, specify which frame index to decode (Default: 0)\n");
@@ -45,10 +45,10 @@ static void syntax(void)
     printf("    -i,--info         : Decode all frames and display all image information instead of saving to disk\n");
     printf("    --icc FILENAME    : Provide an ICC profile payload (implies --ignore-icc)\n");
     printf("    --ignore-icc      : If the input file contains an embedded ICC profile, ignore it (no-op if absent)\n");
-    printf("    --size-limit C    : Maximum image size (in total pixels) that should be tolerated.\n");
-    printf("                        Default: %u, set to a smaller value to further restrict.\n", AVIF_DEFAULT_IMAGE_SIZE_LIMIT);
+    printf("    --size-limit C    : Maximum image size (in total pixels) that should be tolerated. (Default: %u)\n",
+           AVIF_DEFAULT_IMAGE_SIZE_LIMIT);
     printf("  --dimension-limit C : Maximum image dimension (width or height) that should be tolerated.\n");
-    printf("                        Default: %u, set to 0 to ignore.\n", AVIF_DEFAULT_IMAGE_DIMENSION_LIMIT);
+    printf("                        Set to 0 to ignore. (Default: %u)\n", AVIF_DEFAULT_IMAGE_DIMENSION_LIMIT);
     printf("    --                : Signal the end of options. Everything after this is interpreted as file names.\n");
     printf("\n");
     avifPrintVersions();

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -34,7 +34,7 @@ static void syntax(void)
     printf("    -c,--codec C      : Codec to use (choose from versions list below)\n");
     printf("    -d,--depth D      : Output depth [8,16]. (PNG only; For y4m, depth is retained, and JPEG is always 8bpc)\n");
     printf("    -q,--quality Q    : Output quality [0-100]. (JPEG only, default: %d)\n", DEFAULT_JPEG_QUALITY);
-    printf("    --png-compress L  : Set PNG compression level (PNG only; 0-9, 0=none, 9=max). Defaults to libpng's builtin default.\n");
+    printf("    --png-compress L  : PNG compression level (PNG only; 0-9, 0=none, 9=max). Defaults to libpng's builtin default.\n");
     printf("    -u,--upsampling U : Chroma upsampling (for 420/422). automatic (default), fastest, best, nearest, or bilinear\n");
     printf("    -r,--raw-color    : Output raw RGB values instead of multiplying by alpha when saving to opaque formats\n");
     printf("                        (JPEG only; not applicable to y4m)\n");
@@ -45,11 +45,11 @@ static void syntax(void)
     printf("    -i,--info         : Decode all frames and display all image information instead of saving to disk\n");
     printf("    --icc FILENAME    : Provide an ICC profile payload (implies --ignore-icc)\n");
     printf("    --ignore-icc      : If the input file contains an embedded ICC profile, ignore it (no-op if absent)\n");
-    printf("    --size-limit C    : Specifies the image size limit (in total pixels) that should be tolerated.\n");
+    printf("    --size-limit C    : Maximum image size (in total pixels) that should be tolerated.\n");
     printf("                        Default: %u, set to a smaller value to further restrict.\n", AVIF_DEFAULT_IMAGE_SIZE_LIMIT);
-    printf("  --dimension-limit C : Specifies the image dimension limit (width or height) that should be tolerated.\n");
+    printf("  --dimension-limit C : Maximum image dimension (width or height) that should be tolerated.\n");
     printf("                        Default: %u, set to 0 to ignore.\n", AVIF_DEFAULT_IMAGE_DIMENSION_LIMIT);
-    printf("    --                : Signals the end of options. Everything after this is interpreted as file names.\n");
+    printf("    --                : Signal the end of options. Everything after this is interpreted as file names.\n");
     printf("\n");
     avifPrintVersions();
 }

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -190,28 +190,28 @@ static void syntaxLong(void)
     printf("    -V,--version                      : Show the version number\n");
     printf("\n");
     printf("Basic options:\n");
-    printf("    -q,--qcolor Q                     : Quality for color (%d-%d, where %d is lossless)\n",
+    printf("    -q,--qcolor Q                     : Quality for color in %d..%d where %d is lossless\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
-    printf("    --qalpha Q                        : Quality for alpha (%d-%d, where %d is lossless)\n",
+    printf("    --qalpha Q                        : Quality for alpha in %d..%d where %d is lossless\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
-    printf("    -s,--speed S                      : Encoder speed (%d-%d, slowest-fastest, 'default' or 'd' for codec internal defaults. default speed: 6)\n",
+    printf("    -s,--speed S                      : Encoder speed in %d..%d where 0 is the slowest, 10 is the fastest. Or 'default' or 'd' for codec internal defaults. (Default: 6)\n",
            AVIF_SPEED_SLOWEST,
            AVIF_SPEED_FASTEST);
     printf("\n");
     printf("Advanced options:\n");
-    printf("    -j,--jobs J                       : Number of jobs (worker threads). Use \"all\" to potentially use as many cores as possible (default: all)\n");
+    printf("    -j,--jobs J                       : Number of jobs (worker threads), or 'all' to potentially use as many cores as possible. (Default: all)\n");
     printf("    --no-overwrite                    : Never overwrite existing output file\n");
     printf("    -o,--output FILENAME              : Instead of using the last filename given as output, use this filename\n");
 #if defined(AVIF_ENABLE_EXPERIMENTAL_MINI)
-    printf("    --mini                            : Use reduced header if possible (experimental, backward-incompatible)\n");
+    printf("    --mini                            : EXPERIMENTAL: Use reduced header if possible (backward-incompatible)\n");
 #endif
     printf("    -l,--lossless                     : Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it\n");
-    printf("    -d,--depth D                      : Output depth [8, 10, 12]. (JPEG/PNG only; For y4m or stdin, depth is retained)\n");
-    printf("    -y,--yuv FORMAT                   : Output format [default=auto, 444, 422, 420, 400]. Ignored for y4m or stdin (y4m format is retained)\n");
+    printf("    -d,--depth D                      : Output depth, one of 8, 10 or 12. (JPEG/PNG only; For y4m or stdin, depth is retained)\n");
+    printf("    -y,--yuv FORMAT                   : Output format, one of 'auto' (default), 444, 422, 420 or 400. Ignored for y4m or stdin (y4m format is retained)\n");
     printf("                                        For JPEG, auto honors the JPEG's internal format, if possible. For grayscale PNG, auto defaults to 400. For all other cases, auto defaults to 444\n");
     printf("    -p,--premultiply                  : Premultiply color by the alpha channel and signal this in the AVIF\n");
     printf("    --sharpyuv                        : Use sharp RGB to YUV420 conversion (if supported). Ignored for y4m or if output is not 420.\n");
@@ -221,7 +221,7 @@ static void syntaxLong(void)
     printf("                                        T = transfer characteristics\n");
     printf("                                        M = matrix coefficients\n");
     printf("                                        Use 2 for any you wish to leave unspecified\n");
-    printf("    -r,--range RANGE                  : YUV range [limited or l, full or f]. (JPEG/PNG only, default: full; For y4m or stdin, range is retained)\n");
+    printf("    -r,--range RANGE                  : YUV range, one of 'limited' or 'l', 'full' or 'f'. (JPEG/PNG only, default: full; For y4m or stdin, range is retained)\n");
     printf("    --target-size S                   : Set target file size in bytes (up to 7 times slower)\n");
     printf("    --progressive                     : EXPERIMENTAL: Auto set parameters to encode a simple layered image supporting progressive rendering from a single input frame.\n");
     printf("    --layered                         : EXPERIMENTAL: Encode a layered AVIF. Each input is encoded as one layer and at most %d layers can be encoded.\n",
@@ -233,7 +233,7 @@ static void syntaxLong(void)
     printf("    --exif FILENAME                   : Provide an Exif metadata payload to be associated with the primary item (implies --ignore-exif)\n");
     printf("    --xmp FILENAME                    : Provide an XMP metadata payload to be associated with the primary item (implies --ignore-xmp)\n");
     printf("    --icc FILENAME                    : Provide an ICC profile payload to be associated with the primary item (implies --ignore-icc)\n");
-    printf("    --timescale,--fps V               : Timescale for image sequences. If all frames are 1 timescale in length, this is equivalent to frames per second (Default: 30)\n");
+    printf("    --timescale,--fps V               : Timescale for image sequences. If all frames are 1 timescale in length, this is equivalent to frames per second. (Default: 30)\n");
     printf("                                        If neither duration nor timescale are set, avifenc will attempt to use the framerate stored in a y4m header, if present.\n");
     printf("    -k,--keyframe INTERVAL            : Maximum keyframe interval for image sequences (any set of INTERVAL consecutive frames will have at least one keyframe). Set to 0 to disable (default).\n");
     printf("    --ignore-exif                     : If the input file contains embedded Exif metadata, ignore it (no-op if absent)\n");
@@ -241,44 +241,44 @@ static void syntaxLong(void)
     printf("    --ignore-profile,--ignore-icc     : If the input file contains an embedded color profile, ignore it (no-op if absent)\n");
 #if defined(AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION)
     printf("    --ignore-gain-map                 : If the input file contains an embedded gain map, ignore it (no-op if absent)\n");
-    printf("    --qgain-map Q                     : Quality for the gain map (%d-%d, where %d is lossless)\n",
+    printf("    --qgain-map Q                     : Quality for the gain map in %d..%d where %d is lossless\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
 #endif
     printf("    --pasp H,V                        : Add pasp property (aspect ratio). H=horizontal spacing, V=vertical spacing\n");
     printf("    --crop CROPX,CROPY,CROPW,CROPH    : Add clap property (clean aperture), but calculated from a crop rectangle\n");
-    printf("    --clap WN,WD,HN,HD,HON,HOD,VON,VOD: Add clap property (clean aperture). Width, Height, HOffset, VOffset (in num/denom pairs)\n");
-    printf("    --irot ANGLE                      : Add irot property (rotation). [0-3], makes (90 * ANGLE) degree rotation anti-clockwise\n");
+    printf("    --clap WN,WD,HN,HD,HON,HOD,VON,VOD: Add clap property (clean aperture). Width, Height, HOffset, VOffset (in numerator/denominator pairs)\n");
+    printf("    --irot ANGLE                      : Add irot property (rotation), in 0..3. Makes (90 * ANGLE) degree rotation anti-clockwise\n");
     printf("    --imir AXIS                       : Add imir property (mirroring). 0=top-to-bottom, 1=left-to-right\n");
     printf("    --clli MaxCLL,MaxPALL             : Add clli property (content light level information).\n");
-    printf("    --repetition-count N or infinite  : Number of times an animated image sequence will be repeated. Use 'infinite' for infinite repetitions (Default: infinite)\n");
+    printf("    --repetition-count N              : Number of times an animated image sequence will be repeated, or 'infinite' for infinite repetitions. (Default: infinite)\n");
     printf("    --                                : Signal the end of options. Everything after this is interpreted as file names.\n");
     printf("\n");
     printf("Updatable options:\n");
     printf("  The following options can optionally have a :u (or :update) suffix like `-q:u Q`, to apply only to input files appearing after the option:\n");
-    printf("    -q,--qcolor Q                     : Quality for color (%d-%d, where %d is lossless)\n",
+    printf("    -q,--qcolor Q                     : Quality for color in %d..%d where %d is lossless\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
-    printf("    --qalpha Q                        : Quality for alpha (%d-%d, where %d is lossless)\n",
+    printf("    --qalpha Q                        : Quality for alpha in %d..%d where %d is lossless\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
 #if defined(AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION)
-    printf("    --qgain-map Q                     : Quality for the gain map (%d-%d, where %d is lossless)\n",
+    printf("    --qgain-map Q                     : Quality for the gain map in %d..%d where %d is lossless\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
 #endif
-    printf("    --tilerowslog2 R                  : log2 of number of tile rows (0-6, default: 0)\n");
-    printf("    --tilecolslog2 C                  : log2 of number of tile columns (0-6, default: 0)\n");
+    printf("    --tilerowslog2 R                  : log2 of number of tile rows in 0..6. (Default: 0)\n");
+    printf("    --tilecolslog2 C                  : log2 of number of tile columns 0..6. (Default: 0)\n");
     printf("    --autotiling                      : Set --tilerowslog2 and --tilecolslog2 automatically\n");
-    printf("    --min QP                          : Deprecated, use -q [0-100] instead\n");
-    printf("    --max QP                          : Deprecated, use -q [0-100] instead\n");
-    printf("    --minalpha QP                     : Deprecated, use --qalpha [0-100] instead\n");
-    printf("    --maxalpha QP                     : Deprecated, use --qalpha [0-100] instead\n");
-    printf("    --scaling-mode N[/D]              : EXPERIMENTAL: Set frame (layer) scaling mode as given fraction. If omitted, D default to 1. (Default: 1/1)\n");
+    printf("    --min QP                          : Deprecated, use -q 0..100 instead\n");
+    printf("    --max QP                          : Deprecated, use -q 0..100 instead\n");
+    printf("    --minalpha QP                     : Deprecated, use --qalpha 0..100 instead\n");
+    printf("    --maxalpha QP                     : Deprecated, use --qalpha 0..100 instead\n");
+    printf("    --scaling-mode N[/D]              : EXPERIMENTAL: Set frame (layer) scaling mode as given fraction. If omitted, the denominator defaults to 1. (Default: 1/1)\n");
     printf("    --duration D                      : Frame durations (in timescales) (default: 1). This option always applies to following inputs with or without the `:u` suffix.\n");
     printf("    -a,--advanced KEY[=VALUE]         : Pass an advanced, codec-specific key/value string pair directly to the codec. avifenc will warn on any not used by the codec.\n");
     printf("\n");
@@ -294,13 +294,13 @@ static void syntaxLong(void)
         printf("    When used with libaom 3.0.0 or later, any key-value pairs supported by the aom_codec_set_option() function\n");
         printf("    can be used. When used with libaom 2.0.x or older, the following key-value pairs can be used:\n");
         printf("\n");
-        printf("    aq-mode=M                         : Adaptive quantization mode (0: off (default), 1: variance, 2: complexity, 3: cyclic refresh)\n");
-        printf("    cq-level=Q                        : Constant/Constrained Quality level (0-63, end-usage must be set to cq or q)\n");
-        printf("    enable-chroma-deltaq=B            : Enable delta quantization in chroma planes (0: disable (default), 1: enable)\n");
-        printf("    end-usage=MODE                    : Rate control mode (vbr, cbr, cq, or q)\n");
-        printf("    sharpness=S                       : Bias towards block sharpness in rate-distortion optimization of transform coefficients (0-7, default: 0)\n");
-        printf("    tune=METRIC                       : Tune the encoder for distortion metric (psnr or ssim, default: psnr)\n");
-        printf("    film-grain-test=TEST              : Film grain test vectors (0: none (default), 1: test-1  2: test-2, ... 16: test-16)\n");
+        printf("    aq-mode=M                         : Adaptive quantization mode. 0=off (default), 1=variance, 2=complexity, 3=cyclic refresh\n");
+        printf("    cq-level=Q                        : Constant/Constrained Quality level in 0..63, end-usage must be set to cq or q\n");
+        printf("    enable-chroma-deltaq=B            : Enable delta quantization in chroma planes. 0=disable (default), 1=enable\n");
+        printf("    end-usage=MODE                    : Rate control mode, one of 'vbr', 'cbr', 'cq', or 'q'\n");
+        printf("    sharpness=S                       : Bias towards block sharpness in rate-distortion optimization of transform coefficients in 0..7. (Default: 0)\n");
+        printf("    tune=METRIC                       : Tune the encoder for distortion metric, one of 'psnr' or 'ssim'. (Default: psnr)\n");
+        printf("    film-grain-test=TEST              : Film grain test vectors in 0..16. 0=none (default), 1=test1, 2=test2, ... 16=test16\n");
         printf("    film-grain-table=FILENAME         : Path to file containing film grain parameters\n");
         printf("\n");
     }
@@ -2103,7 +2103,7 @@ int main(int argc, char * argv[])
             }
             if (fileSettings->minQuantizer.set && fileSettings->maxQuantizer.set) {
                 fprintf(stderr,
-                        "WARNING: --min and --max are deprecated, please use --q [0-100] instead. "
+                        "WARNING: --min and --max are deprecated, please use --q 0..100 instead. "
                         "--min %d --max %d is equivalent to -q %d\n",
                         fileSettings->minQuantizer.value,
                         fileSettings->maxQuantizer.value,
@@ -2111,7 +2111,7 @@ int main(int argc, char * argv[])
             }
             if (fileSettings->minQuantizerAlpha.set && fileSettings->maxQuantizerAlpha.set) {
                 fprintf(stderr,
-                        "WARNING: --minalpha and --maxalpha are deprecated, please use --qalpha [0-100] instead. "
+                        "WARNING: --minalpha and --maxalpha are deprecated, please use --qalpha 0..100 instead. "
                         "--minalpha %d --maxalpha %d is equivalent to --qalpha %d\n",
                         fileSettings->minQuantizerAlpha.value,
                         fileSettings->maxQuantizerAlpha.value,

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -220,7 +220,7 @@ static void syntaxLong(void)
     printf("                                        P = color primaries\n");
     printf("                                        T = transfer characteristics\n");
     printf("                                        M = matrix coefficients\n");
-    printf("                                        (use 2 for any you wish to leave unspecified)\n");
+    printf("                                        Use 2 for any you wish to leave unspecified\n");
     printf("    -r,--range RANGE                  : YUV range [limited or l, full or f]. (JPEG/PNG only, default: full; For y4m or stdin, range is retained)\n");
     printf("    --target-size S                   : Set target file size in bytes (up to 7 times slower)\n");
     printf("    --progressive                     : EXPERIMENTAL: Auto set parameters to encode a simple layered image supporting progressive rendering from a single input frame.\n");
@@ -241,11 +241,10 @@ static void syntaxLong(void)
     printf("    --ignore-profile,--ignore-icc     : If the input file contains an embedded color profile, ignore it (no-op if absent)\n");
 #if defined(AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION)
     printf("    --ignore-gain-map                 : If the input file contains an embedded gain map, ignore it (no-op if absent)\n");
-    printf("    --qgain-map Q                      : Set quality for the gain map (%d-%d, where %d is lossless)\n",
+    printf("    --qgain-map Q                     : Set quality for the gain map (%d-%d, where %d is lossless)\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
-    // TODO(maryla): add quality setting for the gain map.
 #endif
     printf("    --pasp H,V                        : Add pasp property (aspect ratio). H=horizontal spacing, V=vertical spacing\n");
     printf("    --crop CROPX,CROPY,CROPW,CROPH    : Add clap property (clean aperture), but calculated from a crop rectangle\n");
@@ -256,6 +255,7 @@ static void syntaxLong(void)
     printf("    --repetition-count N or infinite  : Number of times an animated image sequence will be repeated. Use 'infinite' for infinite repetitions (Default: infinite)\n");
     printf("    --                                : Signals the end of options. Everything after this is interpreted as file names.\n");
     printf("\n");
+    printf("Updatable options:\n");
     printf("  The following options can optionally have a :u (or :update) suffix like `-q:u Q`, to apply only to input files appearing after the option:\n");
     printf("    -q,--qcolor Q                     : Set quality for color (%d-%d, where %d is lossless)\n",
            AVIF_QUALITY_WORST,
@@ -265,6 +265,12 @@ static void syntaxLong(void)
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
+#if defined(AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION)
+    printf("    --qgain-map Q                     : Set quality for the gain map (%d-%d, where %d is lossless)\n",
+           AVIF_QUALITY_WORST,
+           AVIF_QUALITY_BEST,
+           AVIF_QUALITY_LOSSLESS);
+#endif
     printf("    --tilerowslog2 R                  : Set log2 of number of tile rows (0-6, default: 0)\n");
     printf("    --tilecolslog2 C                  : Set log2 of number of tile columns (0-6, default: 0)\n");
     printf("    --autotiling                      : Set --tilerowslog2 and --tilecolslog2 automatically\n");

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -229,7 +229,7 @@ static void syntaxLong(void)
     printf("    -g,--grid MxN                     : Encode a single-image grid AVIF with M cols & N rows. Either supply MxN identical W/H/D images, or a single\n");
     printf("                                        image that can be evenly split into the MxN grid and follow AVIF grid image restrictions. The grid will adopt\n");
     printf("                                        the color profile of the first image supplied.\n");
-    printf("    -c,--codec C                      : codec to use (choose from versions list below)\n");
+    printf("    -c,--codec C                      : Codec to use (choose from versions list below)\n");
     printf("    --exif FILENAME                   : Provide an Exif metadata payload to be associated with the primary item (implies --ignore-exif)\n");
     printf("    --xmp FILENAME                    : Provide an XMP metadata payload to be associated with the primary item (implies --ignore-xmp)\n");
     printf("    --icc FILENAME                    : Provide an ICC profile payload to be associated with the primary item (implies --ignore-icc)\n");

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -190,11 +190,11 @@ static void syntaxLong(void)
     printf("    -V,--version                      : Show the version number\n");
     printf("\n");
     printf("Basic options:\n");
-    printf("    -q,--qcolor Q                     : Set quality for color (%d-%d, where %d is lossless)\n",
+    printf("    -q,--qcolor Q                     : Quality for color (%d-%d, where %d is lossless)\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
-    printf("    --qalpha Q                        : Set quality for alpha (%d-%d, where %d is lossless)\n",
+    printf("    --qalpha Q                        : Quality for alpha (%d-%d, where %d is lossless)\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
@@ -210,7 +210,7 @@ static void syntaxLong(void)
     printf("    --mini                            : Use reduced header if possible (experimental, backward-incompatible)\n");
 #endif
     printf("    -l,--lossless                     : Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it\n");
-    printf("    -d,--depth D                      : Output depth [8,10,12]. (JPEG/PNG only; For y4m or stdin, depth is retained)\n");
+    printf("    -d,--depth D                      : Output depth [8, 10, 12]. (JPEG/PNG only; For y4m or stdin, depth is retained)\n");
     printf("    -y,--yuv FORMAT                   : Output format [default=auto, 444, 422, 420, 400]. Ignored for y4m or stdin (y4m format is retained)\n");
     printf("                                        For JPEG, auto honors the JPEG's internal format, if possible. For grayscale PNG, auto defaults to 400. For all other cases, auto defaults to 444\n");
     printf("    -p,--premultiply                  : Premultiply color by the alpha channel and signal this in the AVIF\n");
@@ -233,15 +233,15 @@ static void syntaxLong(void)
     printf("    --exif FILENAME                   : Provide an Exif metadata payload to be associated with the primary item (implies --ignore-exif)\n");
     printf("    --xmp FILENAME                    : Provide an XMP metadata payload to be associated with the primary item (implies --ignore-xmp)\n");
     printf("    --icc FILENAME                    : Provide an ICC profile payload to be associated with the primary item (implies --ignore-icc)\n");
-    printf("    --timescale,--fps V               : Set the timescale to V. If all frames are 1 timescale in length, this is equivalent to frames per second (Default: 30)\n");
+    printf("    --timescale,--fps V               : Timescale for image sequences. If all frames are 1 timescale in length, this is equivalent to frames per second (Default: 30)\n");
     printf("                                        If neither duration nor timescale are set, avifenc will attempt to use the framerate stored in a y4m header, if present.\n");
-    printf("    -k,--keyframe INTERVAL            : Set the maximum keyframe interval (any set of INTERVAL consecutive frames will have at least one keyframe). Set to 0 to disable (default).\n");
+    printf("    -k,--keyframe INTERVAL            : Maximum keyframe interval for image sequences (any set of INTERVAL consecutive frames will have at least one keyframe). Set to 0 to disable (default).\n");
     printf("    --ignore-exif                     : If the input file contains embedded Exif metadata, ignore it (no-op if absent)\n");
     printf("    --ignore-xmp                      : If the input file contains embedded XMP metadata, ignore it (no-op if absent)\n");
     printf("    --ignore-profile,--ignore-icc     : If the input file contains an embedded color profile, ignore it (no-op if absent)\n");
 #if defined(AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION)
     printf("    --ignore-gain-map                 : If the input file contains an embedded gain map, ignore it (no-op if absent)\n");
-    printf("    --qgain-map Q                     : Set quality for the gain map (%d-%d, where %d is lossless)\n",
+    printf("    --qgain-map Q                     : Quality for the gain map (%d-%d, where %d is lossless)\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
@@ -253,33 +253,33 @@ static void syntaxLong(void)
     printf("    --imir AXIS                       : Add imir property (mirroring). 0=top-to-bottom, 1=left-to-right\n");
     printf("    --clli MaxCLL,MaxPALL             : Add clli property (content light level information).\n");
     printf("    --repetition-count N or infinite  : Number of times an animated image sequence will be repeated. Use 'infinite' for infinite repetitions (Default: infinite)\n");
-    printf("    --                                : Signals the end of options. Everything after this is interpreted as file names.\n");
+    printf("    --                                : Signal the end of options. Everything after this is interpreted as file names.\n");
     printf("\n");
     printf("Updatable options:\n");
     printf("  The following options can optionally have a :u (or :update) suffix like `-q:u Q`, to apply only to input files appearing after the option:\n");
-    printf("    -q,--qcolor Q                     : Set quality for color (%d-%d, where %d is lossless)\n",
+    printf("    -q,--qcolor Q                     : Quality for color (%d-%d, where %d is lossless)\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
-    printf("    --qalpha Q                        : Set quality for alpha (%d-%d, where %d is lossless)\n",
+    printf("    --qalpha Q                        : Quality for alpha (%d-%d, where %d is lossless)\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
 #if defined(AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION)
-    printf("    --qgain-map Q                     : Set quality for the gain map (%d-%d, where %d is lossless)\n",
+    printf("    --qgain-map Q                     : Quality for the gain map (%d-%d, where %d is lossless)\n",
            AVIF_QUALITY_WORST,
            AVIF_QUALITY_BEST,
            AVIF_QUALITY_LOSSLESS);
 #endif
-    printf("    --tilerowslog2 R                  : Set log2 of number of tile rows (0-6, default: 0)\n");
-    printf("    --tilecolslog2 C                  : Set log2 of number of tile columns (0-6, default: 0)\n");
+    printf("    --tilerowslog2 R                  : log2 of number of tile rows (0-6, default: 0)\n");
+    printf("    --tilecolslog2 C                  : log2 of number of tile columns (0-6, default: 0)\n");
     printf("    --autotiling                      : Set --tilerowslog2 and --tilecolslog2 automatically\n");
     printf("    --min QP                          : Deprecated, use -q [0-100] instead\n");
     printf("    --max QP                          : Deprecated, use -q [0-100] instead\n");
     printf("    --minalpha QP                     : Deprecated, use --qalpha [0-100] instead\n");
     printf("    --maxalpha QP                     : Deprecated, use --qalpha [0-100] instead\n");
     printf("    --scaling-mode N[/D]              : EXPERIMENTAL: Set frame (layer) scaling mode as given fraction. If omitted, D default to 1. (Default: 1/1)\n");
-    printf("    --duration D                      : Set frame durations (in timescales) to D; default 1. This option always apply to following inputs with or without suffix.\n");
+    printf("    --duration D                      : Frame durations (in timescales) (default: 1). This option always applies to following inputs with or without the `:u` suffix.\n");
     printf("    -a,--advanced KEY[=VALUE]         : Pass an advanced, codec-specific key/value string pair directly to the codec. avifenc will warn on any not used by the codec.\n");
     printf("\n");
     if (avifCodecName(AVIF_CODEC_CHOICE_AOM, 0)) {

--- a/doc/avifdec.1.md
+++ b/doc/avifdec.1.md
@@ -31,13 +31,11 @@ Output format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Show the version number.
 
 **-j**, **\--jobs** _J_
-:   Number of jobs (worker threads).
-    1 or less means single-threaded.
-    Default is 1.
-    Use **all** to use all available cores.
+:   Number of jobs (worker threads). Use "all" to potentially use as many cores as possible (default: all).
 
 **-c**, **\--codec** _C_
-:   AV1 codec to use.
+:   Codec to use.
+
     Possible values depend on the codecs enabled at build time (see **\--help**
     or **\--version** for the available codecs).
     Default is auto-selected from the available codecs.
@@ -49,73 +47,47 @@ Output format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
         - **libgav1**
 
 **-d**, **\--depth** _D_
-:   Output PNG depth.
-    Ignored when the output format is JPEG (always 8 bits per channel) or Y4M
-    (input depth is retained).
-
-    Possible values are:
-
-    :   - **8**
-        - **16**
+:   Output depth [8,16]. (PNG only; For y4m, depth is retained, and JPEG is always 8bpc).
 
 **-q**, **\--quality** _Q_
-:   Output JPEG quality in the range **0**-**100**.
-    Default is 90.
-    Ignored if the output format is not JPEG.
+:   Output quality [0-100]. (JPEG only, default: 90).
 
 **\--png-compress** _L_
-:   Output PNG compression level in the range **0**-**9** (fastest to maximum
-    compression).
-    Default is libpng's built-in default.
-    Ignored if the output format is not PNG.
+:   Set PNG compression level (PNG only; 0-9, 0=none, 9=max). Defaults to libpng's builtin default.
 
 **-u**, **\--upsampling** _U_
-:   Chroma upsampling method.
-    Ignored unless the input format is 4:2:0 or 4:2:2.
-
-    Possible values are:
-
-    :   - **automatic** (default)
-        - **fastest**
-        - **best**
-        - **nearest**
-        - **bilinear**
+:   Chroma upsampling (for 420/422). automatic (default), fastest, best, nearest, or bilinear.
 
 **-r**, **\--raw-color**
-:   Output raw RGB values instead of multiplying by alpha when saving to opaque
-    formats.
-    This is available if the output format is JPEG, and not applicable to y4m.
+:   Output raw RGB values instead of multiplying by alpha when saving to opaque formats
+    (JPEG only; not applicable to y4m).
 
 **\--index** _I_
-:   When decoding an image sequence or progressive image, specify which frame
-    index to decode.
-    Default is 0.
+:   When decoding an image sequence or progressive image, specify which frame index to decode (Default: 0).
 
 **\--progressive**
-:   Enable progressive AVIF processing.
-    If a progressive image is encountered and **\--progressive** is passed,
-    **avifdec** will use **\--index** to choose which layer to decode (in
-    progressive order).
+:   Enable progressive AVIF processing. If a progressive image is encountered and \--progressive is passed,
+    avifdec will use \--index to choose which layer to decode (in progressive order).
 
 **\--no-strict**
 :   Disable strict decoding, which disables strict validation checks and errors.
 
 **-i**, **\--info**
-:   Decode all frames and display all image information instead of saving to
-    disk.
+:   Decode all frames and display all image information instead of saving to disk.
+
+**\--icc** _FILENAME_
+:   Provide an ICC profile payload (implies \--ignore-icc).
 
 **\--ignore-icc**
-:   If the input file contains an embedded ICC profile, ignore it (no-op if
-    absent).
+:   If the input file contains an embedded ICC profile, ignore it (no-op if absent).
 
 **\--size-limit** _C_
 :   Specifies the image size limit (in total pixels) that should be tolerated.
-    Default is 268,435,456 pixels (16,384 by 16,384 pixels for a square image).
+    Default: 268435456, set to a smaller value to further restrict.
 
 **\--dimension-limit** _C_
-:   Specifies the image dimension limit (width or height) that should be
-    tolerated.
-    Default is 32,768. Set it to 0 to ignore the limit.
+:   Specifies the image dimension limit (width or height) that should be tolerated.
+    Default: 32768, set to 0 to ignore.
 
 **\--**
 :   Signals the end of options. Everything after this is interpreted as file names.

--- a/doc/avifdec.1.md
+++ b/doc/avifdec.1.md
@@ -53,7 +53,7 @@ Output format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Output quality [0-100]. (JPEG only, default: 90).
 
 **\--png-compress** _L_
-:   Set PNG compression level (PNG only; 0-9, 0=none, 9=max). Defaults to libpng's builtin default.
+:   PNG compression level (PNG only; 0-9, 0=none, 9=max). Defaults to libpng's builtin default.
 
 **-u**, **\--upsampling** _U_
 :   Chroma upsampling (for 420/422). automatic (default), fastest, best, nearest, or bilinear.
@@ -82,15 +82,15 @@ Output format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   If the input file contains an embedded ICC profile, ignore it (no-op if absent).
 
 **\--size-limit** _C_
-:   Specifies the image size limit (in total pixels) that should be tolerated.
+:   Maximum image size (in total pixels) that should be tolerated.
     Default: 268435456, set to a smaller value to further restrict.
 
 **\--dimension-limit** _C_
-:   Specifies the image dimension limit (width or height) that should be tolerated.
+:   Maximum image dimension (width or height) that should be tolerated.
     Default: 32768, set to 0 to ignore.
 
 **\--**
-:   Signals the end of options. Everything after this is interpreted as file names.
+:   Signal the end of options. Everything after this is interpreted as file names.
 
 # EXAMPLES
 

--- a/doc/avifdec.1.md
+++ b/doc/avifdec.1.md
@@ -31,7 +31,7 @@ Output format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Show the version number.
 
 **-j**, **\--jobs** _J_
-:   Number of jobs (worker threads). Use "all" to potentially use as many cores as possible (default: all).
+:   Number of jobs (worker threads), or 'all' to potentially use as many cores as possible. (Default: all).
 
 **-c**, **\--codec** _C_
 :   Codec to use.
@@ -47,16 +47,16 @@ Output format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
         - **libgav1**
 
 **-d**, **\--depth** _D_
-:   Output depth [8,16]. (PNG only; For y4m, depth is retained, and JPEG is always 8bpc).
+:   Output depth, either 8 or 16. (PNG only; For y4m, depth is retained, and JPEG is always 8bpc).
 
 **-q**, **\--quality** _Q_
-:   Output quality [0-100]. (JPEG only, default: 90).
+:   Output quality in 0..100. (JPEG only, default: 90).
 
 **\--png-compress** _L_
-:   PNG compression level (PNG only; 0-9, 0=none, 9=max). Defaults to libpng's builtin default.
+:   PNG compression level in 0..9 (PNG only; 0=none, 9=max). Defaults to libpng's builtin default.
 
 **-u**, **\--upsampling** _U_
-:   Chroma upsampling (for 420/422). automatic (default), fastest, best, nearest, or bilinear.
+:   Chroma upsampling (for 420/422). One of 'automatic' (default), 'fastest', 'best', 'nearest', or 'bilinear'.
 
 **-r**, **\--raw-color**
 :   Output raw RGB values instead of multiplying by alpha when saving to opaque formats
@@ -83,11 +83,11 @@ Output format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 
 **\--size-limit** _C_
 :   Maximum image size (in total pixels) that should be tolerated.
-    Default: 268435456, set to a smaller value to further restrict.
+    (Default: 268435456).
 
 **\--dimension-limit** _C_
 :   Maximum image dimension (width or height) that should be tolerated.
-    Default: 32768, set to 0 to ignore.
+    Set to 0 to ignore. (Default: 32768).
 
 **\--**
 :   Signal the end of options. Everything after this is interpreted as file names.

--- a/doc/avifenc.1.md
+++ b/doc/avifenc.1.md
@@ -36,6 +36,9 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 **\--qalpha** _Q_
 :   Set quality for alpha (0-100, where 100 is lossless).
 
+**\--qgain-map** _Q_
+:   Set quality for the gain map (0-100, where 100 is lossless).
+
 **-s**, **\--speed** _S_
 :   Encoder speed (0-10, slowest-fastest, 'default' or 'd' for codec internal defaults. default speed: 6).
 
@@ -74,11 +77,11 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 **\--cicp**, **\--nclx** _P_/_T_/_M_
 :   Set CICP values (nclx colr box) (3 raw numbers, use -r to set range flag).
 
-    - P = color primaries
-    - T = transfer characteristics
-    - M = matrix coefficients
-     
-    (use 2 for any you wish to leave unspecified)
+    - _P_ = color primaries
+    - _T_ = transfer characteristics
+    - _M_ = matrix coefficients
+
+    Use 2 for any you wish to leave unspecified.
 
 **-r**, **\--range** _RANGE_
 :   YUV range [limited or l, full or f]. (JPEG/PNG only, default: full; For y4m or stdin, range is retained).
@@ -165,6 +168,7 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 **\--**
 :   Signals the end of options. Everything after this is interpreted as file names.
 
+## UPDATABLE OPTIONS
 
 The following options can optionally have a :u (or :update) suffix like `-q:u Q`, to apply only to input files appearing after the option:
 

--- a/doc/avifenc.1.md
+++ b/doc/avifenc.1.md
@@ -31,18 +31,18 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 ## BASIC OPTIONS
 
 **-q**, **\--qcolor** _Q_
-:   Quality for color (0-100, where 100 is lossless).
+:   Quality for color in 0..100 where 100 is lossless.
 
 **\--qalpha** _Q_
-:   Quality for alpha (0-100, where 100 is lossless).
+:   Quality for alpha in 0..100 where 100 is lossless.
 
 **-s**, **\--speed** _S_
-:   Encoder speed (0-10, slowest-fastest, 'default' or 'd' for codec internal defaults. default speed: 6).
+:   Encoder speed in 0..10 where 0 is the slowest, 10 is the fastest. Or 'default' or 'd' for codec internal defaults. (Default: 6).
 
 ## ADVANCED OPTIONS
 
 **-j**, **\--jobs** _J_
-:   Number of jobs (worker threads). Use "all" to potentially use as many cores as possible (default: all).
+:   Number of jobs (worker threads), or 'all' to potentially use as many cores as possible. (Default: all).
 
 **\--no-overwrite**
 :   Never overwrite existing output file.
@@ -54,10 +54,10 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it.
 
 **-d**, **\--depth** _D_
-:   Output depth [8, 10, 12]. (JPEG/PNG only; For y4m or stdin, depth is retained).
+:   Output depth, one of 8, 10 or 12. (JPEG/PNG only; For y4m or stdin, depth is retained).
 
 **-y**, **\--yuv** _FORMAT_
-:   Output format [default=auto, 444, 422, 420, 400]. Ignored for y4m or stdin (y4m format is retained).
+:   Output format, one of 'auto' (default), 444, 422, 420 or 400. Ignored for y4m or stdin (y4m format is retained).
 
     For JPEG, auto honors the JPEG's internal format, if possible. For grayscale PNG, auto defaults to 400.\
     For all other cases, auto defaults to 444.
@@ -72,7 +72,7 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Read y4m frames from stdin instead of files; no input filenames allowed, must set before offering output filename.
 
 **\--cicp**, **\--nclx** _P_/_T_/_M_
-:   Set CICP values (nclx colr box) (3 raw numbers, use -r to set range flag).
+:   Set CICP values (nclx colr box) (3 raw numbers, use **-r** to set range flag).
 
     - _P_ = color primaries
     - _T_ = transfer characteristics
@@ -81,7 +81,7 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
     Use 2 for any you wish to leave unspecified.
 
 **-r**, **\--range** _RANGE_
-:   YUV range [limited or l, full or f]. (JPEG/PNG only, default: full; For y4m or stdin, range is retained).
+:   YUV range, one of 'limited' or 'l', 'full' or 'f'. (JPEG/PNG only, default: full; For y4m or stdin, range is retained).
 
 **\--target-size** _S_
 :   Set target file size in bytes (up to 7 times slower)
@@ -120,7 +120,7 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Provide an ICC profile payload to be associated with the primary item (implies \--ignore-icc).
 
 **\--timescale**, **\--fps** _V_
-:   Timescale for image sequences. If all frames are 1 timescale in length, this is equivalent to frames per second (Default: 30)
+:   Timescale for image sequences. If all frames are 1 timescale in length, this is equivalent to frames per second. (Default: 30)
     If neither duration nor timescale are set, avifenc will attempt to use the framerate stored in a y4m header, if present.
 
 **-k**, **\--keyframe** _INTERVAL_
@@ -139,7 +139,7 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   If the input file contains an embedded gain map, ignore it (no-op if absent).
 
 **\--qgain-map** _Q_
-:   Quality for the gain map (0-100, where 100 is lossless).
+:   Quality for the gain map in 0..100 where 100 is lossless.
 
 **\--pasp** _H_,_V_
 :   Add pasp property (aspect ratio). H=horizontal spacing, V=vertical spacing.
@@ -148,10 +148,10 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Add clap property (clean aperture), but calculated from a crop rectangle.
 
 **\--clap** _WN_,_WD_,_HN_,_HD_,_HON_,_HOD_,_VON_,_VOD_
-:   Add clap property (clean aperture). Width, Height, HOffset, VOffset (in num/denom pairs).
+:   Add clap property (clean aperture). Width, Height, HOffset, VOffset (in numerator/denominator pairs).
 
 **\--irot** _ANGLE_
-:   Add irot property (rotation). [0-3], makes (90 * ANGLE) degree rotation anti-clockwise.
+:   Add irot property (rotation) in 0..3. Makes (90 * ANGLE) degree rotation anti-clockwise.
 
 **\--imir** _AXIS_
 :   Add imir property (mirroring). 0=top-to-bottom, 1=left-to-right.
@@ -159,36 +159,36 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 **\--clli** _MaxCLL_,_MaxPALL_
 :   Add clli property (content light level information).
 
-**\--repetition-count** _N_ or infinite
-:   Number of times an animated image sequence will be repeated. Use 'infinite' for infinite repetitions (Default: infinite).
+**\--repetition-count** _N_
+:   Number of times an animated image sequence will be repeated, or 'infinite' for infinite repetitions. (Default: infinite).
 
 **\--**
 :   Signal the end of options. Everything after this is interpreted as file names.
 
 ## UPDATABLE OPTIONS
 
-The following options can optionally have a :u (or :update) suffix like **-q:u _Q_**, to apply only to input files appearing after the option:
+The following options can optionally have a **:u** (or **:update**) suffix like **-q:u _Q_**, to apply only to input files appearing after the option:
 
 **-q**, **\--qcolor** _Q_
-:   Quality for color (0-100, where 100 is lossless).
+:   Quality for color in 0..100 where 100 is lossless.
 
 **\--qalpha** _Q_
-:   Quality for alpha (0-100, where 100 is lossless).
+:   Quality for alpha in 0..100 where 100 is lossless.
 
 **\--qgain-map** _Q_
-:   Quality for the gain map (0-100, where 100 is lossless).
+:   Quality for the gain map in 0..100 where 100 is lossless.
 
 **\--tilerowslog2** _R_
-:   log2 of number of tile rows (0-6, default: 0).
+:   log2 of number of tile rows in 0..6. (Default: 0).
 
 **\--tilecolslog2** _C_
-:   log2 of number of tile columns (0-6, default: 0).
+:   log2 of number of tile columns in 0..6. (Default: 0).
 
 **\--autotiling**
 :   Set \--tilerowslog2 and \--tilecolslog2 automatically.
 
 **\--scaling-mode** _N_[/_D_]
-:   EXPERIMENTAL: Set frame (layer) scaling mode as given fraction. If omitted, D default to 1. (Default: 1/1).
+:   EXPERIMENTAL: Set frame (layer) scaling mode as given fraction. If omitted, the denominator defaults to 1. (Default: 1/1).
 
 **\--duration** _D_
 :   Frame durations (in timescales) (default: 1). This option always applies to following inputs with or without the `:u` suffix.
@@ -209,25 +209,25 @@ When used with libaom 3.0.0 or later, any key-value pairs supported by the aom_c
 can be used. When used with libaom 2.0.x or older, the following key-value pairs can be used:
 
 **aq-mode=_M_**
-:   Adaptive quantization mode (0: off (default), 1: variance, 2: complexity, 3: cyclic refresh).
+:   Adaptive quantization mode. 0=off (default), 1=variance, 2=complexity, 3=cyclic refresh.
 
 **cq-level=_Q_**
-:   Constant/Constrained Quality level (0-63, end-usage must be set to cq or q).
+:   Constant/Constrained Quality level in 0..63, end-usage must be set to cq or q.
 
 **enable-chroma-deltaq=_B_**
-:   Enable delta quantization in chroma planes (0: disable (default), 1: enable).
+:   Enable delta quantization in chroma planes. 0=disable (default), 1=enable.
 
 **end-usage=_MODE_**
-:   Rate control mode (vbr, cbr, cq, or q)
+:   Rate control mode, one of 'vbr', 'cbr', 'cq', or 'q'
 
 **sharpness=_S_**
-:   Bias towards block sharpness in rate-distortion optimization of transform coefficients (0-7, default: 0).
+:   Bias towards block sharpness in rate-distortion optimization of transform coefficients in  0..7. (Default: 0).
 
 **tune=_METRIC_**
-:   Tune the encoder for distortion metric (psnr or ssim, default: psnr).
+:   Tune the encoder for distortion metric, one of 'psnr' or 'ssim'. (Default: psnr).
 
 **film-grain-test=_TEST_**
-:   Film grain test vectors (0: none (default), 1: test-1  2: test-2, ... 16: test-16).
+:   Film grain test vectors in 0..16. 0=none (default), 1=test1, 2=test2, ... 16=test16.
 
 **film-grain-table=_FILENAME_**
 :   Path to file containing film grain parameters.

--- a/doc/avifenc.1.md
+++ b/doc/avifenc.1.md
@@ -28,122 +28,78 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 **-V**, **\--version**
 :   Show the version number.
 
+## BASIC OPTIONS
+
+**-q**, **\--qcolor** _Q_
+:   Set quality for color (0-100, where 100 is lossless).
+
+**\--qalpha** _Q_
+:   Set quality for alpha (0-100, where 100 is lossless).
+
+**-s**, **\--speed** _S_
+:   Encoder speed (0-10, slowest-fastest, 'default' or 'd' for codec internal defaults. default speed: 6).
+
+## ADVANCED OPTIONS
+
 **-j**, **\--jobs** _J_
-:   Number of jobs (worker threads).
-    1 or less means single-threaded.
-    Default is 1.
-    Use **all** to use all available cores.
+:   Number of jobs (worker threads). Use "all" to potentially use as many cores as possible (default: all).
+
+**\--no-overwrite**
+:   Never overwrite existing output file.
 
 **-o**, **\--output** _FILENAME_
 :   Instead of using the last filename given as output, use this filename.
 
 **-l**, **\--lossless**
-:   Set all defaults to encode losslessly, and emit warnings when
-    settings/input don't allow for it.
+:   Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it.
 
 **-d**, **\--depth** _D_
-:   Output depth.
-    This is available if the input format is JPEG/PNG, and for y4m or stdin,
-    depth is retained.
-
-    Possible values are:
-
-    :   - **8**
-        - **10**
-        - **12**
+:   Output depth [8,10,12]. (JPEG/PNG only; For y4m or stdin, depth is retained).
 
 **-y**, **\--yuv** _FORMAT_
-:   Output format.
-    Ignored for y4m or stdin (y4m format is retained).
-    For JPEG, auto honors the JPEG's internal format, if possible.
+:   Output format [default=auto, 444, 422, 420, 400]. Ignored for y4m or stdin (y4m format is retained).
+
+    For JPEG, auto honors the JPEG's internal format, if possible. For grayscale PNG, auto defaults to 400.\
     For all other cases, auto defaults to 444.
-
-    Possible values are:
-
-    :   - **auto** (default)
-        - **444**
-        - **422**
-        - **420**
-        - **400**
 
 **-p**, **\--premultiply**
 :   Premultiply color by the alpha channel and signal this in the AVIF.
 
 **\--sharpyuv**
-:   Use sharp RGB to YUV420 conversion (if supported). Ignored for y4m or if
-    output is not 420.
+:   Use sharp RGB to YUV420 conversion (if supported). Ignored for y4m or if output is not 420.
 
 **\--stdin**
-:   Read y4m frames from stdin instead of files.
-    No input filenames allowed, must be set before specifying the output
-    filename.
+:   Read y4m frames from stdin instead of files; no input filenames allowed, must set before offering output filename.
 
-**\--cicp**, **\--nclx** *P***/***T***/***M*
-:   Specify CICP values (nclx colr box) by 3 raw numbers.
-    Use **2** for any you wish to leave unspecified.
+**\--cicp**, **\--nclx** _P_/_T_/_M_
+:   Set CICP values (nclx colr box) (3 raw numbers, use -r to set range flag).
 
-    - _P_ = color primaries
-    - _T_ = transfer characteristics
-    - _M_ = matrix coefficients
+    - P = color primaries
+    - T = transfer characteristics
+    - M = matrix coefficients
+     
+    (use 2 for any you wish to leave unspecified)
 
 **-r**, **\--range** _RANGE_
-:   YUV range.
-    This is available if the input format is JPEG/PNG, and for y4m or stdin,
-    range is retained.
+:   YUV range [limited or l, full or f]. (JPEG/PNG only, default: full; For y4m or stdin, range is retained).
 
-    Possible values are:
+**\--target-size** _S_
+:   Set target file size in bytes (up to 7 times slower)
 
-    :   - **full**, **f** (default)
-        - **limited**, **l**
+**\--progressive**
+:   EXPERIMENTAL: Auto set parameters to encode a simple layered image supporting progressive rendering from a single input frame.
 
-**\--min** _Q_
-:   Set min quantizer for color.
-    Possible values are in the range **0**-**63**, where 0 is lossless.
+**\--layered**
+:   EXPERIMENTAL: Encode a layered AVIF. Each input is encoded as one layer and at most 4 layers can be encoded.
 
-**\--max** _Q_
-:   Set max quantizer for color.
-    Possible values are in the range **0**-**63**, where 0 is lossless.
-
-**\--minalpha** _Q_
-:   Set min quantizer for alpha.
-    Possible values are in the range **0**-**63**, where 0 is lossless.
-
-**\--maxalpha** _Q_
-:   Set max quantizer for alpha.
-    Possible values are in the range **0**-**63**, where 0 is lossless.
-
-**\--tilerowslog2** _R_
-:   Set log2 of number of tile rows.
-    Possible values are in the range **0**-**6**.
-    Default is 0.
-
-**\--tilecolslog2** _C_
-:   Set log2 of number of tile columns.
-    Possible values are in the range **0**-**6**.
-    Default is 0.
-
-**\--autotiling**
-:   Set **\--tilerowslog2** and **\--tilecolslog2** automatically.
-
-**-g**, **\--grid** *M***x***N*
-:   Encode a single-image grid AVIF with _M_ cols and _N_ rows.
-    Either supply MxN images of the same width, height and depth, or a single
-    image that can be evenly split into the MxN grid and follow AVIF grid image
-    restrictions.
-    The grid will adopt the color profile of the first image supplied.
-    Possible values for _M_ and _N_ are in the range **1**-**256**.
-
-**-s**, **\--speed** _S_
-:   Encoder speed.
-    Default is 6.
-
-    Possible values are:
-
-    :   - **0**-**10** (slowest-fastest)
-        - **default**, **d** (codec internal defaults)
+**-g**, **\--grid** _MxN_
+:   Encode a single-image grid AVIF with M cols & N rows. Either supply MxN identical W/H/D images, or a single
+    image that can be evenly split into the MxN grid and follow AVIF grid image restrictions. The grid will adopt
+    the color profile of the first image supplied.
 
 **-c**, **\--codec** _C_
-:   AV1 codec to use.
+:   Codec to use.
+
     Possible values depend on the codecs enabled at build time (see **\--help**
     or **\--version** for the available codecs).
     Default is auto-selected from the available codecs.
@@ -155,97 +111,122 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
         - **svt**
 
 **\--exif** _FILENAME_
-:   Provide an Exif metadata payload to be associated with the primary item
-    (implies --ignore-exif).
+:   Provide an Exif metadata payload to be associated with the primary item (implies \--ignore-exif).
 
 **\--xmp** _FILENAME_
-:   Provide an XMP metadata payload to be associated with the primary item
-    (implies --ignore-xmp).
+:   Provide an XMP metadata payload to be associated with the primary item (implies \--ignore-xmp).
 
 **\--icc** _FILENAME_
-:   Provide an ICC profile payload to be associated with the primary item
-    (implies --ignore-icc).
-
-**-a**, **\--advanced** _KEY_[_=VALUE_]
-:   Pass an advanced, codec-specific key/value string pair directly to the
-    codec.
-    **avifenc** will warn on any unused by the codec.
-    The aom-specific advanced options can be used if the AOM codec is available
-    (see **\--help** for details).
-
-**\--duration** _D_
-:   Set all following frame durations (in timescales) to _D_.
-    Can be set multiple times (before supplying each filename).
-    Default is 1.
+:   Provide an ICC profile payload to be associated with the primary item (implies \--ignore-icc).
 
 **\--timescale**, **\--fps** _V_
-:   Set the timescale to _V_.
-    If all frames are 1 timescale in length, this is equivalent to frames per
-    second.
-    If neither duration nor timescale are set, **avifenc** will attempt to use
-    the framerate stored in a y4m header, if present.
-    Default is 30.
+:   Set the timescale to V. If all frames are 1 timescale in length, this is equivalent to frames per second (Default: 30)
+    If neither duration nor timescale are set, avifenc will attempt to use the framerate stored in a y4m header, if present.
 
 **-k**, **\--keyframe** _INTERVAL_
-:   Set the forced keyframe interval (maximum frames between keyframes).
-    Set to **0** to disable.
-    Default is 0.
+:   Set the maximum keyframe interval (any set of INTERVAL consecutive frames will have at least one keyframe). Set to 0 to disable (default).
 
 **\--ignore-exif**
-:   If the input file contains embedded Exif metadata, ignore it (no-op if
-    absent).
+:   If the input file contains embedded Exif metadata, ignore it (no-op if absent).
 
 **\--ignore-xmp**
-:   If the input file contains embedded XMP metadata, ignore it (no-op if
-    absent).
+:   If the input file contains embedded XMP metadata, ignore it (no-op if absent).
 
-**\--ignore-icc**
-:   If the input file contains an embedded ICC profile, ignore it (no-op if
-    absent).
+**\--ignore-profile**, **\--ignore-icc**
+:   If the input file contains an embedded color profile, ignore it (no-op if absent).
 
-**\--pasp** *H***,***V*
-:   Add pasp property (aspect ratio).
+**\--ignore-gain-map**
+:   If the input file contains an embedded gain map, ignore it (no-op if absent).
 
-    - _H_ = horizontal spacing
-    - _V_ = vertical spacing
+**\--qgain-map** _Q_
+:   Set quality for the gain map (0-100, where 100 is lossless).
 
-**\--crop** *CROPX***,***CROPY***,***CROPW***,***CROPH*
+**\--pasp** _H_,_V_
+:   Add pasp property (aspect ratio). H=horizontal spacing, V=vertical spacing.
+
+**\--crop** _CROPX_,_CROPY_,_CROPW_,_CROPH_
 :   Add clap property (clean aperture), but calculated from a crop rectangle.
 
-    - _CROPX_ = X-axis of a crop rectangle
-    - _CROPY_ = Y-axis of a crop rectangle
-    - _CROPW_ = width of a crop rectangle
-    - _CROPH_ = height of a crop rectangle
-
-**\--clap** *WN***,***WD***,***HN***,***HD***,***HON***,***HOD***,***VON***,***VOD*
-:   Add clap property (clean aperture).
-
-    - _WN_ = numerator of width
-    - _WD_ = denominator of width
-    - _HN_ = numerator of height
-    - _HD_ = denominator of height
-    - _HON_ = numerator of horizontal offset
-    - _HOD_ = denominator of horizontal offset
-    - _VON_ = numerator of vertical offset
-    - _VOD_ = denominator of vertical offset
+**\--clap** _WN_,_WD_,_HN_,_HD_,_HON_,_HOD_,_VON_,_VOD_
+:   Add clap property (clean aperture). Width, Height, HOffset, VOffset (in num/denom pairs).
 
 **\--irot** _ANGLE_
-:   Add irot property (rotation).
-    Possible values are in the range **0**-**3**, and makes (90 * _ANGLE_)
-    degree rotation anti-clockwise.
+:   Add irot property (rotation). [0-3], makes (90 * ANGLE) degree rotation anti-clockwise.
 
-**\--imir** _MODE_
-:   Add imir property (mirroring).
+**\--imir** _AXIS_
+:   Add imir property (mirroring). 0=top-to-bottom, 1=left-to-right.
 
-    Note: Rotation is applied before mirroring at rendering.
+**\--clli** _MaxCLL_,_MaxPALL_
+:   Add clli property (content light level information).
 
-    Possible values are:
-
-    :   - **0** (top-to-bottom)
-        - **1** (left-to-right)
+**\--repetition-count** _N_ or infinite
+:   Number of times an animated image sequence will be repeated. Use 'infinite' for infinite repetitions (Default: infinite).
 
 **\--**
 :   Signals the end of options. Everything after this is interpreted as file names.
+
+
+The following options can optionally have a :u (or :update) suffix like `-q:u Q`, to apply only to input files appearing after the option:
+
+**-q**, **\--qcolor** _Q_
+:   Set quality for color (0-100, where 100 is lossless).
+
+**\--qalpha** _Q_
+:   Set quality for alpha (0-100, where 100 is lossless).
+
+**\--tilerowslog2** _R_
+:   Set log2 of number of tile rows (0-6, default: 0).
+
+**\--tilecolslog2** _C_
+:   Set log2 of number of tile columns (0-6, default: 0).
+
+**\--autotiling**
+:   Set \--tilerowslog2 and \--tilecolslog2 automatically.
+
+**\--scaling-mode** _N_[/_D_]
+:   EXPERIMENTAL: Set frame (layer) scaling mode as given fraction. If omitted, D default to 1. (Default: 1/1).
+
+**\--duration** _D_
+:   Set frame durations (in timescales) to D; default 1. This option always apply to following inputs with or without suffix.
+
+**-a**, **\--advanced** _KEY_[=_VALUE_]
+:   Pass an advanced, codec-specific key/value string pair directly to the codec. avifenc will warn on any not used by the codec.
+
+## AOM-SPECIFIC ADVANCED OPTIONS
+
+1. **_\<key>_=_\<value>_** applies to both the color (YUV) planes and the alpha plane (if present).
+2. **color:_\<key>_=_\<value>_** or **c:_\<key>_=_\<value>_** applies only to the color (YUV) planes.
+3. **alpha:_\<key>_=_\<value>_** or **a:_\<key>_=_\<value>_** applies only to the alpha plane (if present).
+    Since the alpha plane is encoded as a monochrome image, the options that refer to the chroma planes,
+    such as enable-chroma-deltaq=B, should not be used with the alpha plane. In addition, the film grain
+    options are unlikely to make sense for the alpha plane.
+
+When used with libaom 3.0.0 or later, any key-value pairs supported by the aom_codec_set_option() function
+can be used. When used with libaom 2.0.x or older, the following key-value pairs can be used:
+
+**aq-mode=_M_**
+:   Adaptive quantization mode (0: off (default), 1: variance, 2: complexity, 3: cyclic refresh).
+
+**cq-level=_Q_**
+:   Constant/Constrained Quality level (0-63, end-usage must be set to cq or q).
+
+**enable-chroma-deltaq=_B_**
+:   Enable delta quantization in chroma planes (0: disable (default), 1: enable).
+
+**end-usage=_MODE_**
+:   Rate control mode (vbr, cbr, cq, or q)
+
+**sharpness=_S_**
+:   Bias towards block sharpness in rate-distortion optimization of transform coefficients (0-7, default: 0).
+
+**tune=_METRIC_**
+:   Tune the encoder for distortion metric (psnr or ssim, default: psnr).
+
+**film-grain-test=_TEST_**
+:   Film grain test vectors (0: none (default), 1: test-1  2: test-2, ... 16: test-16).
+
+**film-grain-table=_FILENAME_**
+:   Path to file containing film grain parameters.
 
 # EXAMPLES
 

--- a/doc/avifenc.1.md
+++ b/doc/avifenc.1.md
@@ -31,13 +31,10 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 ## BASIC OPTIONS
 
 **-q**, **\--qcolor** _Q_
-:   Set quality for color (0-100, where 100 is lossless).
+:   Quality for color (0-100, where 100 is lossless).
 
 **\--qalpha** _Q_
-:   Set quality for alpha (0-100, where 100 is lossless).
-
-**\--qgain-map** _Q_
-:   Set quality for the gain map (0-100, where 100 is lossless).
+:   Quality for alpha (0-100, where 100 is lossless).
 
 **-s**, **\--speed** _S_
 :   Encoder speed (0-10, slowest-fastest, 'default' or 'd' for codec internal defaults. default speed: 6).
@@ -57,7 +54,7 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it.
 
 **-d**, **\--depth** _D_
-:   Output depth [8,10,12]. (JPEG/PNG only; For y4m or stdin, depth is retained).
+:   Output depth [8, 10, 12]. (JPEG/PNG only; For y4m or stdin, depth is retained).
 
 **-y**, **\--yuv** _FORMAT_
 :   Output format [default=auto, 444, 422, 420, 400]. Ignored for y4m or stdin (y4m format is retained).
@@ -123,11 +120,11 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Provide an ICC profile payload to be associated with the primary item (implies \--ignore-icc).
 
 **\--timescale**, **\--fps** _V_
-:   Set the timescale to V. If all frames are 1 timescale in length, this is equivalent to frames per second (Default: 30)
+:   Timescale for image sequences. If all frames are 1 timescale in length, this is equivalent to frames per second (Default: 30)
     If neither duration nor timescale are set, avifenc will attempt to use the framerate stored in a y4m header, if present.
 
 **-k**, **\--keyframe** _INTERVAL_
-:   Set the maximum keyframe interval (any set of INTERVAL consecutive frames will have at least one keyframe). Set to 0 to disable (default).
+:   Maximum keyframe interval for image sequences (any set of _INTERVAL_ consecutive frames will have at least one keyframe). Set to 0 to disable (default).
 
 **\--ignore-exif**
 :   If the input file contains embedded Exif metadata, ignore it (no-op if absent).
@@ -142,7 +139,7 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   If the input file contains an embedded gain map, ignore it (no-op if absent).
 
 **\--qgain-map** _Q_
-:   Set quality for the gain map (0-100, where 100 is lossless).
+:   Quality for the gain map (0-100, where 100 is lossless).
 
 **\--pasp** _H_,_V_
 :   Add pasp property (aspect ratio). H=horizontal spacing, V=vertical spacing.
@@ -166,23 +163,26 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Number of times an animated image sequence will be repeated. Use 'infinite' for infinite repetitions (Default: infinite).
 
 **\--**
-:   Signals the end of options. Everything after this is interpreted as file names.
+:   Signal the end of options. Everything after this is interpreted as file names.
 
 ## UPDATABLE OPTIONS
 
-The following options can optionally have a :u (or :update) suffix like `-q:u Q`, to apply only to input files appearing after the option:
+The following options can optionally have a :u (or :update) suffix like **-q:u _Q_**, to apply only to input files appearing after the option:
 
 **-q**, **\--qcolor** _Q_
-:   Set quality for color (0-100, where 100 is lossless).
+:   Quality for color (0-100, where 100 is lossless).
 
 **\--qalpha** _Q_
-:   Set quality for alpha (0-100, where 100 is lossless).
+:   Quality for alpha (0-100, where 100 is lossless).
+
+**\--qgain-map** _Q_
+:   Quality for the gain map (0-100, where 100 is lossless).
 
 **\--tilerowslog2** _R_
-:   Set log2 of number of tile rows (0-6, default: 0).
+:   log2 of number of tile rows (0-6, default: 0).
 
 **\--tilecolslog2** _C_
-:   Set log2 of number of tile columns (0-6, default: 0).
+:   log2 of number of tile columns (0-6, default: 0).
 
 **\--autotiling**
 :   Set \--tilerowslog2 and \--tilecolslog2 automatically.
@@ -191,7 +191,7 @@ The following options can optionally have a :u (or :update) suffix like `-q:u Q`
 :   EXPERIMENTAL: Set frame (layer) scaling mode as given fraction. If omitted, D default to 1. (Default: 1/1).
 
 **\--duration** _D_
-:   Set frame durations (in timescales) to D; default 1. This option always apply to following inputs with or without suffix.
+:   Frame durations (in timescales) (default: 1). This option always applies to following inputs with or without the `:u` suffix.
 
 **-a**, **\--advanced** _KEY_[=_VALUE_]
 :   Pass an advanced, codec-specific key/value string pair directly to the codec. avifenc will warn on any not used by the codec.


### PR DESCRIPTION
Try to minimize differences with the --help message. Ideally, any change should be made in both, unless it's man-page specific formatting.
Do not include deprecated flags (--min/--max etc.) Don't impose any line length limit in the markdown files to minimize work.

Fixes #2534