### PR TITLE
Disable PNG tRNS before PLTE test

### DIFF
--- a/tests/gtest/avifreadimagetest.cc
+++ b/tests/gtest/avifreadimagetest.cc
@@ -84,7 +84,10 @@ TEST(PngTest, RgbColorTypeWithTrnsAfterPlte) {
 // Verify we can read a PNG file with PNG_COLOR_TYPE_RGB and a tRNS chunk
 // before a PLTE chunk. libpng considers the tRNS chunk as invalid and ignores
 // it, so the decoded image should have no alpha.
-TEST(PngTest, RgbColorTypeWithTrnsBeforePlte) {
+// This test is disabled because the behavior seemed to have changed starting
+// with libpng 1.6.47.
+// See https://github.com/pnggroup/libpng/blob/libpng16/CHANGES#L6243-L6246.
+TEST(PngTest, DISABLED_RgbColorTypeWithTrnsBeforePlte) {
   const ImagePtr image = testutil::ReadImage(
       data_path, "circle-trns-before-plte.png", AVIF_PIXEL_FORMAT_YUV444, 8);
   ASSERT_NE(image, nullptr);


### PR DESCRIPTION
https://github.com/AOMediaCodec/libavif/pull/2630 failed with the unrelated error:

```
-- Found PNG: /opt/homebrew/lib/libpng.dylib (found suitable version "1.6.47", minimum required is "1.6.32")
```
```
[ RUN      ] PngTest.RgbColorTypeWithTrnsBeforePlte
libpng warning: PLTE: out of place
/Users/runner/work/libavif/libavif/tests/gtest/avifreadimagetest.cc:93: Failure
Expected equality of these values:
  image->alphaPlane
    Which is: 0x11930a900
  nullptr
    Which is: (nullptr)

[  FAILED  ] PngTest.RgbColorTypeWithTrnsBeforePlte (0 ms)
```

This seems to match libpng 1.6.47 CHANGELOG:  
https://github.com/pnggroup/libpng/blob/738f5e743ccc59de62a7b789460636f6f9d12c93/CHANGES#L6243-L6246

Note that this test was added in https://github.com/AOMediaCodec/libavif/pull/1435.