### PR TITLE
avifenc.c Use better formula in quantizerToQuality

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -1424,7 +1424,8 @@ static void avifInputAdd(avifInput * input, const char * filePath, uint64_t dura
 static int quantizerToQuality(int minQuantizer, int maxQuantizer)
 {
     const int quantizer = (minQuantizer + maxQuantizer) / 2;
-    return (int)(100 - (100 * quantizer - 50) / 63.0);
+    const int quality = ((63 - quantizer) * 100 + 31) / 63;
+    return quality;
 }
 
 int main(int argc, char * argv[])


### PR DESCRIPTION
The original formula was apparently derived by inverting the quality-to-quantizer conversion formula in src/write.c. That derivation is not ideal because it included the `+ 50` rounding term. It is better to omit the `+ 50` rounding term, invert the formula, and then add a `+ 31` rounding term.

The new formula is already used in avifenc.c.