### PR TITLE
Partial revert "Ignore descr props after transf"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,6 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Deprecate avifCropRectConvertCleanApertureBox() and
   avifCleanApertureBoxConvertCropRect(). Replace them with
   avifCropRectFromCleanApertureBox() and avifCleanApertureBoxFromCropRect().
-* Ignore descriptive properties associated after transformative ones.
 * Reject non-essential transformative properties.
 
 ## [1.1.1] - 2024-07-30

--- a/tests/gtest/aviftransformtest.cc
+++ b/tests/gtest/aviftransformtest.cc
@@ -85,11 +85,15 @@ TEST(TransformTest, ClopIrotImor) {
   ASSERT_EQ(avifDecoderSetIOFile(decoder.get(), path.c_str()), AVIF_RESULT_OK);
   ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_OK);
 
-  // 'imor' shall be ignored by libavif as it is after a transformative property
-  // in the 'ipma' association order.
-  ASSERT_EQ(decoder->image->numProperties, 1u);
+  // 'imor' should be ignored as it is after a transformative property in the
+  // 'ipma' association order. libavif still surfaces it because this constraint
+  // is relaxed in Amd2 of HEIF ISO/IEC 23008-12.
+  // See https://github.com/MPEGGroup/FileFormat/issues/113.
+  ASSERT_EQ(decoder->image->numProperties, 2u);
   const avifImageItemProperty& clop = decoder->image->properties[0];
   EXPECT_EQ(std::string(clop.boxtype, clop.boxtype + 4), "clop");
+  const avifImageItemProperty& imor = decoder->image->properties[1];
+  EXPECT_EQ(std::string(imor.boxtype, imor.boxtype + 4), "imor");
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Partially reverts https://github.com/AOMediaCodec/libavif/pull/2571.  
See https://github.com/MPEGGroup/FileFormat/issues/113.