### PR TITLE
Add another integer overflow check to makeRoom

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -334,17 +334,16 @@ avifBool avifROStreamReadAndEnforceVersion(avifROStream * stream, uint8_t enforc
 #define AVIF_STREAM_BUFFER_INCREMENT (1024 * 1024)
 static avifResult makeRoom(avifRWStream * stream, size_t size)
 {
-    if (size > SIZE_MAX - stream->offset) {
-        return AVIF_RESULT_OUT_OF_MEMORY;
+    AVIF_CHECKERR(size <= SIZE_MAX - stream->offset, AVIF_RESULT_OUT_OF_MEMORY);
+    size_t newSize = stream->offset + size;
+    if (newSize <= stream->raw->size) {
+        return AVIF_RESULT_OK;
     }
-    size_t neededSize = stream->offset + size;
-    size_t newSize = stream->raw->size;
-    while (newSize < neededSize) {
-        if (newSize > SIZE_MAX - AVIF_STREAM_BUFFER_INCREMENT) {
-            return AVIF_RESULT_OUT_OF_MEMORY;
-        }
-        newSize += AVIF_STREAM_BUFFER_INCREMENT;
-    }
+    // Make newSize a multiple of AVIF_STREAM_BUFFER_INCREMENT.
+    size_t rem = newSize % AVIF_STREAM_BUFFER_INCREMENT;
+    size_t padding = (rem == 0) ? 0 : AVIF_STREAM_BUFFER_INCREMENT - rem;
+    AVIF_CHECKERR(newSize <= SIZE_MAX - padding, AVIF_RESULT_OUT_OF_MEMORY);
+    newSize += padding;
     return avifRWDataRealloc(stream->raw, newSize);
 }
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -340,6 +340,9 @@ static avifResult makeRoom(avifRWStream * stream, size_t size)
     size_t neededSize = stream->offset + size;
     size_t newSize = stream->raw->size;
     while (newSize < neededSize) {
+        if (newSize > SIZE_MAX - AVIF_STREAM_BUFFER_INCREMENT) {
+            return AVIF_RESULT_OUT_OF_MEMORY;
+        }
         newSize += AVIF_STREAM_BUFFER_INCREMENT;
     }
     return avifRWDataRealloc(stream->raw, newSize);

--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -202,6 +202,22 @@ TEST(StreamTest, WriteBitsLimit) {
             AVIF_RESULT_INVALID_ARGUMENT);
 }
 
+// Test the overflow checks in the makeRoom() function in src/stream.c.
+TEST(StreamTest, OverflowChecksInMakeRoom) {
+  testutil::AvifRwData rw_data;
+  avifRWStream rw_stream;
+  avifRWStreamStart(&rw_stream, &rw_data);
+  const char ten_bytes[10] = {0};
+  EXPECT_EQ(avifRWStreamWrite(&rw_stream, ten_bytes, 10), AVIF_RESULT_OK);
+  EXPECT_EQ(avifRWStreamWrite(&rw_stream, ten_bytes, SIZE_MAX - 9),
+            AVIF_RESULT_OUT_OF_MEMORY);
+  // The next test takes a very long time if size_t is 64 bits.
+#if SIZE_MAX == UINT32_MAX
+  EXPECT_EQ(avifRWStreamWrite(&rw_stream, ten_bytes, SIZE_MAX - 10),
+            AVIF_RESULT_OUT_OF_MEMORY);
+#endif
+}
+
 //------------------------------------------------------------------------------
 
 }  // namespace

--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -211,11 +211,8 @@ TEST(StreamTest, OverflowChecksInMakeRoom) {
   EXPECT_EQ(avifRWStreamWrite(&rw_stream, ten_bytes, 10), AVIF_RESULT_OK);
   EXPECT_EQ(avifRWStreamWrite(&rw_stream, ten_bytes, SIZE_MAX - 9),
             AVIF_RESULT_OUT_OF_MEMORY);
-  // The next test takes a very long time if size_t is 64 bits.
-#if SIZE_MAX == UINT32_MAX
   EXPECT_EQ(avifRWStreamWrite(&rw_stream, ten_bytes, SIZE_MAX - 10),
             AVIF_RESULT_OUT_OF_MEMORY);
-#endif
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Test the previous integer overflow check in makeRoom.

See https://github.com/AOMediaCodec/libavif/pull/2768.