### PR TITLE
Add a warning to catch 0 to pointer conversion.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
     message(STATUS "libavif: Enabling warnings for Clang")
     target_compile_options(
         avif_enable_warnings INTERFACE -Wall -Wextra -Wgnu-empty-initializer -Wshorten-64-to-32 -Wstrict-prototypes
+                                       -Wzero-as-null-pointer-constant
     )
 elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
     message(STATUS "libavif: Enabling warnings for GCC")

--- a/apps/avifgainmaputil/extractgainmap_command.cc
+++ b/apps/avifgainmaputil/extractgainmap_command.cc
@@ -18,7 +18,7 @@ ExtractGainMapCommand::ExtractGainMapCommand()
 
 avifResult ExtractGainMapCommand::Run() {
   DecoderPtr decoder(avifDecoderCreate());
-  if (decoder == NULL) {
+  if (decoder == nullptr) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
   decoder->imageContentToDecode = AVIF_IMAGE_CONTENT_GAIN_MAP;

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -98,7 +98,7 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
     return AVIF_RESULT_INVALID_ARGUMENT;
   } else if (input_format == AVIF_APP_FILE_FORMAT_AVIF) {
     DecoderPtr decoder(avifDecoderCreate());
-    if (decoder == NULL) {
+    if (decoder == nullptr) {
       return AVIF_RESULT_OUT_OF_MEMORY;
     }
     avifResult result = ReadAvif(decoder.get(), input_filename, ignore_profile);
@@ -106,7 +106,7 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
       return result;
     }
     if (decoder->image->imageOwnsYUVPlanes &&
-        (decoder->image->alphaPlane == NULL ||
+        (decoder->image->alphaPlane == nullptr ||
          decoder->image->imageOwnsAlphaPlane)) {
       std::swap(*image, *decoder->image);
     } else {

--- a/apps/avifgainmaputil/printmetadata_command.cc
+++ b/apps/avifgainmaputil/printmetadata_command.cc
@@ -38,7 +38,7 @@ PrintMetadataCommand::PrintMetadataCommand()
 
 avifResult PrintMetadataCommand::Run() {
   DecoderPtr decoder(avifDecoderCreate());
-  if (decoder == NULL) {
+  if (decoder == nullptr) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
 

--- a/apps/avifgainmaputil/swapbase_command.cc
+++ b/apps/avifgainmaputil/swapbase_command.cc
@@ -128,7 +128,7 @@ SwapBaseCommand::SwapBaseCommand()
 
 avifResult SwapBaseCommand::Run() {
   DecoderPtr decoder(avifDecoderCreate());
-  if (decoder == NULL) {
+  if (decoder == nullptr) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
   decoder->imageContentToDecode |= AVIF_IMAGE_CONTENT_GAIN_MAP;

--- a/apps/avifgainmaputil/tonemap_command.cc
+++ b/apps/avifgainmaputil/tonemap_command.cc
@@ -68,7 +68,7 @@ avifResult TonemapCommand::Run() {
   const bool tone_mapping_to_hdr = (headroom > 0.0f);
 
   DecoderPtr decoder(avifDecoderCreate());
-  if (decoder == NULL) {
+  if (decoder == nullptr) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
   decoder->imageContentToDecode |= AVIF_IMAGE_CONTENT_GAIN_MAP;


### PR DESCRIPTION
This could help finding some weird casts (like bool to ptr).
This is a split of https://github.com/AOMediaCodec/libavif/pull/2734