### PR TITLE
libargparse: use a git patch file instead of sed command

### DIFF
--- a/cmake/Modules/LocalLibargparse.cmake
+++ b/cmake/Modules/LocalLibargparse.cmake
@@ -24,10 +24,7 @@ else()
         GIT_REPOSITORY "https://github.com/kmurray/libargparse.git"
         GIT_TAG ${AVIF_LIBARGPARSE_GIT_TAG}
         # TODO(vrabaud) remove once CMake 3.13 is not supported anymore.
-        PATCH_COMMAND
-            sed -i.bak -e
-            "s:install.*:include(GNUInstallDirs)\\\\ninstall(TARGETS libargparse RUNTIME DESTINATION \\\\$\\\\{CMAKE_INSTALL_BINDIR\\\\} LIBRARY DESTINATION \\\\$\\\\{CMAKE_INSTALL_LIBDIR\\\\} ARCHIVE DESTINATION \\\\$\\\\{CMAKE_INSTALL_LIBDIR\\\\}):"
-            CMakeLists.txt
+        PATCH_COMMAND git apply --ignore-whitespace "${AVIF_SOURCE_DIR}/ext/libargparse.patch"
         UPDATE_COMMAND ""
     )
     avif_fetchcontent_populate_cmake(libargparse)

--- a/ext/libargparse.patch
+++ b/ext/libargparse.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8ca16ae..605a062 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,7 +21,8 @@ add_library(libargparse STATIC
+ set_target_properties(libargparse PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
+ set_target_properties(libargparse PROPERTIES PUBLIC_HEADER "${LIB_HEADERS}")
+ target_include_directories(libargparse PUBLIC ${LIB_INCLUDE_DIRS})
+-install(TARGETS libargparse)
++include(GNUInstallDirs)
++install(TARGETS libargparse RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+     #Create the test executable


### PR DESCRIPTION
This should work better cross platform. #2653