### PR TITLE
This PR replaces the use of ftell() with platform-correct 64-bit file…

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -157,7 +157,6 @@ avifIO * avifIOCreateFileReader(const char * filename)
         fclose(f);
         return NULL;
     }
-
 #else
     // POSIX large file support
     if (fseeko(f, 0, SEEK_END) != 0) {


### PR DESCRIPTION
… APIs when determining file size in avifIOCreateFileReader().
The previous implementation relied on long, which may be 32-bit on some platforms, causing incorrect file size detection for files larger than 2GB.

The change ensures consistent and correct large-file handling across Windows and POSIX systems without altering public APIs or parsing behavior.