### PR TITLE
Remove empty comments

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -3291,14 +3291,14 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     AVIF_CHECKRES(avifRWStreamWriteChars(&s, majorBrand, 4)); // unsigned int(32) major_brand;
     AVIF_CHECKRES(avifRWStreamWriteU32(&s, minorVersion));    // unsigned int(32) minor_version;
     AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avif", 4));     // unsigned int(32) compatible_brands[];
-    if (useAvioBrand) {                                       //
+    if (useAvioBrand) {
         AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avio", 4)); // ... compatible_brands[]
-    } //
-    if (isSequence) {                                         //
+    }
+    if (isSequence) {
         AVIF_CHECKRES(avifRWStreamWriteChars(&s, "avis", 4)); // ... compatible_brands[]
         AVIF_CHECKRES(avifRWStreamWriteChars(&s, "msf1", 4)); // ... compatible_brands[]
         AVIF_CHECKRES(avifRWStreamWriteChars(&s, "iso8", 4)); // ... compatible_brands[]
-    } //
+    }
     AVIF_CHECKRES(avifRWStreamWriteChars(&s, "mif1", 4));                  // ... compatible_brands[]
     AVIF_CHECKRES(avifRWStreamWriteChars(&s, "miaf", 4));                  // ... compatible_brands[]
     if ((imageMetadata->depth == 8) || (imageMetadata->depth == 10)) {     //


### PR DESCRIPTION
They were introduced by the migration to clang-format-19 in #2851.
It may be a bug but it is not worth spending time on it.