### PR TITLE
Fix improper handling of negative ftell

### DIFF
--- a/examples/avif_example_decode_memory.c
+++ b/examples/avif_example_decode_memory.c
@@ -39,6 +39,7 @@ int main(int argc, char * argv[])
     long fileSize = ftell(f);
     if (fileSize < 0) {
         fprintf(stderr, "Truncated file: %s\n", inputFilename);
+        goto cleanup;
     }
     fseek(f, 0, SEEK_SET);
     fileBuffer = malloc(fileSize);


### PR DESCRIPTION
In the file processing section of the main function:

```c
fseek(f, 0, SEEK_END);  
long fileSize = ftell(f);  
if (fileSize < 0) {  
    fprintf(stderr, "Truncated file: %s\n", inputFilename);  
}  
fseek(f, 0, SEEK_SET);  
fileBuffer = malloc(fileSize);  
long bytesRead = (long)fread(fileBuffer, 1, fileSize, f);
```

When fileSize < 0, the program only prints an error message but doesn't interrupt the execution flow, continuing with subsequent operations:

1. malloc(fileSize) is called with fileSize being negative
2. Since malloc accepts parameters of type size_t (unsigned integer), negative numbers will be interpreted as very large unsigned values
3. This results in attempting to allocate an enormous memory block, potentially causing memory allocation errors or successfully allocating excessive memory
Even if malloc returns successfully, the subsequent fread(fileBuffer, 1, fileSize, f) will attempt to read a negative number of bytes, which is undefined behavior.

```sh
abc@abc-virtual-machine:~/test$ gcc -fsanitize=address -g -fno-omit-frame-pointer     /home/abc/test/libavif/examples/avif_example_decode_memory.c   -I/home/abc/test/libavif/include     -L/home/abc/test/libavif/build -lavif     -o avif_example_decode_memory
abc@abc-virtual-machine:~/test$ ./avif_example_decode_memory /proc/self/fd/0
Truncated file: /proc/self/fd/0
=================================================================
==126054==ERROR: AddressSanitizer: requested allocation size 0xffffffffffffffff (0x800 after adjustments for alignment, red zones etc.) exceeds maximum supported size of 0x10000000000 (thread T0)
    #0 0x753b366b4887 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x564aac4ac7f7 in main /home/abc/test/libavif/examples/avif_example_decode_memory.c:44
    #2 0x753b36229d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

==126054==HINT: if you don't care about these errors you may set allocator_may_return_null=1
SUMMARY: AddressSanitizer: allocation-size-too-big ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145 in __interceptor_malloc
==126054==ABORTING
```