### PR TITLE
Remove unused libaom and AVM image formats

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -191,7 +191,6 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
         avifPixelFormat yuvFormat = AVIF_PIXEL_FORMAT_NONE;
         switch (codec->internal->image->fmt) {
             case AOM_IMG_FMT_I420:
-            case AOM_IMG_FMT_AOMI420:
             case AOM_IMG_FMT_I42016:
                 yuvFormat = AVIF_PIXEL_FORMAT_YUV420;
                 break;
@@ -210,7 +209,6 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
             case AOM_IMG_FMT_NV12:
 #endif
             case AOM_IMG_FMT_YV12:
-            case AOM_IMG_FMT_AOMYV12:
             case AOM_IMG_FMT_YV1216:
             default:
                 return AVIF_FALSE;

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -130,7 +130,6 @@ static avifBool avmCodecGetNextImage(struct avifCodec * codec,
         avifPixelFormat yuvFormat = AVIF_PIXEL_FORMAT_NONE;
         switch (codec->internal->image->fmt) {
             case AVM_IMG_FMT_I420:
-            case AVM_IMG_FMT_AVMI420:
             case AVM_IMG_FMT_I42016:
                 yuvFormat = AVIF_PIXEL_FORMAT_YUV420;
                 break;
@@ -144,7 +143,6 @@ static avifBool avmCodecGetNextImage(struct avifCodec * codec,
                 break;
             case AVM_IMG_FMT_NONE:
             case AVM_IMG_FMT_YV12:
-            case AVM_IMG_FMT_AVMYV12:
             case AVM_IMG_FMT_YV1216:
             default:
                 return AVIF_FALSE;


### PR DESCRIPTION
AOM_IMG_FMT_AOMYV12 and AOM_IMG_FMT_AOMI420 are unused.

AVM_IMG_FMT_AVMYV12 and AVM_IMG_FMT_AVMI420 are unused.