### PR TITLE
avifenc: read jpeg/png through stdin with --stdin-format flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The changes are relative to the previous release, unless the baseline is specifi
 
 ## [Unreleased]
 
+### Added since 1.2.1
+
+* Allow avifenc to read png or jpeg files through stdin using --stdin-format
+
 ### Changed since 1.2.1
 
 * Reject the conversion in avifenc from non-monochrome/monochrome to

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -73,6 +73,7 @@ typedef struct
     avifTransferCharacteristics transferCharacteristics;
     avifMatrixCoefficients matrixCoefficients;
     avifChromaDownsampling chromaDownsampling;
+    avifAppFileFormat stdinFormat;
 } avifSettings;
 
 typedef struct
@@ -145,7 +146,7 @@ static const char * avifPrettyFilename(const char * filename)
 
 typedef struct avifInputFile
 {
-    const char * filename; // If AVIF_FILENAME_STDIN, use stdin (y4m)
+    const char * filename; // If AVIF_FILENAME_STDIN, use stdin
     uint64_t duration;     // If 0, use the default duration
     avifInputFileSettings settings;
 } avifInputFile;
@@ -222,7 +223,8 @@ static void syntaxLong(void)
     printf("                                        For JPEG, auto honors the JPEG's internal format, if possible. For grayscale PNG, auto defaults to 400. For all other cases, auto defaults to 444\n");
     printf("    -p,--premultiply                  : Premultiply color by the alpha channel and signal this in the AVIF\n");
     printf("    --sharpyuv                        : Use sharp RGB to YUV420 conversion (if supported). Ignored for y4m or if output is not 420.\n");
-    printf("    --stdin                           : Read y4m frames from stdin instead of file paths. No other input is allowed. The output file path must still be provided.\n");
+    printf("    --stdin                           : Read input from stdin instead of file paths. No other input is allowed. The input format is assumed to be y4m unless --stdin-format is specified. The output file path must still be provided.\n");
+    printf("    --stdin-format FORMAT             : Format of the data from stdin, when --stdin is specified. One of: jpeg/png/y4m. (Default: y4m)\n");
     printf("    --cicp,--nclx P/T/M               : Set CICP values (nclx colr box) (3 raw numbers, use -r to set range flag)\n");
     printf("                                        P = color primaries\n");
     printf("                                        T = transfer characteristics\n");
@@ -518,7 +520,8 @@ static avifBool avifInputReadImage(avifInput * input,
                                    uint32_t * outDepth,
                                    avifBool * sourceIsRGB,
                                    avifAppSourceTiming * sourceTiming,
-                                   avifChromaDownsampling chromaDownsampling)
+                                   avifChromaDownsampling chromaDownsampling,
+                                   avifAppFileFormat stdinFormat)
 {
     if (imageIndex < input->cacheCount) {
         const avifInputCacheEntry * cached = &input->cache[imageIndex];
@@ -585,16 +588,30 @@ static avifBool avifInputReadImage(avifInput * input,
     const avifInputFile * currentFile = &input->files[input->fileIndex];
     avifAppFileFormat inputFormat;
     if (currentFile->filename == AVIF_FILENAME_STDIN) {
-        inputFormat = AVIF_APP_FILE_FORMAT_Y4M;
         if (feof(stdin)) {
             return AVIF_FALSE;
         }
-        if (!y4mRead(NULL, UINT32_MAX, dstImage, dstSourceTiming, &input->frameIter)) {
-            fprintf(stderr, "ERROR: Cannot read y4m through standard input");
+        inputFormat = stdinFormat;
+        if (!avifReadFormat(currentFile->filename,
+                            inputFormat,
+                            input->requestedFormat,
+                            input->requestedDepth,
+                            chromaDownsampling,
+                            ignoreColorProfile,
+                            ignoreExif,
+                            ignoreXMP,
+                            allowChangingCicp,
+                            ignoreGainMap,
+                            UINT32_MAX,
+                            dstImage,
+                            dstDepth,
+                            dstSourceTiming,
+                            &input->frameIter)) {
+            fprintf(stderr, "ERROR: Couldn't read %s file from standard input\n", avifFileFormatToString(inputFormat));
+            if (inputFormat == AVIF_APP_FILE_FORMAT_Y4M) {
+                fprintf(stderr, "Specifify --stdin-format if the input is not y4m\n");
+            }
             return AVIF_FALSE;
-        }
-        if (dstDepth) {
-            *dstDepth = dstImage->depth;
         }
     } else {
         inputFormat = avifReadImage(currentFile->filename,
@@ -612,12 +629,12 @@ static avifBool avifInputReadImage(avifInput * input,
                                     dstSourceTiming,
                                     &input->frameIter);
         if (inputFormat == AVIF_APP_FILE_FORMAT_UNKNOWN) {
-            fprintf(stderr, "Cannot read input file: %s\n", currentFile->filename);
+            fprintf(stderr, "Couldn't read input file: %s\n", currentFile->filename);
             return AVIF_FALSE;
         }
-        if (!input->frameIter) {
-            ++input->fileIndex;
-        }
+    }
+    if (!input->frameIter) {
+        ++input->fileIndex;
     }
     if (dstSourceIsRGB) {
         *dstSourceIsRGB = (inputFormat != AVIF_APP_FILE_FORMAT_Y4M);
@@ -642,7 +659,8 @@ static avifBool avifInputReadImage(avifInput * input,
                                   outDepth,
                                   sourceIsRGB,
                                   sourceTiming,
-                                  chromaDownsampling);
+                                  chromaDownsampling,
+                                  stdinFormat);
     }
     return AVIF_TRUE;
 }
@@ -995,7 +1013,8 @@ static avifBool avifEncodeRestOfImageSequence(avifEncoder * encoder,
                                 /*outDepth=*/NULL,
                                 /*sourceIsRGB=*/NULL,
                                 /*sourceTiming=*/NULL,
-                                settings->chromaDownsampling)) {
+                                settings->chromaDownsampling,
+                                settings->stdinFormat)) {
             goto cleanup;
         }
         if (!avifEncoderVerifyImageCompatibility(firstImage, nextImage, "sequence", avifPrettyFilename(nextFile->filename))) {
@@ -1092,7 +1111,8 @@ static avifBool avifEncodeRestOfLayeredImage(avifEncoder * encoder,
                                     /*outDepth=*/NULL,
                                     /*sourceIsRGB=*/NULL,
                                     /*sourceTiming=*/NULL,
-                                    settings->chromaDownsampling)) {
+                                    settings->chromaDownsampling,
+                                    settings->stdinFormat)) {
                 goto cleanup;
             }
             // frameIter is NULL if y4m reached end, so single frame y4m is still supported.
