### PR TITLE
Parse the gain map version before parsing the gain map item.

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -808,6 +808,9 @@ uint8_t avifCodecConfigurationBoxGetSubsamplingType(const avifCodecConfiguration
 // ---------------------------------------------------------------------------
 // gain maps
 
+// Initializes avifGainMap to default values.
+void avifGainMapSetDefaults(avifGainMap * gainMap);
+
 // Finds the approximate min/max values from the given gain map values, excluding outliers.
 // Uses a histogram, with outliers defined as having at least one empty bucket between them
 // and the rest of the distribution. Discards at most 0.1% of values.

--- a/src/avif.c
+++ b/src/avif.c
@@ -1310,6 +1310,12 @@ avifGainMap * avifGainMapCreate(void)
     if (!gainMap) {
         return NULL;
     }
+    avifGainMapSetDefaults(gainMap);
+    return gainMap;
+}
+
+void avifGainMapSetDefaults(avifGainMap * gainMap)
+{
     memset(gainMap, 0, sizeof(avifGainMap));
     gainMap->altColorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
     gainMap->altTransferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
@@ -1327,7 +1333,6 @@ avifGainMap * avifGainMapCreate(void)
     }
     gainMap->baseHdrHeadroom.d = 1;
     gainMap->alternateHdrHeadroom.d = 1;
-    return gainMap;
 }
 
 void avifGainMapDestroy(avifGainMap * gainMap)

--- a/src/avif.c
+++ b/src/avif.c
@@ -1311,6 +1311,11 @@ avifGainMap * avifGainMapCreate(void)
         return NULL;
     }
     avifGainMapSetDefaults(gainMap);
+    // Note that some functions like avifDecoderFindGainMapItem() allocate avifGainMap direclty on
+    // the stack instead of calling avifGainMapCreate() to simplify error handling. This works under
+    // the assumtion that no complex initialization (such as dynamic allocation of fields) takes
+    // place here. If this function becomes more complex than one alloc + setDefaults, such code
+    // might need to be changed.
     return gainMap;
 }
 

--- a/src/avif.c
+++ b/src/avif.c
@@ -1311,9 +1311,9 @@ avifGainMap * avifGainMapCreate(void)
         return NULL;
     }
     avifGainMapSetDefaults(gainMap);
-    // Note that some functions like avifDecoderFindGainMapItem() allocate avifGainMap direclty on
+    // Note that some functions like avifDecoderFindGainMapItem() allocate avifGainMap directly on
     // the stack instead of calling avifGainMapCreate() to simplify error handling. This works under
-    // the assumtion that no complex initialization (such as dynamic allocation of fields) takes
+    // the assumption that no complex initialization (such as dynamic allocation of fields) takes
     // place here. If this function becomes more complex than one alloc + setDefaults, such code
     // might need to be changed.
     return gainMap;

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -7,7 +7,7 @@
 #include <math.h>
 #include <string.h>
 
-static void avifGainMapSetDefaults(avifGainMap * gainMap)
+static void avifGainMapSetEncodingDefaults(avifGainMap * gainMap)
 {
     for (int i = 0; i < 3; ++i) {
         gainMap->gainMapMin[i] = (avifSignedFraction) { 1, 1 };
@@ -569,7 +569,7 @@ avifResult avifRGBImageComputeGainMap(const avifRGBImage * baseRgbImage,
         }
     }
 
-    avifGainMapSetDefaults(gainMap);
+    avifGainMapSetEncodingDefaults(gainMap);
     gainMap->useBaseColorSpace = (gainMapMathPrimaries == baseColorPrimaries);
 
     float (*baseGammaToLinear)(float) = avifTransferCharacteristicsGetGammaToLinearFunction(baseTransferCharacteristics);

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -67,6 +67,8 @@ ImagePtr CreateTestImageWithGainMap(bool base_rendition_is_hdr) {
   if (image == nullptr) {
     return nullptr;
   }
+  image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT2020;
+  image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
   image->transferCharacteristics =
       (avifTransferCharacteristics)(base_rendition_is_hdr
                                         ? AVIF_TRANSFER_CHARACTERISTICS_PQ
@@ -78,6 +80,9 @@ ImagePtr CreateTestImageWithGainMap(bool base_rendition_is_hdr) {
   if (gain_map == nullptr) {
     return nullptr;
   }
+  gain_map->colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
+  gain_map->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT709;
+  gain_map->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
   testutil::FillImageGradient(gain_map.get());
   image->gainMap = avifGainMapCreate();
   if (image->gainMap == nullptr) {
@@ -152,6 +157,13 @@ TEST(GainMapTest, EncodeDecodeBaseImageSdr) {
   EXPECT_EQ(decoded->gainMap->image->width, image->gainMap->image->width);
   EXPECT_EQ(decoded->gainMap->image->height, image->gainMap->image->height);
   EXPECT_EQ(decoded->gainMap->image->depth, image->gainMap->image->depth);
+  EXPECT_EQ(decoded->gainMap->image->colorPrimaries,
+            image->gainMap->image->colorPrimaries);
+  EXPECT_EQ(decoded->gainMap->image->transferCharacteristics,
+            image->gainMap->image->transferCharacteristics);
+  EXPECT_EQ(decoded->gainMap->image->matrixCoefficients,
+            image->gainMap->image->matrixCoefficients);
+  EXPECT_EQ(decoded->gainMap->image->yuvRange, image->gainMap->image->yuvRange);
   CheckGainMapMetadataMatches(*decoded->gainMap, *image->gainMap);
 
   // Decode the image.


### PR DESCRIPTION
Also ignore the gain map if it points to an unsupported item.

These changes make sure unsupported gain maps are ignored instead of causing errors.