### PR TITLE
Check width * 4 in avifReorderARGBThenConvertToYUV

### DIFF
--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -159,6 +159,9 @@ static int avifReorderARGBThenConvertToYUV(int (*ReorderARGB)(const uint8_t *, i
 
     // A temporary buffer is needed to call ReorderARGB().
     uint8_t * src_argb;
+    if ((int64_t)width * 4 > INT_MAX) {
+        return -1;
+    }
     const int src_stride_argb = width * 4;
     const int soft_allocation_limit = 16384; // Arbitrarily chosen trade-off between CPU and memory footprints.
     int num_allocated_rows;


### PR DESCRIPTION
The issue was reported by `uwezkhan06 <uwezkhan055@gmail.com>` in https://github.com/AOMediaCodec/libavif/pull/3147.