### PR TITLE
Document API contract of avifReadColorNclxProperty

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -5521,6 +5521,8 @@ static avifResult avifMetaFindAlphaItem(avifMeta * meta,
     return AVIF_RESULT_OK;
 }
 
+// If cicpSet is not NULL, the caller must set |*cicpSet| to AVIF_FALSE before
+// calling this function.
 // On success, this function returns AVIF_RESULT_OK and does the following:
 // * If a nclx property was found in |properties|:
 //   - Set |*colorPrimaries|, |*transferCharacteristics|, |*matrixCoefficients|
@@ -5536,6 +5538,7 @@ static avifResult avifReadColorNclxProperty(const avifPropertyArray * properties
                                             avifRange * yuvRange,
                                             avifBool * cicpSet)
 {
+    assert(cicpSet == NULL || *cicpSet == AVIF_FALSE);
     avifBool colrNCLXSeen = AVIF_FALSE;
     for (uint32_t propertyIndex = 0; propertyIndex < properties->count; ++propertyIndex) {
         avifProperty * prop = &properties->prop[propertyIndex];


### PR DESCRIPTION
Document that if cicpSet is not NULL, *cicpSet must be AVIF_FALSE on entry.

Note: This API contract isn't that obvious, and may have been the source of https://issues.oss-fuzz.com/460535483.