### PR TITLE
src/codec_aom.c: Include <stdint.h>

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -32,6 +32,7 @@
 
 #include <assert.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
This file uses uint8_t, uint32_t, etc.