### PR TITLE
More CI cache improvements

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -56,7 +56,6 @@ runs:
         path: |
           ~/.cargo
           build/cargo
-          build/_deps/cargoc-src/
         key: ${{ env.CARGO_CACHE_KEY }}-${{ github.run_id }}
         restore-keys: ${{ env.CARGO_CACHE_KEY }}
       env:

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           codec-aom: "LOCAL"
           codec-dav1d: ${{ matrix.also-enable-av1-codecs }}
-          codec-rav1e: ${{ matrix.also-enable-av1-codecs }}
           extra-cache-key: ${{ matrix.also-enable-av1-codecs }}
           gcc-version: ${{ matrix.gcc }}
           libyuv: "LOCAL"
@@ -50,7 +49,6 @@ jobs:
           -DAVIF_CODEC_AVM=LOCAL
           -DAVIF_CODEC_AOM=${{ matrix.also-enable-av1-codecs }}
           -DAVIF_CODEC_DAV1D=${{ matrix.also-enable-av1-codecs }}
-          -DAVIF_CODEC_RAV1E=${{ matrix.also-enable-av1-codecs }}
           -DAVIF_CODEC_SVT=${{ matrix.also-enable-av1-codecs }}
           -DAVIF_LIBYUV=LOCAL
           -DAVIF_LIBSHARPYUV=LOCAL

--- a/cmake/Modules/LocalAvm.cmake
+++ b/cmake/Modules/LocalAvm.cmake
@@ -37,7 +37,7 @@ FetchContent_Declare(
     BINARY_DIR "${AVM_BINARY_DIR}"
     GIT_TAG ${AVIF_AVM_GIT_TAG}
     GIT_PROGRESS ON
-    GIT_SHALLOW OFF
+    GIT_SHALLOW ON
     UPDATE_COMMAND ""
     # Avoid the following error when both aom and avm are built:
     #   CMake Error at build/_deps/libavm-src/CMakeLists.txt:1103 (add_custom_target):


### PR DESCRIPTION
- disable rav1e for AV2
- no need for whole git history for AV2 (only this job is doing it)
- build/_deps/cargoc-src/ already included in the dep cache