### PR TITLE
Do not check the handler type of the color track.

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -5823,9 +5823,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             // HEIF (ISO/IEC 23008-12:2022), Section 7.1:
             //   In order to distinguish image sequences from video, the handler type in the
             //   HandlerBox of the track is 'pict' to indicate an image sequence track.
-            if (memcmp(track->handlerType, "pict", 4)) {
-                continue;
-            }
+            // But we do not check the handler type because it may break some existing files.
 
             // Found one!
             break;


### PR DESCRIPTION
It should be pict according to the spec but some very old files might use "vide". For example
https://chromium.googlesource.com/external/w3c/web-platform-tests/+/9d6ac04/webcodecs/four-colors-flip.avif
This file was generated by editing an mp4 according to https://chromium.googlesource.com/external/w3c/web-platform-tests/+/9d6ac04/webcodecs/README.md#four_colors_flip_avif

In the future we may check this under an AVIF_STRICT flag.
For onw the check is just removed.