### PR TITLE
Update libyuv.cmd: dc47c71b3 (1907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Forbid encoding with AVIF_MATRIX_COEFFICIENTS_IDENTITY and
   AVIF_PIXEL_FORMAT_YUV400 to be AV1 spec compatible.
 * Ignore tmap items not present in `grpl` box
+* Update libyuv.cmd: dc47c71b3 (1907)
 
 ## [1.2.1] - 2025-03-17
 

--- a/cmake/Modules/LocalLibyuv.cmake
+++ b/cmake/Modules/LocalLibyuv.cmake
@@ -1,4 +1,4 @@
-set(AVIF_LIBYUV_TAG "ccdf870348764e4b77fa3b56accb2a896a901bad")
+set(AVIF_LIBYUV_TAG "dc47c71b3ec6900ca336e712b2217ffe0c9e5a27")
 
 set(AVIF_LIBYUV_BUILD_DIR "${AVIF_SOURCE_DIR}/ext/libyuv/build")
 # If ${ANDROID_ABI} is set, look for the library under that subdirectory.

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -17,7 +17,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout ccdf87034
+git checkout dc47c71b3
 
 : # TODO: https://libyuv.issues.chromium.org/issues/399856238 - Remove when fixed upstream
 git apply --ignore-whitespace ../libyuv.patch


### PR DESCRIPTION
Pick up the build fix "Bump cmake_minimum_required version to 3.5": https://chromium-review.googlesource.com/c/libyuv/libyuv/+/6416369