### PR TITLE
Switch layered images to all-intra encoding under certain conditions

### DIFF
--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define TWO_LAYER_ALL_INTRA_QUALITY_THRESHOLD 10
+
 struct avifCodecInternal
 {
     avifBool decoderInitialized;
@@ -547,7 +549,17 @@ static avifResult avmCodecEncodeImage(avifCodec * codec,
             // libavm to set still_picture and reduced_still_picture_header to
             // 1 in AV2 sequence headers.
             cfg->g_limit = 1;
+        }
 
+        // All-intra encoding is beneficial when encoding a two-layer image item and the quality of the first layer is very low.
+        // Switching to all-intra encoding comes with the following benefits:
+        // - The first layer will be smaller than the second layer (which is often not the case with inter encoding)
+        // - Outputs have predictable file sizes: the sum of the first layer (quality <= 10) plus the second layer (quality set by the caller)
+        // - Because the first layer is very small, layered encoding overhead is also smaller and more stable (about 5-8% for quality 40 and 2-4% for quality 60)
+        avifBool useAllIntraForLayered = encoder->extraLayerCount == 1 && quality <= TWO_LAYER_ALL_INTRA_QUALITY_THRESHOLD;
+        avifBool useAllIntra = (addImageFlags & AVIF_ADD_IMAGE_FLAG_SINGLE) || useAllIntraForLayered;
+
+        if (useAllIntra) {
             // Use the default settings of the new AVM_USAGE_ALL_INTRA (added in
             // https://crbug.com/aomedia/2959).
             //


### PR DESCRIPTION
Switch layered images to all-intra encoding under certain conditions:
- The total number of layers is 2
- Quality of the first layer is very low (q <= 10)

Using all-intra encoding comes with the following benefits:
1. First layer will be smaller than the second layer (which can oftentimes not be the case with good mode at quality < 40)
2. Outputs have predictable file sizes: the sum of the first layer (quality 2) plus the second layer (quality set by the caller)
3. Because the first layer is very small, progressive encoding overhead is also smaller and more stable (about 5-8% for quality 40 and 2-4% for quality 60)
4. Availability of choosing tune IQ in libaom AV1 (which requires all-intra usage)

From the point of view of `avifenc`, encoding an image with `--progressive` will result in all-intra encoding being used, which is the main use case this change targets.