### PR TITLE
Cast avifImagePlaneRowBytes() to size_t in product

### DIFF
--- a/src/sampletransform.c
+++ b/src/sampletransform.c
@@ -316,7 +316,7 @@ static avifResult avifImageApplyExpression32b(avifImage * dstImage,
                         const avifImage * image = inputImageItems[token->inputImageItemIndex - 1]; // 1-based
                         const uint8_t * row = avifImagePlane(image, c);
                         AVIF_ASSERT_OR_RETURN(row != NULL);
-                        row += avifImagePlaneRowBytes(image, c) * y;
+                        row += (size_t)avifImagePlaneRowBytes(image, c) * y;
                         AVIF_ASSERT_OR_RETURN(stackSize < stackCapacity);
                         stack[stackSize++] = avifImageUsesU16(image) ? ((const uint16_t *)row)[x] : row[x];
                     } else if (token->type == AVIF_SAMPLE_TRANSFORM_NEGATION || token->type == AVIF_SAMPLE_TRANSFORM_ABSOLUTE ||
@@ -337,7 +337,7 @@ static avifResult avifImageApplyExpression32b(avifImage * dstImage,
 
                 uint8_t * row = avifImagePlane(dstImage, c);
                 AVIF_ASSERT_OR_RETURN(row != NULL);
-                row += avifImagePlaneRowBytes(dstImage, c) * y;
+                row += (size_t)avifImagePlaneRowBytes(dstImage, c) * y;
                 if (avifImageUsesU16(dstImage)) {
                     ((uint16_t *)row)[x] = (uint16_t)stack[0];
                 } else {


### PR DESCRIPTION
Ensure that the multiplication of avifImagePlaneRowBytes() by y (which can be as large as height - 1) is done using the size_t type to avoid overflow.