### PR TITLE
Assert `sample` not null on entry to getNextImage

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -96,6 +96,8 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
                                      avifBool * isLimitedRangeAlpha,
                                      avifImage * image)
 {
+    assert(sample);
+
     if (!codec->internal->decoderInitialized) {
         aom_codec_dec_cfg_t cfg;
         memset(&cfg, 0, sizeof(aom_codec_dec_cfg_t));

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -59,6 +59,8 @@ static avifBool avmCodecGetNextImage(struct avifCodec * codec,
                                      avifBool * isLimitedRangeAlpha,
                                      avifImage * image)
 {
+    assert(sample);
+
     if (!codec->internal->decoderInitialized) {
         AVIF_CHECKRES(avifCheckCodecVersionAVM());
 


### PR DESCRIPTION
The aomCodecGetNextImage() and avmCodecGetNextImage() functions may set `sample` to NULL internally.