### PR TITLE
test_cmd_targetsize.sh: fix aom version parsing

### DIFF
--- a/tests/test_cmd_targetsize.sh
+++ b/tests/test_cmd_targetsize.sh
@@ -81,7 +81,7 @@ pushd ${TMP_DIR}
   # TODO(yguyon): Investigate.
   # The grep and cut commands are not pretty but seem to work on most platforms.
   if "${AVIFENC}" -V | grep -o "aom" --quiet; then
-    AOM_VERSION=$("${AVIFENC}" -V | grep -o "aom.*[0-9]*\.")        # "aom [enc/dec]:X.Y."
+    AOM_VERSION=$("${AVIFENC}" -V | grep -o "aom[^,]*[0-9]*\.")     # "aom [enc/dec]:X.Y."
     AOM_VERSION=$(echo "${AOM_VERSION}" | cut -d ":" -f 2)          # "X.Y" maybe prepended by a 'v'
     AOM_VERSION=$(echo "${AOM_VERSION}" | grep -o "[0-9]*\.[0-9]*") # "X.Y"
     AOM_MAJOR_VERSION=$(echo "${AOM_VERSION}" | cut -d "." -f 1)


### PR DESCRIPTION
when multiple codecs are present. With `Version: 1.2.0 (dav1d
[dec]:1.5.1-0-g42b2b24, aom [enc/dec]:v3.12.0, svt [enc]:v3.0.0)` this
fixes:

```
+ [[ 12
0 -ge 6 ]]
test_cmd_targetsize.sh: line 92: [[: 12
0: syntax error in expression (error token is "0")
```

Previously the match was too greedy would include both the libaom and
SVT-AV1 version numbers. This change matches everything until a ',' is
encountered or the end of line.
