### PR TITLE
Use size_t arithmetic for pixel offset calculations in reformat.c

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -307,24 +307,24 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
 
                         // Unpack RGB into normalized float
                         if (state.rgb.channelBytes > 1) {
-                            rgbPixel[0] = *((uint16_t *)(&rgb->pixels[offsetBytesR + (i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                            rgbPixel[0] = *((uint16_t *)(&rgb->pixels[offsetBytesR + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) /
                                           rgbMaxChannelF;
-                            rgbPixel[1] = *((uint16_t *)(&rgb->pixels[offsetBytesG + (i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                            rgbPixel[1] = *((uint16_t *)(&rgb->pixels[offsetBytesG + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) /
                                           rgbMaxChannelF;
-                            rgbPixel[2] = *((uint16_t *)(&rgb->pixels[offsetBytesB + (i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                            rgbPixel[2] = *((uint16_t *)(&rgb->pixels[offsetBytesB + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) /
                                           rgbMaxChannelF;
                         } else {
-                            rgbPixel[0] = rgb->pixels[offsetBytesR + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
-                            rgbPixel[1] = rgb->pixels[offsetBytesG + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
-                            rgbPixel[2] = rgb->pixels[offsetBytesB + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
+                            rgbPixel[0] = rgb->pixels[offsetBytesR + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
+                            rgbPixel[1] = rgb->pixels[offsetBytesG + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
+                            rgbPixel[2] = rgb->pixels[offsetBytesB + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
                         }
 
                         if (alphaMode != AVIF_ALPHA_MULTIPLY_MODE_NO_OP) {
                             float a;
                             if (state.rgb.channelBytes > 1) {
-                                a = *((uint16_t *)(&rgb->pixels[offsetBytesA + (i * rgbPixelBytes) + (j * rgbRowBytes)])) / rgbMaxChannelF;
+                                a = *((uint16_t *)(&rgb->pixels[offsetBytesA + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) / rgbMaxChannelF;
                             } else {
-                                a = rgb->pixels[offsetBytesA + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
+                                a = rgb->pixels[offsetBytesA + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
                             }
 
                             if (alphaMode == AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY) {
@@ -384,13 +384,13 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                         }
 
                         if (state.yuv.channelBytes > 1) {
-                            uint16_t * pY = (uint16_t *)&yPlane[(i * 2) + (j * yRowBytes)];
+                            uint16_t * pY = (uint16_t *)&yPlane[((size_t)i * 2) + (j * yRowBytes)];
                             *pY = (uint16_t)avifYUVColorSpaceInfoYToUNorm(&state.yuv, yuvBlock[bI][bJ].y);
                             if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
                                 // YUV444, full chroma
-                                uint16_t * pU = (uint16_t *)&uPlane[(i * 2) + (j * uRowBytes)];
+                                uint16_t * pU = (uint16_t *)&uPlane[((size_t)i * 2) + (j * uRowBytes)];
                                 *pU = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, yuvBlock[bI][bJ].u);
-                                uint16_t * pV = (uint16_t *)&vPlane[(i * 2) + (j * vRowBytes)];
+                                uint16_t * pV = (uint16_t *)&vPlane[((size_t)i * 2) + (j * vRowBytes)];
                                 *pV = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, yuvBlock[bI][bJ].v);
                             }
                         } else {
@@ -427,9 +427,9 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                     int uvI = outerI >> chromaShiftX;
                     int uvJ = outerJ >> chromaShiftY;
                     if (state.yuv.channelBytes > 1) {
-                        uint16_t * pU = (uint16_t *)&uPlane[(uvI * 2) + (uvJ * uRowBytes)];
+                        uint16_t * pU = (uint16_t *)&uPlane[((size_t)uvI * 2) + (uvJ * uRowBytes)];
                         *pU = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgU);
-                        uint16_t * pV = (uint16_t *)&vPlane[(uvI * 2) + (uvJ * vRowBytes)];
+                        uint16_t * pV = (uint16_t *)&vPlane[((size_t)uvI * 2) + (uvJ * vRowBytes)];
                         *pV = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgV);
                     } else {
                         uPlane[uvI + (uvJ * uRowBytes)] = (uint8_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgU);
@@ -453,9 +453,9 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                         int uvI = outerI >> chromaShiftX;
                         int uvJ = outerJ + bJ;
                         if (state.yuv.channelBytes > 1) {
-                            uint16_t * pU = (uint16_t *)&uPlane[(uvI * 2) + (uvJ * uRowBytes)];
+                            uint16_t * pU = (uint16_t *)&uPlane[((size_t)uvI * 2) + (uvJ * uRowBytes)];
                             *pU = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgU);
-                            uint16_t * pV = (uint16_t *)&vPlane[(uvI * 2) + (uvJ * vRowBytes)];
+                            uint16_t * pV = (uint16_t *)&vPlane[((size_t)uvI * 2) + (uvJ * vRowBytes)];
                             *pV = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgV);
                         } else {
                             uPlane[uvI + (uvJ * uRowBytes)] = (uint8_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgU);
@@ -477,16 +477,16 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
             for (uint32_t i = 0; i < image->width; ++i) {
                 float g;
                 if (state.rgb.channelBytes > 1) {
-                    g = *(uint16_t *)&rgb->pixels[offsetBytesGray + i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
+                    g = *(uint16_t *)&rgb->pixels[offsetBytesGray + (size_t)i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
                 } else {
-                    g = rgb->pixels[offsetBytesGray + i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
+                    g = rgb->pixels[offsetBytesGray + (size_t)i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
                 }
                 if (alphaMode != AVIF_ALPHA_MULTIPLY_MODE_NO_OP) {
                     float a;
                     if (state.rgb.channelBytes > 1) {
-                        a = *((uint16_t *)(&rgb->pixels[offsetBytesA + (i * grayPixelBytes) + (j * grayRowBytes)])) / grayMaxChannelF;
+                        a = *((uint16_t *)(&rgb->pixels[offsetBytesA + ((size_t)i * grayPixelBytes) + (j * grayRowBytes)])) / grayMaxChannelF;
                     } else {
-                        a = rgb->pixels[offsetBytesA + (i * grayPixelBytes) + (j * grayRowBytes)] / grayMaxChannelF;
+                        a = rgb->pixels[offsetBytesA + ((size_t)i * grayPixelBytes) + (j * grayRowBytes)] / grayMaxChannelF;
                     }
 
                     if (alphaMode == AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY) {
@@ -507,7 +507,7 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                 }
                 int gInt = avifYUVColorSpaceInfoYToUNorm(&state.yuv, g);
                 if (state.yuv.channelBytes > 1) {
-                    uint16_t * pY = (uint16_t *)&yPlane[(i * 2) + j * yRowBytes];
+                    uint16_t * pY = (uint16_t *)&yPlane[((size_t)i * 2) + j * yRowBytes];
                     *pY = (uint16_t)gInt;
                 } else {
                     yPlane[i + (j * yRowBytes)] = (uint8_t)gInt;
@@ -792,23 +792,23 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
                     }
 
                     if (image->depth == 8) {
-                        unormU[0][0] = uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes)];
-                        unormV[0][0] = vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes)];
-                        unormU[1][0] = uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjCol];
-                        unormV[1][0] = vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjCol];
-                        unormU[0][1] = uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjRow];
-                        unormV[0][1] = vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjRow];
-                        unormU[1][1] = uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjCol + uAdjRow];
-                        unormV[1][1] = vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjCol + vAdjRow];
+                        unormU[0][0] = uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes)];
+                        unormV[0][0] = vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes)];
+                        unormU[1][0] = uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol];
+                        unormV[1][0] = vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol];
+                        unormU[0][1] = uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjRow];
+                        unormV[0][1] = vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjRow];
+                        unormU[1][1] = uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol + uAdjRow];
+                        unormV[1][1] = vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol + vAdjRow];
                     } else {
-                        unormU[0][0] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes)]);
-                        unormV[0][0] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes)]);
-                        unormU[1][0] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjCol]);
-                        unormV[1][0] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjCol]);
-                        unormU[0][1] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjRow]);
-                        unormV[0][1] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjRow]);
-                        unormU[1][1] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjCol + uAdjRow]);
-                        unormV[1][1] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjCol + vAdjRow]);
+                        unormU[0][0] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes)]);
+                        unormV[0][0] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes)]);
+                        unormU[1][0] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol]);
+                        unormV[1][0] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol]);
+                        unormU[0][1] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjRow]);
+                        unormV[0][1] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjRow]);
+                        unormU[1][1] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol + uAdjRow]);
+                        unormV[1][1] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol + vAdjRow]);
 
                         // clamp incoming data to protect against bad LUT lookups
                         for (int bJ = 0; bJ < 2; ++bJ) {

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -322,7 +322,8 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                         if (alphaMode != AVIF_ALPHA_MULTIPLY_MODE_NO_OP) {
                             float a;
                             if (state.rgb.channelBytes > 1) {
-                                a = *((uint16_t *)(&rgb->pixels[offsetBytesA + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) / rgbMaxChannelF;
+                                a = *((uint16_t *)(&rgb->pixels[offsetBytesA + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                                    rgbMaxChannelF;
                             } else {
                                 a = rgb->pixels[offsetBytesA + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
                             }
@@ -807,8 +808,10 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
                         unormV[1][0] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol]);
                         unormU[0][1] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjRow]);
                         unormV[0][1] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjRow]);
-                        unormU[1][1] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol + uAdjRow]);
-                        unormV[1][1] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol + vAdjRow]);
+                        unormU[1][1] =
+                            *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol + uAdjRow]);
+                        unormV[1][1] =
+                            *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol + vAdjRow]);
 
                         // clamp incoming data to protect against bad LUT lookups
                         for (int bJ = 0; bJ < 2; ++bJ) {

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -289,8 +289,8 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
         const size_t yRowBytes = image->yuvRowBytes[AVIF_CHAN_Y];
         const size_t uRowBytes = image->yuvRowBytes[AVIF_CHAN_U];
         const size_t vRowBytes = image->yuvRowBytes[AVIF_CHAN_V];
-        for (uint32_t outerJ = 0; outerJ < image->height; outerJ += 2) {
-            for (uint32_t outerI = 0; outerI < image->width; outerI += 2) {
+        for (size_t outerJ = 0; outerJ < image->height; outerJ += 2) {
+            for (size_t outerI = 0; outerI < image->width; outerI += 2) {
                 uint32_t blockW = 2, blockH = 2;
                 if ((outerI + 1) >= image->width) {
                     blockW = 1;
@@ -300,32 +300,31 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                 }
 
                 // Convert an entire 2x2 block to YUV, and populate any fully sampled channels as we go
-                for (uint32_t bJ = 0; bJ < blockH; ++bJ) {
-                    for (uint32_t bI = 0; bI < blockW; ++bI) {
-                        const uint32_t i = outerI + bI;
-                        const uint32_t j = outerJ + bJ;
+                for (size_t bJ = 0; bJ < blockH; ++bJ) {
+                    for (size_t bI = 0; bI < blockW; ++bI) {
+                        const size_t i = outerI + bI;
+                        const size_t j = outerJ + bJ;
 
                         // Unpack RGB into normalized float
                         if (state.rgb.channelBytes > 1) {
-                            rgbPixel[0] = *((uint16_t *)(&rgb->pixels[offsetBytesR + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                            rgbPixel[0] = *((uint16_t *)(&rgb->pixels[offsetBytesR + (i * rgbPixelBytes) + (j * rgbRowBytes)])) /
                                           rgbMaxChannelF;
-                            rgbPixel[1] = *((uint16_t *)(&rgb->pixels[offsetBytesG + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                            rgbPixel[1] = *((uint16_t *)(&rgb->pixels[offsetBytesG + (i * rgbPixelBytes) + (j * rgbRowBytes)])) /
                                           rgbMaxChannelF;
-                            rgbPixel[2] = *((uint16_t *)(&rgb->pixels[offsetBytesB + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                            rgbPixel[2] = *((uint16_t *)(&rgb->pixels[offsetBytesB + (i * rgbPixelBytes) + (j * rgbRowBytes)])) /
                                           rgbMaxChannelF;
                         } else {
-                            rgbPixel[0] = rgb->pixels[offsetBytesR + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
-                            rgbPixel[1] = rgb->pixels[offsetBytesG + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
-                            rgbPixel[2] = rgb->pixels[offsetBytesB + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
+                            rgbPixel[0] = rgb->pixels[offsetBytesR + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
+                            rgbPixel[1] = rgb->pixels[offsetBytesG + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
+                            rgbPixel[2] = rgb->pixels[offsetBytesB + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
                         }
 
                         if (alphaMode != AVIF_ALPHA_MULTIPLY_MODE_NO_OP) {
                             float a;
                             if (state.rgb.channelBytes > 1) {
-                                a = *((uint16_t *)(&rgb->pixels[offsetBytesA + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)])) /
-                                    rgbMaxChannelF;
+                                a = *((uint16_t *)(&rgb->pixels[offsetBytesA + (i * rgbPixelBytes) + (j * rgbRowBytes)])) / rgbMaxChannelF;
                             } else {
-                                a = rgb->pixels[offsetBytesA + ((size_t)i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
+                                a = rgb->pixels[offsetBytesA + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
                             }
 
                             if (alphaMode == AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY) {
@@ -385,13 +384,13 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                         }
 
                         if (state.yuv.channelBytes > 1) {
-                            uint16_t * pY = (uint16_t *)&yPlane[((size_t)i * 2) + (j * yRowBytes)];
+                            uint16_t * pY = (uint16_t *)&yPlane[(i * 2) + (j * yRowBytes)];
                             *pY = (uint16_t)avifYUVColorSpaceInfoYToUNorm(&state.yuv, yuvBlock[bI][bJ].y);
                             if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
                                 // YUV444, full chroma
-                                uint16_t * pU = (uint16_t *)&uPlane[((size_t)i * 2) + (j * uRowBytes)];
+                                uint16_t * pU = (uint16_t *)&uPlane[(i * 2) + (j * uRowBytes)];
                                 *pU = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, yuvBlock[bI][bJ].u);
-                                uint16_t * pV = (uint16_t *)&vPlane[((size_t)i * 2) + (j * vRowBytes)];
+                                uint16_t * pV = (uint16_t *)&vPlane[(i * 2) + (j * vRowBytes)];
                                 *pV = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, yuvBlock[bI][bJ].v);
                             }
                         } else {
@@ -425,12 +424,12 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
 
                     const int chromaShiftX = 1;
                     const int chromaShiftY = 1;
-                    int uvI = outerI >> chromaShiftX;
-                    int uvJ = outerJ >> chromaShiftY;
+                    size_t uvI = outerI >> chromaShiftX;
+                    size_t uvJ = outerJ >> chromaShiftY;
                     if (state.yuv.channelBytes > 1) {
-                        uint16_t * pU = (uint16_t *)&uPlane[((size_t)uvI * 2) + (uvJ * uRowBytes)];
+                        uint16_t * pU = (uint16_t *)&uPlane[(uvI * 2) + (uvJ * uRowBytes)];
                         *pU = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgU);
-                        uint16_t * pV = (uint16_t *)&vPlane[((size_t)uvI * 2) + (uvJ * vRowBytes)];
+                        uint16_t * pV = (uint16_t *)&vPlane[(uvI * 2) + (uvJ * vRowBytes)];
                         *pV = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgV);
                     } else {
                         uPlane[uvI + (uvJ * uRowBytes)] = (uint8_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgU);
@@ -451,12 +450,12 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                         float avgV = sumV / totalSamples;
 
                         const int chromaShiftX = 1;
-                        int uvI = outerI >> chromaShiftX;
-                        int uvJ = outerJ + bJ;
+                        size_t uvI = outerI >> chromaShiftX;
+                        size_t uvJ = outerJ + bJ;
                         if (state.yuv.channelBytes > 1) {
-                            uint16_t * pU = (uint16_t *)&uPlane[((size_t)uvI * 2) + (uvJ * uRowBytes)];
+                            uint16_t * pU = (uint16_t *)&uPlane[(uvI * 2) + (uvJ * uRowBytes)];
                             *pU = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgU);
-                            uint16_t * pV = (uint16_t *)&vPlane[((size_t)uvI * 2) + (uvJ * vRowBytes)];
+                            uint16_t * pV = (uint16_t *)&vPlane[(uvI * 2) + (uvJ * vRowBytes)];
                             *pV = (uint16_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgV);
                         } else {
                             uPlane[uvI + (uvJ * uRowBytes)] = (uint8_t)avifYUVColorSpaceInfoUVToUNorm(&state.yuv, avgU);
@@ -474,20 +473,20 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
         const float grayMaxChannelF = state.rgb.maxChannelF;
         uint8_t * yPlane = image->yuvPlanes[AVIF_CHAN_Y];
         const size_t yRowBytes = image->yuvRowBytes[AVIF_CHAN_Y];
-        for (uint32_t j = 0; j < image->height; ++j) {
-            for (uint32_t i = 0; i < image->width; ++i) {
+        for (size_t j = 0; j < image->height; ++j) {
+            for (size_t i = 0; i < image->width; ++i) {
                 float g;
                 if (state.rgb.channelBytes > 1) {
-                    g = *(uint16_t *)&rgb->pixels[offsetBytesGray + (size_t)i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
+                    g = *(uint16_t *)&rgb->pixels[offsetBytesGray + i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
                 } else {
-                    g = rgb->pixels[offsetBytesGray + (size_t)i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
+                    g = rgb->pixels[offsetBytesGray + i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
                 }
                 if (alphaMode != AVIF_ALPHA_MULTIPLY_MODE_NO_OP) {
                     float a;
                     if (state.rgb.channelBytes > 1) {
-                        a = *((uint16_t *)(&rgb->pixels[offsetBytesA + ((size_t)i * grayPixelBytes) + (j * grayRowBytes)])) / grayMaxChannelF;
+                        a = *((uint16_t *)(&rgb->pixels[offsetBytesA + (i * grayPixelBytes) + (j * grayRowBytes)])) / grayMaxChannelF;
                     } else {
-                        a = rgb->pixels[offsetBytesA + ((size_t)i * grayPixelBytes) + (j * grayRowBytes)] / grayMaxChannelF;
+                        a = rgb->pixels[offsetBytesA + (i * grayPixelBytes) + (j * grayRowBytes)] / grayMaxChannelF;
                     }
 
                     if (alphaMode == AVIF_ALPHA_MULTIPLY_MODE_MULTIPLY) {
@@ -508,7 +507,7 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                 }
                 int gInt = avifYUVColorSpaceInfoYToUNorm(&state.yuv, g);
                 if (state.yuv.channelBytes > 1) {
-                    uint16_t * pY = (uint16_t *)&yPlane[((size_t)i * 2) + j * yRowBytes];
+                    uint16_t * pY = (uint16_t *)&yPlane[(i * 2) + j * yRowBytes];
                     *pY = (uint16_t)gInt;
                 } else {
                     yPlane[i + (j * yRowBytes)] = (uint8_t)gInt;
@@ -681,9 +680,9 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
     // to clang's analyzer.
     assert((alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP) || aPlane);
 
-    for (uint32_t j = 0; j < image->height; ++j) {
+    for (size_t j = 0; j < image->height; ++j) {
         // uvJ is used only when yuvHasColor is true.
-        const uint32_t uvJ = yuvHasColor ? (j >> state->yuv.formatInfo.chromaShiftY) : 0;
+        const size_t uvJ = yuvHasColor ? (j >> state->yuv.formatInfo.chromaShiftY) : 0;
         const uint8_t * ptrY8 = &yPlane[j * yRowBytes];
         const uint8_t * ptrU8 = uPlane ? &uPlane[(uvJ * uRowBytes)] : NULL;
         const uint8_t * ptrV8 = vPlane ? &vPlane[(uvJ * vRowBytes)] : NULL;
@@ -693,12 +692,12 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
         const uint16_t * ptrV16 = (const uint16_t *)ptrV8;
         const uint16_t * ptrA16 = (const uint16_t *)ptrA8;
 
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrGray = &rgb->pixels[state->rgb.offsetBytesGray + ((size_t)j * rgb->rowBytes)];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
+        uint8_t * ptrGray = &rgb->pixels[state->rgb.offsetBytesGray + (j * rgb->rowBytes)];
 
-        for (uint32_t i = 0; i < image->width; ++i) {
+        for (size_t i = 0; i < image->width; ++i) {
             float Y, Cb = 0.5f, Cr = 0.5f;
 
             // Calculate Y
@@ -713,7 +712,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
 
             // Calculate Cb and Cr
             if (yuvHasColor) {
-                const uint32_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
+                const size_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
                 if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
                     uint16_t unormU, unormV;
 
@@ -793,25 +792,23 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
                     }
 
                     if (image->depth == 8) {
-                        unormU[0][0] = uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes)];
-                        unormV[0][0] = vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes)];
-                        unormU[1][0] = uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol];
-                        unormV[1][0] = vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol];
-                        unormU[0][1] = uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjRow];
-                        unormV[0][1] = vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjRow];
-                        unormU[1][1] = uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol + uAdjRow];
-                        unormV[1][1] = vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol + vAdjRow];
+                        unormU[0][0] = uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes)];
+                        unormV[0][0] = vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes)];
+                        unormU[1][0] = uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjCol];
+                        unormV[1][0] = vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjCol];
+                        unormU[0][1] = uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjRow];
+                        unormV[0][1] = vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjRow];
+                        unormU[1][1] = uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjCol + uAdjRow];
+                        unormV[1][1] = vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjCol + vAdjRow];
                     } else {
-                        unormU[0][0] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes)]);
-                        unormV[0][0] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes)]);
-                        unormU[1][0] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol]);
-                        unormV[1][0] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol]);
-                        unormU[0][1] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjRow]);
-                        unormV[0][1] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjRow]);
-                        unormU[1][1] =
-                            *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + ((size_t)uvI * yuvChannelBytes) + uAdjCol + uAdjRow]);
-                        unormV[1][1] =
-                            *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + ((size_t)uvI * yuvChannelBytes) + vAdjCol + vAdjRow]);
+                        unormU[0][0] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes)]);
+                        unormV[0][0] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes)]);
+                        unormU[1][0] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjCol]);
+                        unormV[1][0] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjCol]);
+                        unormU[0][1] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjRow]);
+                        unormV[0][1] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjRow]);
+                        unormU[1][1] = *((const uint16_t *)&uPlane[(uvJ * uRowBytes) + (uvI * yuvChannelBytes) + uAdjCol + uAdjRow]);
+                        unormV[1][1] = *((const uint16_t *)&vPlane[(uvJ * vRowBytes) + (uvI * yuvChannelBytes) + vAdjCol + vAdjRow]);
 
                         // clamp incoming data to protect against bad LUT lookups
                         for (int bJ = 0; bJ < 2; ++bJ) {
@@ -987,17 +984,17 @@ static avifResult avifImageYUV16ToRGB16Color(const avifImage * image, avifRGBIma
 
     const uint16_t yuvMaxChannel = (uint16_t)state->yuv.maxChannel;
     const float rgbMaxChannelF = state->rgb.maxChannelF;
-    for (uint32_t j = 0; j < image->height; ++j) {
-        const uint32_t uvJ = j >> state->yuv.formatInfo.chromaShiftY;
-        const uint16_t * const ptrY = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_Y][((size_t)j * image->yuvRowBytes[AVIF_CHAN_Y])];
-        const uint16_t * const ptrU = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_U][((size_t)uvJ * image->yuvRowBytes[AVIF_CHAN_U])];
-        const uint16_t * const ptrV = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_V][((size_t)uvJ * image->yuvRowBytes[AVIF_CHAN_V])];
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+    for (size_t j = 0; j < image->height; ++j) {
+        const size_t uvJ = j >> state->yuv.formatInfo.chromaShiftY;
+        const uint16_t * const ptrY = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_Y][(j * image->yuvRowBytes[AVIF_CHAN_Y])];
+        const uint16_t * const ptrU = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_U][(uvJ * image->yuvRowBytes[AVIF_CHAN_U])];
+        const uint16_t * const ptrV = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_V][(uvJ * image->yuvRowBytes[AVIF_CHAN_V])];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
 
