### PR TITLE
Skip ImageMagick test in MinGW

### DIFF
--- a/tests/test_cmd_icc_profile.sh
+++ b/tests/test_cmd_icc_profile.sh
@@ -79,7 +79,8 @@ pushd ${TMP_DIR}
 
   # Avoid ImageMagick 7.1.2-17 errors in MinGW. See
   # https://github.com/AOMediaCodec/libavif/issues/3111.
-  if [[ -n "${MSYSTEM:-}" ]]; then
+  if [[ -n "${MSYSTEM:-}" ]]
+  then
     echo "Skipping ImageMagick test in MinGW"
     touch "${ENCODED_FILE}"
     touch "${DECODED_FILE}"

--- a/tests/test_cmd_transform.sh
+++ b/tests/test_cmd_transform.sh
@@ -97,7 +97,8 @@ pushd ${TMP_DIR}
 
   # Avoid ImageMagick 7.1.2-17 errors in MinGW. See
   # https://github.com/AOMediaCodec/libavif/issues/3111.
-  if [[ -n "${MSYSTEM:-}" ]]; then
+  if [[ -n "${MSYSTEM:-}" ]]
+  then
       echo "Skipping ImageMagick test in MinGW"
       popd
       exit 0


### PR DESCRIPTION
ImageMagick 7.1.2-17 fails or crashes in MinGW. Skip the ImageMagick test to avoid test failures in test_cmd_icc_profile.sh and test_cmd_transform.sh.

Fixes https://github.com/AOMediaCodec/libavif/issues/3111.