### PR TITLE
Move the avifCodecSpecificOptionsClear() call

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -2121,10 +2121,10 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         }
     }
 
-    avifCodecSpecificOptionsClear(encoder->csOptions);
     avifEncoderFrame * frame = (avifEncoderFrame *)avifArrayPush(&encoder->data->frames);
     AVIF_CHECKERR(frame != NULL, AVIF_RESULT_OUT_OF_MEMORY);
     frame->durationInTimescales = durationInTimescales;
+    avifCodecSpecificOptionsClear(encoder->csOptions);
     return AVIF_RESULT_OK;
 }
 


### PR DESCRIPTION
In avifEncoderAddImageInternal(), move the
avifCodecSpecificOptionsClear() call after the last statement that may fail, so that we can simply say that avifEncoderAddImageInternal() calls avifCodecSpecificOptionsClear() before it returns AVIF_RESULT_OK.