### PR TITLE
avifavmtest:Lower PSNR threshold from 38.1 to 36.6

### DIFF
--- a/tests/gtest/avifavmminitest.cc
+++ b/tests/gtest/avifavmminitest.cc
@@ -45,7 +45,7 @@ TEST_P(AvmMiniTest, EncodeDecode) {
             AVIF_RESULT_OK);
 
   // Verify that the input and decoded images are close.
-  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 40.0);
+  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 36.6);
 
   // Forcing an AV1 decoding codec should fail.
   for (avifCodecChoice av1_codec :

--- a/tests/gtest/avifavmtest.cc
+++ b/tests/gtest/avifavmtest.cc
@@ -44,7 +44,7 @@ TEST_P(AvmTest, EncodeDecode) {
             AVIF_RESULT_OK);
 
   // Verify that the input and decoded images are close.
-  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 38.1);
+  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 36.6);
 
   // Forcing an AV1 decoding codec should fail.
   for (avifCodecChoice av1_codec :


### PR DESCRIPTION
https://github.com/AOMediaCodec/libavif/pull/2813 did not lower the PSNR threshold low enough for the way AVM is configured in Google's internal repository. Also lower the PSNR threshold in avifavmminitest.

Bug: b:421144885