### PR TITLE
Don't declare avifImagePushProperty with AVIF_API

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -150,11 +150,11 @@ void avifImageCopyNoAlloc(avifImage * dstImage, const avifImage * srcImage);
 void avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes);
 
 // Appends an opaque image item property.
-AVIF_API avifResult avifImagePushProperty(avifImage * image,
-                                          const uint8_t boxtype[4],
-                                          const uint8_t usertype[16],
-                                          const uint8_t * boxPayload,
-                                          size_t boxPayloadSize);
+avifResult avifImagePushProperty(avifImage * image,
+                                 const uint8_t boxtype[4],
+                                 const uint8_t usertype[16],
+                                 const uint8_t * boxPayload,
+                                 size_t boxPayloadSize);
 
 // Check if the FourCC property value is a known value
 AVIF_NODISCARD avifBool avifIsKnownPropertyType(const uint8_t boxtype[4]);


### PR DESCRIPTION
avifImagePushProperty() is not a public API function. It was added with AVIF_API in https://github.com/AOMediaCodec/libavif/pull/2420 inadvertently.