### PR TITLE
fix: patch libyuv CMakeLists for compatibility with gcc 10

### DIFF
--- a/cmake/Modules/LocalLibyuv.cmake
+++ b/cmake/Modules/LocalLibyuv.cmake
@@ -40,6 +40,7 @@ else()
         GIT_REPOSITORY "https://chromium.googlesource.com/libyuv/libyuv"
         BINARY_DIR "${LIBYUV_BINARY_DIR}"
         GIT_TAG "${AVIF_LIBYUV_TAG}"
+        PATCH_COMMAND git apply --ignore-whitespace "${AVIF_SOURCE_DIR}/ext/libyuv.patch"
         UPDATE_COMMAND ""
     )
 

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -19,6 +19,8 @@ cd libyuv
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
 git checkout ccdf87034
 
+git apply --ignore-whitespace ../libyuv.patch
+
 mkdir build
 cd build
 

--- a/ext/libyuv.patch
+++ b/ext/libyuv.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5df76856..1ac840fb 100644
+index 5df76856..eae0b729 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -112,7 +112,7 @@ if(NOT MSVC)
+@@ -112,13 +112,13 @@ if(NOT MSVC)
        ${ly_src_dir}/rotate_neon64.cc
        ${ly_src_dir}/row_neon64.cc
        ${ly_src_dir}/scale_neon64.cc)
@@ -11,3 +11,10 @@ index 5df76856..1ac840fb 100644
      list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_neon64>)
  
      # Enable AArch64 SVE kernels.
+     add_library(${ly_lib_name}_sve OBJECT
+       ${ly_src_dir}/row_sve.cc)
+-    target_compile_options(${ly_lib_name}_sve PRIVATE -march=armv9-a+sve2)
++    target_compile_options(${ly_lib_name}_sve PRIVATE -march=armv8.5-a+sve2)
+     list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_sve>)
+ 
+     set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})

--- a/ext/libyuv.patch
+++ b/ext/libyuv.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5df76856..1ac840fb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -112,7 +112,7 @@ if(NOT MSVC)
+       ${ly_src_dir}/rotate_neon64.cc
+       ${ly_src_dir}/row_neon64.cc
+       ${ly_src_dir}/scale_neon64.cc)
+-    target_compile_options(${ly_lib_name}_neon64 PRIVATE -march=armv8-a+dotprod+i8mm)
++    target_compile_options(${ly_lib_name}_neon64 PRIVATE -march=armv8.2-a+dotprod+i8mm)
+     list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_neon64>)
+ 
+     # Enable AArch64 SVE kernels.


### PR DESCRIPTION
This provides a resolution for #2659 until a fix gets committed for [libyuv issue 399856238](https://libyuv.issues.chromium.org/issues/399856238).

Here is a [successful Pillow manylinux 2014 build](https://github.com/fdintino/Pillow/actions/runs/13637057763/job/38118334872) using this patch.