### PR TITLE
Revert "Use SVT_LOG=0 in avifsvttest for SVT-AV1 3.0.0"

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,8 +154,6 @@ if(AVIF_GTEST)
 
     if(AVIF_CODEC_SVT_ENABLED)
         add_avif_internal_gtest(avifsvttest)
-        # TODO: https://gitlab.com/AOMediaCodec/SVT-AV1/-/issues/2251 - Remove when fixed upstream
-        set_property(TEST avifsvttest PROPERTY ENVIRONMENT "SVT_LOG=0")
     endif()
 
     add_avif_internal_gtest(aviftilingtest)


### PR DESCRIPTION
Reverts AOMediaCodec/libavif#2668

See https://gitlab.com/AOMediaCodec/SVT-AV1/-/issues/2251#note_2385158657.