### PR TITLE
replace assert with proper checks in avifImageCopySamples

### DIFF
--- a/include/avif/internal.h
+++ b/include/avif/internal.h
@@ -62,6 +62,13 @@ static inline void avifBreakOnError()
 // AVIF_ASSERT_OR_RETURN() can be used instead of assert() for extra security in release builds.
 #ifdef NDEBUG
 #define AVIF_ASSERT_OR_RETURN(A) AVIF_CHECKERR((A), AVIF_RESULT_INTERNAL_ERROR)
+#define AVIF_ASSERT_OR_RETURN_VOID(A) \
+    do {                              \
+        if (!(A)) {                   \
+            avifBreakOnError();       \
+            return;                   \
+        }                             \
+    } while (0)
 #define AVIF_ASSERT_NOT_REACHED_OR_RETURN  \
     do {                                   \
         avifBreakOnError();                \
@@ -69,6 +76,7 @@ static inline void avifBreakOnError()
     } while (0)
 #else
 #define AVIF_ASSERT_OR_RETURN(A) assert(A)
+#define AVIF_ASSERT_OR_RETURN_VOID(A) assert(A)
 #define AVIF_ASSERT_NOT_REACHED_OR_RETURN assert(0);
 #endif
 
@@ -153,7 +161,7 @@ void avifImageCopyNoAlloc(avifImage * dstImage, const avifImage * srcImage);
 // srcImage and dstImage must have the same width, height, and depth.
 // If the AVIF_PLANES_YUV bit is set in planes, then srcImage and dstImage must have the same yuvFormat.
 // Ignores the gainMap field.
-void avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes);
+avifResult avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes);
 
 // Appends an opaque image item property.
 avifResult avifImagePushProperty(avifImage * image,

--- a/src/alpha.c
+++ b/src/alpha.c
@@ -165,7 +165,7 @@ avifResult avifRGBImagePremultiplyAlpha(avifRGBImage * rgb)
         return libyuvResult;
     }
 
-    assert(rgb->depth >= 8 && rgb->depth <= 16);
+    AVIF_ASSERT_OR_RETURN(rgb->depth >= 8 && rgb->depth <= 16);
 
     uint32_t max = (1 << rgb->depth) - 1;
     float maxF = (float)max;
@@ -352,7 +352,7 @@ avifResult avifRGBImageUnpremultiplyAlpha(avifRGBImage * rgb)
         return libyuvResult;
     }
 
-    assert(rgb->depth >= 8 && rgb->depth <= 16);
+    AVIF_ASSERT_OR_RETURN(rgb->depth >= 8 && rgb->depth <= 16);
 
     uint32_t max = (1 << rgb->depth) - 1;
     float maxF = (float)max;

--- a/src/avif.c
+++ b/src/avif.c
@@ -184,11 +184,11 @@ void avifImageCopyNoAlloc(avifImage * dstImage, const avifImage * srcImage)
     dstImage->imir = srcImage->imir;
 }
 
-void avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes)
+avifResult avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes)
 {
-    assert(srcImage->depth == dstImage->depth);
+    AVIF_CHECKERR(srcImage->depth == dstImage->depth, AVIF_RESULT_INVALID_ARGUMENT);
     if (planes & AVIF_PLANES_YUV) {
-        assert(srcImage->yuvFormat == dstImage->yuvFormat);
+        AVIF_CHECKERR(srcImage->yuvFormat == dstImage->yuvFormat, AVIF_RESULT_INVALID_ARGUMENT);
         // Note that there may be a mismatch between srcImage->yuvRange and dstImage->yuvRange
         // because libavif allows for 'colr' and AV1 OBU video range values to differ.
     }
@@ -208,12 +208,12 @@ void avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avif
         uint8_t * dstRow = avifImagePlane(dstImage, c);
         const uint32_t srcRowBytes = avifImagePlaneRowBytes(srcImage, c);
         const uint32_t dstRowBytes = avifImagePlaneRowBytes(dstImage, c);
-        assert(!srcRow == !dstRow);
+        AVIF_CHECKERR(!srcRow == !dstRow, AVIF_RESULT_INVALID_ARGUMENT);
         if (!srcRow) {
             continue;
         }
-        assert(planeWidth == avifImagePlaneWidth(dstImage, c));
-        assert(planeHeight == avifImagePlaneHeight(dstImage, c));
+        AVIF_CHECKERR(planeWidth == avifImagePlaneWidth(dstImage, c), AVIF_RESULT_INVALID_ARGUMENT);
+        AVIF_CHECKERR(planeHeight == avifImagePlaneHeight(dstImage, c), AVIF_RESULT_INVALID_ARGUMENT);
 
         const size_t planeWidthBytes = planeWidth * bytesPerPixel;
         for (uint32_t y = 0; y < planeHeight; ++y) {
@@ -222,6 +222,7 @@ void avifImageCopySamples(avifImage * dstImage, const avifImage * srcImage, avif
             dstRow += dstRowBytes;
         }
     }
+    return AVIF_RESULT_OK;
 }
 
 static avifResult avifImageCopyProperties(avifImage * dstImage, const avifImage * srcImage)
