### PR TITLE
Revert "Skip ImageMagick test in MinGW"

### DIFF
--- a/tests/test_cmd_icc_profile.sh
+++ b/tests/test_cmd_icc_profile.sh
@@ -77,18 +77,6 @@ pushd ${TMP_DIR}
   fi
   "${IMAGEMAGICK}" --version
 
-  # Avoid ImageMagick 7.1.2-17 errors in MinGW. See
-  # https://github.com/AOMediaCodec/libavif/issues/3111.
-  if [[ -n "${MSYSTEM:-}" ]]
-  then
-    echo "Skipping ImageMagick test in MinGW"
-    touch "${ENCODED_FILE}"
-    touch "${DECODED_FILE}"
-    touch "${CORRECTED_FILE}"
-    popd
-    exit 0
-  fi
-
   "${AVIFENC}" -s 8 -l "${INPUT_COLOR_PNG}" -o "${ENCODED_FILE}"
   # Old version of ImageMagick may not support reading ICC from AVIF.
   # Decode to PNG using avifdec first.

--- a/tests/test_cmd_transform.sh
+++ b/tests/test_cmd_transform.sh
@@ -95,15 +95,6 @@ pushd ${TMP_DIR}
   fi
   "${IMAGEMAGICK}" --version
 
-  # Avoid ImageMagick 7.1.2-17 errors in MinGW. See
-  # https://github.com/AOMediaCodec/libavif/issues/3111.
-  if [[ -n "${MSYSTEM:-}" ]]
-  then
-      echo "Skipping ImageMagick test in MinGW"
-      popd
-      exit 0
-  fi
-
   JPEG_PSNR_THRESHOLD=48
 
   # Crop


### PR DESCRIPTION
This reverts commit b3be0b951f11deed2603b339b799037a65bba818.

Remove workaround for issue
https://github.com/AOMediaCodec/libavif/issues/3111.

The MinGW ImageMagick package bug has been fixed:
https://github.com/msys2/MINGW-packages/issues/28550