### PR TITLE
Try to improve cargo-c caching on Windows Visual Studio 2017

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -56,6 +56,7 @@ runs:
         path: |
           ~/.cargo
           build/cargo
+          cargo*
           corrosion
         key: ${{ env.CARGO_KEY }}-${{ runner.os }}-${{ runner.arch }}
     - name: Cache external dependencies in ext

--- a/.github/actions/setup-common/action.yml
+++ b/.github/actions/setup-common/action.yml
@@ -44,3 +44,7 @@ runs:
       uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         toolchain: stable
+    - name: Set up cargo-c
+      if: ${{ inputs.codec-rav1e == 'LOCAL' }}
+      run: cargo install cargo-c --features=vendored-openssl
+      shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Update libxml2.cmd/LocalLibXml2.cmake: v2.15.1
 * Update aom.cmd/LocalAom.cmake: v3.13.1
 * Update LocalAvm.cmake: research-v13.0.0
-* Update rav1e.cmd/LocalRav1e.cmake: cargo-c v0.10.14, corrosion v0.5.2,
+* Update rav1e.cmd/LocalRav1e.cmake: cargo-c v0.10.20, corrosion v0.6.1,
   rav1e v0.8.1
 * Update svt.cmd/svt.sh/LocalSvt.cmake: v4.0.1
 * Update zlibpng.cmd/LocalZlibpng.cmake: libpng 1.6.51, zlib 1.3.1.2

--- a/cmake/Modules/LocalRav1e.cmake
+++ b/cmake/Modules/LocalRav1e.cmake
@@ -1,6 +1,6 @@
 set(AVIF_RAV1E_GIT_TAG v0.8.1)
-set(AVIF_CORROSION_GIT_TAG v0.6.0)
-set(AVIF_CARGOC_GIT_TAG v0.10.18)
+set(AVIF_CORROSION_GIT_TAG v0.6.1)
+set(AVIF_CARGOC_GIT_TAG v0.10.20)
 
 set(RAV1E_LIB_FILENAME
     "${AVIF_SOURCE_DIR}/ext/rav1e/build.libavif/usr/lib/${AVIF_LIBRARY_PREFIX}rav1e${CMAKE_STATIC_LIBRARY_SUFFIX}"
@@ -38,7 +38,7 @@ else()
 
     FetchContent_MakeAvailable(Corrosion)
 
-    find_program(CARGO_CINSTALL cargo-cinstall HINTS "$ENV{HOME}/.cargo/bin")
+    find_program(CARGO_CINSTALL cargo-cinstall HINTS "$ENV{HOME}/.cargo/bin" HINTS ${CMAKE_BINARY_DIR})
 
     if(CARGO_CINSTALL)
         add_executable(cargo-cinstall IMPORTED GLOBAL)


### PR DESCRIPTION
- on that platform, binaries are copied in the build folder.
- install cargo-c on the CI for speed
- as we update the cache, also update corrosion and cargo-c.
