### PR TITLE
Use unspecified matrix coeffs in avifsvttest

### DIFF
--- a/tests/gtest/avifsvttest.cc
+++ b/tests/gtest/avifsvttest.cc
@@ -39,9 +39,6 @@ TEST_P(SvtAv1Test, EncodeDecodeStillImage) {
                             AVIF_PIXEL_FORMAT_YUV420, AVIF_PLANES_YUV);
   ASSERT_NE(image, nullptr);
   testutil::FillImageGradient(image.get());
-  if (quality == AVIF_QUALITY_LOSSLESS) {
-    image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
-  }
 
   EncoderPtr encoder(avifEncoderCreate());
   ASSERT_NE(encoder, nullptr);
@@ -87,9 +84,6 @@ TEST_P(SvtAv1Test, EncodeDecodeSequence) {
     // Generate different frames.
     testutil::FillImageGradient(sequence.back().get(),
                                 /*offset=*/static_cast<int>(i) * 100);
-    if (quality == AVIF_QUALITY_LOSSLESS) {
-      sequence.back()->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
-    }
   }
 
   EncoderPtr encoder(avifEncoderCreate());


### PR DESCRIPTION
4:2:0 with identity matrix coefficients are not AV1 compliant and SVT-AV1 does not support 4:4:4.