### PR TITLE
Handle null detail after aom_codec_decode failure

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -153,10 +153,11 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
         } else if (sample) {
             codec->internal->iter = NULL;
             if (aom_codec_decode(&codec->internal->decoder, sample->data.data, sample->data.size, NULL)) {
+                const char * error_detail = aom_codec_error_detail(&codec->internal->decoder);
                 avifDiagnosticsPrintf(codec->diag,
                                       "aom_codec_decode() failed: %s: %s",
                                       aom_codec_error(&codec->internal->decoder),
-                                      aom_codec_error_detail(&codec->internal->decoder));
+                                      error_detail ? error_detail : "no error detail");
                 return AVIF_FALSE;
             }
             spatialID = sample->spatialID;


### PR DESCRIPTION
After aom_codec_decode() fails, aom_codec_error_detail() may return a null pointer. Handle it and replace a null pointer with the "no error detail" string.