### PR TITLE
Add tune=iq quality to QP formula for libaom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Always forward the CICP color primaries, transfer characteristics,
   and matrix coefficients to the AV1 encoder, which writes them in the Sequence
   Header OBU, for compatibility with libraries that wrongly ignore the colr box.
+* Use a "quality to quantizer (QP)" mapping formula designed for AOM_TUNE_IQ.
 
 ### Removed since 1.3.0
 

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -440,7 +440,8 @@ static int avmScaleQuantizer(int quantizer, uint32_t depth)
 
 static int avmQualityToQuantizer(int quality, uint32_t depth)
 {
-    int quantizer = ((100 - quality) * 63 + 50) / 100;
+    const int quantizer = ((100 - quality) * 63 + 50) / 100;
+
     return quantizer;
 }
 


### PR DESCRIPTION
Add a "quality to quantizer (QP)" mapping formula designed for libaom's `tune=iq` AKA `AOM_TUNE_IQ`.