@@ -1242,7 +1262,8 @@ static avifBool avifEncodeImagesFixedQuality(const avifSettings * settings,
         }
 
         uint64_t firstDurationInTimescales = firstFile->duration ? firstFile->duration : settings->outputTiming.duration;
-        if (firstFile->filename == AVIF_FILENAME_STDIN || (settings->layers == 1 && input->filesCount > 1)) {
+        if ((firstFile->filename == AVIF_FILENAME_STDIN && settings->stdinFormat == AVIF_APP_FILE_FORMAT_Y4M) ||
+            (settings->layers == 1 && input->filesCount > 1)) {
             printf(" * Encoding frame %d [%" PRIu64 "/%" PRIu64 " ts] color quality [%d (%s)], alpha quality [%d (%s)]: %s\n",
                    0,
                    firstDurationInTimescales,
@@ -1460,6 +1481,7 @@ int main(int argc, char * argv[])
     settings.ignoreColorProfile = AVIF_FALSE;
     settings.ignoreGainMap = AVIF_FALSE;
     settings.cicpExplicitlySet = AVIF_FALSE;
+    settings.stdinFormat = AVIF_APP_FILE_FORMAT_Y4M;
 
     avifInputFileSettings pendingSettings;
     memset(&pendingSettings, 0, sizeof(pendingSettings));
@@ -1551,6 +1573,18 @@ int main(int argc, char * argv[])
 
             } else if (input.filesCount > 2) {
                 fprintf(stderr, "ERROR: there cannot be any other input if --stdin is specified\n");
+                goto cleanup;
+            }
+        } else if (!strcmp(arg, "--stdin-format")) {
+            NEXTARG();
+            if (!strcmp(arg, "jpg") || !strcmp(arg, "jpeg")) {
+                settings.stdinFormat = AVIF_APP_FILE_FORMAT_JPEG;
+            } else if (!strcmp(arg, "png")) {
+                settings.stdinFormat = AVIF_APP_FILE_FORMAT_PNG;
+            } else if (!strcmp(arg, "y4m")) {
+                settings.stdinFormat = AVIF_APP_FILE_FORMAT_Y4M;
+            } else {
+                fprintf(stderr, "ERROR: invalid stdin file format (expected one of jpeg/png/y4m): %s\n", arg);
                 goto cleanup;
             }
         } else if (!strcmp(arg, "-o") || !strcmp(arg, "--output")) {
@@ -2314,7 +2348,8 @@ int main(int argc, char * argv[])
                             &sourceDepth,
                             &sourceWasRGB,
                             &firstSourceTiming,
-                            settings.chromaDownsampling)) {
+                            settings.chromaDownsampling,
+                            settings.stdinFormat)) {
         goto cleanup;
     }
 
