### PR TITLE
update libyuv to d32d19ccf (1904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Update dav1d.cmd/dav1d_android.sh/LocalDav1d.cmake: 1.5.1
 * Update libjpeg.cmd/LocalJpeg.cmake: v3.0.4
 * Update libxml2.cmd/LocalLibXml2.cmake: v2.13.5
+* Update libyuv.cmd: d32d19ccf (1904)
 * Update svt.cmd/svt.sh/LocalSvt.cmake: v2.3.0
 * Change experimental gainmap API: remove avifGainMapMetadata and
   avifGainMapMetadataDouble structs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Update dav1d.cmd/dav1d_android.sh/LocalDav1d.cmake: 1.5.1
 * Update libjpeg.cmd/LocalJpeg.cmake: v3.0.4
 * Update libxml2.cmd/LocalLibXml2.cmake: v2.13.5
-* Update libyuv.cmd: d32d19ccf (1904)
+* Update libyuv.cmd: ccdf87034 (1903)
 * Update svt.cmd/svt.sh/LocalSvt.cmake: v2.3.0
 * Change experimental gainmap API: remove avifGainMapMetadata and
   avifGainMapMetadataDouble structs.

--- a/cmake/Modules/LocalLibyuv.cmake
+++ b/cmake/Modules/LocalLibyuv.cmake
@@ -1,4 +1,4 @@
-set(AVIF_LIBYUV_TAG "a6a2ec654b1be1166b376476a7555c89eca0c275")
+set(AVIF_LIBYUV_TAG "d32d19ccf2711d8bdf43a68dc5f8daedb7965c62")
 
 set(AVIF_LIBYUV_BUILD_DIR "${AVIF_SOURCE_DIR}/ext/libyuv/build")
 # If ${ANDROID_ABI} is set, look for the library under that subdirectory.

--- a/cmake/Modules/LocalLibyuv.cmake
+++ b/cmake/Modules/LocalLibyuv.cmake
@@ -1,4 +1,4 @@
-set(AVIF_LIBYUV_TAG "d32d19ccf2711d8bdf43a68dc5f8daedb7965c62")
+set(AVIF_LIBYUV_TAG "ccdf870348764e4b77fa3b56accb2a896a901bad")
 
 set(AVIF_LIBYUV_BUILD_DIR "${AVIF_SOURCE_DIR}/ext/libyuv/build")
 # If ${ANDROID_ABI} is set, look for the library under that subdirectory.

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -17,7 +17,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout a6a2ec65
+git checkout d32d19ccf
 
 mkdir build
 cd build

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -17,7 +17,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout d32d19ccf
+git checkout ccdf87034
 
 mkdir build
 cd build


### PR DESCRIPTION
This adds RAWToI444 and RAWToJ444 functions which will be used in
reformat_libyuv.c in a follow up.

Bug: b:345259429
