### PR TITLE
Allow lowercase GUID when parsing extended XMP in JPEG files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The changes are relative to the previous release, unless the baseline is specifi
   AVIF file has an ImageRotation property with angle set to 1 or 3, has no
   ImageMirror property, and carries an Exif chunk. Note that Exif orientation is
   usually ignored in PNG files, so this mainly impacts JPEG files.
+* Allow lowercase GUIDs in XMP when reading JPEG files.
 
 ## [1.2.1] - 2025-03-17
 

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -1074,8 +1074,7 @@ static avifBool avifJPEGReadInternal(FILE * f,
                     // According to Adobe XMP Specification Part 3 section 1.1.3.1:
                     //   "128-bit GUID stored as a 32-byte ASCII hex string, capital A-F, no null termination"
                     // Also allow lowercase since some cameras use lowercase. https://github.com/AOMediaCodec/libavif/issues/2755
-                    if (((guid[c] < '0') || (guid[c] > '9')) && ((guid[c] < 'A') || (guid[c] > 'F')) &&
-                        ((guid[c] < 'a') || (guid[c] > 'f'))) {
+                    if (!isxdigit(guid[c])) {
                         fprintf(stderr, "XMP extraction failed: invalid XMP segment GUID\n");
                         goto cleanup;
                     }

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -1073,7 +1073,9 @@ static avifBool avifJPEGReadInternal(FILE * f,
                 for (size_t c = 0; c < AVIF_JPEG_EXTENDED_XMP_GUID_LENGTH; ++c) {
                     // According to Adobe XMP Specification Part 3 section 1.1.3.1:
                     //   "128-bit GUID stored as a 32-byte ASCII hex string, capital A-F, no null termination"
-                    if (((guid[c] < '0') || (guid[c] > '9')) && ((guid[c] < 'A') || (guid[c] > 'F'))) {
+                    // Also allow lowercase since some cameras use lowercase. https://github.com/AOMediaCodec/libavif/issues/2755
+                    if (((guid[c] < '0') || (guid[c] > '9')) && ((guid[c] < 'A') || (guid[c] > 'F')) &&
+                        ((guid[c] < 'a') || (guid[c] > 'f'))) {
                         fprintf(stderr, "XMP extraction failed: invalid XMP segment GUID\n");
                         goto cleanup;
                     }


### PR DESCRIPTION
#2755