### PR TITLE
Use const pointers with codec->csOptions

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -597,10 +597,10 @@ typedef void (*avifCodecDestroyInternalFunc)(struct avifCodec * codec);
 
 typedef struct avifCodec
 {
-    avifCodecSpecificOptions * csOptions; // Contains codec-specific key/value pairs for advanced tuning.
-                                          // This array is NOT owned by avifCodec.
-    struct avifCodecInternal * internal;  // up to each codec to use how it wants
-    avifDiagnostics * diag;               // Shallow copy; owned by avifEncoder or avifDecoder
+    const avifCodecSpecificOptions * csOptions; // Contains codec-specific key/value pairs for advanced tuning.
+                                                // This array is NOT owned by avifCodec.
+    struct avifCodecInternal * internal;        // up to each codec to use how it wants
+    avifDiagnostics * diag;                     // Shallow copy; owned by avifEncoder or avifDecoder
 
     // Decoder options (for getNextImage):
     int maxThreads;               // See avifDecoder::maxThreads.

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -390,7 +390,7 @@ static avifBool avifAOMOptionsContainExplicitTuning(const avifCodec * codec, avi
 static avifBool avifProcessAOMOptionsPreInit(avifCodec * codec, avifBool alpha, struct aom_codec_enc_cfg * cfg)
 {
     for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
-        avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
+        const avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
         int val;
         if (avifKeyEqualsName(entry->key, "end-usage", alpha)) { // Rate control mode
             if (!aomOptionParseEnum(entry->value, endUsageEnum, &val)) {
@@ -484,7 +484,7 @@ static const struct aomOptionDef aomOptionDefs[] = {
 static avifBool avifProcessAOMOptionsPostInit(avifCodec * codec, avifBool alpha)
 {
     for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
-        avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
+        const avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
         // Skip options for the other kind of plane.
         const char * otherPrefix = alpha ? "color:" : "alpha:";
         size_t otherPrefixLen = 6;

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -341,7 +341,7 @@ static avifBool avifKeyEqualsName(const char * key, const char * name, avifBool 
 static avifBool avifProcessAVMOptionsPreInit(avifCodec * codec, avifBool alpha, struct avm_codec_enc_cfg * cfg)
 {
     for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
-        avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
+        const avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
         int val;
         if (avifKeyEqualsName(entry->key, "end-usage", alpha)) { // Rate control mode
             if (!avmOptionParseEnum(entry->value, endUsageEnum, &val)) {
@@ -357,7 +357,7 @@ static avifBool avifProcessAVMOptionsPreInit(avifCodec * codec, avifBool alpha, 
 static avifBool avifProcessAVMOptionsPostInit(avifCodec * codec, avifBool alpha)
 {
     for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
-        avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
+        const avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
         // Skip options for the other kind of plane.
         const char * otherPrefix = alpha ? "color:" : "alpha:";
         size_t otherPrefixLen = 6;

--- a/src/codec_rav1e.c
+++ b/src/codec_rav1e.c
@@ -202,7 +202,7 @@ static avifResult rav1eCodecEncodeImage(avifCodec * codec,
             }
         }
         for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
-            avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
+            const avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
             if (rav1e_config_parse(rav1eConfig, entry->key, entry->value) < 0) {
                 avifDiagnosticsPrintf(codec->diag, "Invalid value for %s: %s.", entry->key, entry->value);
                 result = AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -228,7 +228,7 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
 
 #if SVT_AV1_CHECK_VERSION(0, 9, 1)
         for (uint32_t i = 0; i < codec->csOptions->count; ++i) {
-            avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
+            const avifCodecSpecificOption * entry = &codec->csOptions->entries[i];
             if (svt_av1_enc_parse_parameter(svt_config, entry->key, entry->value) < 0) {
                 avifDiagnosticsPrintf(codec->diag, "Invalid value for %s: %s.", entry->key, entry->value);
                 result = AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION;


### PR DESCRIPTION
Ensure that the codecs cannot modify codec->csOptions, which they do not own.