### PR TITLE
Set offsetBytesA for AVIF_RGB_FORMAT_GRAY

### DIFF
--- a/src/reformat.c
+++ b/src/reformat.c
@@ -93,6 +93,7 @@ avifBool avifGetRGBColorSpaceInfo(const avifRGBImage * rgb, avifRGBColorSpaceInf
             break;
         case AVIF_RGB_FORMAT_GRAY:
             info->offsetBytesGray = info->channelBytes * 0;
+            info->offsetBytesA = 0;
             break;
         case AVIF_RGB_FORMAT_GRAYA:
             info->offsetBytesGray = info->channelBytes * 0;


### PR DESCRIPTION
Within `avifGetRGBColorSpaceInfo()`, `AVIF_RGB_FORMAT_GRAY` is the only `rgb->format` that doesn't set `info->offsetBytesA`. This adds it.

`avifImageRGBToYUV()` calls `avifPrepareReformatState()`, which calls `avifGetRGBColorSpaceInfo()`.
https://github.com/AOMediaCodec/libavif/blob/24eff5475e6275b7655c4bbc68386b5fb89dba02/src/reformat.c#L218-L225
https://github.com/AOMediaCodec/libavif/blob/24eff5475e6275b7655c4bbc68386b5fb89dba02/src/reformat.c#L158-L169

I expected `offsetBytesA` to be set so that `avifImageRGBToYUV()` could access it later at
https://github.com/AOMediaCodec/libavif/blob/24eff5475e6275b7655c4bbc68386b5fb89dba02/src/reformat.c#L471