-        for (uint32_t i = 0; i < image->width; ++i) {
-            uint32_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
+        for (size_t i = 0; i < image->width; ++i) {
+            size_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
 
             // clamp incoming data to protect against bad LUT lookups
             const uint16_t unormY = AVIF_MIN(ptrY[i], yuvMaxChannel);
@@ -1040,13 +1037,13 @@ static avifResult avifImageYUV16ToRGB16Mono(const avifImage * image, avifRGBImag
 
     const uint16_t maxChannel = (uint16_t)state->yuv.maxChannel;
     const float maxChannelF = state->rgb.maxChannelF;
-    for (uint32_t j = 0; j < image->height; ++j) {
-        const uint16_t * const ptrY = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_Y][((size_t)j * image->yuvRowBytes[AVIF_CHAN_Y])];
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+    for (size_t j = 0; j < image->height; ++j) {
+        const uint16_t * const ptrY = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_Y][(j * image->yuvRowBytes[AVIF_CHAN_Y])];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
 
-        for (uint32_t i = 0; i < image->width; ++i) {
+        for (size_t i = 0; i < image->width; ++i) {
             // clamp incoming data to protect against bad LUT lookups
             const uint16_t unormY = AVIF_MIN(ptrY[i], maxChannel);
 
@@ -1087,17 +1084,17 @@ static avifResult avifImageYUV16ToRGB8Color(const avifImage * image, avifRGBImag
 
     const uint16_t yuvMaxChannel = (uint16_t)state->yuv.maxChannel;
     const float rgbMaxChannelF = state->rgb.maxChannelF;
-    for (uint32_t j = 0; j < image->height; ++j) {
-        const uint32_t uvJ = j >> state->yuv.formatInfo.chromaShiftY;
-        const uint16_t * const ptrY = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_Y][((size_t)j * image->yuvRowBytes[AVIF_CHAN_Y])];
-        const uint16_t * const ptrU = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_U][((size_t)uvJ * image->yuvRowBytes[AVIF_CHAN_U])];
-        const uint16_t * const ptrV = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_V][((size_t)uvJ * image->yuvRowBytes[AVIF_CHAN_V])];
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+    for (size_t j = 0; j < image->height; ++j) {
+        const size_t uvJ = j >> state->yuv.formatInfo.chromaShiftY;
+        const uint16_t * const ptrY = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_Y][(j * image->yuvRowBytes[AVIF_CHAN_Y])];
+        const uint16_t * const ptrU = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_U][(uvJ * image->yuvRowBytes[AVIF_CHAN_U])];
+        const uint16_t * const ptrV = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_V][(uvJ * image->yuvRowBytes[AVIF_CHAN_V])];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
 
-        for (uint32_t i = 0; i < image->width; ++i) {
-            uint32_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
+        for (size_t i = 0; i < image->width; ++i) {
+            size_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
 
             // clamp incoming data to protect against bad LUT lookups
             const uint16_t unormY = AVIF_MIN(ptrY[i], yuvMaxChannel);
@@ -1144,13 +1141,13 @@ static avifResult avifImageYUV16ToRGB8Mono(const avifImage * image, avifRGBImage
 
     const uint16_t yuvMaxChannel = (uint16_t)state->yuv.maxChannel;
     const float rgbMaxChannelF = state->rgb.maxChannelF;
-    for (uint32_t j = 0; j < image->height; ++j) {
-        const uint16_t * const ptrY = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_Y][((size_t)j * image->yuvRowBytes[AVIF_CHAN_Y])];
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+    for (size_t j = 0; j < image->height; ++j) {
+        const uint16_t * const ptrY = (uint16_t *)&image->yuvPlanes[AVIF_CHAN_Y][(j * image->yuvRowBytes[AVIF_CHAN_Y])];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
 
-        for (uint32_t i = 0; i < image->width; ++i) {
+        for (size_t i = 0; i < image->width; ++i) {
             // clamp incoming data to protect against bad LUT lookups
             const uint16_t unormY = AVIF_MIN(ptrY[i], yuvMaxChannel);
 
@@ -1194,17 +1191,17 @@ static avifResult avifImageYUV8ToRGB16Color(const avifImage * image, avifRGBImag
     AVIF_CHECKERR(avifCreateYUVToRGBLookUpTables(&unormFloatTableY, &unormFloatTableUV, image->depth, state), AVIF_RESULT_OUT_OF_MEMORY);
 
     const float rgbMaxChannelF = state->rgb.maxChannelF;
-    for (uint32_t j = 0; j < image->height; ++j) {
-        const uint32_t uvJ = j >> state->yuv.formatInfo.chromaShiftY;
-        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][((size_t)j * image->yuvRowBytes[AVIF_CHAN_Y])];
-        const uint8_t * const ptrU = &image->yuvPlanes[AVIF_CHAN_U][((size_t)uvJ * image->yuvRowBytes[AVIF_CHAN_U])];
-        const uint8_t * const ptrV = &image->yuvPlanes[AVIF_CHAN_V][((size_t)uvJ * image->yuvRowBytes[AVIF_CHAN_V])];
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+    for (size_t j = 0; j < image->height; ++j) {
+        const size_t uvJ = j >> state->yuv.formatInfo.chromaShiftY;
+        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][(j * image->yuvRowBytes[AVIF_CHAN_Y])];
+        const uint8_t * const ptrU = &image->yuvPlanes[AVIF_CHAN_U][(uvJ * image->yuvRowBytes[AVIF_CHAN_U])];
+        const uint8_t * const ptrV = &image->yuvPlanes[AVIF_CHAN_V][(uvJ * image->yuvRowBytes[AVIF_CHAN_V])];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
 
-        for (uint32_t i = 0; i < image->width; ++i) {
-            uint32_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
+        for (size_t i = 0; i < image->width; ++i) {
+            size_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
 
             // Convert unorm to float (no clamp necessary, the full uint8_t range is a legal lookup)
             const float Y = unormFloatTableY[ptrY[i]];
@@ -1241,13 +1238,13 @@ static avifResult avifImageYUV8ToRGB16Mono(const avifImage * image, avifRGBImage
     AVIF_CHECKERR(avifCreateYUVToRGBLookUpTables(&unormFloatTableY, NULL, image->depth, state), AVIF_RESULT_OUT_OF_MEMORY);
 
     const float rgbMaxChannelF = state->rgb.maxChannelF;
-    for (uint32_t j = 0; j < image->height; ++j) {
-        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][((size_t)j * image->yuvRowBytes[AVIF_CHAN_Y])];
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+    for (size_t j = 0; j < image->height; ++j) {
+        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][(j * image->yuvRowBytes[AVIF_CHAN_Y])];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
 
-        for (uint32_t i = 0; i < image->width; ++i) {
+        for (size_t i = 0; i < image->width; ++i) {
             // Convert unorm to float (no clamp necessary, the full uint8_t range is a legal lookup)
             const float Y = unormFloatTableY[ptrY[i]];
             const float Cb = 0.0f;
@@ -1276,24 +1273,24 @@ static avifResult avifImageYUV8ToRGB16Mono(const avifImage * image, avifRGBImage
 static avifResult avifImageIdentity8ToRGB8ColorFullRange(const avifImage * image, avifRGBImage * rgb, avifReformatState * state)
 {
     const uint32_t rgbPixelBytes = state->rgb.pixelBytes;
-    for (uint32_t j = 0; j < image->height; ++j) {
-        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][((size_t)j * image->yuvRowBytes[AVIF_CHAN_Y])];
-        const uint8_t * const ptrU = &image->yuvPlanes[AVIF_CHAN_U][((size_t)j * image->yuvRowBytes[AVIF_CHAN_U])];
-        const uint8_t * const ptrV = &image->yuvPlanes[AVIF_CHAN_V][((size_t)j * image->yuvRowBytes[AVIF_CHAN_V])];
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+    for (size_t j = 0; j < image->height; ++j) {
+        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][(j * image->yuvRowBytes[AVIF_CHAN_Y])];
+        const uint8_t * const ptrU = &image->yuvPlanes[AVIF_CHAN_U][(j * image->yuvRowBytes[AVIF_CHAN_U])];
+        const uint8_t * const ptrV = &image->yuvPlanes[AVIF_CHAN_V][(j * image->yuvRowBytes[AVIF_CHAN_V])];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
 
         // This is intentionally a per-row conditional instead of a per-pixel
         // conditional. This makes the "else" path (much more common than the
         // "if" path) much faster than having a per-pixel branch.
         if (rgb->format == AVIF_RGB_FORMAT_RGB_565) {
-            for (uint32_t i = 0; i < image->width; ++i) {
+            for (size_t i = 0; i < image->width; ++i) {
                 *(uint16_t *)ptrR = RGB565(ptrV[i], ptrY[i], ptrU[i]);
                 ptrR += rgbPixelBytes;
             }
         } else {
-            for (uint32_t i = 0; i < image->width; ++i) {
+            for (size_t i = 0; i < image->width; ++i) {
                 *ptrR = ptrV[i];
                 *ptrG = ptrY[i];
                 *ptrB = ptrU[i];
@@ -1317,17 +1314,17 @@ static avifResult avifImageYUV8ToRGB8Color(const avifImage * image, avifRGBImage
     AVIF_CHECKERR(avifCreateYUVToRGBLookUpTables(&unormFloatTableY, &unormFloatTableUV, image->depth, state), AVIF_RESULT_OUT_OF_MEMORY);
 
     const float rgbMaxChannelF = state->rgb.maxChannelF;
-    for (uint32_t j = 0; j < image->height; ++j) {
-        const uint32_t uvJ = j >> state->yuv.formatInfo.chromaShiftY;
-        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][((size_t)j * image->yuvRowBytes[AVIF_CHAN_Y])];
-        const uint8_t * const ptrU = &image->yuvPlanes[AVIF_CHAN_U][((size_t)uvJ * image->yuvRowBytes[AVIF_CHAN_U])];
-        const uint8_t * const ptrV = &image->yuvPlanes[AVIF_CHAN_V][((size_t)uvJ * image->yuvRowBytes[AVIF_CHAN_V])];
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+    for (size_t j = 0; j < image->height; ++j) {
+        const size_t uvJ = j >> state->yuv.formatInfo.chromaShiftY;
+        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][(j * image->yuvRowBytes[AVIF_CHAN_Y])];
+        const uint8_t * const ptrU = &image->yuvPlanes[AVIF_CHAN_U][(uvJ * image->yuvRowBytes[AVIF_CHAN_U])];
+        const uint8_t * const ptrV = &image->yuvPlanes[AVIF_CHAN_V][(uvJ * image->yuvRowBytes[AVIF_CHAN_V])];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
 
-        for (uint32_t i = 0; i < image->width; ++i) {
-            uint32_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
+        for (size_t i = 0; i < image->width; ++i) {
+            size_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
 
             // Convert unorm to float (no clamp necessary, the full uint8_t range is a legal lookup)
             const float Y = unormFloatTableY[ptrY[i]];
@@ -1368,13 +1365,13 @@ static avifResult avifImageYUV8ToRGB8Mono(const avifImage * image, avifRGBImage 
     AVIF_CHECKERR(avifCreateYUVToRGBLookUpTables(&unormFloatTableY, NULL, image->depth, state), AVIF_RESULT_OUT_OF_MEMORY);
 
     const float rgbMaxChannelF = state->rgb.maxChannelF;
-    for (uint32_t j = 0; j < image->height; ++j) {
-        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][((size_t)j * image->yuvRowBytes[AVIF_CHAN_Y])];
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+    for (size_t j = 0; j < image->height; ++j) {
+        const uint8_t * const ptrY = &image->yuvPlanes[AVIF_CHAN_Y][(j * image->yuvRowBytes[AVIF_CHAN_Y])];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
 
-        for (uint32_t i = 0; i < image->width; ++i) {
+        for (size_t i = 0; i < image->width; ++i) {
             // Convert unorm to float (no clamp necessary, the full uint8_t range is a legal lookup)
             const float Y = unormFloatTableY[ptrY[i]];
             const float Cb = 0.0f;
@@ -1428,9 +1425,9 @@ static avifResult avifRGBImageToF16(avifRGBImage * rgb)
     const float multiplier = F16_MULTIPLIER * scale;
     uint16_t * pixelRowBase = (uint16_t *)rgb->pixels;
     const uint32_t stride = rgb->rowBytes >> 1;
-    for (uint32_t j = 0; j < rgb->height; ++j) {
+    for (size_t j = 0; j < rgb->height; ++j) {
         uint16_t * pixel = pixelRowBase;
-        for (uint32_t i = 0; i < rgb->width * channelCount; ++i, ++pixel) {
+        for (size_t i = 0; i < rgb->width * channelCount; ++i, ++pixel) {
             avifF16 f16;
             f16.f = *pixel * multiplier;
             *pixel = (uint16_t)(f16.u32 >> 13);
@@ -1703,7 +1700,7 @@ avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
     }
     const uint32_t rowsForLastJob = image->height - rowsPerJob * (jobs - 1);
     uint32_t startRow = 0;
-    uint32_t i;
+    size_t i;
     for (i = 0; i < jobs; ++i, startRow += rowsPerJob) {
         YUVToRGBThreadData * tdata = &threadData[i];
         const avifCropRect rect = { .x = 0, .y = startRow, .width = image->width, .height = (i == jobs - 1) ? rowsForLastJob : rowsPerJob };

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -300,8 +300,8 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                 }
 
                 // Convert an entire 2x2 block to YUV, and populate any fully sampled channels as we go
-                for (size_t bJ = 0; bJ < blockH; ++bJ) {
-                    for (size_t bI = 0; bI < blockW; ++bI) {
+                for (uint32_t bJ = 0; bJ < blockH; ++bJ) {
+                    for (uint32_t bI = 0; bI < blockW; ++bI) {
                         const size_t i = outerI + bI;
                         const size_t j = outerJ + bJ;
 
@@ -680,9 +680,9 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
     // to clang's analyzer.
     assert((alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP) || aPlane);
 
-    for (size_t j = 0; j < image->height; ++j) {
+    for (uint32_t j = 0; j < image->height; ++j) {
         // uvJ is used only when yuvHasColor is true.
-        const size_t uvJ = yuvHasColor ? (j >> state->yuv.formatInfo.chromaShiftY) : 0;
+        const uint32_t uvJ = yuvHasColor ? (j >> state->yuv.formatInfo.chromaShiftY) : 0;
         const uint8_t * ptrY8 = &yPlane[j * yRowBytes];
         const uint8_t * ptrU8 = uPlane ? &uPlane[(uvJ * uRowBytes)] : NULL;
         const uint8_t * ptrV8 = vPlane ? &vPlane[(uvJ * vRowBytes)] : NULL;
@@ -692,12 +692,12 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
         const uint16_t * ptrV16 = (const uint16_t *)ptrV8;
         const uint16_t * ptrA16 = (const uint16_t *)ptrA8;
 
-        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + (j * rgb->rowBytes)];
-        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + (j * rgb->rowBytes)];
-        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + (j * rgb->rowBytes)];
-        uint8_t * ptrGray = &rgb->pixels[state->rgb.offsetBytesGray + (j * rgb->rowBytes)];
+        uint8_t * ptrR = &rgb->pixels[state->rgb.offsetBytesR + ((size_t)j * rgb->rowBytes)];
+        uint8_t * ptrG = &rgb->pixels[state->rgb.offsetBytesG + ((size_t)j * rgb->rowBytes)];
+        uint8_t * ptrB = &rgb->pixels[state->rgb.offsetBytesB + ((size_t)j * rgb->rowBytes)];
+        uint8_t * ptrGray = &rgb->pixels[state->rgb.offsetBytesGray + ((size_t)j * rgb->rowBytes)];
 
-        for (size_t i = 0; i < image->width; ++i) {
+        for (uint32_t i = 0; i < image->width; ++i) {
             float Y, Cb = 0.5f, Cr = 0.5f;
 
             // Calculate Y
@@ -712,7 +712,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
 
             // Calculate Cb and Cr
             if (yuvHasColor) {
-                const size_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
+                const uint32_t uvI = i >> state->yuv.formatInfo.chromaShiftX;
                 if (image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
                     uint16_t unormU, unormV;
 
@@ -1420,7 +1420,7 @@ static avifResult avifRGBImageToF16(avifRGBImage * rgb)
     if (libyuvResult != AVIF_RESULT_NOT_IMPLEMENTED) {
         return libyuvResult;
     }
-    const uint32_t channelCount = avifRGBFormatChannelCount(rgb->format);
+    const size_t channelCount = avifRGBFormatChannelCount(rgb->format);
     const float scale = 1.0f / ((1 << rgb->depth) - 1);
     const float multiplier = F16_MULTIPLIER * scale;
     uint16_t * pixelRowBase = (uint16_t *)rgb->pixels;
@@ -1700,7 +1700,7 @@ avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
     }
     const uint32_t rowsForLastJob = image->height - rowsPerJob * (jobs - 1);
     uint32_t startRow = 0;
-    size_t i;
+    uint32_t i;
     for (i = 0; i < jobs; ++i, startRow += rowsPerJob) {
         YUVToRGBThreadData * tdata = &threadData[i];
         const avifCropRect rect = { .x = 0, .y = startRow, .width = image->width, .height = (i == jobs - 1) ? rowsForLastJob : rowsPerJob };


### PR DESCRIPTION
This change promotes several pixel offset multiplications in avifImageRGBToYUV and avifImageYUVAnyToRGBAnySlow to size_t before pointer arithmetic.

Currently, expressions such as:

(i * rgbPixelBytes)

are evaluated using 32-bit arithmetic before being promoted to size_t. While current AV1 frame dimension limits prevent overflow under normal conditions, performing these calculations directly in size_t ensures correctness and avoids reliance on implicit width constraints.