### PR TITLE
avifavmtest:Lower PSNR threshold from 39.0 to 38.1

### DIFF
--- a/tests/gtest/avifavmtest.cc
+++ b/tests/gtest/avifavmtest.cc
@@ -44,7 +44,7 @@ TEST_P(AvmTest, EncodeDecode) {
             AVIF_RESULT_OK);
 
   // Verify that the input and decoded images are close.
-  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 39.0);
+  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 38.1);
 
   // Forcing an AV1 decoding codec should fail.
   for (avifCodecChoice av1_codec :


### PR DESCRIPTION
The lower PSNR was introduced in one of the AVM commits from https://gitlab.com/AOMediaCodec/avm/-/commit/45332a6c to https://gitlab.com/AOMediaCodec/avm/-/commit/d57c1e27, inclusive. I could not track down the commit because avifavmtest started to crash in tflite in https://gitlab.com/AOMediaCodec/avm/-/commit/6191f463 and the crash was not fixed until
https://gitlab.com/AOMediaCodec/avm/-/commit/d57c1e27.

Bug: b:421144885