### PR TITLE
Fix avifcicptest.cc when building with SVT-AV1 older than v3.0.0.

### DIFF
--- a/tests/gtest/avifcicptest.cc
+++ b/tests/gtest/avifcicptest.cc
@@ -28,8 +28,9 @@ TEST_P(CicpTest, EncodeDecode) {
   const avifPlanesFlag planes = std::get<5>(GetParam());
   const avifRange range = std::get<6>(GetParam());
 
+  // At least 64x64 to support SVT-AV1 older than v3.0.0.
   ImagePtr image =
-      testutil::CreateImage(32, 32, /*depth=*/8, subsampling, planes, range);
+      testutil::CreateImage(64, 64, /*depth=*/8, subsampling, planes, range);
   ASSERT_NE(image, nullptr);
   testutil::FillImageGradient(image.get());
   image->colorPrimaries = cp;


### PR DESCRIPTION
Note that many more tests fail if SVT-AV1 older than v3.0.0 is the only encoder available. There are also tests that fail if SVT-AV1 v3.1.0 is the only encoder availble because of the lack of 444 support.

Fixes #2863