### PR TITLE
MinGW: fix error of undefined strcmp()

### DIFF
--- a/contrib/gdk-pixbuf/loader.c
+++ b/contrib/gdk-pixbuf/loader.c
@@ -4,6 +4,7 @@
 
 #include <avif/avif.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define GDK_PIXBUF_ENABLE_BACKEND
 #include <gdk-pixbuf/gdk-pixbuf-io.h>


### PR DESCRIPTION
I cross-compiled latest sources of libavif with` x86_64-w64-mingw32` but I got an error:
```
src/libavif-1.3.0/contrib/gdk-pixbuf/loader.c:366:17: error: implicit declaration of function ‘strcmp’ [-Wimplicit-function-declaration]
  366 |             if (strcmp (*kiter, "quality") == 0) {
      |                 ^~~~~~
src/libavif-1.3.0/contrib/gdk-pixbuf/loader.c:11:1: note: include ‘<string.h>’ or provide a declaration of ‘strcmp’
   10 | #include <gdk-pixbuf/gdk-pixbuf.h>
  +++ |+#include <string.h>
   11 |
ninja: build stopped: subcommand failed.
*** ERROR: cygninja: command failed: all
```
Actually, the error is correct and it happens because `strcmp()` is used instead of `g_strcmp0()`, attached patch fixes this issue.