### PR TITLE
Do not go through RGB when reading a gray PNG/JPG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Add support for outputting all frames of an image sequence in `avifdec`.
   `avifdec --index all sequence.avif out.png` creates files named
   `out-xxxxxxxxxx.png` where xxxxxxxxxx are the zero-padded frame indices.
+* Add grayscale conversions in avifImageRGBToYUV and avifImageYUVToRGB.
 
 ### Changed since 1.2.0
 
@@ -30,6 +31,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Patch local libyuv dependency for compatibility with gcc 10.
 * Use stricter C99 syntax to avoid related compilation issues.
 * Update svt.cmd/svt.sh/LocalSvt.cmake to v3.0.1.
+* Properly deal with grayscale PNG/JPG images in avifenc/avifdec
 
 ## [1.2.0] - 2025-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The changes are relative to the previous release, unless the baseline is specifi
   `avifdec --index all sequence.avif out.png` creates files named
   `out-xxxxxxxxxx.png` where xxxxxxxxxx are the zero-padded frame indices.
 * Add grayscale conversions in avifImageRGBToYUV and avifImageYUVToRGB.
+* Add avifRGBFormatIsGray to check whether an avifRGBFormat is gray.
 
 ### Changed since 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Patch local libyuv dependency for compatibility with gcc 10.
 * Use stricter C99 syntax to avoid related compilation issues.
 * Update svt.cmd/svt.sh/LocalSvt.cmake to v3.0.1.
