### PR TITLE
Install NASM when building SVT-AV1 locally

### DIFF
--- a/.github/actions/setup-common/action.yml
+++ b/.github/actions/setup-common/action.yml
@@ -10,6 +10,9 @@ inputs:
   codec-rav1e:
     description: "Can take the values: OFF, LOCAL, SYSTEM"
     default: "OFF"
+  codec-svt:
+    description: "Can take the values: OFF, LOCAL, SYSTEM"
+    default: "OFF"
   oldest-cmake:
     description: "Can take the values: true, false. Only useful on Linux to force using the minimum required CMake"
     default: "false"
@@ -35,7 +38,7 @@ runs:
       run: cmake --version
       shell: bash
     - name: Set up nasm
-      if: ${{ inputs.codec-aom == 'LOCAL' || inputs.codec-dav1d == 'LOCAL' }}
+      if: ${{ inputs.codec-aom == 'LOCAL' || inputs.codec-dav1d == 'LOCAL' || inputs.codec-svt == 'LOCAL' }}
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
     - name: Set up rust
       if: ${{ inputs.codec-rav1e == 'LOCAL' }}

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -10,6 +10,9 @@ inputs:
   codec-rav1e:
     description: "Can take the values: OFF, LOCAL, SYSTEM"
     default: "OFF"
+  codec-svt:
+    description: "Can take the values: OFF, LOCAL, SYSTEM"
+    default: "OFF"
   extra-cache-key:
     description: "Extra cache key to use in the cache name. Useful when several caches are used in one workflow."
     default: ""
@@ -51,6 +54,10 @@ runs:
       if: ${{ inputs.codec-rav1e == 'SYSTEM' }}
       run: sudo apt install -y librav1e-dev
       shell: bash
+    - name: Install SVT-AV1 library
+      if: ${{ inputs.codec-rav1e == 'SYSTEM' }}
+      run: sudo apt install -y libsvtav1enc-dev
+      shell: bash
     - name: Install libxml2 library
       if: ${{ inputs.libxml2 == 'SYSTEM' }}
       run: sudo apt install -y libxml2
@@ -79,6 +86,7 @@ runs:
         codec-aom: ${{ inputs.codec-aom }}
         codec-dav1d: ${{ inputs.codec-dav1d }}
         codec-rav1e: ${{ inputs.codec-rav1e }}
+        codec-svt: ${{ inputs.codec-svt }}
         oldest-cmake: ${{ inputs.oldest-cmake }}
 
     - name: Set GCC & G++ compiler

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -10,6 +10,9 @@ inputs:
   codec-rav1e:
     description: "Can take the values: OFF, LOCAL, SYSTEM"
     default: "OFF"
+  codec-svt:
+    description: "Can take the values: OFF, LOCAL, SYSTEM"
+    default: "OFF"
   gtest:
     description: "Can take the values: OFF, LOCAL, SYSTEM"
     default: "OFF"
@@ -65,3 +68,4 @@ runs:
         codec-aom: ${{ inputs.codec-aom }}
         codec-dav1d: ${{ inputs.codec-dav1d }}
         codec-rav1e: ${{ inputs.codec-rav1e }}
+        codec-svt: ${{ inputs.codec-svt }}

--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -10,6 +10,9 @@ inputs:
   codec-rav1e:
     description: "Can take the values: OFF, LOCAL, SYSTEM"
     default: "OFF"
+  codec-svt:
+    description: "Can take the values: OFF, LOCAL, SYSTEM"
+    default: "OFF"
   extra-cache-key:
     description: "Extra cache key to use in the cache name. Useful when several caches are used in one workflow."
     default: ""
@@ -47,6 +50,10 @@ runs:
     - name: Install libdav1d library
       if: ${{ inputs.codec-dav1d == 'SYSTEM' }}
       run: echo "AVIF_WIN_LIBRARIES=${{ env.AVIF_WIN_LIBRARIES }} dav1d" >> "$GITHUB_ENV"
+      shell: bash
+    - name: Install SVT-AV1 library
+      if: ${{ inputs.codec-svt == 'SYSTEM' }}
+      run: echo "AVIF_WIN_LIBRARIES=${{ env.AVIF_WIN_LIBRARIES }} svt-av1" >> "$GITHUB_ENV"
       shell: bash
     - name: Install libjpeg-turbo library
       if: ${{ inputs.libjpeg-turbo == 'SYSTEM' }}
@@ -109,3 +116,4 @@ runs:
         codec-aom: ${{ inputs.codec-aom }}
         codec-dav1d: ${{ inputs.codec-dav1d }}
         codec-rav1e: ${{ inputs.codec-rav1e }}
+        codec-svt: ${{ inputs.codec-svt }}

--- a/.github/workflows/ci-disable-gtest.yml
+++ b/.github/workflows/ci-disable-gtest.yml
@@ -42,6 +42,7 @@ jobs:
           codec-aom: "LOCAL"
           codec-dav1d: "LOCAL"
           codec-rav1e: "LOCAL"
+          codec-svt: "LOCAL"
           gcc-version: ${{ matrix.gcc }}
           libyuv: "LOCAL"
 

--- a/.github/workflows/ci-unix-static-av2.yml
+++ b/.github/workflows/ci-unix-static-av2.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           codec-aom: "LOCAL"
           codec-dav1d: ${{ matrix.also-enable-av1-codecs }}
+          codec-svt: ${{ matrix.also-enable-av1-codecs }}
           extra-cache-key: ${{ matrix.also-enable-av1-codecs }}
           gcc-version: ${{ matrix.gcc }}
           libyuv: "LOCAL"

--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -38,6 +38,7 @@ jobs:
           codec-aom: "LOCAL"
           codec-dav1d: "LOCAL"
           codec-rav1e: "LOCAL"
+          codec-svt: "LOCAL"
           gcc-version: ${{ matrix.gcc }}
           libxml2: "LOCAL"
           libyuv: "LOCAL"

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -43,6 +43,7 @@ jobs:
           codec-aom: "LOCAL"
           codec-dav1d: "LOCAL"
           codec-rav1e: "LOCAL"
+          codec-svt: "LOCAL"
           extra-cache-key: ${{ matrix.generator }}
           libjpeg-turbo: "LOCAL"
           libxml2: "LOCAL"


### PR DESCRIPTION
This is to make sure there is at least one assembler available. Otherwise, MSVC can be chosen as an assembler while it is not, cf https://cmake.org/cmake/help/latest/policy/CMP0194.html