### PR TITLE
Have dependabot update all of .github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github/**/*"
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
Otherwise, it only looks into .github/workflows and action.yml, cf https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--