-* Properly deal with grayscale PNG/JPG images in avifenc/avifdec
+* Do not go through RGB when reading/writing a grayscale PNG/JPG images in
+  avifenc/avifdec
 
 ## [1.2.0] - 2025-02-25
 

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -179,7 +179,8 @@ static avifBool avifJPEGReadCopy(avifImage * avif, uint32_t sizeLimit, struct jp
         if ((cinfo->comp_info[0].h_samp_factor == cinfo->max_h_samp_factor &&
              cinfo->comp_info[0].v_samp_factor == cinfo->max_v_samp_factor)) {
             // Import to YUV/Grayscale: must use compatible matrixCoefficients.
-            if (avifJPEGHasCompatibleMatrixCoefficients(avif->matrixCoefficients)) {
+            if (avifJPEGHasCompatibleMatrixCoefficients(avif->matrixCoefficients) ||
+                avif->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED) {
                 // Grayscale->Grayscale: direct copy.
                 if ((avif->yuvFormat == AVIF_PIXEL_FORMAT_YUV400) || (avif->yuvFormat == AVIF_PIXEL_FORMAT_NONE)) {
                     avif->yuvFormat = AVIF_PIXEL_FORMAT_YUV400;
@@ -1269,7 +1270,7 @@ avifBool avifJPEGWrite(const char * outputFilename, const avifImage * avif, int 
 
     avifRGBImage rgb;
     avifRGBImageSetDefaults(&rgb, avif);
-    rgb.format = AVIF_RGB_FORMAT_RGB;
+    rgb.format = avif->yuvFormat == AVIF_PIXEL_FORMAT_YUV400 ? AVIF_RGB_FORMAT_GRAY : AVIF_RGB_FORMAT_RGB;
     rgb.chromaUpsampling = chromaUpsampling;
     rgb.depth = 8;
     if (avifRGBImageAllocatePixels(&rgb) != AVIF_RESULT_OK) {

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -455,7 +455,7 @@ avifBool avifPNGRead(const char * inputFilename,
 
     const int numChannels = png_get_channels(png, info);
     if (numChannels < 1 || numChannels > 4) {
-        fprintf(stderr, "png_get_channels() should return 1,2,3 or 4 but returns %d.\n", numChannels);
+        fprintf(stderr, "png_get_channels() should return 1, 2, 3 or 4 but returns %d.\n", numChannels);
         goto cleanup;
     }
     if (avif->width > imageSizeLimit / avif->height) {

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -972,10 +972,14 @@ typedef enum avifRGBFormat
     // This format is only supported for YUV -> RGB conversion and when
     // avifRGBImage.depth is set to 8.
     AVIF_RGB_FORMAT_RGB_565,
+    AVIF_RGB_FORMAT_GRAY,
+    AVIF_RGB_FORMAT_GRAYA,
+    AVIF_RGB_FORMAT_AGRAY,
     AVIF_RGB_FORMAT_COUNT
 } avifRGBFormat;
 AVIF_API uint32_t avifRGBFormatChannelCount(avifRGBFormat format);
 AVIF_API avifBool avifRGBFormatHasAlpha(avifRGBFormat format);
+AVIF_API avifBool avifRGBFormatIsGray(avifRGBFormat format);
 
 typedef enum avifChromaUpsampling
 {

--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -287,12 +287,13 @@ typedef enum avifAlphaMultiplyMode
 // Information about an RGB color space.
 typedef struct avifRGBColorSpaceInfo
 {
-    uint32_t channelBytes; // Number of bytes per channel.
-    uint32_t pixelBytes;   // Number of bytes per pixel (= channelBytes * num channels).
-    uint32_t offsetBytesR; // Offset in bytes of the red channel in a pixel.
-    uint32_t offsetBytesG; // Offset in bytes of the green channel in a pixel.
-    uint32_t offsetBytesB; // Offset in bytes of the blue channel in a pixel.
-    uint32_t offsetBytesA; // Offset in bytes of the alpha channel in a pixel.
+    uint32_t channelBytes;    // Number of bytes per channel.
+    uint32_t pixelBytes;      // Number of bytes per pixel (= channelBytes * num channels).
+    uint32_t offsetBytesR;    // Offset in bytes of the red channel in a pixel.
+    uint32_t offsetBytesG;    // Offset in bytes of the green channel in a pixel.
+    uint32_t offsetBytesB;    // Offset in bytes of the blue channel in a pixel.
+    uint32_t offsetBytesA;    // Offset in bytes of the alpha channel in a pixel.
+    uint32_t offsetBytesGray; // Offset in bytes of the gray channel in a pixel.
 
     int maxChannel;    // Maximum value for a channel (e.g. 255 for 8 bit).
     float maxChannelF; // Same as maxChannel but as a float.

--- a/src/avif.c
+++ b/src/avif.c
@@ -681,7 +681,7 @@ uint32_t avifRGBFormatChannelCount(avifRGBFormat format)
     if (format == AVIF_RGB_FORMAT_GRAY) {
         return 1;
     }
-    if (format == AVIF_RGB_FORMAT_GRAYA || format == AVIF_RGB_FORMAT_AGRAY) {
+    if ((format == AVIF_RGB_FORMAT_GRAYA) || (format == AVIF_RGB_FORMAT_AGRAY)) {
         return 2;
     }
     return avifRGBFormatHasAlpha(format) ? 4 : 3;

--- a/src/avif.c
+++ b/src/avif.c
@@ -665,13 +665,25 @@ void avifCodecDestroy(avifCodec * codec)
 // ---------------------------------------------------------------------------
 // avifRGBImage
 
+avifBool avifRGBFormatIsGray(avifRGBFormat format)
+{
+    return (format == AVIF_RGB_FORMAT_GRAY) || (format == AVIF_RGB_FORMAT_GRAYA) || (format == AVIF_RGB_FORMAT_AGRAY);
+}
+
 avifBool avifRGBFormatHasAlpha(avifRGBFormat format)
 {
-    return (format != AVIF_RGB_FORMAT_RGB) && (format != AVIF_RGB_FORMAT_BGR) && (format != AVIF_RGB_FORMAT_RGB_565);
+    return (format != AVIF_RGB_FORMAT_RGB) && (format != AVIF_RGB_FORMAT_BGR) && (format != AVIF_RGB_FORMAT_RGB_565) &&
+           (format != AVIF_RGB_FORMAT_GRAY);
 }
 
 uint32_t avifRGBFormatChannelCount(avifRGBFormat format)
 {
+    if (format == AVIF_RGB_FORMAT_GRAY) {
+        return 1;
+    }
+    if (format == AVIF_RGB_FORMAT_GRAYA || format == AVIF_RGB_FORMAT_AGRAY) {
+        return 2;
+    }
     return avifRGBFormatHasAlpha(format) ? 4 : 3;
 }
 

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -498,8 +498,8 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                         }
                     }
                 }
-                g = avifRoundf(AVIF_CLAMP(g, 0.0f, grayMaxChannelF));
-                if (state.rgb.channelBytes > 1) {
+                g = avifRoundf(AVIF_CLAMP(g, 0.0f, state.yuv.maxChannel));
+                if (state.yuv.channelBytes > 1) {
                     uint16_t * pY = (uint16_t *)&yPlane[(i * 2) + j * yRowBytes];
                     *pY = (uint16_t)g;
                 } else {

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -832,7 +832,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
                         G = Y + Cb;
                         B = t - Cr;
                         R = t + Cr;
-                    } else if (state->yuv.mode == AVIF_REFORMAT_MODE_YCGCO_RE || state->yuv.mode == AVIF_REFORMAT_MODE_YCGCO_RO) {
+                    } else if ((state->yuv.mode == AVIF_REFORMAT_MODE_YCGCO_RE) || (state->yuv.mode == AVIF_REFORMAT_MODE_YCGCO_RO)) {
                         // YCgCoRe/YCgCoRo: Formulas 62,63,64,65 from
                         // https://www.itu.int/rec/T-REC-H.273-202407-P
                         const int YY = unormY;

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -126,8 +126,7 @@ avifBool avifGetYUVColorSpaceInfo(const avifImage * image, avifYUVColorSpaceInfo
         return AVIF_FALSE;
     }
 
-    // Removing 400 here would break backward behavior but would respect the
-    // spec.
+    // Removing 400 here would break backward behavior but would respect the spec.
     if ((image->matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_IDENTITY) && (image->yuvFormat != AVIF_PIXEL_FORMAT_YUV444) &&
         (image->yuvFormat != AVIF_PIXEL_FORMAT_YUV400)) {
         return AVIF_FALSE;

--- a/tests/avifyuv.c
+++ b/tests/avifyuv.c
@@ -40,6 +40,12 @@ static const char * rgbFormatToString(avifRGBFormat format)
             return "ABGR";
         case AVIF_RGB_FORMAT_RGB_565:
             return "RGB_565";
+        case AVIF_RGB_FORMAT_GRAY:
+            return "RGB_GRAY";
+        case AVIF_RGB_FORMAT_GRAYA:
+            return "RGB_GRAYA";
+        case AVIF_RGB_FORMAT_AGRAY:
+            return "RGB_AGRAY";
         case AVIF_RGB_FORMAT_COUNT:
             break;
     }

--- a/tests/gtest/aviflosslesstest.cc
+++ b/tests/gtest/aviflosslesstest.cc
@@ -44,15 +44,12 @@ void ReadImageSimple(const std::string& file_path, avifPixelFormat pixel_format,
   ASSERT_NE(image, nullptr);
   image->matrixCoefficients = matrix_coefficients;
   const avifAppFileFormat file_format = avifReadImage(
-      file_path.c_str(),
-      /*requestedFormat=*/pixel_format,
-      /*requestedDepth=*/0,
+      file_path.c_str(), /*requestedFormat=*/pixel_format, /*requestedDepth=*/0,
       /*chromaDownsampling=*/AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC,
       /*ignoreColorProfile=*/ignore_icc, /*ignoreExif=*/false,
-      /*ignoreXMP=*/false, /*allowChangingCicp=*/true,
-      /*ignoreGainMap=*/true, AVIF_DEFAULT_IMAGE_SIZE_LIMIT, image.get(),
-      /*outDepth=*/nullptr, /*sourceTiming=*/nullptr,
-      /*frameIter=*/nullptr);
+      /*ignoreXMP=*/false, /*allowChangingCicp=*/true, /*ignoreGainMap=*/true,
+      AVIF_DEFAULT_IMAGE_SIZE_LIMIT, image.get(), /*outDepth=*/nullptr,
+      /*sourceTiming=*/nullptr, /*frameIter=*/nullptr);
   if (matrix_coefficients == AVIF_MATRIX_COEFFICIENTS_IDENTITY &&
       image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420) {
     // 420 cannot be converted from RGB to YUV with
@@ -70,27 +67,27 @@ void ReadImageSimple(const std::string& file_path, avifPixelFormat pixel_format,
 void IsGray(const std::string& path, bool& is_gray) {
   ImagePtr image(avifImageCreateEmpty());
   ASSERT_NE(image, nullptr);
-  // In the first iteration, figure out if the image is grayscale.
   image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
-  ASSERT_NE(AVIF_APP_FILE_FORMAT_UNKNOWN,
-            avifReadImage(
-                path.c_str(), AVIF_PIXEL_FORMAT_NONE, /*requested_depth=*/0,
-                /*chroma_downsampling=*/AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC,
-                /*ignore_icc=*/true, /*ignore_exif=*/true, /*ignore_xmp=*/true,
-                /*allow_changing_cicp=*/true, /*ignore_gain_map=*/true,
-                AVIF_DEFAULT_IMAGE_SIZE_LIMIT, image.get(),
-                /*outDepth=*/nullptr, /*sourceTiming=*/nullptr,
-                /*frameIter=*/nullptr));
+  ASSERT_NE(
+      AVIF_APP_FILE_FORMAT_UNKNOWN,
+      avifReadImage(path.c_str(), AVIF_PIXEL_FORMAT_NONE, /*requestedDepth=*/0,
+                    /*chromaDownsampling=*/AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC,
+                    /*ignoreColorProfile=*/true, /*ignoreExif=*/true,
+                    /*ignoreXMP=*/true,
+                    /*allowChangingCicp=*/true, /*ignoreGainMap=*/true,
+                    AVIF_DEFAULT_IMAGE_SIZE_LIMIT, image.get(),
+                    /*outDepth=*/nullptr, /*sourceTiming=*/nullptr,
+                    /*frameIter=*/nullptr));
   is_gray = image->yuvFormat == AVIF_PIXEL_FORMAT_YUV400;
 }
 
 // The test parameters are: the file path, the matrix coefficients and the pixel
 // format.
-class EncodeDecodeRam
+class EncodeDecodeMemory
     : public testing::TestWithParam<std::tuple<std::string, int, int>> {};
 
 // Tests encode/decode round trips in RAM.
-TEST_P(EncodeDecodeRam, RoundTrip) {
+TEST_P(EncodeDecodeMemory, RoundTrip) {
   const std::string& file_path =
       std::string(data_path) + std::get<0>(GetParam());
   const avifMatrixCoefficients matrix_coefficients =
@@ -162,7 +159,7 @@ TEST_P(EncodeDecodeRam, RoundTrip) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    EncodeDecodeRamInstantiation, EncodeDecodeRam,
+    EncodeDecodeMemoryInstantiation, EncodeDecodeMemory,
     testing::Combine(
         testing::Values("paris_icc_exif_xmp.png", "paris_exif_xmp_icc.jpg",
                         "kodim03_grayscale_gamma1.6.png"),

--- a/tests/gtest/aviflosslesstest.cc
+++ b/tests/gtest/aviflosslesstest.cc
@@ -64,7 +64,7 @@ void ReadImageSimple(const std::string& file_path, avifPixelFormat pixel_format,
 
 // Checks whether an image is grayscale. ASSERT_NO_FATAL_FAILURE should be used
 // when calling it.
-void IsGray(const std::string& path, bool& is_gray) {
+void GetIsGray(const std::string& path, bool& is_gray) {
   ImagePtr image(avifImageCreateEmpty());
   ASSERT_NE(image, nullptr);
   image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
@@ -86,7 +86,7 @@ void IsGray(const std::string& path, bool& is_gray) {
 class EncodeDecodeMemory
     : public testing::TestWithParam<std::tuple<std::string, int, int>> {};
 
-// Tests encode/decode round trips in RAM.
+// Tests encode/decode round trips in memory.
 TEST_P(EncodeDecodeMemory, RoundTrip) {
   const std::string& file_path =
       std::string(data_path) + std::get<0>(GetParam());
@@ -97,7 +97,7 @@ TEST_P(EncodeDecodeMemory, RoundTrip) {
 
   // Check if the input image is grayscale.
   bool gt_is_gray = false;
-  ASSERT_NO_FATAL_FAILURE(IsGray(file_path, gt_is_gray));
+  ASSERT_NO_FATAL_FAILURE(GetIsGray(file_path, gt_is_gray));
 
   // Ignore ICC when going from RGB to gray or gray to RGB.
   avifBool ignore_icc;

--- a/tests/gtest/avifreadimagetest.cc
+++ b/tests/gtest/avifreadimagetest.cc
@@ -380,7 +380,6 @@ TEST(GrayTest, Roundtrip) {
   ASSERT_NE(avifReadImageForRGB2Gray2RGB(file_path, AVIF_PIXEL_FORMAT_YUV400,
                                          /*ignore_icc=*/true, image),
             AVIF_APP_FILE_FORMAT_UNKNOWN);
-
   for (const std::string ext : {"png", "jpg"}) {
     // Write the image with the appropriate codec.
     const std::string new_path =
@@ -392,7 +391,7 @@ TEST(GrayTest, Roundtrip) {
                        /*compressionLevel=*/0),
           AVIF_TRUE);
     } else {
-      ASSERT_EQ(avifJPEGWrite(new_path.c_str(), image.get(), /*jpegQuality=*/75,
+      ASSERT_EQ(avifJPEGWrite(new_path.c_str(), image.get(), /*jpegQuality=*/99,
                               AVIF_CHROMA_UPSAMPLING_BEST_QUALITY),
                 AVIF_TRUE);
     }
@@ -404,6 +403,52 @@ TEST(GrayTest, Roundtrip) {
         new_path, AVIF_PIXEL_FORMAT_NONE, /*ignore_icc=*/true, rt_image);
     ASSERT_NE(AVIF_APP_FILE_FORMAT_UNKNOWN, new_file_format);
     ASSERT_EQ(AVIF_PIXEL_FORMAT_YUV400, rt_image->yuvFormat);
+    if (ext == "png") {
+      ASSERT_TRUE(testutil::AreImagesEqual(*image, *rt_image));
+    } else {
+      ASSERT_GT(testutil::GetPsnr(*image, *rt_image, /*ignore_alpha=*/false),
+                60);
+    }
+  }
+}
+
+TEST(GrayAlphaTest, Roundtrip) {
+  constexpr char file_name[] = "paris_icc_exif_xmp.png";
+  const std::string file_path = std::string(data_path) + file_name;
+
+  for (bool use_alpha : {false, true}) {
+    // Read the ground truth image as gray.
+    ImagePtr image(avifImageCreateEmpty());
+    ASSERT_NE(image, nullptr);
+    ASSERT_NE(avifReadImageForRGB2Gray2RGB(file_path, AVIF_PIXEL_FORMAT_YUV400,
+                                           /*ignore_icc=*/true, image),
+              AVIF_APP_FILE_FORMAT_UNKNOWN);
+    if (use_alpha) {
+      // Have alpha point to the Y plane, just to get some data.
+      image->alphaRowBytes = image->yuvRowBytes[AVIF_CHAN_Y];
+      const size_t size = image->height * image->alphaRowBytes;
+      image->alphaPlane = (uint8_t*)avifAlloc(size);
+      ASSERT_NE(nullptr, image->alphaPlane);
+      image->imageOwnsAlphaPlane = AVIF_TRUE;
+      for (size_t i = 0; i < size; ++i) image->alphaPlane[i] = i % 256;
+    }
+
+    // Write the image.
+    const std::string new_path =
+        testing::TempDir() + "tmp_GrayTestRoundtrip.png";
+    ASSERT_EQ(avifPNGWrite(new_path.c_str(), image.get(), /*requestedDepth=*/0,
+                           AVIF_CHROMA_UPSAMPLING_BEST_QUALITY,
+                           /*compressionLevel=*/0),
+              AVIF_TRUE);
+
+    // Read the image back with the default color space.
+    ImagePtr rt_image(avifImageCreateEmpty());
+    ASSERT_NE(rt_image, nullptr);
+    const avifAppFileFormat new_file_format = avifReadImageForRGB2Gray2RGB(
+        new_path, AVIF_PIXEL_FORMAT_NONE, /*ignore_icc=*/true, rt_image);
+    ASSERT_NE(AVIF_APP_FILE_FORMAT_UNKNOWN, new_file_format);
+    ASSERT_EQ(AVIF_PIXEL_FORMAT_YUV400, rt_image->yuvFormat);
+    ASSERT_TRUE(testutil::AreImagesEqual(*image, *rt_image));
   }
 }
 

--- a/tests/gtest/avifreadimagetest.cc
+++ b/tests/gtest/avifreadimagetest.cc
@@ -382,8 +382,8 @@ TEST(GrayTest, Roundtrip) {
             AVIF_APP_FILE_FORMAT_UNKNOWN);
   for (const std::string ext : {"png", "jpg"}) {
     // Write the image with the appropriate codec.
-    const std::string new_path =
-        testing::TempDir() + "tmp_GrayTestRoundtrip." + ext;
+    const std::string new_path = testing::TempDir() + std::string(file_name) +
+                                 "_tmp_GrayTestRoundtrip." + ext;
     if (ext == "png") {
       ASSERT_EQ(
           avifPNGWrite(new_path.c_str(), image.get(), /*requestedDepth=*/0,

--- a/tests/gtest/avifreadimagetest.cc
+++ b/tests/gtest/avifreadimagetest.cc
@@ -380,7 +380,7 @@ TEST(GrayTest, Roundtrip) {
   ASSERT_NE(avifReadImageForRGB2Gray2RGB(file_path, AVIF_PIXEL_FORMAT_YUV400,
                                          /*ignore_icc=*/true, image),
             AVIF_APP_FILE_FORMAT_UNKNOWN);
-  for (const std::string ext : {"png", "jpg"}) {
+  for (const std::string ext : {"jpg", "png"}) {
     // Write the image with the appropriate codec.
     const std::string new_path = testing::TempDir() + std::string(file_name) +
                                  "_tmp_GrayTestRoundtrip." + ext;

--- a/tests/gtest/avifreadimagetest.cc
+++ b/tests/gtest/avifreadimagetest.cc
@@ -333,20 +333,20 @@ TEST(ICCTest, RGB2Gray2RGB) {
     ASSERT_EQ(avifImageSetProfileICC(image.get(), icc.data, icc.size),
               AVIF_RESULT_OK);
 
-    for (const std::string ext : {"png", "jpg"}) {
+    for (const std::string ext : {"jpg", "png"}) {
       // Write the image with the appropriate codec.
       const std::string new_path =
           testing::TempDir() + "tmp_RGB2Gray2RGB." + ext;
-      if (ext == "png") {
+      if (ext == "jpg") {
+        ASSERT_EQ(
+            avifJPEGWrite(new_path.c_str(), image.get(), /*jpegQuality=*/75,
+                          AVIF_CHROMA_UPSAMPLING_BEST_QUALITY),
+            AVIF_TRUE);
+      } else {
         ASSERT_EQ(
             avifPNGWrite(new_path.c_str(), image.get(), /*requestedDepth=*/0,
                          AVIF_CHROMA_UPSAMPLING_BEST_QUALITY,
                          /*compressionLevel=*/0),
-            AVIF_TRUE);
-      } else {
-        ASSERT_EQ(
-            avifJPEGWrite(new_path.c_str(), image.get(), /*jpegQuality=*/75,
-                          AVIF_CHROMA_UPSAMPLING_BEST_QUALITY),
             AVIF_TRUE);
       }
 
@@ -401,8 +401,8 @@ TEST(GrayTest, Roundtrip) {
     ASSERT_NE(rt_image, nullptr);
     const avifAppFileFormat new_file_format = avifReadImageForRGB2Gray2RGB(
         new_path, AVIF_PIXEL_FORMAT_NONE, /*ignore_icc=*/true, rt_image);
-    ASSERT_NE(AVIF_APP_FILE_FORMAT_UNKNOWN, new_file_format);
-    ASSERT_EQ(AVIF_PIXEL_FORMAT_YUV400, rt_image->yuvFormat);
+    ASSERT_NE(new_file_format, AVIF_APP_FILE_FORMAT_UNKNOWN);
+    ASSERT_EQ(rt_image->yuvFormat, AVIF_PIXEL_FORMAT_YUV400);
     if (ext == "png") {
       ASSERT_TRUE(testutil::AreImagesEqual(*image, *rt_image));
     } else {
@@ -428,7 +428,7 @@ TEST(GrayAlphaTest, Roundtrip) {
       image->alphaRowBytes = image->yuvRowBytes[AVIF_CHAN_Y];
       const size_t size = image->height * image->alphaRowBytes;
       image->alphaPlane = (uint8_t*)avifAlloc(size);
-      ASSERT_NE(nullptr, image->alphaPlane);
+      ASSERT_NE(image->alphaPlane, nullptr);
       image->imageOwnsAlphaPlane = AVIF_TRUE;
       for (size_t i = 0; i < size; ++i) image->alphaPlane[i] = i % 256;
     }
@@ -446,8 +446,8 @@ TEST(GrayAlphaTest, Roundtrip) {
     ASSERT_NE(rt_image, nullptr);
     const avifAppFileFormat new_file_format = avifReadImageForRGB2Gray2RGB(
         new_path, AVIF_PIXEL_FORMAT_NONE, /*ignore_icc=*/true, rt_image);
-    ASSERT_NE(AVIF_APP_FILE_FORMAT_UNKNOWN, new_file_format);
-    ASSERT_EQ(AVIF_PIXEL_FORMAT_YUV400, rt_image->yuvFormat);
+    ASSERT_NE(new_file_format, AVIF_APP_FILE_FORMAT_UNKNOWN);
+    ASSERT_EQ(rt_image->yuvFormat, AVIF_PIXEL_FORMAT_YUV400);
     ASSERT_TRUE(testutil::AreImagesEqual(*image, *rt_image));
   }
 }


### PR DESCRIPTION
This is a follow-up on https://github.com/AOMediaCodec/libavif/issues/2639 where I realized we are not treating grayscale images properly