### PR TITLE
Lower PSNR threshold from 37.0 to 36.4 in AVM test

### DIFF
--- a/tests/gtest/avifavmminitest.cc
+++ b/tests/gtest/avifavmminitest.cc
@@ -45,7 +45,7 @@ TEST_P(AvmMiniTest, EncodeDecode) {
             AVIF_RESULT_OK);
 
   // Verify that the input and decoded images are close.
-  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 37.0);
+  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 36.4);
 
   // Forcing an AV1 decoding codec should fail.
   for (avifCodecChoice av1_codec :

--- a/tests/gtest/avifavmtest.cc
+++ b/tests/gtest/avifavmtest.cc
@@ -44,7 +44,7 @@ TEST_P(AvmTest, EncodeDecode) {
             AVIF_RESULT_OK);
 
   // Verify that the input and decoded images are close.
-  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 37.0);
+  EXPECT_GT(testutil::GetPsnr(*image, *decoded), 36.4);
 
   // Forcing an AV1 decoding codec should fail.
   for (avifCodecChoice av1_codec :


### PR DESCRIPTION
Lower PSNR is expected from
https://gitlab.com/AOMediaCodec/avm/-/commit/e96f4adb because the implicit QP offsets in TCQ were removed in that commit.