### PR TITLE
codec_aom: disable loop restoration w/12-bit input

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -877,9 +877,11 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             }
         }
 
-        if (image->depth == 12) {
-            // The encoder may produce integer overflows with 12-bit input when loop restoration is enabled.
-            aom_codec_control(&codec->internal->encoder, AV1E_SET_ENABLE_RESTORATION, 0);
+        if (image->depth == 12 && cfg->g_limit != 1) {
+            // The encoder may produce integer overflows with 12-bit input when loop restoration is enabled. See crbug.com/aomedia/42302587.
+            if (aom_codec_control(&codec->internal->encoder, AV1E_SET_ENABLE_RESTORATION, 0) != AOM_CODEC_OK) {
+                return AVIF_RESULT_UNKNOWN_ERROR;
+            }
         }
     } else {
         avifBool dimensionsChanged = AVIF_FALSE;

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -876,6 +876,11 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
                 return AVIF_RESULT_UNKNOWN_ERROR;
             }
         }
+
+        if (image->depth == 12) {
+            // The encoder may produce integer overflows with 12-bit input when loop restoration is enabled.
+            aom_codec_control(&codec->internal->encoder, AV1E_SET_ENABLE_RESTORATION, 0);
+        }
     } else {
         avifBool dimensionsChanged = AVIF_FALSE;
         if ((cfg->g_w != image->width) || (cfg->g_h != image->height)) {


### PR DESCRIPTION
The libaom encoder may produce integer overflows with 12-bit input when
loop restoration is enabled. This is only done with animation for now as
that is the only time the issue has surfaced.
