### PR TITLE
Stop testing the mingw64 system in ci-mingw.yml

### DIFF
--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         sys:
-          - mingw64
           - ucrt64
           - clang64
 


### PR DESCRIPTION
On 2026-03-15, MSYS2 announced that they are deprecating the MINGW64 Environment:

    [...], we are beginning to phase out the MINGW64 environment. [...]
    If you are currently relying on the MINGW64 environment, please
    consider switching to UCRT64 or CLANG64 instead.

https://www.msys2.org/news/#2026-03-15-deprecating-the-mingw64-environment