### PR TITLE
Remove avm_codec_control(AV2D_SET_OPERATING_POINT)

### DIFF
--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -80,7 +80,8 @@ static avifBool avmCodecGetNextImage(struct avifCodec * codec,
         if (avm_codec_control(&codec->internal->decoder, AV2D_SET_OUTPUT_ALL_LAYERS, codec->allLayers)) {
             return AVIF_FALSE;
         }
-        if (avm_codec_control(&codec->internal->decoder, AV2D_SET_OPERATING_POINT, codec->operatingPoint)) {
+        if (codec->operatingPoint != 0) {
+            // Not implemented.
             return AVIF_FALSE;
         }
 


### PR DESCRIPTION
The AV2D_SET_OPERATING_POINT codec control has been replaced by AV2D_SET_SELECTED_OPS and AV2D_SET_SELECTED_LOCAL_OPS in https://gitlab.com/AOMediaCodec/avm/-/merge_requests/3169. Since we don't have any layered AV2 images, simply remove the avm_codec_control(AV2D_SET_OPERATING_POINT) call and check that the operating point is the default (0).