### PR TITLE
Quality to QP refactor

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -544,8 +544,8 @@ typedef enum avifEncoderChange
     AVIF_ENCODER_CHANGE_MAX_QUANTIZER_ALPHA = (1 << 3),
     AVIF_ENCODER_CHANGE_TILE_ROWS_LOG2 = (1 << 4),
     AVIF_ENCODER_CHANGE_TILE_COLS_LOG2 = (1 << 5),
-    AVIF_ENCODER_CHANGE_QUANTIZER = (1 << 6),
-    AVIF_ENCODER_CHANGE_QUANTIZER_ALPHA = (1 << 7),
+    AVIF_ENCODER_CHANGE_QUALITY = (1 << 6),
+    AVIF_ENCODER_CHANGE_QUALITY_ALPHA = (1 << 7),
     AVIF_ENCODER_CHANGE_SCALING_MODE = (1 << 8),
 
     AVIF_ENCODER_CHANGE_CODEC_SPECIFIC = (1 << 30)
@@ -565,10 +565,10 @@ typedef avifBool (*avifCodecGetNextImageFunc)(struct avifCodec * codec,
 // encoder->tileRowsLog2, encoder->tileColsLog2, and encoder->autoTiling. The caller of
 // avifCodecEncodeImageFunc is responsible for automatic tiling if encoder->autoTiling is set to
 // AVIF_TRUE. The actual tiling values are passed to avifCodecEncodeImageFunc as parameters.
-// Similarly, avifCodecEncodeImageFunc should use the quantizer parameter instead of
-// encoder->quality and encoder->qualityAlpha. If disableLaggedOutput is AVIF_TRUE, then the encoder will emit the output frame
-// without any lag (if supported). Note that disableLaggedOutput is only used by the first call to this function (which
-// initializes the encoder) and is ignored by the subsequent calls.
+// Similarly, avifCodecEncodeImageFunc should use the quality parameter instead of
+// encoder->quality, encoder->qualityAlpha, and encoder->qualityGainMap. If disableLaggedOutput is AVIF_TRUE, then
+// the encoder will emit the output frame without any lag (if supported). Note that disableLaggedOutput is only
+// used by the first call to this function (which initializes the encoder) and is ignored by the subsequent calls.
 //
 // Note: The caller of avifCodecEncodeImageFunc always passes encoder->data->tileRowsLog2 and
 // encoder->data->tileColsLog2 as the tileRowsLog2 and tileColsLog2 arguments. Because
@@ -581,7 +581,7 @@ typedef avifResult (*avifCodecEncodeImageFunc)(struct avifCodec * codec,
                                                avifBool alpha,
                                                int tileRowsLog2,
                                                int tileColsLog2,
-                                               int quantizer,
+                                               int quality,
                                                avifEncoderChanges encoderChanges,
                                                avifBool disableLaggedOutput,
                                                avifAddImageFlags addImageFlags,

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -49,13 +49,21 @@ static avifBool rav1eSupports400(void)
     return minorVersion >= 4;
 }
 
+// rav1e's QP range is [0,255]
+static int rav1eQualityToQuantizer(int quality)
+{
+    const int quantizer = ((100 - quality) * 255 + 50) / 100;
+
+    return quantizer;
+}
+
 static avifResult rav1eCodecEncodeImage(avifCodec * codec,
                                         avifEncoder * encoder,
                                         const avifImage * image,
                                         avifBool alpha,
                                         int tileRowsLog2,
                                         int tileColsLog2,
-                                        int quantizer,
+                                        int quality,
                                         avifEncoderChanges encoderChanges,
                                         avifBool disableLaggedOutput,
                                         uint32_t addImageFlags,
@@ -164,7 +172,7 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
             minQuantizer = AVIF_CLAMP(encoder->minQuantizerAlpha, 0, 63);
         }
         minQuantizer = (minQuantizer * 255) / 63; // Rescale quantizer values as rav1e's QP range is [0,255]
-        quantizer = (quantizer * 255) / 63;
+        const int quantizer = rav1eQualityToQuantizer(quality);
         if (rav1e_config_parse_int(rav1eConfig, "min_quantizer", minQuantizer) == -1) {
             goto cleanup;
         }

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -44,13 +44,20 @@ typedef struct avifCodecInternal
 static avifBool allocate_svt_buffers(EbBufferHeaderType ** input_buf);
 static avifResult dequeue_frame(avifCodec * codec, avifCodecEncodeOutput * output, avifBool done_sending_pics);
 
+static int svtQualityToQuantizer(int quality)
+{
+    const int quantizer = ((100 - quality) * 63 + 50) / 100;
+
+    return quantizer;
+}
+
 static avifResult svtCodecEncodeImage(avifCodec * codec,
                                       avifEncoder * encoder,
                                       const avifImage * image,
                                       avifBool alpha,
                                       int tileRowsLog2,
                                       int tileColsLog2,
-                                      int quantizer,
+                                      int quality,
                                       avifEncoderChanges encoderChanges,
                                       avifBool disableLaggedOutput,
                                       uint32_t addImageFlags,
@@ -180,7 +187,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
             svt_config->min_qp_allowed = AVIF_CLAMP(encoder->minQuantizer, 0, 62);
             svt_config->max_qp_allowed = AVIF_CLAMP(encoder->maxQuantizer, 0, 63);
         }
-        svt_config->qp = quantizer;
+        svt_config->qp = svtQualityToQuantizer(quality);
 
         if (tileRowsLog2 != 0) {
             svt_config->tile_rows = tileRowsLog2;


### PR DESCRIPTION
- Pass down `quality` to `xxxCodecEncodeImage()` instead of the `quantizer` (QP) value
- Delegate `quality` -> `quantizer` conversions to each encoder's `xxxCodecEncodeImage()` instead
- Remove double-conversions (`quality` -> `AOM quantizer` -> `quantizer`) in the rav1e and AVM encoders