### PR TITLE
Add integer overflow checks to makeRoom.

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -335,6 +335,9 @@ avifBool avifROStreamReadAndEnforceVersion(avifROStream * stream, uint8_t enforc
 static avifResult makeRoom(avifRWStream * stream, size_t size)
 {
     size_t neededSize = stream->offset + size;
+    if (neededSize < stream->offset) {
+        return AVIF_RESULT_INVALID_ARGUMENT;
+    }
     size_t newSize = stream->raw->size;
     while (newSize < neededSize) {
         newSize += AVIF_STREAM_BUFFER_INCREMENT;


### PR DESCRIPTION
In the function `makeRoom`, when `stream->offset` or `size` is very large, the calculation `stream->offset + size` may cause an integer overflow, resulting in an abnormally small `neededSize`.

This can lead to an incorrect `newSize` and insufficient buffer allocation, which may subsequently cause a buffer overflow during the memcpy operation.

This commit add a integer overflow check to prevent such issues.