### PR TITLE
Fix avifCodec::csOptions comment

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -598,10 +598,8 @@ typedef void (*avifCodecDestroyInternalFunc)(struct avifCodec * codec);
 typedef struct avifCodec
 {
     avifCodecSpecificOptions * csOptions; // Contains codec-specific key/value pairs for advanced tuning.
-                                          // If a codec uses a value, it must mark it as used.
                                           // This array is NOT owned by avifCodec.
     struct avifCodecInternal * internal;  // up to each codec to use how it wants
-                                          //
     avifDiagnostics * diag;               // Shallow copy; owned by avifEncoder or avifDecoder
 
     // Decoder options (for getNextImage):


### PR DESCRIPTION
I could not find any codec specific option value "marked as used".