### PR TITLE
zlibpng.cmd: zlib 5a82f71 and libpng 1.6.47

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -57,11 +57,8 @@ jobs:
           CXX: clang-cl
 
       - name: Prepare libavif (cmake)
-        # CMake 4.0.0 removed compatibility with CMake < 3.5. Add
-        # -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
         run: >
           cmake -G Ninja -S . -B build
-          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
           -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
           -DAVIF_CODEC_RAV1E=LOCAL -DAVIF_CODEC_SVT=LOCAL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Update libsharpyuv: v1.5.0
 * Update libxml2.cmd/LocalLibXml2.cmake: v2.14.0
 * Update libyuv.cmd: dc47c71b3 (1907)
+* Update zlibpng.cmd: zlib 5a82f71 and libpng 1.6.47
 * Fix wrong Exif orientation set in JPEG or PNG output by avifdec when the input
   AVIF file has an ImageRotation property with angle set to 1 or 3, has no
   ImageMirror property, and carries an Exif chunk. Note that Exif orientation is

--- a/cmake/Modules/LocalZlibpng.cmake
+++ b/cmake/Modules/LocalZlibpng.cmake
@@ -1,7 +1,6 @@
-# To upgrade libpng to > v1.6.40, you need zlib containing f1f503da85d52e56aae11557b4d79a42bcaa2b86
-# hence a version > v1.3.1 .
-set(AVIF_ZLIB_GIT_TAG v1.3.1)
-set(AVIF_LIBPNG_GIT_TAG v1.6.40)
+# When a zlib version > v1.3.1 is released, set AVIF_ZLIB_GIT_TAG to a release tag.
+set(AVIF_ZLIB_GIT_TAG 5a82f71ed1dfc0bec044d9702463dbdf84ea3b71)
+set(AVIF_LIBPNG_GIT_TAG v1.6.47)
 
 if(EXISTS "${AVIF_SOURCE_DIR}/ext/zlib")
     message(STATUS "libavif(AVIF_ZLIBPNG=LOCAL): ext/zlib found; using as FetchContent SOURCE_DIR")
@@ -31,30 +30,16 @@ FetchContent_Declare(
 # cmake policy CMP0102 in cmake 3.17. Remove the CACHE workaround when we require cmake 3.17 or later. See
 # https://gitlab.kitware.com/cmake/cmake/-/issues/21343.
 set(ZLIB_INCLUDE_DIR "${ZLIB_SOURCE_DIR}" CACHE PATH "zlib include dir")
-set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "")
-# This include_directories() call must be before add_subdirectory(ext/zlib) to work around the
-# zlib/CMakeLists.txt bug fixed by https://github.com/madler/zlib/pull/818.
-include_directories(SYSTEM $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIR}>)
+set(ZLIB_BUILD_TESTING OFF CACHE BOOL "")
+set(ZLIB_BUILD_SHARED OFF CACHE BOOL "")
 
 if(NOT zlib_POPULATED)
     avif_fetchcontent_populate_cmake(zlib)
 endif()
 
-target_include_directories(zlibstatic INTERFACE $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIR}>)
-
-# This include_directories() call and the previous include_directories() call provide the zlib
-# include directories for add_subdirectory(ext/libpng). Because we set PNG_BUILD_ZLIB,
-# libpng/CMakeLists.txt won't call find_package(ZLIB REQUIRED) and will see an empty
-# ${ZLIB_INCLUDE_DIR}.
-include_directories("${zlib_BINARY_DIR}")
 set(CMAKE_DEBUG_POSTFIX "")
 
 add_library(ZLIB::ZLIB ALIAS zlibstatic)
-
-# TODO Uncomment for zlib > v1.3
-# install(TARGETS zlib zlibstatic EXPORT zlib)
-# install(EXPORT zlib
-#         DESTINATION ${CMAKE_INSTALL_LIBDIR}/zlib)
 
 message(CHECK_PASS "complete")
 
@@ -69,10 +54,11 @@ endif()
 # This is the only way I could avoid libpng going crazy if it found awk.exe, seems benign otherwise
 set(PREV_ANDROID ${ANDROID})
 set(ANDROID TRUE)
-set(PNG_BUILD_ZLIB "${zlib_SOURCE_DIR}" CACHE STRING "" FORCE)
+set(ZLIB_LIBRARY zlibstatic)
+set(ZLIB_ROOT "${zlib_SOURCE_DIR}" CACHE STRING "" FORCE)
 set(PNG_SHARED OFF CACHE BOOL "")
 set(PNG_TESTS OFF CACHE BOOL "")
-set(PNG_EXECUTABLES OFF CACHE BOOL "")
+set(PNG_TOOLS OFF CACHE BOOL "")
 
 set(LIBPNG_BINARY_DIR "${FETCHCONTENT_BASE_DIR}/libpng")
 if(ANDROID_ABI)

--- a/ext/zlibpng.cmd
+++ b/ext/zlibpng.cmd
@@ -4,5 +4,9 @@
 
 : # The odd choice of comment style in this file is to try to share this script between *nix and win32.
 
-git clone -b v1.3.1 --depth 1 https://github.com/madler/zlib.git
-git clone -b v1.6.40 --depth 1 https://github.com/glennrp/libpng.git
+git clone --single-branch https://github.com/madler/zlib.git
+cd zlib
+git checkout 5a82f71
+cd ..
+
+git clone -b v1.6.47 --depth 1 https://github.com/glennrp/libpng.git


### PR DESCRIPTION
ZLIB_BUILD_EXAMPLES has apparently been renamed ZLIB_BUILD_TESTING.

PNG_BUILD_ZLIB is deprecated. Use ZLIB_ROOT instead.

Revert the -DCMAKE_POLICY_VERSION_MINIMUM=3.5 workaround in .github/workflows/ci-windows.yml because the CMakeLists.txt in libpng v1.6.47 passes version 3.14 to cmake_minimum_required().