### PR TITLE
Replace memcpy call with struct member assignment

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1533,7 +1533,7 @@ static avifResult avifDecoderItemRead(avifDecoderItem * item,
         }
 
         if (singlePersistentBuffer) {
-            item->mergedExtents.data = (uint8_t *)offsetBuffer.data;  // const_cast
+            item->mergedExtents.data = (uint8_t *)offsetBuffer.data; // const_cast
             AVIF_ASSERT_OR_RETURN(bytesToRead <= offsetBuffer.size);
             item->mergedExtents.size = bytesToRead;
         } else {

--- a/src/read.c
+++ b/src/read.c
@@ -1533,7 +1533,8 @@ static avifResult avifDecoderItemRead(avifDecoderItem * item,
         }
 
         if (singlePersistentBuffer) {
-            memcpy(&item->mergedExtents, &offsetBuffer, sizeof(avifRWData));
+            item->mergedExtents.data = (uint8_t *)offsetBuffer.data;  // const_cast
+            AVIF_ASSERT_OR_RETURN(bytesToRead <= offsetBuffer.size);
             item->mergedExtents.size = bytesToRead;
         } else {
             AVIF_ASSERT_OR_RETURN(item->ownsMergedExtents);


### PR DESCRIPTION
The following memcpy call assigns an avifROData struct to an avifRWData struct:

    memcpy(&item->mergedExtents, &offsetBuffer, sizeof(avifRWData));

Replace it with assignments of the `data` and `size` fields of the structs. Then, omit the assignment of the `size` field because it will be immediately overwritten. Add an assertion to ensure the new value of the `size` field is valid (does not exceed the original value).