### PR TITLE
Update AVM to commit e3b7bd42

### DIFF
--- a/cmake/Modules/LocalAom.cmake
+++ b/cmake/Modules/LocalAom.cmake
@@ -1,5 +1,5 @@
 set(AVIF_AOM_GIT_TAG v3.13.1)
-set(AVIF_AVM_GIT_TAG research-v12.0.0)
+set(AVIF_AVM_GIT_TAG e3b7bd426c282494c07eaa3e559e461a3e96f823)
 
 if(AVIF_CODEC_AVM)
     # Building the avm repository generates files such as "libaom.a" because it is a fork of aom,
@@ -95,7 +95,7 @@ else()
             BINARY_DIR "${AOM_BINARY_DIR}"
             GIT_TAG ${AVIF_AVM_GIT_TAG}
             GIT_PROGRESS ON
-            GIT_SHALLOW ON
+            GIT_SHALLOW OFF
             UPDATE_COMMAND ""
         )
         # There can be a duplicate cpuinfo in SVT so find_package has to be used.

--- a/tests/gtest/avifavmminitest.cc
+++ b/tests/gtest/avifavmminitest.cc
@@ -70,16 +70,11 @@ INSTANTIATE_TEST_SUITE_P(Basic, AvmMiniTest,
                                         AVIF_PIXEL_FORMAT_YUV444),
                                  /*alpha=*/Values(false, true)));
 
-// TODO(wtc): Re-enable when
-// https://gitlab.com/AOMediaCodec/avm/-/merge_requests/2692 is imported into
-// Google's internal repository.
-#if 0
 INSTANTIATE_TEST_SUITE_P(Tiny, AvmMiniTest,
                          Combine(/*width=*/Values(1), /*height=*/Values(1),
                                  /*depth=*/Values(8),
                                  Values(AVIF_PIXEL_FORMAT_YUV444),
                                  /*alpha=*/Values(false)));
-#endif
 
 // TODO(yguyon): Implement or fix in avm then test the following combinations.
 INSTANTIATE_TEST_SUITE_P(DISABLED_Broken, AvmMiniTest,

--- a/tests/gtest/avifavmtest.cc
+++ b/tests/gtest/avifavmtest.cc
@@ -69,16 +69,11 @@ INSTANTIATE_TEST_SUITE_P(Basic, AvmTest,
                                         AVIF_PIXEL_FORMAT_YUV444),
                                  /*alpha=*/Values(false, true)));
 
-// TODO(wtc): Re-enable when
-// https://gitlab.com/AOMediaCodec/avm/-/merge_requests/2692 is imported into
-// Google's internal repository.
-#if 0
 INSTANTIATE_TEST_SUITE_P(Tiny, AvmTest,
                          Combine(/*width=*/Values(1), /*height=*/Values(1),
                                  /*depth=*/Values(8, 10, 12),
                                  Values(AVIF_PIXEL_FORMAT_YUV444),
                                  /*alpha=*/Values(false)));
-#endif
 
 INSTANTIATE_TEST_SUITE_P(HighBitDepthAndEvenDimensions, AvmTest,
                          Combine(/*width=*/Values(5), /*height=*/Values(34),


### PR DESCRIPTION
AVM commit https://gitlab.com/AOMediaCodec/avm/-/commit/e3b7bd42 includes https://gitlab.com/AOMediaCodec/avm/-/merge_requests/2692. This allows us to re-enable Tiny tests in avifavmminitest.cc and avifavmtest.cc.