### PR TITLE
Use AOM_TUNE_IQ by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Update rav1e.cmd/LocalRav1e.cmake: cargo-c v0.10.13, corrosion v0.5.2,
   rav1e v0.8.0
 * Fix grayscale conversion when changing the bit depth.
+* Use AOM_TUNE_IQ by default when possible.
 
 ### Removed since 1.3.0
 

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -312,7 +312,7 @@ static void syntaxLong(void)
         printf("    enable-chroma-deltaq=B            : Enable delta quantization in chroma planes. 0=disable (default), 1=enable\n");
         printf("    end-usage=MODE                    : Rate control mode, one of 'vbr', 'cbr', 'cq', or 'q'\n");
         printf("    sharpness=S                       : Bias towards block sharpness in rate-distortion optimization of transform coefficients in 0..7. (Default: 0)\n");
-        printf("    tune=METRIC                       : Tune the encoder for distortion metric, one of 'psnr' or 'ssim'. (Default: psnr)\n");
+        printf("    tune=METRIC                       : Tune the encoder for distortion metric, one of 'psnr', 'ssim' or 'iq'. (Default for aom 3.12+ still images: iq, otherwise ssim)\n");
         printf("    film-grain-test=TEST              : Film grain test vectors in 0..16. 0=none (default), 1=test1, 2=test2, ... 16=test16\n");
         printf("    film-grain-table=FILENAME         : Path to file containing film grain parameters\n");
         printf("\n");

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -886,8 +886,15 @@ static avifResult aomCodecEncodeImage(avifCodec * codec,
         if (!avifProcessAOMOptionsPostInit(codec, alpha)) {
             return AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;
         }
-        if (!codec->internal->tuningSet) {
-            if (aom_codec_control(&codec->internal->encoder, AOME_SET_TUNING, AOM_TUNE_SSIM) != AOM_CODEC_OK) {
+        if (!lossless && !codec->internal->tuningSet) {
+            aom_tune_metric tuneMetric = AOM_TUNE_SSIM;
+#if defined(AOM_HAVE_TUNE_IQ)
+            // AOM_TUNE_IQ sets --deltaq-mode=6 which can only be used in all intra mode.
+            if (aomUsage == AOM_USAGE_ALL_INTRA) {
+                tuneMetric = AOM_TUNE_IQ;
+            }
+#endif
+            if (aom_codec_control(&codec->internal->encoder, AOME_SET_TUNING, tuneMetric) != AOM_CODEC_OK) {
                 return AVIF_RESULT_UNKNOWN_ERROR;
             }
         }


### PR DESCRIPTION
Based on https://github.com/AOMediaCodec/libavif/pull/2599.

Note that "(Default: psnr)" was incorrect.