### PR TITLE
Encode alpha with unspecified matrix coefficients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The changes are relative to the previous release, unless the baseline is specifi
   discarded.
 * Forbid encoding with AVIF_MATRIX_COEFFICIENTS_IDENTITY and
   AVIF_PIXEL_FORMAT_YUV400 to be AV1 spec compatible.
+* Forward the CICP color primaries, transfer characteristics, and matrix
+  coefficients to the SVT-AV1 encoder.
 * Update svt.cmd/svt.sh/LocalSvt.cmake to v3.0.1.
 
 ## [1.2.0] - 2025-02-25

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -1025,6 +1025,13 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
     avifBool monochromeRequested = AVIF_FALSE;
 
     if (alpha) {
+        // AV1 specification section 6.4.2. Color config semantics:
+        //   subsampling_x | subsampling_y | mono_chrome | Description
+        //   1             | 1             | 1           | Monochrome 4:0:0
+        //   If matrix_coefficients is equal to MC_IDENTITY, it is a requirement of bitstream
+        //   conformance that subsampling_x is equal to 0 and subsampling_y is equal to 0.
+        // Use AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED instead.
+        aomImage.mc = (aom_matrix_coefficients_t)AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
         aomImage.range = AOM_CR_FULL_RANGE;
         monochromeRequested = AVIF_TRUE;
         if (aomImageAllocated) {

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -920,6 +920,13 @@ static avifResult avmCodecEncodeImage(avifCodec * codec,
     avifBool monochromeRequested = AVIF_FALSE;
 
     if (alpha) {
+        // AV1 specification section 6.4.2. Color config semantics:
+        //   subsampling_x | subsampling_y | mono_chrome | Description
+        //   1             | 1             | 1           | Monochrome 4:0:0
+        //   If matrix_coefficients is equal to MC_IDENTITY, it is a requirement of bitstream
+        //   conformance that subsampling_x is equal to 0 and subsampling_y is equal to 0.
+        // Use AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED instead.
+        aomImage.mc = (aom_matrix_coefficients_t)AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
         aomImage.range = AOM_CR_FULL_RANGE;
         monochromeRequested = AVIF_TRUE;
         if (aomImageAllocated) {

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -89,12 +89,29 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
 
     if (!codec->internal->rav1eContext) {
         const avifBool supports400 = rav1eSupports400();
+        RaColorPrimaries rav1eCp;
+        RaTransferCharacteristics rav1eTf;
+        RaMatrixCoefficients rav1eMc;
         RaPixelRange rav1eRange;
         if (alpha) {
+            rav1eCp = (RaColorPrimaries)AVIF_COLOR_PRIMARIES_UNSPECIFIED;
+            rav1eTf = (RaTransferCharacteristics)AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
+            // AV1 specification section 6.4.2. Color config semantics:
+            //   subsampling_x | subsampling_y | mono_chrome | Description
+            //   1             | 1             | 1           | Monochrome 4:0:0
+            //   If matrix_coefficients is equal to MC_IDENTITY, it is a requirement of bitstream
+            //   conformance that subsampling_x is equal to 0 and subsampling_y is equal to 0.
+            // Use AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED instead.
+            rav1eMc = (RaMatrixCoefficients)AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
+
             rav1eRange = RA_PIXEL_RANGE_FULL;
             codec->internal->chromaSampling = supports400 ? RA_CHROMA_SAMPLING_CS400 : RA_CHROMA_SAMPLING_CS420;
             codec->internal->yShift = 1;
         } else {
+            rav1eCp = (RaColorPrimaries)image->colorPrimaries;
+            rav1eTf = (RaTransferCharacteristics)image->transferCharacteristics;
+            rav1eMc = (RaMatrixCoefficients)image->matrixCoefficients;
+
             rav1eRange = (image->yuvRange == AVIF_RANGE_FULL) ? RA_PIXEL_RANGE_FULL : RA_PIXEL_RANGE_LIMITED;
             codec->internal->yShift = 0;
             switch (image->yuvFormat) {
@@ -186,10 +203,7 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
             }
         }
 
-        rav1e_config_set_color_description(rav1eConfig,
-                                           (RaMatrixCoefficients)image->matrixCoefficients,
-                                           (RaColorPrimaries)image->colorPrimaries,
-                                           (RaTransferCharacteristics)image->transferCharacteristics);
+        rav1e_config_set_color_description(rav1eConfig, rav1eMc, rav1eCp, rav1eTf);
 
         codec->internal->rav1eContext = rav1e_context_new(rav1eConfig);
         if (!codec->internal->rav1eContext) {

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -83,11 +83,28 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
     EbErrorType res = EB_ErrorNone;
 
     int y_shift = 0;
+    EbColorPrimaries color_primaries;
+    EbTransferCharacteristics transfer_characteristics;
+    EbMatrixCoefficients matrix_coefficients;
     EbColorRange svt_range;
     if (alpha) {
+        color_primaries = (EbColorPrimaries)AVIF_COLOR_PRIMARIES_UNSPECIFIED;
+        transfer_characteristics = (EbTransferCharacteristics)AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
+        // AV1 specification section 6.4.2. Color config semantics:
+        //   subsampling_x | subsampling_y | mono_chrome | Description
+        //   1             | 1             | 1           | Monochrome 4:0:0
+        //   If matrix_coefficients is equal to MC_IDENTITY, it is a requirement of bitstream
+        //   conformance that subsampling_x is equal to 0 and subsampling_y is equal to 0.
+        // Use AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED instead.
+        matrix_coefficients = (EbMatrixCoefficients)AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
+
         svt_range = EB_CR_FULL_RANGE;
         y_shift = 1;
     } else {
+        color_primaries = (EbColorPrimaries)image->colorPrimaries;
+        transfer_characteristics = (EbTransferCharacteristics)image->transferCharacteristics;
+        matrix_coefficients = (EbMatrixCoefficients)image->matrixCoefficients;
+
         svt_range = (image->yuvRange == AVIF_RANGE_FULL) ? EB_CR_FULL_RANGE : EB_CR_STUDIO_RANGE;
         switch (image->yuvFormat) {
             case AVIF_PIXEL_FORMAT_YUV444:
@@ -125,6 +142,9 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
         }
         svt_config->encoder_color_format = color_format;
         svt_config->encoder_bit_depth = (uint8_t)image->depth;
+        svt_config->color_primaries = color_primaries;
+        svt_config->transfer_characteristics = transfer_characteristics;
+        svt_config->matrix_coefficients = matrix_coefficients;
         svt_config->color_range = svt_range;
 #if !SVT_AV1_CHECK_VERSION(0, 9, 0)
         svt_config->is_16bit_pipeline = image->depth > 8;

--- a/tests/gtest/aviflosslesstest.cc
+++ b/tests/gtest/aviflosslesstest.cc
@@ -115,7 +115,7 @@ TEST_P(LosslessTest, EncodeDecode) {
   ASSERT_TRUE(testutil::AreImagesEqual(*image, *decoded));
 }
 
-// Reads an image losslessly, using identiy MC.
+// Reads an image losslessly, using identity MC.
 ImagePtr ReadImageLossless(const std::string& path,
                            avifPixelFormat requested_format,
                            avifBool ignore_icc) {


### PR DESCRIPTION
Forward CICP to SVT-AV1.
Fix typo in aviflosslesstest.

Fixes https://github.com/AOMediaCodec/libavif/issues/2685.