### PR TITLE
avifenc: add --noalpha flag to discard alpha channel on encode

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -528,6 +528,7 @@ static avifBool avifInputReadImage(avifInput * input,
                                    avifBool ignoreColorProfile,
                                    avifBool ignoreExif,
                                    avifBool ignoreXMP,
+                                   avifBool ignoreAlpha,
                                    avifBool allowChangingCicp,
                                    avifBool ignoreGainMap,
                                    avifImage * image,
@@ -635,6 +636,11 @@ static avifBool avifInputReadImage(avifInput * input,
         }
         return AVIF_FALSE;
     }
+    
+    if (ignoreAlpha) {
+        dstImage->alphaPlane = NULL;
+        dstImage->alphaRowBytes = 0;
+    }
     if (!allowChangingCicp) {
         // Restore the previous primaries/transfer in case avifReadImage changed them.
         dstImage->colorPrimaries = colorPrimariesBefore;
@@ -660,6 +666,7 @@ static avifBool avifInputReadImage(avifInput * input,
                                   ignoreColorProfile,
                                   ignoreExif,
                                   ignoreXMP,
+                                  ignoreAlpha,
                                   allowChangingCicp,
                                   ignoreGainMap,
                                   image,
@@ -921,6 +928,7 @@ static avifBool avifEncodeRestOfImageSequence(avifEncoder * encoder,
                                 /*ignoreColorProfile=*/AVIF_TRUE,
                                 /*ignoreExif=*/AVIF_TRUE,
                                 /*ignoreXMP=*/AVIF_TRUE,
+                                settings->ignoreAlpha,
                                 /*allowChangingCicp=*/AVIF_FALSE,
                                 /*ignoreGainMap=*/AVIF_TRUE,
                                 nextImage,
@@ -1023,6 +1031,7 @@ static avifBool avifEncodeRestOfLayeredImage(avifEncoder * encoder,
                                     /*ignoreColorProfile=*/AVIF_TRUE,
                                     /*ignoreExif=*/AVIF_TRUE,
                                     /*ignoreXMP=*/AVIF_TRUE,
+                                    settings->ignoreAlpha,
                                     !settings->cicpExplicitlySet,
                                     /*ignoreGainMap=*/AVIF_TRUE,
                                     nextImage,
@@ -2322,6 +2331,7 @@ int main(int argc, char * argv[])
                             settings.ignoreColorProfile,
                             settings.ignoreExif,
                             settings.ignoreXMP,
+                            settings.ignoreAlpha,
                             /*allowChangingCicp=*/!settings.cicpExplicitlySet,
                             ignoreGainMap,
                             image,
@@ -2450,11 +2460,6 @@ int main(int argc, char * argv[])
         image->clli.maxPALL = (uint16_t)settings.clliValues[1];
     }
 
-    if (settings.ignoreAlpha) {
-        image->alphaPlane    = NULL;
-        image->alphaRowBytes = 0;
-    }
-
     avifBool hasAlpha = (image->alphaPlane && image->alphaRowBytes);
     avifBool usingLosslessColor = (firstFile->settings.quality.value == AVIF_QUALITY_LOSSLESS);
     avifBool usingLosslessAlpha = (firstFile->settings.qualityAlpha.value == AVIF_QUALITY_LOSSLESS);
@@ -2572,6 +2577,7 @@ int main(int argc, char * argv[])
                                     /*ignoreColorProfile=*/AVIF_TRUE,
                                     /*ignoreExif=*/AVIF_TRUE,
                                     /*ignoreXMP=*/AVIF_TRUE,
+                                    settings.ignoreAlpha,
                                     /*allowChangingCicp=*/AVIF_FALSE,
                                     settings.ignoreGainMap,
                                     cellImage,

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -59,6 +59,7 @@ typedef struct
     avifBool ignoreExif;
     avifBool ignoreXMP;
     avifBool ignoreColorProfile;
+    avifBool ignoreAlpha;
 
     // These settings are only relevant when compiled with AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION.
     avifBool qualityGainMapIsConstrained; // true if qualityGainMap explicitly set by the user
@@ -256,6 +257,7 @@ static void syntaxLong(void)
     printf("    --ignore-exif                     : If the input file contains embedded Exif metadata, ignore it (no-op if absent)\n");
     printf("    --ignore-xmp                      : If the input file contains embedded XMP metadata, ignore it (no-op if absent)\n");
     printf("    --ignore-profile,--ignore-icc     : If the input file contains an embedded color profile, ignore it (no-op if absent)\n");
+    printf("    --ignore-alpha,--noalpha          : Discard the alpha channel when encoding.\n");
 #if defined(AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION)
     printf("    --ignore-gain-map                 : If the input file contains an embedded gain map, ignore it (no-op if absent)\n");
     printf("    --qgain-map Q                     : Quality for the gain map in %d..%d where %d is lossless\n",
@@ -1418,6 +1420,7 @@ int main(int argc, char * argv[])
     settings.ignoreExif = AVIF_FALSE;
     settings.ignoreXMP = AVIF_FALSE;
     settings.ignoreColorProfile = AVIF_FALSE;
+    settings.ignoreAlpha = AVIF_FALSE;
     settings.ignoreGainMap = AVIF_FALSE;
     settings.cicpExplicitlySet = AVIF_FALSE;
     settings.inputFormat = AVIF_APP_FILE_FORMAT_UNKNOWN;
@@ -1824,6 +1827,8 @@ int main(int argc, char * argv[])
                 goto cleanup;
             }
             settings.ignoreColorProfile = AVIF_TRUE;
+        } else if (!strcmp(arg, "--ignore-alpha") || !strcmp(arg, "--noalpha")) {
+            settings.ignoreAlpha = AVIF_TRUE;
         } else if (!strcmp(arg, "--duration") || strpre(arg, "--duration:")) {
             // --duration is special, we always treat it as suffixed with :u, so don't print warning for it.
             avifOptionSuffixType type = parseOptionSuffix(arg, /*warnNoSuffix=*/AVIF_FALSE);
@@ -2443,6 +2448,11 @@ int main(int argc, char * argv[])
     if (settings.clliPresent) {
         image->clli.maxCLL = (uint16_t)settings.clliValues[0];
         image->clli.maxPALL = (uint16_t)settings.clliValues[1];
+    }
+
+    if (settings.ignoreAlpha) {
+        image->alphaPlane    = NULL;
+        image->alphaRowBytes = 0;
     }
 
     avifBool hasAlpha = (image->alphaPlane && image->alphaRowBytes);


### PR DESCRIPTION
Adds an option to avifenc to ignore and discard any alpha channel present in the input image and encode the output as fully opaque. This is useful for cases where input assets contain unintended or accidental alpha channels (for example, PNGs exported by certain tools that always include an alpha plane), but the final AVIF output is intended to be RGB-only. Also helps with avoiding unnecessary alpha processing overhead during encoding.

The feature aligns with existing behavior in encoders such as WebP's [cwebp](https://developers.google.com/speed/webp/docs/cwebp), which already provides a -noalpha option to discard transparency when it is not required.

It was also requested by users at [#1665 ](https://github.com/AOMediaCodec/libavif/issues/1665)