@@ -277,7 +278,7 @@ avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifP
             return allocationResult;
         }
     }
-    avifImageCopySamples(dstImage, srcImage, planes);
+    AVIF_CHECKRES(avifImageCopySamples(dstImage, srcImage, planes));
 
     if (srcImage->gainMap) {
         if (!dstImage->gainMap) {

--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -98,7 +98,10 @@ static avifBool aomCodecGetNextImage(struct avifCodec * codec,
                                      avifBool * isLimitedRangeAlpha,
                                      avifImage * image)
 {
-    assert(sample);
+    if (!sample) {
+        avifBreakOnError();
+        return AVIF_FALSE;
+    }
 
     aom_codec_iface_t * const decoderInterface = aom_codec_av1_dx();
     struct aom_codec_stream_info streamInfo = { 0 };
@@ -408,7 +411,10 @@ static avifBool avifAOMOptionsContainExplicitTuning(const avifCodec * codec, avi
 
             int val;
             if (aomOptionParseEnum(entry->value, tuneIqEnum, &val)) {
-                assert(val == AOM_TUNE_IQ);
+                if (val != AOM_TUNE_IQ) {
+                    avifBreakOnError();
+                    return AVIF_RESULT_INVALID_ARGUMENT;
+                }
                 *useTuneIq = AVIF_TRUE;
             } else {
                 *useTuneIq = AVIF_FALSE;

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -54,7 +54,10 @@ static avifBool avmCodecGetNextImage(struct avifCodec * codec,
                                      avifBool * isLimitedRangeAlpha,
                                      avifImage * image)
 {
-    assert(sample);
+    if (!sample) {
+        avifBreakOnError();
+        return AVIF_FALSE;
+    }
 
     if (!codec->internal->decoderInitialized) {
         avm_codec_dec_cfg_t cfg;
@@ -425,7 +428,10 @@ static int avmScaleQuantizer(int quantizer, uint32_t depth)
     if (depth == 12) {
         return AVIF_CLAMP((quantizer * (255 + 96) + 31) / 63 - 96, -96, 255);
     }
-    assert(depth == 8);
+    if (depth != 8) {
+        avifBreakOnError();
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
     return AVIF_CLAMP((quantizer * 255 + 31) / 63, 0, 255);
 }
 
@@ -440,7 +446,10 @@ static int avmQualityToQuantizer(int quality, uint32_t depth)
     if (depth == 12) {
         return 255 - (quality * (255 + 96) + 50) / 100;
     }
-    assert(depth == 8);
+    if (depth != 8) {
+        avifBreakOnError();
+        return AVIF_RESULT_NOT_IMPLEMENTED;
+    }
     return 255 - (quality * 255 + 50) / 100;
 }
 

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -113,8 +113,8 @@ avifResult avifRGBImageApplyGainMap(const avifRGBImage * baseImage,
     if (weight == 0.0f && outputTransferCharacteristics == baseTransferCharacteristics &&
         outputColorPrimaries == baseColorPrimaries && baseImage->format == toneMappedImage->format &&
         baseImage->depth == toneMappedImage->depth && baseImage->isFloat == toneMappedImage->isFloat) {
-        assert(baseImage->rowBytes == toneMappedImage->rowBytes);
-        assert(baseImage->height == toneMappedImage->height);
+        AVIF_ASSERT_OR_RETURN(baseImage->rowBytes == toneMappedImage->rowBytes);
+        AVIF_ASSERT_OR_RETURN(baseImage->height == toneMappedImage->height);
         // Copy the base image.
         memcpy(toneMappedImage->pixels, baseImage->pixels, (size_t)baseImage->rowBytes * baseImage->height);
         goto cleanup;

--- a/src/mem.c
+++ b/src/mem.c
@@ -8,7 +8,10 @@
 
 void * avifAlloc(size_t size)
 {
-    assert(size != 0); // Implementation-defined. See https://en.cppreference.com/w/cpp/memory/c/malloc
+    if (size == 0) {
+        avifBreakOnError();
+        return NULL;
+    }
     return malloc(size);
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -65,7 +65,7 @@ static const char * avifGetConfigurationPropertyName(avifCodecType codecType)
             return "av2C";
 #endif
         default:
-            assert(AVIF_FALSE);
+            avifBreakOnError();
             return kUnknown; // Easier to deal with than NULL.
     }
 }
@@ -1870,7 +1870,7 @@ static avifResult avifDecoderDataCopyTileToImage(avifDecoderData * data,
     const avifCropRect srcTileViewRect = { 0, 0, dstTileViewRect.width, dstTileViewRect.height };
     AVIF_ASSERT_OR_RETURN(avifImageSetViewRect(&dstTileView, &dstView, &dstTileViewRect) == AVIF_RESULT_OK);
     AVIF_ASSERT_OR_RETURN(avifImageSetViewRect(&srcTileView, tile->image, &srcTileViewRect) == AVIF_RESULT_OK);
-    avifImageCopySamples(&dstTileView, &srcTileView, avifIsAlpha(tile->input->itemCategory) ? AVIF_PLANES_A : AVIF_PLANES_YUV);
+    AVIF_ASSERT_OR_RETURN(avifImageCopySamples(&dstTileView, &srcTileView, avifIsAlpha(tile->input->itemCategory) ? AVIF_PLANES_A : AVIF_PLANES_YUV) == AVIF_RESULT_OK);
     return AVIF_RESULT_OK;
 }
 
@@ -2311,7 +2311,8 @@ static const avifProperty * avifDecoderItemCodecConfigOrFirstCellCodecConfig(con
             }
         }
         // The number of tiles was verified in avifDecoderItemReadAndParse().
-        assert(AVIF_FALSE);
+        avifBreakOnError();
+        return NULL;
     }
     return avifPropertyArrayFind(&item->properties, avifGetConfigurationPropertyName(avifGetCodecType(item->type)));
 }
@@ -4549,7 +4550,7 @@ static avifResult avifParseMinimizedImageBox(avifDecoderData * data,
     if (orientation == 3 || orientation == 5 || orientation == 6 || orientation == 7 || orientation == 8) {
         irotPropIndex = meta->properties.count; // Store index instead of pointer which may be invalidated by avifMetaCreateProperty().
         // Property with fixed 1-based index 9.
-        assert(irotPropIndex + 1 == 9);
+        AVIF_ASSERT_OR_RETURN(irotPropIndex + 1 == 9);
         avifProperty * irotProp = avifMetaCreateProperty(meta, "irot");
         AVIF_CHECKERR(irotProp, AVIF_RESULT_OUT_OF_MEMORY);
         irotProp->u.irot.angle = orientation == 3 ? 2 : (orientation == 5 || orientation == 8) ? 1 : 3;
@@ -4559,7 +4560,7 @@ static avifResult avifParseMinimizedImageBox(avifDecoderData * data,
     if (orientation == 2 || orientation == 4 || orientation == 5 || orientation == 7) {
         imirPropIndex = meta->properties.count;
         // Property with fixed 1-based index 10.
-        assert(imirPropIndex + 1 == 10);
+        AVIF_ASSERT_OR_RETURN(imirPropIndex + 1 == 10);
         avifProperty * imirProp = avifMetaCreateProperty(meta, "imir");
         AVIF_CHECKERR(imirProp, AVIF_RESULT_OUT_OF_MEMORY);
         imirProp->u.imir.axis = orientation == 2 ? 1 : 0;
@@ -5626,7 +5627,7 @@ static avifResult avifReadColorNclxProperty(const avifPropertyArray * properties
                                             avifRange * yuvRange,
                                             avifBool * cicpSet)
 {
-    assert(cicpSet == NULL || *cicpSet == AVIF_FALSE);
+    AVIF_ASSERT_OR_RETURN(cicpSet == NULL || *cicpSet == AVIF_FALSE);
     avifBool colrNCLXSeen = AVIF_FALSE;
     for (uint32_t propertyIndex = 0; propertyIndex < properties->count; ++propertyIndex) {
         avifProperty * prop = &properties->prop[propertyIndex];

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -576,7 +576,10 @@ static avifBool avifCreateYUVToRGBLookUpTables(float ** unormFloatTableY, float 
 {
     const size_t cpCount = (size_t)1 << depth;
 
-    assert(unormFloatTableY);
+    if (!unormFloatTableY) {
+        avifBreakOnError();
+        return AVIF_FALSE;
+    }
     *unormFloatTableY = (float *)avifAlloc(cpCount * sizeof(float));
     AVIF_CHECK(*unormFloatTableY);
     for (uint32_t cp = 0; cp < cpCount; ++cp) {
@@ -681,7 +684,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
     // If toRGBAlphaMode is active (not no-op), assert that the alpha plane is present. The end of
     // the avifPrepareReformatState() function should ensure this, but this assert makes it clear
     // to clang's analyzer.
-    assert((alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP) || aPlane);
+    AVIF_ASSERT_OR_RETURN((alphaMultiplyMode == AVIF_ALPHA_MULTIPLY_MODE_NO_OP) || aPlane);
 
     for (uint32_t j = 0; j < image->height; ++j) {
         // uvJ is used only when yuvHasColor is true.

--- a/src/sampletransform.c
+++ b/src/sampletransform.c
@@ -218,7 +218,8 @@ static int32_t avifSampleTransformOperation32bOneOperand(int32_t operand, uint8_
             return log2;
         }
         default:
-            assert(AVIF_FALSE);
+            avifBreakOnError();
+            return AVIF_RESULT_INTERNAL_ERROR;
     }
     return 0;
 }
@@ -271,7 +272,8 @@ static int32_t avifSampleTransformOperation32bTwoOperands(int32_t leftOperand, i
         case AVIF_SAMPLE_TRANSFORM_MAX:
             return leftOperand <= rightOperand ? rightOperand : leftOperand;
         default:
-            assert(AVIF_FALSE);
+            avifBreakOnError();
+            return AVIF_RESULT_INTERNAL_ERROR;
     }
     return 0;
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -25,7 +25,7 @@ void avifROStreamStart(avifROStream * stream, avifROData * raw, avifDiagnostics 
     stream->diagContext = diagContext;
 
     // If diag is non-NULL, diagContext must also be non-NULL
-    assert(!stream->diag || stream->diagContext);
+    AVIF_ASSERT_OR_RETURN_VOID(!stream->diag || stream->diagContext);
 }
 
 avifBool avifROStreamHasBytesLeft(const avifROStream * stream, size_t byteCount)
@@ -45,7 +45,7 @@ size_t avifROStreamOffset(const avifROStream * stream)
 
 void avifROStreamSetOffset(avifROStream * stream, size_t offset)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     stream->offset = offset;
     if (stream->offset > stream->raw->size) {
         stream->offset = stream->raw->size;
@@ -54,7 +54,7 @@ void avifROStreamSetOffset(avifROStream * stream, size_t offset)
 
 avifBool avifROStreamSkip(avifROStream * stream, size_t byteCount)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     if (!avifROStreamHasBytesLeft(stream, byteCount)) {
         avifDiagnosticsPrintf(stream->diag, "%s: Failed to skip %zu bytes, truncated data?", stream->diagContext, byteCount);
         return AVIF_FALSE;
@@ -65,7 +65,7 @@ avifBool avifROStreamSkip(avifROStream * stream, size_t byteCount)
 
 avifBool avifROStreamRead(avifROStream * stream, uint8_t * data, size_t size)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     if (!avifROStreamHasBytesLeft(stream, size)) {
         avifDiagnosticsPrintf(stream->diag, "%s: Failed to read %zu bytes, truncated data?", stream->diagContext, size);
         return AVIF_FALSE;
@@ -78,7 +78,7 @@ avifBool avifROStreamRead(avifROStream * stream, uint8_t * data, size_t size)
 
 avifBool avifROStreamReadUX8(avifROStream * stream, uint64_t * v, uint64_t factor)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     if (factor == 0) {
         // Don't read anything, just set to 0
         *v = 0;
@@ -108,7 +108,7 @@ avifBool avifROStreamReadUX8(avifROStream * stream, uint64_t * v, uint64_t facto
 
 avifBool avifROStreamReadU16(avifROStream * stream, uint16_t * v)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     AVIF_CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint16_t)));
     *v = avifNTOHS(*v);
     return AVIF_TRUE;
@@ -116,7 +116,7 @@ avifBool avifROStreamReadU16(avifROStream * stream, uint16_t * v)
 
 avifBool avifROStreamReadU16Endianness(avifROStream * stream, uint16_t * v, avifBool littleEndian)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     AVIF_CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint16_t)));
     *v = littleEndian ? avifCTOHS(*v) : avifNTOHS(*v);
     return AVIF_TRUE;
@@ -124,7 +124,7 @@ avifBool avifROStreamReadU16Endianness(avifROStream * stream, uint16_t * v, avif
 
 avifBool avifROStreamReadU32(avifROStream * stream, uint32_t * v)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     AVIF_CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint32_t)));
     *v = avifNTOHL(*v);
     return AVIF_TRUE;
@@ -132,7 +132,7 @@ avifBool avifROStreamReadU32(avifROStream * stream, uint32_t * v)
 
 avifBool avifROStreamReadU32Endianness(avifROStream * stream, uint32_t * v, avifBool littleEndian)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     AVIF_CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint32_t)));
     *v = littleEndian ? avifCTOHL(*v) : avifNTOHL(*v);
     return AVIF_TRUE;
@@ -140,7 +140,7 @@ avifBool avifROStreamReadU32Endianness(avifROStream * stream, uint32_t * v, avif
 
 avifBool avifROStreamReadU64(avifROStream * stream, uint64_t * v)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     AVIF_CHECK(avifROStreamRead(stream, (uint8_t *)v, sizeof(uint64_t)));
     *v = avifNTOH64(*v);
     return AVIF_TRUE;
@@ -149,7 +149,7 @@ avifBool avifROStreamReadU64(avifROStream * stream, uint64_t * v)
 avifBool avifROStreamSkipBits(avifROStream * stream, size_t bitCount)
 {
     if (stream->numUsedBitsInPartialByte != 0) {
-        assert(stream->numUsedBitsInPartialByte < 8);
+        AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte < 8);
         const size_t padding = AVIF_MIN(8 - stream->numUsedBitsInPartialByte, bitCount);
         stream->numUsedBitsInPartialByte = (stream->numUsedBitsInPartialByte + padding) % 8;
         bitCount -= padding;
@@ -189,7 +189,7 @@ avifBool avifROStreamReadBitsU32(avifROStream * stream, uint32_t * v, size_t bit
         if (stream->numUsedBitsInPartialByte == 0) {
             AVIF_CHECK(avifROStreamSkip(stream, sizeof(uint8_t))); // Book a new partial byte in the stream.
         }
-        assert(stream->offset > 0);
+        AVIF_ASSERT_OR_RETURN_VOID(stream->offset > 0);
         const uint8_t * packedBits = stream->raw->data + stream->offset - 1;
 
         const size_t numBits = AVIF_MIN(bitCount, 8 - stream->numUsedBitsInPartialByte);
@@ -213,7 +213,7 @@ avifBool avifROStreamReadBitsU32(avifROStream * stream, uint32_t * v, size_t bit
 
 avifBool avifROStreamReadString(avifROStream * stream, char * output, size_t outputSize)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
 
     // Check for the presence of a null terminator in the stream.
     size_t remainingBytes = avifROStreamRemainingBytes(stream);
@@ -380,7 +380,7 @@ void avifRWStreamFinishWrite(avifRWStream * stream)
 
 avifResult avifRWStreamWrite(avifRWStream * stream, const void * data, size_t size)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     if (size) {
         AVIF_CHECKRES(makeRoom(stream, size));
         memcpy(stream->raw->data + stream->offset, data, size);
@@ -396,7 +396,7 @@ avifResult avifRWStreamWriteChars(avifRWStream * stream, const char * chars, siz
 
 avifResult avifRWStreamWriteFullBox(avifRWStream * stream, const char * type, size_t contentSize, int version, uint32_t flags, avifBoxMarker * marker)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     if (marker) {
         *marker = stream->offset;
     }
@@ -428,14 +428,14 @@ avifResult avifRWStreamWriteBox(avifRWStream * stream, const char * type, size_t
 
 void avifRWStreamFinishBox(avifRWStream * stream, avifBoxMarker marker)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     uint32_t noSize = avifHTONL((uint32_t)(stream->offset - marker));
     memcpy(stream->raw->data + marker, &noSize, sizeof(uint32_t));
 }
 
 avifResult avifRWStreamWriteU8(avifRWStream * stream, uint8_t v)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     AVIF_CHECKRES(makeRoom(stream, 1));
     stream->raw->data[stream->offset] = v;
     stream->offset += 1;
@@ -444,7 +444,7 @@ avifResult avifRWStreamWriteU8(avifRWStream * stream, uint8_t v)
 
 avifResult avifRWStreamWriteU16(avifRWStream * stream, uint16_t v)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     const size_t size = sizeof(uint16_t);
     AVIF_CHECKRES(makeRoom(stream, size));
     v = avifHTONS(v);
@@ -455,7 +455,7 @@ avifResult avifRWStreamWriteU16(avifRWStream * stream, uint16_t v)
 
 avifResult avifRWStreamWriteU32(avifRWStream * stream, uint32_t v)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     const size_t size = sizeof(uint32_t);
     AVIF_CHECKRES(makeRoom(stream, size));
     v = avifHTONL(v);
@@ -466,7 +466,7 @@ avifResult avifRWStreamWriteU32(avifRWStream * stream, uint32_t v)
 
 avifResult avifRWStreamWriteU64(avifRWStream * stream, uint64_t v)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     const size_t size = sizeof(uint64_t);
     AVIF_CHECKRES(makeRoom(stream, size));
     v = avifHTON64(v);
@@ -477,7 +477,7 @@ avifResult avifRWStreamWriteU64(avifRWStream * stream, uint64_t v)
 
 avifResult avifRWStreamWriteZeros(avifRWStream * stream, size_t byteCount)
 {
-    assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
+    AVIF_ASSERT_OR_RETURN_VOID(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
     AVIF_CHECKRES(makeRoom(stream, byteCount));
     memset(stream->raw->data + stream->offset, 0, byteCount);
     stream->offset += byteCount;
@@ -493,7 +493,7 @@ avifResult avifRWStreamWriteBits(avifRWStream * stream, uint32_t v, size_t bitCo
             stream->raw->data[stream->offset] = 0;
             stream->offset += 1;
         }
-        assert(stream->offset > 0);
+        AVIF_ASSERT_OR_RETURN_VOID(stream->offset > 0);
         uint8_t * packedBits = stream->raw->data + stream->offset - 1;
 
         const size_t numBits = AVIF_MIN(bitCount, 8 - stream->numUsedBitsInPartialByte);

--- a/src/utils.c
+++ b/src/utils.c
@@ -132,7 +132,10 @@ void * avifArrayPush(void * arrayStruct)
 void avifArrayPop(void * arrayStruct)
 {
     avifArrayInternal * arr = (avifArrayInternal *)arrayStruct;
-    assert(arr->count > 0);
+    if (arr->count == 0) {
+        avifBreakOnError();
+        return;
+    }
     --arr->count;
     memset(&arr->ptr[arr->count * (size_t)arr->elementSize], 0, arr->elementSize);
 }
@@ -256,7 +259,10 @@ static avifBool avifDoubleToUnsignedFractionImpl(double v, uint32_t maxNumerator
     const int maxIter = 39;
     while (iter < maxIter) {
         const double numeratorDouble = (double)(*denominator) * v;
-        assert(numeratorDouble <= maxNumerator);
+        if (numeratorDouble > (double)maxNumerator) {
+            avifBreakOnError();
+            return AVIF_FALSE;
+        }
         *numerator = (uint32_t)round(numeratorDouble);
         if (fabs(numeratorDouble - (*numerator)) == 0.0) {
             return AVIF_TRUE;
@@ -268,7 +274,10 @@ static avifBool avifDoubleToUnsignedFractionImpl(double v, uint32_t maxNumerator
             return AVIF_TRUE;
         }
         previousD = *denominator;
-        assert(newD <= UINT32_MAX);
+        if (newD > (double)UINT32_MAX) {
+            avifBreakOnError();
+            return AVIF_FALSE;
+        }
         *denominator = (uint32_t)newD;
         currentV -= floor(currentV);
         ++iter;

--- a/src/write.c
+++ b/src/write.c
@@ -48,7 +48,10 @@ static avifResult writeConfigBox(avifRWStream * s, const avifCodecConfigurationB
 
 static int floorLog2(uint32_t n)
 {
-    assert(n > 0);
+    if (n == 0) {
+        avifBreakOnError();
+        return 0;
+    }
     int count = 0;
     while (n != 0) {
         ++count;
@@ -66,7 +69,10 @@ static int floorLog2(uint32_t n)
 //     *tileDim1Log2 >= *tileDim2Log2
 static void splitTilesLog2(uint32_t dim1, uint32_t dim2, int tilesLog2, int * tileDim1Log2, int * tileDim2Log2)
 {
-    assert(dim1 >= dim2);
+    if (dim1 < dim2) {
+        avifBreakOnError();
+        return;
+    }
     uint32_t ratio = dim1 / dim2;
     int diffLog2 = floorLog2(ratio);
     int subtract = tilesLog2 - diffLog2;
@@ -75,7 +81,10 @@ static void splitTilesLog2(uint32_t dim1, uint32_t dim2, int tilesLog2, int * ti
     }
     *tileDim2Log2 = subtract / 2;
     *tileDim1Log2 = tilesLog2 - *tileDim2Log2;
-    assert(*tileDim1Log2 >= *tileDim2Log2);
+    if (*tileDim1Log2 < *tileDim2Log2) {
+        avifBreakOnError();
+        return;
+    }
 }
 
 // Set the tile configuration: the number of tiles and the tile size.
@@ -1335,7 +1344,7 @@ static avifResult avifEncoderCreateBitDepthExtensionItems(avifEncoder * encoder,
     AVIF_CHECKRES(
         avifEncoderAddImageItems(encoder, gridCols, gridRows, gridWidth, gridHeight, AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_COLOR, &bitDepthExtensionColorItemId));
     avifEncoderItem * bitDepthExtensionColorItem = avifEncoderDataFindItemByID(encoder->data, bitDepthExtensionColorItemId);
-    assert(bitDepthExtensionColorItem);
+    AVIF_ASSERT_OR_RETURN(bitDepthExtensionColorItem != NULL);
     bitDepthExtensionColorItem->hiddenImage = AVIF_TRUE;
 
     // Set the color and bit depth extension items' dimgFromID value to point to the sample transform item.
@@ -1354,13 +1363,13 @@ static avifResult avifEncoderCreateBitDepthExtensionItems(avifEncoder * encoder,
         AVIF_CHECKRES(
             avifEncoderAddImageItems(encoder, gridCols, gridRows, gridWidth, gridHeight, AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_ALPHA, &bitDepthExtensionAlphaItemId));
         avifEncoderItem * bitDepthExtensionAlphaItem = avifEncoderDataFindItemByID(encoder->data, bitDepthExtensionAlphaItemId);
-        assert(bitDepthExtensionAlphaItem);
+        AVIF_ASSERT_OR_RETURN(bitDepthExtensionAlphaItem != NULL);
         bitDepthExtensionAlphaItem->irefType = "auxl";
         bitDepthExtensionAlphaItem->irefToID = bitDepthExtensionColorItemId;
         if (encoder->data->imageMetadata->alphaPremultiplied) {
             // The reference may have changed; fetch it again.
             bitDepthExtensionColorItem = avifEncoderDataFindItemByID(encoder->data, bitDepthExtensionColorItemId);
-            assert(bitDepthExtensionColorItem);
+            AVIF_ASSERT_OR_RETURN(bitDepthExtensionColorItem != NULL);
             bitDepthExtensionColorItem->irefType = "prem";
             bitDepthExtensionColorItem->irefToID = bitDepthExtensionAlphaItemId;
         }
@@ -1548,9 +1557,11 @@ static avifResult avifEncoderCreateBitDepthExtensionImage(avifEncoder * encoder,
 
 static avifCodecType avifEncoderGetCodecType(const avifEncoder * encoder)
 {
-    // This asserts that images cannot be encoded with AVM unless AVIF_CODEC_CHOICE_AVM is explicitly selected.
-    assert((encoder->codecChoice != AVIF_CODEC_CHOICE_AUTO) ||
-           (strcmp(avifCodecName(encoder->codecChoice, AVIF_CODEC_FLAG_CAN_ENCODE), "avm") != 0));
+    // Images cannot be encoded with AVM unless AVIF_CODEC_CHOICE_AVM is explicitly selected.
+    if ((encoder->codecChoice == AVIF_CODEC_CHOICE_AUTO) && (strcmp(avifCodecName(encoder->codecChoice, AVIF_CODEC_FLAG_CAN_ENCODE), "avm") == 0)) {
+        avifBreakOnError();
+        return AVIF_CODEC_TYPE_UNKNOWN;
+    }
     return avifCodecTypeFromChoice(encoder->codecChoice, AVIF_CODEC_FLAG_CAN_ENCODE);
 }
 
@@ -2080,7 +2091,8 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
                     *encoderMinQuantizer = AVIF_QUANTIZER_LOSSLESS;
                     *encoderMaxQuantizer = AVIF_QUANTIZER_LOSSLESS;
                     if (!avifEncoderDetectChanges(encoder, &encoderChanges)) {
-                        assert(AVIF_FALSE);
+                        avifBreakOnError();
+                        return AVIF_RESULT_CANNOT_CHANGE_SETTING;
                     }
                 }
 
@@ -2093,7 +2105,10 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
                 }
                 AVIF_CHECKRES(
                     avifEncoderCreateBitDepthExtensionImage(encoder, item, itemWillBeEncodedLosslessly, cellImage, &sampleTransformedImage));
-                assert(cellImagePlaceholder == NULL);
+                if (cellImagePlaceholder != NULL) {
+                    avifBreakOnError();
+                    return AVIF_RESULT_INTERNAL_ERROR;
+                }
                 cellImagePlaceholder = sampleTransformedImage; // Transfer ownership.
                 cellImage = cellImagePlaceholder;
             }
@@ -2436,7 +2451,9 @@ static avifBool avifEncoderIsMiniCompatible(const avifEncoder * encoder)
         }
 
         if (item->id == encoder->data->primaryItemID) {
-            assert(!colorItem);
+            if (colorItem != NULL) {
+                return AVIF_FALSE;
+            }
             colorItem = item;
             // main_item_data_size_minus1
             if (item->encodeOutput->samples.count != 1 || item->encodeOutput->samples.sample[0].data.size > (1 << 28)) {
@@ -2459,15 +2476,21 @@ static avifBool avifEncoderIsMiniCompatible(const avifEncoder * encoder)
             continue; // The gainmap input image item can be stored in the MinimizedImageBox.
         }
         if (!memcmp(item->type, "tmap", 4)) {
-            assert(item->itemCategory == AVIF_ITEM_COLOR); // Cannot be differentiated from the primary item by its itemCategory.
+            if (item->itemCategory != AVIF_ITEM_COLOR) {
+                return AVIF_FALSE;
+            } // Cannot be differentiated from the primary item by its itemCategory.
             continue; // The tone mapping derived image item can be represented in the MinimizedImageBox.
         }
         if (!memcmp(item->type, "mime", 4) && !memcmp(item->infeName, "XMP", item->infeNameSize)) {
-            assert(item->metadataPayload.size == encoder->data->imageMetadata->xmp.size);
+            if (item->metadataPayload.size != encoder->data->imageMetadata->xmp.size) {
+                return AVIF_FALSE;
+            }
             continue; // XMP metadata can be stored in the MinimizedImageBox.
         }
         if (!memcmp(item->type, "Exif", 4) && !memcmp(item->infeName, "Exif", item->infeNameSize)) {
-            assert(item->metadataPayload.size == encoder->data->imageMetadata->exif.size + 4);
+            if (item->metadataPayload.size != encoder->data->imageMetadata->exif.size + 4) {
+                return AVIF_FALSE;
+            }
             const uint32_t exif_tiff_header_offset = *(uint32_t *)item->metadataPayload.data;
             if (exif_tiff_header_offset != 0) {
                 return AVIF_FALSE;
@@ -2970,7 +2993,7 @@ static avifResult avifRWStreamWriteProperties(avifItemPropertyDedup * const dedu
         } else {
             AVIF_CHECKERR(encoder->sampleTransformRecipe == AVIF_SAMPLE_TRANSFORM_NONE, AVIF_RESULT_NOT_IMPLEMENTED);
         }
-        assert(isSampleTransformImage == (item->itemCategory == AVIF_ITEM_SAMPLE_TRANSFORM));
+        AVIF_ASSERT_OR_RETURN(isSampleTransformImage == (item->itemCategory == AVIF_ITEM_SAMPLE_TRANSFORM));
 
         if (hasPixi) {
             avifItemPropertyDedupStart(dedup);


### PR DESCRIPTION
assert was getting skipped in release builds, so added normal validation instead to avoid unexpected issues