### PR TITLE
Prevent integer overflows in src/gainmap.c

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -813,7 +813,7 @@ void avifGainMapSetDefaults(avifGainMap * gainMap);
 // Uses a histogram, with outliers defined as having at least one empty bucket between them
 // and the rest of the distribution. Discards at most 0.1% of values.
 // Removing outliers helps with accuracy/compression.
-avifResult avifFindMinMaxWithoutOutliers(const float * gainMapF, int numPixels, float * rangeMin, float * rangeMax);
+avifResult avifFindMinMaxWithoutOutliers(const float * gainMapF, size_t numPixels, float * rangeMin, float * rangeMax);
 
 avifResult avifGainMapValidateMetadata(const avifGainMap * gainMap, avifDiagnostics * diag);
 


### PR DESCRIPTION
Prevent integer overflows in multiplications involving width, height, and rowBytes in src/gainmap.c by performing the multiplications in the size_t type. The size_t type is large enough because pixel buffers for the width, height, and rowBytes have been allocated successfully.

"Dexter.k" <164054284+rootvector2@users.noreply.github.com> reported an integer overflow in the allocation of the gainMapF buffers in avifRGBImageComputeGainMap() and suggested a fix in https://github.com/AOMediaCodec/libavif/pull/3049.