### PR TITLE
avifenc: reject mismatched --depth for Y4M input

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -222,7 +222,7 @@ static void syntaxLong(void)
     printf("    --mini                            : EXPERIMENTAL: Use reduced header if possible (backward-incompatible)\n");
 #endif
     printf("    -l,--lossless                     : Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it\n");
-    printf("    -d,--depth D[,Dextension]         : D is the output bit depth per channel. D must be 8, 10 or 12. (JPEG/PNG only; y4m or stdin: bit depth is retained)\n");
+    printf("    -d,--depth D[,Dextension]         : D is the output bit depth per channel. D must be 8, 10 or 12. (JPEG/PNG only; y4m or stdin: bit depth is retained and must match if specified; Dextension is unsupported)\n");
     printf("                                        If specified, Dextension adds a hidden encoded image of Dextension bit depth in the same file as the primary image to reach 16-bit depth at decoding.\n");
     printf("                                        See avifSampleTransformRecipe for the supported combinations (8,8 and 12,4 and 12,8).\n");
     printf("    -y,--yuv FORMAT                   : Output format, one of 'auto' (default), 444, 422, 420 or 400. Ignored for y4m or stdin (y4m format is retained)\n");
@@ -610,20 +610,21 @@ static avifBool avifInputReadImage(avifInput * input,
 
     const avifColorPrimaries colorPrimariesBefore = dstImage->colorPrimaries;
     const avifTransferCharacteristics transferCharacteristicsBefore = dstImage->transferCharacteristics;
-    if (avifReadImage(currentFile->filename,
-                      inputFormat,
-                      input->requestedFormat,
-                      input->requestedDepthExtension == 0 ? input->requestedDepth : 16,
-                      chromaDownsampling,
-                      ignoreColorProfile,
-                      ignoreExif,
-                      ignoreXMP,
-                      ignoreGainMap,
-                      UINT32_MAX,
-                      dstImage,
-                      dstDepth,
-                      dstSourceTiming,
-                      &input->frameIter) == AVIF_APP_FILE_FORMAT_UNKNOWN) {
+    const avifAppFileFormat actualInputFormat = avifReadImage(currentFile->filename,
+                                                              inputFormat,
+                                                              input->requestedFormat,
+                                                              input->requestedDepthExtension == 0 ? input->requestedDepth : 16,
+                                                              chromaDownsampling,
+                                                              ignoreColorProfile,
+                                                              ignoreExif,
+                                                              ignoreXMP,
+                                                              ignoreGainMap,
+                                                              UINT32_MAX,
+                                                              dstImage,
+                                                              dstDepth,
+                                                              dstSourceTiming,
+                                                              &input->frameIter);
+    if (actualInputFormat == AVIF_APP_FILE_FORMAT_UNKNOWN) {
         fprintf(stderr,
                 "ERROR: Couldn't read %s file %s\n",
                 avifFileFormatToString(inputFormat),
@@ -632,6 +633,19 @@ static avifBool avifInputReadImage(avifInput * input,
             fprintf(stderr, "Specify --input-format if the input is not y4m\n");
         }
         return AVIF_FALSE;
+    }
+    if (actualInputFormat == AVIF_APP_FILE_FORMAT_Y4M) {
+        if (input->requestedDepthExtension) {
+            fprintf(stderr, "ERROR: --depth %d,%d is not supported for Y4M input\n", input->requestedDepth, input->requestedDepthExtension);
+            return AVIF_FALSE;
+        }
+        if (input->requestedDepth && (input->requestedDepth != (int)dstImage->depth)) {
+            fprintf(stderr,
+                    "ERROR: --depth %d does not match Y4M bit depth %u; Y4M bit-depth conversion is not supported\n",
+                    input->requestedDepth,
+                    dstImage->depth);
+            return AVIF_FALSE;
+        }
     }
     if (!allowChangingCicp) {
         // Restore the previous primaries/transfer in case avifReadImage changed them.
@@ -643,7 +657,7 @@ static avifBool avifInputReadImage(avifInput * input,
         ++input->fileIndex;
     }
     if (dstSourceIsRGB) {
-        *dstSourceIsRGB = (inputFormat != AVIF_APP_FILE_FORMAT_Y4M);
+        *dstSourceIsRGB = (actualInputFormat != AVIF_APP_FILE_FORMAT_Y4M);
     }
     if (dstSettings) {
         *dstSettings = &currentFile->settings;

--- a/doc/avifenc.1.md
+++ b/doc/avifenc.1.md
@@ -54,7 +54,7 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it.
 
 **-d**, **\--depth** _D_[,_EXTENSION_]
-:   D is the output bit depth per channel. D must be 8, 10 or 12. (JPEG/PNG only; y4m or stdin: bit depth is retained).
+:   D is the output bit depth per channel. D must be 8, 10 or 12. (JPEG/PNG only; y4m or stdin: bit depth is retained and must match if specified; EXTENSION is unsupported).
     If specified, EXTENSION adds a hidden encoded image of EXTENSION bit depth in the same file as the primary image to reach 16-bit depth at decoding.
     See avifSampleTransformRecipe for the supported combinations (8,8 and 12,4 and 12,8).
 

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -69,6 +69,11 @@ pushd ${TMP_DIR}
   if [[ ${RET} -ne 1 ]]; then
     exit 1
   fi
+  "${AVIFENC}" -s 8 --depth 8 "${INPUT_Y4M}" -o "${ENCODED_FILE}"
+  "${AVIFENC}" -s 8 --depth 8,8 "${INPUT_Y4M}" -o "${ENCODED_FILE}" 2> "${OUT_MSG}" && exit 1
+  grep "ERROR: --depth 8,8 is not supported for Y4M input" "${OUT_MSG}"
+  "${AVIFENC}" -s 8 --depth 10 "${INPUT_Y4M}" -o "${ENCODED_FILE}" 2> "${OUT_MSG}" && exit 1
+  grep "ERROR: --depth 10 does not match Y4M bit depth 8" "${OUT_MSG}"
 
   # Argument parsing test with filenames starting with a dash.
   echo "Testing arguments"

--- a/tests/test_cmd_stdin.sh
+++ b/tests/test_cmd_stdin.sh
@@ -23,11 +23,12 @@ INPUT_JPEG="${TESTDATA_DIR}/paris_extended_xmp.jpg"
 # Output file names.
 ENCODED_FILE_REGULAR="avif_test_cmd_stdin_encoded.avif"
 ENCODED_FILE_STDIN="avif_test_cmd_stdin_encoded_with_stdin.avif"
+OUT_MSG="avif_test_cmd_stdin_out_msg.txt"
 
 # Cleanup
 cleanup() {
   pushd ${TMP_DIR}
-    rm -f -- "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}"
+    rm -f -- "${ENCODED_FILE_REGULAR}" "${ENCODED_FILE_STDIN}" "${OUT_MSG}"
   popd
 }
 trap cleanup EXIT
@@ -80,6 +81,9 @@ test_stdin() {
 
 pushd ${TMP_DIR}
   test_stdin "${INPUT_Y4M_STILL}" y4m
+  "${AVIFENC}" -s 8 --stdin --input-format y4m --depth 10 -o "${ENCODED_FILE_STDIN}" \
+    < "${INPUT_Y4M_STILL}" 2> "${OUT_MSG}" && exit 1
+  grep "ERROR: --depth 10 does not match Y4M bit depth 8" "${OUT_MSG}"
   test_stdin "${INPUT_PNG}" png
   test_stdin "${INPUT_JPEG}" jpeg
 


### PR DESCRIPTION
Reject mismatched `--depth` values for Y4M input instead of silently ignoring them.

Y4M inputs carry their bit depth in the stream header, and avifenc currently retains that depth. If a different `--depth` is specified, fail with a clear error because Y4M bit-depth conversion is not supported. Bit-depth extension is also rejected for Y4M input.

This covers both file input and `--stdin --input-format y4m`.

Refs #2849

Tested:
- cmake --build build/local -j 8
- ctest --test-dir build/local --output-on-failure
- bash tests/test_cmd_stdin.sh "" /Users/solario/Projects/Solido/libavif/build/local /Users/solario/Projects/Solido/libavif/tests/data /tmp/libavif-test-stdin