### PR TITLE
Add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 for CMake 4

### DIFF
--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -41,8 +41,11 @@ jobs:
           libyuv: "LOCAL"
 
       - name: Prepare libavif (cmake)
+        # CMake 4.0.0 removed compatibility with CMake < 3.5. Add
+        # -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
         run: >
           cmake -G Ninja -S . -B build
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
           -DAVIF_CODEC_AVM=LOCAL
           -DAVIF_CODEC_DAV1D=${{ matrix.also-enable-av1-codecs }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -57,8 +57,11 @@ jobs:
           CXX: clang-cl
 
       - name: Prepare libavif (cmake)
+        # CMake 4.0.0 removed compatibility with CMake < 3.5. Add
+        # -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
         run: >
           cmake -G Ninja -S . -B build
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
           -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
           -DAVIF_CODEC_RAV1E=LOCAL -DAVIF_CODEC_SVT=LOCAL


### PR DESCRIPTION
If a dependency such as libpng has a cmake_minimum_required < 3.5, we get an error message like the following from CMake 4.0.0:

  CMake Error at [...]/CMakeLists.txt:33 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

Add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to the CI workflow files that had this error.

Fix https://github.com/AOMediaCodec/libavif/issues/2724.