### PR TITLE
Restrict sato image item's depth to 8,10,12,16

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2308,6 +2308,12 @@ static avifResult avifDecoderSampleTransformItemValidateProperties(const avifDec
         // This is enforced in avifParsePixelInformationProperty().
         AVIF_ASSERT_OR_RETURN(pixiProp->u.pixi.planeDepths[i] == pixiProp->u.pixi.planeDepths[0]);
     }
+    AVIF_ASSERT_OR_RETURN(pixiProp->u.pixi.planeCount >= 1);
+    const uint8_t depth = pixiProp->u.pixi.planeDepths[0];
+    if (depth != 8 && depth != 10 && depth != 12 && depth != 16) {
+        avifDiagnosticsPrintf(diag, "Item ID %u depth specified by pixi property [%u] is not supported", item->id, depth);
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
 
     const avifProperty * ispeProp = avifPropertyArrayFind(&item->properties, "ispe");
     if (!ispeProp) {

--- a/tests/gtest/avif16bittest.cc
+++ b/tests/gtest/avif16bittest.cc
@@ -430,9 +430,10 @@ TEST(Avif16bitTest, SampleTransformWithOtherBitDepths) {
     const avifResult result = avifDecoderReadMemory(
         decoder.get(), decoded.get(), encoded.data(), encoded.size());
     const avifResult expected_result =
-        num_bits == 0   ? AVIF_RESULT_BMFF_PARSE_FAILED
-        : num_bits > 16 ? AVIF_RESULT_NOT_IMPLEMENTED
-                        : AVIF_RESULT_OK;
+        num_bits == 0 ? AVIF_RESULT_BMFF_PARSE_FAILED
+        : (num_bits == 8 || num_bits == 10 || num_bits == 12 || num_bits == 16)
+            ? AVIF_RESULT_OK
+            : AVIF_RESULT_NOT_IMPLEMENTED;
     ASSERT_EQ(result, expected_result) << "bits_per_channels " << num_bits;
     if (result == AVIF_RESULT_OK) {
       // The output image should be highly distorted because of the pixel value


### PR DESCRIPTION
Restrict sample transform derived image item's bit depth to 8, 10, 12, and 16, which are supported by commonly-used libraries such as libyuv.