### PR TITLE
Fix broken anchor by removing duplicate {#build-command-lines}

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ the `avif_coverage` target, e.g. `make avif_coverage -j`. It requires
 compiling with clang (`-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`)
 and LLVM must be installed on the system.
 
-### Build Command Lines {#build-command-lines}
+### Build Command Lines
 
 The following instructions can be used to build the libavif library and the
 `avifenc` and `avifdec` tools.


### PR DESCRIPTION
GitHub auto-generates an anchor ID from the heading text. The manual {#build-command-lines} anchor causes the final anchor to be `#build-command-lines-build-command-lines`, which makes the link in 
> See [Build Command Lines](#build-command-lines) below for example command lines. 

doesn't work.