### PR TITLE
scale: fix a potential memory leak

### DIFF
--- a/src/scale.c
+++ b/src/scale.c
@@ -141,7 +141,8 @@ avifResult avifImageScaleWithLimit(avifImage * image,
         const avifResult allocationResult = avifImageAllocatePlanes(image, AVIF_PLANES_A);
         if (allocationResult != AVIF_RESULT_OK) {
             avifDiagnosticsPrintf(diag, "Allocation of alpha plane failed: %s", avifResultToString(allocationResult));
-            return AVIF_RESULT_OUT_OF_MEMORY;
+            result = AVIF_RESULT_OUT_OF_MEMORY;
+            goto cleanup;
         }
 
         if (image->depth > 8) {


### PR DESCRIPTION
In `src/scale.c`, `avifImageScaleWithLimit()` did not properly do the error handling when `avifImageAllocatePlanes()` fails, which can result in memory leak. This PR fixes it.