### PR TITLE
Fail if imageContentToDecode is color xor alpha

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -5229,6 +5229,12 @@ avifResult avifDecoderParse(avifDecoder * decoder)
     if ((decoder->imageSizeLimit > AVIF_DEFAULT_IMAGE_SIZE_LIMIT) || (decoder->imageSizeLimit == 0)) {
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
+    // Color only or alpha only is not currently supported.
+    if ((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) != 0 &&
+        (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) != AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) {
+        avifDiagnosticsPrintf(&decoder->diag, "imageContentToDecode set to only color or only alpha is not supported");
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
     if (!decoder->io || !decoder->io->read) {
         return AVIF_RESULT_IO_NOT_SET;
     }

--- a/tests/gtest/avifdecodetest.cc
+++ b/tests/gtest/avifdecodetest.cc
@@ -64,6 +64,16 @@ TEST(AvifDecodeTest, ParseEmptyData) {
   ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_INVALID_FTYP);
 }
 
+TEST(AvifDecodeTest, ImageContentToDecodeColorXorAlpha) {
+  DecoderPtr decoder(avifDecoderCreate());
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderSetIOMemory(decoder.get(), nullptr, 0), AVIF_RESULT_OK);
+  decoder->imageContentToDecode = static_cast<avifImageContentTypeFlag>(1 << 0);
+  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_NOT_IMPLEMENTED);
+  decoder->imageContentToDecode = static_cast<avifImageContentTypeFlag>(1 << 1);
+  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_NOT_IMPLEMENTED);
+}
+
 TEST(AvifDecodeTest, Idat) {
   if (!testutil::Av1DecoderAvailable()) {
     GTEST_SKIP() << "AV1 Codec unavailable, skip test.";


### PR DESCRIPTION
Fixes https://github.com/AOMediaCodec/libavif/issues/2983