### PR TITLE
codec_aom: improve decoder diagnostics consistency

### DIFF
--- a/src/codec_aom.c
+++ b/src/codec_aom.c
@@ -90,13 +90,13 @@ static void aomCodecDestroyInternal(avifCodec * codec)
     avifFree(codec->internal);
 }
 
+#if defined(AVIF_CODEC_AOM_DECODE)
+
 // Writes a libaom error code and error detail into diagnostics.
 static void aomDiagPrintf(avifDiagnostics * diag, const char * func, const char * error, const char * detail)
 {
     avifDiagnosticsPrintf(diag, "%s failed: %s: %s", func, error, detail ? detail : "no error detail");
 }
-
-#if defined(AVIF_CODEC_AOM_DECODE)
 
 static avifBool aomCodecGetNextImage(struct avifCodec * codec,
                                      const avifDecodeSample * sample,


### PR DESCRIPTION
This PR refreshes the decoder diagnostics follow-up on top of current main.

Changes:
- Add helper function to format libaom error diagnostics with null-safe detail handling.
- Use the helper for decoder paths:
  - aom_codec_dec_init()
  - aom_codec_control(AV1D_SET_OUTPUT_ALL_LAYERS)
  - aom_codec_control(AV1D_SET_OPERATING_POINT)
  - aom_codec_decode()

Notes:
- Encoder null-safe diagnostics were already merged in #3125, so this PR intentionally keeps scope decoder-only.
- Supersedes #3124.