### PR TITLE
BUG: Use C99 compatible syntax to initialize avifFileType struct

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -4622,7 +4622,7 @@ static avifResult avifParse(avifDecoder * decoder)
 #endif
     avifBool needsTmap = AVIF_FALSE;
     avifBool tmapSeen = AVIF_FALSE;
-    avifFileType ftyp = {};
+    avifFileType ftyp = {0};
 
     for (;;) {
         // Read just enough to get the next box header (a max of 32 bytes)


### PR DESCRIPTION
We experienced the following error when trying to compile v1.2.0 with MSVC over on conda-forge:

```
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\HostX64\x64\cl.exe  /nologo -DAVIF_BUILDING_SHARED_LIBS -DAVIF_CODEC_AOM=1 -DAVIF_CODEC_AOM_DECODE=1 -DAVIF_CODEC_AOM_ENCODE=1 -DAVIF_CODEC_DAV1D=1 -DAVIF_CODEC_RAV1E=1 -DAVIF_CODEC_SVT=1 -DAVIF_DLL -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -I%SRC_DIR%\include -I%SRC_DIR%\third_party\libyuv\include -external:I%PREFIX%\Library\include -external:I%PREFIX%\Library\include\rav1e -external:W0 /DWIN32 /D_WINDOWS /MD /O2 /Ob2 /DNDEBUG /source-charset:utf-8 /execution-charset:us-ascii /W4 /wd4232 /wd4324 /showIncludes /FoCMakeFiles\avif_obj.dir\src\read.c.obj /FdCMakeFiles\avif_obj.dir\ /FS -c %SRC_DIR%\src\read.c
%SRC_DIR%\src\read.c(4625): error C2059: syntax error: '}'
```

It seems that some C23/C++ syntax was accidentally used in a recent change, but my understanding is that this project still supports/targets C99.

> In C, the braced list of initializers cannot be empty (note that C++ allows empty lists, and also note that a struct in C cannot be empty):

https://en.cppreference.com/w/c/language/struct_initialization



