### PR TITLE
codec_aom: rm g_limit check when disabling loop resto

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -877,7 +877,7 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
             }
         }
 
-        if (image->depth == 12 && cfg->g_limit != 1) {
+        if (image->depth == 12) {
             // The encoder may produce integer overflows with 12-bit input when loop restoration is enabled. See crbug.com/aomedia/42302587.
             if (aom_codec_control(&codec->internal->encoder, AV1E_SET_ENABLE_RESTORATION, 0) != AOM_CODEC_OK) {
                 return AVIF_RESULT_UNKNOWN_ERROR;


### PR DESCRIPTION
This may not be the best way to describe animation and may not cover all
fuzzing cases.
