### PR TITLE
Fix the CICP for BT.709 SDR and BT.2100 HLG

### DIFF
--- a/src/obu.c
+++ b/src/obu.c
@@ -526,7 +526,7 @@ static avifBool parseAV2ContentInterpretation(avifBits * bits, avifSequenceHeade
             // BT.709 SDR
             header->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;                   // 1
             header->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_BT709; // 1
-            header->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT470BG;         // 5
+            header->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT709;           // 1
         } else if (colorDescriptionIdc == 2) {
             // BT.2100 PQ
             header->colorPrimaries = AVIF_COLOR_PRIMARIES_BT2100;               // 9
@@ -534,9 +534,9 @@ static avifBool parseAV2ContentInterpretation(avifBits * bits, avifSequenceHeade
             header->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT2020_NCL;   // 9
         } else if (colorDescriptionIdc == 3) {
             // BT.2100 HLG
-            header->colorPrimaries = AVIF_COLOR_PRIMARIES_BT2100;                         // 9
-            header->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_BT2020_10BIT; // 14
-            header->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT2020_NCL;             // 9
+            header->colorPrimaries = AVIF_COLOR_PRIMARIES_BT2100;                // 9
+            header->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_HLG; // 18
+            header->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT2020_NCL;    // 9
         } else if (colorDescriptionIdc == 4) {
             // sRGB
             header->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;                  // 1


### PR DESCRIPTION
The CICP for BT.709 SDR should be 1/1/1, not 1/1/5.

The CICP for BT.2100 HLG should be 9/18/9, not 9/14/9.

Corresponds to the following two pull requests for the AV2 spec: https://github.com/AOMediaCodec/av2-spec-internal/pull/617 https://github.com/AOMediaCodec/av2-spec-internal/pull/615