### PR TITLE
Allow version > 1 in iinf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Set avifDecoder::image->depth to the same value after avifDecoderParse() as
   after avifDecoderNextImage() when AVIF_ENABLE_EXPERIMENTAL_SAMPLE_TRANSFORM is
   enabled and when the file to decode contains a 'sato' derived image item.
+* Allow version > 1 in iinf.
 
 ## [1.3.0] - 2025-05-09
 

--- a/src/read.c
+++ b/src/read.c
@@ -3229,11 +3229,8 @@ static avifResult avifParseItemInfoBox(avifMeta * meta, const uint8_t * raw, siz
         uint16_t tmp;
         AVIF_CHECKERR(avifROStreamReadU16(&s, &tmp), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(16) entry_count;
         entryCount = tmp;
-    } else if (version == 1) {
-        AVIF_CHECKERR(avifROStreamReadU32(&s, &entryCount), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) entry_count;
     } else {
-        avifDiagnosticsPrintf(diag, "Box[iinf] has an unsupported version %u", version);
-        return AVIF_RESULT_BMFF_PARSE_FAILED;
+        AVIF_CHECKERR(avifROStreamReadU32(&s, &entryCount), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(32) entry_count;
     }
 
     for (uint32_t entryIndex = 0; entryIndex < entryCount; ++entryIndex) {


### PR DESCRIPTION
ISO/IEC 14496-12:2022 Clause 8.11.6.2 says:

  aligned(8) class ItemInfoBox
        extends FullBox('iinf', version, 0) {
     if (version == 0) {
        unsigned int(16) entry_count;
     } else {
        unsigned int(32) entry_count;
     }
     ItemInfoEntry[ entry_count ] item_infos;
  }

Do not reject version > 1 in iinf as an error. This will allow version 2 to be added in the future.