### PR TITLE
Fix minor coverity finding

### DIFF
--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -101,7 +101,8 @@ void PrintEncodingSettings(const avifEncoder* encoder, bool has_gain_map) {
             << ")], alpha quality ['" << encoder->qualityAlpha << "' ("
             << QualityLevelString(encoder->qualityAlpha) << ")]" << gain_map_str
             << ", "
-            << (encoder->autoTiling ? "automatic tiling" : manual_tiling_str)
+            << (encoder->autoTiling ? "automatic tiling"
+                                    : std::move(manual_tiling_str))
             << ", " << encoder->maxThreads
             << " worker thread(s), please wait...\n";
 }


### PR DESCRIPTION
CID 559069:         Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
"manual_tiling_str" is passed-by-value as parameter to "operator <<", when it could be moved instead.