### PR TITLE
test_cmd_stdin: avoid outputting binary data to terminal

### DIFF
--- a/tests/test_cmd_stdin.sh
+++ b/tests/test_cmd_stdin.sh
@@ -40,8 +40,8 @@ strip_header_if() {
     #   awk -b -v RS='mdat' '{print length($0); exit}' "${FILE}"
     # Hence the hardcoded variable below.
     MDAT_OFFSET=1061
-    FILE_CONTENTS_AFTER_HEADER=$(tail -c +${MDAT_OFFSET} < "${FILE}")
-    echo "${FILE_CONTENTS_AFTER_HEADER}" > "${FILE}"
+    dd if="${FILE}" of="${FILE}.strip" bs=1 skip="${MDAT_OFFSET}"
+    mv "${FILE}.strip" "${FILE}"
   fi
 }
 


### PR DESCRIPTION
Use `dd` rather than command substitution to avoid outputting binary
data when `set -x` is enabled. This also fixes a related warning:
  test_cmd_stdin.sh: line 43: warning: command substitution: ignored
                                       null byte in input
