### PR TITLE
fix overflow in libyuv allocation

### DIFF
--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -178,7 +178,17 @@ static int avifReorderARGBThenConvertToYUV(int (*ReorderARGB)(const uint8_t *, i
         // allocating more than soft_allocation_limit, unless min_num_rows rows need more than that.
         num_allocated_rows = AVIF_MAX(1, soft_allocation_limit / (src_stride_argb * min_num_rows)) * min_num_rows;
     }
-    src_argb = (uint8_t *)avifAlloc(num_allocated_rows * src_stride_argb);
+    if (src_stride_argb < 0) {
+        return -1;
+    }
+
+    // Check for overflow before multiplication
+    if (num_allocated_rows > 0 && (size_t)num_allocated_rows > SIZE_MAX / (size_t)src_stride_argb) {
+        return -1;
+    }
+
+    const size_t allocationSize = (size_t)num_allocated_rows * (size_t)src_stride_argb;
+    src_argb = (uint8_t *)avifAlloc(allocationSize);
     if (!src_argb) {
         return -1;
     }


### PR DESCRIPTION
fix overflow when calculating allocation size in libyuv path by adding proper checks before multiplication

prevents wrong memory allocation for large or invalid inputs, 