@@ -2558,7 +2593,8 @@ int main(int argc, char * argv[])
                                     /*outDepth=*/NULL,
                                     /*sourceIsRGB=*/NULL,
                                     /*sourceTiming=*/NULL,
-                                    settings.chromaDownsampling)) {
+                                    settings.chromaDownsampling,
+                                    settings.stdinFormat)) {
                 goto cleanup;
             }
             // Let avifEncoderAddImageGrid() verify the grid integrity (valid cell sizes, depths etc.).

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -818,7 +818,12 @@ static avifBool avifJPEGExtractGainMapImage(FILE * f,
 
             const avifROData mpfData = { (const uint8_t *)marker->data + tagMpf.size, marker->data_length - tagMpf.size };
             if (!avifJPEGExtractGainMapImageFromMpf(f, sizeLimit, &mpfData, image, chromaDownsampling)) {
-                fprintf(stderr, "Note: XMP metadata indicated the presence of a gain map, but it could not be found or decoded\n");
+                if (f == stdin) {
+                    // Not supported because fseek doesn't work on stdin.
+                    fprintf(stderr, "Warning: gain map transcoding is not supported with sdtin\n");
+                } else {
+                    fprintf(stderr, "Note: XMP metadata indicated the presence of a gain map, but it could not be found or decoded\n");
+                }
                 avifImageDestroy(image);
                 return AVIF_FALSE;
             }
@@ -1237,10 +1242,16 @@ avifBool avifJPEGRead(const char * inputFilename,
                       avifBool ignoreGainMap,
                       uint32_t sizeLimit)
 {
-    FILE * f = fopen(inputFilename, "rb");
-    if (!f) {
-        fprintf(stderr, "Can't open JPEG file for read: %s\n", inputFilename);
-        return AVIF_FALSE;
+    FILE * f;
+    if (inputFilename) {
+        f = fopen(inputFilename, "rb");
+        if (!f) {
+            fprintf(stderr, "Can't open JPEG file for read: %s\n", inputFilename);
+            return AVIF_FALSE;
+        }
+    } else {
+        f = stdin;
+        inputFilename = "(stdin)";
     }
     const avifBool res = avifJPEGReadInternal(f,
                                               inputFilename,
@@ -1253,7 +1264,9 @@ avifBool avifJPEGRead(const char * inputFilename,
                                               ignoreXMP,
                                               ignoreGainMap,
                                               sizeLimit);
-    fclose(f);
+    if (f && f != stdin) {
+        fclose(f);
+    }
     return res;
 }
 

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -44,6 +44,8 @@ typedef enum avifAppFileFormat
     AVIF_APP_FILE_FORMAT_Y4M
 } avifAppFileFormat;
 
+char * avifFileFormatToString(avifAppFileFormat format);
+
 // Guesses the format of a file by looking at the first bytes, or at the extension if the file
 // can't be read or is empty.
 avifAppFileFormat avifGuessFileFormat(const char * filename);
@@ -62,9 +64,11 @@ typedef struct avifAppSourceTiming
 
 struct y4mFrameIterator;
 // Reads an image from a file with the requested format and depth.
+// The image format is guessed based on the filename or first few bytes.
 // At most imageSizeLimit pixels will be read or an error returned.
 // In case of a y4m file, sourceTiming and frameIter can be set.
-// Returns AVIF_APP_FILE_FORMAT_UNKNOWN in case of error.
+// Returns the format of the file, or AVIF_APP_FILE_FORMAT_UNKNOWN in case of
+// error.
 // 'ignoreGainMap' is only relevant for jpeg files that have a gain map
 // and only if AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION is ON
 // (requires libxml2). Otherwise it has no effect.
@@ -82,6 +86,24 @@ avifAppFileFormat avifReadImage(const char * filename,
                                 uint32_t * outDepth,
                                 avifAppSourceTiming * sourceTiming,
                                 struct y4mFrameIterator ** frameIter);
+// Same as avifReadImage but the input file format is passed in instead of
+// being guessed from the file's name/content.
+// Returns AVIF_FALSE in case of error.
+avifBool avifReadFormat(const char * filename,
+                        avifAppFileFormat inputFormat,
+                        avifPixelFormat requestedFormat,
+                        int requestedDepth,
+                        avifChromaDownsampling chromaDownsampling,
+                        avifBool ignoreColorProfile,
+                        avifBool ignoreExif,
+                        avifBool ignoreXMP,
+                        avifBool allowChangingCicp,
+                        avifBool ignoreGainMap,
+                        uint32_t imageSizeLimit,
+                        avifImage * image,
+                        uint32_t * outDepth,
+                        avifAppSourceTiming * sourceTiming,
+                        struct y4mFrameIterator ** frameIter);
 
 // Copies all the bytes from the file at filename to a newly allocated memory chunk.
 avifBool avifReadEntireFile(const char * filename, avifRWData * raw);

--- a/doc/avifenc.1.md
+++ b/doc/avifenc.1.md
@@ -69,7 +69,10 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Use sharp RGB to YUV420 conversion (if supported). Ignored for y4m or if output is not 420.
 
 **\--stdin**
-:   Read y4m frames from stdin instead of files; no input filenames allowed, must set before offering output filename.
+:   Read input from stdin instead of file paths. No other input is allowed. The input format is assumed to be y4m unless --stdin-format is specified. The output file path must still be provided.
+
+**\--stdin-format**
+:   Format of the data from stdin, when --stdin is specified. One of: jpeg/png/y4m. (Default: y4m)
 
 **\--cicp**, **\--nclx** _P_/_T_/_M_
 :   Set CICP values (nclx colr box) (3 raw numbers, use **-r** to set range flag).

--- a/tests/test_cmd_stdin.sh
+++ b/tests/test_cmd_stdin.sh
@@ -18,6 +18,8 @@ source $(dirname "$0")/cmd_test_common.sh
 # Input file paths.
 INPUT_Y4M_STILL="${TESTDATA_DIR}/kodim03_yuv420_8bpc.y4m"
 INPUT_Y4M_ANIMATED="${TESTDATA_DIR}/webp_logo_animated.y4m"
+INPUT_PNG="${TESTDATA_DIR}/draw_points.png"
+INPUT_JPEG="${TESTDATA_DIR}/paris_extended_xmp.jpg"
 # Output file names.
 ENCODED_FILE_REGULAR="avif_test_cmd_stdin_encoded.avif"
 ENCODED_FILE_STDIN="avif_test_cmd_stdin_encoded_with_stdin.avif"
@@ -43,62 +45,66 @@ strip_header_if() {
 }
 
 test_stdin() {
-  INPUT_Y4M="$1"
+  INPUT="$1"
   STRIP_HEADER="$2"
+  shift 2
+  EXTRA_FLAGS=$@
 
   # Make sure that --stdin can be replaced with a file path and that it leads to
   # the same encoded bytes.
 
-  "${AVIFENC}" -s 8 -o "${ENCODED_FILE_REGULAR}" "${INPUT_Y4M}"
-  "${AVIFENC}" -s 8 -o "${ENCODED_FILE_STDIN}" --stdin < "${INPUT_Y4M}"
+  "${AVIFENC}" -s 8 -o "${ENCODED_FILE_REGULAR}" "${INPUT}"
+  "${AVIFENC}" -s 8 -o "${ENCODED_FILE_STDIN}" --stdin ${EXTRA_FLAGS} < "${INPUT}"
   strip_header_if "${ENCODED_FILE_REGULAR}" ${STRIP_HEADER}
   strip_header_if "${ENCODED_FILE_STDIN}" ${STRIP_HEADER}
   cmp --silent "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}"
 
-  "${AVIFENC}" -s 9 "${INPUT_Y4M}" -o "${ENCODED_FILE_REGULAR}"
-  "${AVIFENC}" -s 9 --stdin -o "${ENCODED_FILE_STDIN}" < "${INPUT_Y4M}"
+  "${AVIFENC}" -s 9 "${INPUT}" -o "${ENCODED_FILE_REGULAR}"
+  "${AVIFENC}" -s 9 --stdin -o "${ENCODED_FILE_STDIN}" ${EXTRA_FLAGS} < "${INPUT}"
   strip_header_if "${ENCODED_FILE_REGULAR}" ${STRIP_HEADER}
   strip_header_if "${ENCODED_FILE_STDIN}" ${STRIP_HEADER}
   cmp --silent "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}"
 
-  "${AVIFENC}" -s 10 "${INPUT_Y4M}" "${ENCODED_FILE_REGULAR}"
-  "${AVIFENC}" -s 10 --stdin "${ENCODED_FILE_STDIN}" < "${INPUT_Y4M}"
+  "${AVIFENC}" -s 10 "${INPUT}" "${ENCODED_FILE_REGULAR}"
+  "${AVIFENC}" -s 10 --stdin "${ENCODED_FILE_STDIN}" ${EXTRA_FLAGS} < "${INPUT}"
   strip_header_if "${ENCODED_FILE_REGULAR}" ${STRIP_HEADER}
   strip_header_if "${ENCODED_FILE_STDIN}" ${STRIP_HEADER}
   cmp --silent "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}"
-  "${AVIFENC}" -s 10 "${ENCODED_FILE_STDIN}" --stdin < "${INPUT_Y4M}"
+  "${AVIFENC}" -s 10 "${ENCODED_FILE_STDIN}" --stdin ${EXTRA_FLAGS} < "${INPUT}"
   strip_header_if "${ENCODED_FILE_STDIN}" ${STRIP_HEADER}
   cmp --silent "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}"
 
-  "${AVIFENC}" -s 10 "${INPUT_Y4M}" -q 90 "${ENCODED_FILE_REGULAR}"
-  "${AVIFENC}" -s 10 --stdin -q 90 "${ENCODED_FILE_STDIN}" < "${INPUT_Y4M}"
+  "${AVIFENC}" -s 10 "${INPUT}" -q 90 "${ENCODED_FILE_REGULAR}"
+  "${AVIFENC}" -s 10 --stdin -q 90 "${ENCODED_FILE_STDIN}" ${EXTRA_FLAGS} < "${INPUT}"
   strip_header_if "${ENCODED_FILE_REGULAR}" ${STRIP_HEADER}
   strip_header_if "${ENCODED_FILE_STDIN}" ${STRIP_HEADER}
   cmp --silent "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}"
-  "${AVIFENC}" -s 10 "${ENCODED_FILE_STDIN}" -q 90 --stdin < "${INPUT_Y4M}"
+  "${AVIFENC}" -s 10 "${ENCODED_FILE_STDIN}" -q 90 --stdin ${EXTRA_FLAGS} < "${INPUT}"
   strip_header_if "${ENCODED_FILE_STDIN}" ${STRIP_HEADER}
   cmp --silent "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}"
-  "${AVIFENC}" -s 10 --stdin "${ENCODED_FILE_STDIN}" -q 90 < "${INPUT_Y4M}"
+  "${AVIFENC}" -s 10 --stdin "${ENCODED_FILE_STDIN}" -q 90 ${EXTRA_FLAGS} < "${INPUT}"
   strip_header_if "${ENCODED_FILE_STDIN}" ${STRIP_HEADER}
   cmp --silent "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}"
 
   # Negative tests.
 
   # WARNING: Trailing options with update suffix has no effect. Place them before the input you intend to apply to.
-  "${AVIFENC}" -s 10 --stdin "${ENCODED_FILE_STDIN}" -q:u 90 < "${INPUT_Y4M}"
+  "${AVIFENC}" -s 10 --stdin "${ENCODED_FILE_STDIN}" -q:u 90 ${EXTRA_FLAGS} < "${INPUT}"
   cmp --silent "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}" && exit 1
 
   # ERROR: there cannot be any other input if --stdin is specified
   "${AVIFENC}" --stdin && exit 1
-  "${AVIFENC}" --stdin "${INPUT_Y4M}" "${ENCODED_FILE_STDIN}" && exit 1
-  "${AVIFENC}" "${INPUT_Y4M}" --stdin "${ENCODED_FILE_STDIN}" && exit 1
-  "${AVIFENC}" "${INPUT_Y4M}" "${ENCODED_FILE_STDIN}" --stdin && exit 1
+  "${AVIFENC}" --stdin "${INPUT}" "${ENCODED_FILE_STDIN}" && exit 1
+  "${AVIFENC}" "${INPUT}" --stdin "${ENCODED_FILE_STDIN}" && exit 1
+  "${AVIFENC}" "${INPUT}" "${ENCODED_FILE_STDIN}" --stdin && exit 1
 
   return 0
 }
 
 pushd ${TMP_DIR}
   test_stdin "${INPUT_Y4M_STILL}" false
+  test_stdin "${INPUT_PNG}" false --stdin-format png
+  test_stdin "${INPUT_JPEG}" false --stdin-format jpeg
 
   # The output of avifenc for animations is not deterministic because of boxes
   # such as mvhd and its field creation_time. Strip the whole header to compare


### PR DESCRIPTION
When transcoding jpegs with a gain map, the gain map is ignored and a warning is printed.

#2676