### PR TITLE
Fix coverity report.

### DIFF
--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -557,7 +557,7 @@ avifBool avifPNGRead(const char * inputFilename,
                                          imageSizeLimit,
                                          outPNGDepth);
 
-    if (f && f != stdin) {
+    if (f != stdin) {
         fclose(f);
     }
     return res;


### PR DESCRIPTION
f is checked for nullness before.
https://scan9.scan.coverity.com/#/project-view/56345/15514?selectedIssue=527773