### PR TITLE
Assume any id is present in only one altr group as per spec.

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -5626,10 +5626,10 @@ static avifBool avifIsPreferredAlternativeTo(const avifDecoderData * data, uint3
             if (group->entityIDs.ids[j] == id1) {
                 id1Found = AVIF_TRUE;
             } else if (group->entityIDs.ids[j] == id2) {
-                if (id1Found) {
-                    return AVIF_TRUE;
-                }
-                break;
+                // Assume id2 is only present in one altr group, as per ISO/IEC 14496-12:2022
+                // Section 8.15.3.1:
+                // Any entity_id value shall be mapped to only one grouping of type 'altr'.
+                return id1Found;
             }
         }
     }


### PR DESCRIPTION
This is a minor behavior change that would only affect invalid files where a given id is in multiple altr groups.

Note that this is still a fairly limited implementation of altr groups.
We only check them to see if the tmap item is present before the color item id in an altr group. We ignore other item ids in the altr groups.

Full definition of altr groups in the spec (14496-12:2022 Section 8.15.3.1)
> 'altr': The items and tracks mapped to this grouping are alternatives to each other, and only one of
them should be played (when the mapped items and tracks are part of the presentation; e.g. are
displayable items or tracks) or processed by other means (when the mapped items or tracks are not
part of the presentation; e.g. are metadata). A player should select the first entity from the list of
entity_id values that it can process (e.g. decode and play for mapped items and tracks that are
part of the presentation) and that suits the application needs. Any entity_id value shall be mapped
to only one grouping of type 'altr'. An alternate group of entities consists of those items and tracks
that are mapped to the same entity group of type 'altr'.