### PR TITLE
avifrgbtoyuvtest: Do not compute diff_sum

### DIFF
--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -281,9 +281,6 @@ void ConvertWholeBuffer(int rgb_depth, int yuv_depth, avifRGBFormat rgb_format,
       num_diffs += src_rgb.width * src_rgb.height * 3;
     }
   }
-  // max_average_abs_diff is not tested here because it is not meaningful for
-  // only 3*3 conversions as it takes the maximum difference per conversion.
-  // PSNR is averaged on all pixels so it can be tested here.
   EXPECT_GE(GetPsnr(static_cast<double>(sq_diff_sum),
                     static_cast<double>(num_diffs), rgb_max),
             min_psnr);
@@ -695,7 +692,6 @@ INSTANTIATE_TEST_SUITE_P(
     SharpYuv16Bit, RGBToYUVTest,
     Combine(
         /*rgb_depth=*/Values(16),
-        // TODO(yguyon): Why max_average_abs_diff>28 if RGB16 to YUV10 full rng?
         /*yuv_depth=*/Values(8, /*10,*/ 12), Values(AVIF_RGB_FORMAT_RGBA),
         Values(AVIF_PIXEL_FORMAT_YUV420), Values(AVIF_RANGE_FULL),
         Values(kMatrixCoefficientsBT601),

--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -486,8 +486,8 @@ INSTANTIATE_TEST_SUITE_P(
             Values(AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC),
             /*add_noise=*/Values(true),
             /*rgb_step=*/Values(3),
-            /*max_abs_average_diff=*/Values(0.35),  // The color drift is almost
-                                                    // centered.
+            /*max_abs_average_diff=*/Values(0.1),  // The color drift is almost
+                                                   // centered.
             /*min_psnr=*/Values(36.)  // Subsampling distortion is acceptable.
             ));
 
@@ -553,7 +553,7 @@ INSTANTIATE_TEST_SUITE_P(
         Values(AVIF_CHROMA_DOWNSAMPLING_AUTOMATIC),
         /*add_noise=*/Values(false),
         /*rgb_step=*/Values(17),
-        /*max_abs_average_diff=*/Values(0.33),  // The color drift is centered.
+        /*max_abs_average_diff=*/Values(0.02),  // The color drift is centered.
         /*min_psnr=*/Values(45.)  // RGB>YUV>RGB distortion is barely
                                   // noticeable.
         ));


### PR DESCRIPTION
The sum of pixel sample differences is not a good measure of distortion
because it does not satisfy all intuitive properties of the length of a
vector (the mathematical term is the norm of a vector). Do not compute
diff_sum.
    
Rename max_abs_average_diff to max_average_abs_diff and use it as the
maximum of the average absolute value of pixel sample difference.