### PR TITLE
Delete ninja install in CI

### DIFF
--- a/.github/actions/setup-common/action.yml
+++ b/.github/actions/setup-common/action.yml
@@ -34,8 +34,6 @@ runs:
     - name: Print CMake version
       run: cmake --version
       shell: bash
-    - name: Set up ninja
-      uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
     - name: Set up nasm
       if: ${{ inputs.codec-aom == 'LOCAL' || inputs.codec-dav1d == 'LOCAL' }}
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2


### PR DESCRIPTION
Quoting https://github.com/seanmiddleditch/gha-setup-ninja: "This action is no longer necessary, as ninja is now included on all default GitHub runner instances."

v1.12.1 is installed with this action while v1.13.2 is out on all runners (cf -latest on https://docs.github.com/en/actions/reference/runners/github-hosted-runners).