### PR TITLE
read: replace strcpy with memcpy for alpha auxiliary URN

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -4524,6 +4524,7 @@ static avifResult avifParseMinimizedImageBox(avifDecoderData * data,
         colorItem->premByID = alphaIsPremultiplied;
         avifProperty * alphaAuxProp = avifMetaCreateProperty(meta, "auxC");
         AVIF_CHECKERR(alphaAuxProp, AVIF_RESULT_OUT_OF_MEMORY);
+        static_assert(sizeof(alphaAuxProp->u.auxC.auxType) >= sizeof(AVIF_URN_ALPHA0), "");
         memcpy(alphaAuxProp->u.auxC.auxType, AVIF_URN_ALPHA0, sizeof(AVIF_URN_ALPHA0));
         AVIF_CHECKERR(avifDecoderItemAddProperty(alphaItem, alphaAuxProp), AVIF_RESULT_OUT_OF_MEMORY);
 


### PR DESCRIPTION
Replaces `strcpy` with `memcpy` when copying `AVIF_URN_ALPHA0` into `alphaAuxProp->u.auxC.auxType` in `avifParseMinimizedImageBox()`.

`AVIF_URN_ALPHA0` is 44 bytes and `AUXTYPE_SIZE` is 64, so there is no overflow risk today. That said, every other string copy in this file uses `memcpy` or `avifROStreamReadString` rather than `strcpy`, so this change makes it consistent with the rest of the file.