### PR TITLE
prevent underflow in stream remaining bytes check

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -30,11 +30,22 @@ void avifROStreamStart(avifROStream * stream, avifROData * raw, avifDiagnostics 
 
 avifBool avifROStreamHasBytesLeft(const avifROStream * stream, size_t byteCount)
 {
+    // Guard against unsigned underflow: if offset has somehow advanced past the
+    // end of the buffer (e.g. via a mishandled early-return leaving stale state),
+    // the subtraction below would wrap to SIZE_MAX and incorrectly return TRUE.
+    if (stream->offset > stream->raw->size) {
+        return AVIF_FALSE;
+    }
     return byteCount <= (stream->raw->size - stream->offset);
 }
 
 size_t avifROStreamRemainingBytes(const avifROStream * stream)
 {
+    // Same underflow guard as avifROStreamHasBytesLeft: return 0 instead of
+    // wrapping to SIZE_MAX when offset has advanced past the buffer end.
+    if (stream->offset > stream->raw->size) {
+        return 0;
+    }
     return stream->raw->size - stream->offset;
 }
 


### PR DESCRIPTION
Summary-
Added a safety check in stream functions to avoid underflow when offset goes past the buffer size.

What was the issue-
Both functions were doing size - offset using unsigned values.
If offset becomes greater than size, it wraps around to a very large number instead of failing.
This can make the parser think there is still data left when there isn’t.

What I changed-
Added a simple check to return false or 0 if offset is already beyond the buffer size.

Impact
Prevents incorrect parsing behavior and avoids using invalid buffer sizes.

