### PR TITLE
read: Fix some return values

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -3390,7 +3390,7 @@ static avifResult avifParseMetaBox(avifMeta * meta, uint64_t rawOffset, const ui
                 //   The handler type for the MetaBox shall be 'pict'.
                 if (memcmp(handlerType, "pict", 4) != 0) {
                     avifDiagnosticsPrintf(diag, "Box[hdlr] handler_type is not 'pict'");
-                    return AVIF_FALSE;
+                    return AVIF_RESULT_BMFF_PARSE_FAILED;
                 }
                 firstBox = AVIF_FALSE;
             } else {
@@ -3958,7 +3958,7 @@ static avifResult avifParseMovieBox(avifDecoderData * data,
                 !memcmp(track->handlerType, "auxv", 4)) {
                 if ((track->width == 0) || (track->height == 0)) {
                     avifDiagnosticsPrintf(data->diag, "Track ID [%u] has an invalid size [%ux%u]", track->id, track->width, track->height);
-                    return AVIF_FALSE;
+                    return AVIF_RESULT_BMFF_PARSE_FAILED;
                 }
                 if (avifDimensionsTooLarge(track->width, track->height, imageSizeLimit, imageDimensionLimit)) {
                     avifDiagnosticsPrintf(data->diag,
@@ -3966,7 +3966,7 @@ static avifResult avifParseMovieBox(avifDecoderData * data,
                                           track->id,
                                           track->width,
                                           track->height);
-                    return AVIF_FALSE;
+                    return AVIF_RESULT_BMFF_PARSE_FAILED;
                 }
             }
         }


### PR DESCRIPTION
`AVIF_FALSE` is being returned from some functions which return
`avifResult`. `AVIF_FALSE` is `0` which translates to
`AVIF_RESULT_OK` when (accidentally) converted to `avifResult`
which is incorrect.

I think this was a copy-paste error from functions which were
previously returning `avifBool`.
