### PR TITLE
Pass AVIF_ENABLE_WERROR to libavif in Android tests

### DIFF
--- a/.github/workflows/ci-android-jni.yml
+++ b/.github/workflows/ci-android-jni.yml
@@ -42,6 +42,8 @@ jobs:
         run: sdkmanager "cmake;3.22.1"
       - name: Build the libavif JNI Wrapper
         working-directory: android_jni
-        run: ./gradlew --no-daemon assembleRelease
+        run: |
+          ./gradlew --no-daemon assembleRelease \
+          -Pandroid.extraCMakeFlags="-DAVIF_ENABLE_WERROR=ON"
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}

--- a/android_jni/avifandroidjni/build.gradle
+++ b/android_jni/avifandroidjni/build.gradle
@@ -13,6 +13,16 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        externalNativeBuild {
+            cmake {
+                if (project.hasProperty('android.extraCMakeFlags')) {
+                    def extraCMakeFlags = project.property('android.extraCMakeFlags')
+                    if (extraCMakeFlags != null && !extraCMakeFlags.toString().isEmpty()) {
+                        arguments extraCMakeFlags.toString()
+                    }
+                }
+            }
+        }
     }
 
     buildTypes {

--- a/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
+++ b/android_jni/avifandroidjni/src/main/jni/CMakeLists.txt
@@ -5,6 +5,10 @@ cmake_minimum_required(VERSION 3.22)
 
 project(avif_android_jni)
 
+# Setting the same option as libavif here ensures the AVIF_ENABLE_WERROR
+# variable is set in the CACHE for add_subdirectory to consume below.
+option(AVIF_ENABLE_WERROR "Treat all compiler warnings as errors" OFF)
+
 # Perform a static build of libavif and link it with the jni shared library so
 # that we end up with a single libavif_android.so file in the end.
 #


### PR DESCRIPTION
This would have been useful to catch the bug fixed in https://github.com/AOMediaCodec/libavif/pull/3132