### PR TITLE
Add an extra cache key for ci-windows

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -46,6 +46,7 @@ jobs:
           codec-aom: "LOCAL"
           codec-dav1d: "LOCAL"
           codec-rav1e: "LOCAL"
+          extra-cache-key: ${{ matrix.generator }}
 
       - name: Build libyuv
         if: steps.setup.outputs.ext-cache-hit != 'true'


### PR DESCRIPTION
Otherwise the two generators use the same cache