### PR TITLE
avifavmtest.cc: Increase width to 5 in HBD test

### DIFF
--- a/tests/gtest/avifavmtest.cc
+++ b/tests/gtest/avifavmtest.cc
@@ -75,8 +75,12 @@ INSTANTIATE_TEST_SUITE_P(Tiny, AvmTest,
                                  Values(AVIF_PIXEL_FORMAT_YUV444),
                                  /*alpha=*/Values(false)));
 
+// The width in this test was originally 2 and that detected
+// https://gitlab.com/AOMediaCodec/avm/-/issues/717. 5 is the smallest width
+// that allows this test to pass. To reproduce the bug, decrease width to 4, 3,
+// or 2.
 INSTANTIATE_TEST_SUITE_P(HighBitDepthAndEvenDimensions, AvmTest,
-                         Combine(/*width=*/Values(2), /*height=*/Values(34),
+                         Combine(/*width=*/Values(5), /*height=*/Values(34),
                                  /*depth=*/Values(10, 12),
                                  Values(AVIF_PIXEL_FORMAT_YUV400,
                                         AVIF_PIXEL_FORMAT_YUV420,


### PR DESCRIPTION
In the HighBitDepthAndEvenDimensions test, increase the width to 5 to avoid https://gitlab.com/AOMediaCodec/avm/-/issues/717.