### PR TITLE
avifenc: Follow up on PR #3179

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -222,7 +222,7 @@ static void syntaxLong(void)
     printf("    --mini                            : EXPERIMENTAL: Use reduced header if possible (backward-incompatible)\n");
 #endif
     printf("    -l,--lossless                     : Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it\n");
-    printf("    -d,--depth D[,Dextension]         : D is the output bit depth per channel. D must be 8, 10 or 12. (JPEG/PNG only; y4m: bit depth is retained and must match if specified; Dextension is unsupported)\n");
+    printf("    -d,--depth D[,Dextension]         : D is the output bit depth per channel. D must be 8, 10 or 12. (JPEG/PNG only; y4m: D must match the input bit depth, and Dextension is unsupported)\n");
     printf("                                        If specified, Dextension adds a hidden encoded image of Dextension bit depth in the same file as the primary image to reach 16-bit depth at decoding.\n");
     printf("                                        See avifSampleTransformRecipe for the supported combinations (8,8 and 12,4 and 12,8).\n");
     printf("    -y,--yuv FORMAT                   : Output format, one of 'auto' (default), 444, 422, 420 or 400. Ignored for y4m (y4m format is retained)\n");

--- a/doc/avifenc.1.md
+++ b/doc/avifenc.1.md
@@ -54,7 +54,7 @@ Input format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 :   Set all defaults to encode losslessly, and emit warnings when settings/input don't allow for it.
 
 **-d**, **\--depth** _D_[,_EXTENSION_]
-:   D is the output bit depth per channel. D must be 8, 10 or 12. (JPEG/PNG only; y4m: bit depth is retained and must match if specified; EXTENSION is unsupported).
+:   D is the output bit depth per channel. D must be 8, 10 or 12. (JPEG/PNG only; y4m: D must match the input bit depth, and EXTENSION is unsupported).
     If specified, EXTENSION adds a hidden encoded image of EXTENSION bit depth in the same file as the primary image to reach 16-bit depth at decoding.
     See avifSampleTransformRecipe for the supported combinations (8,8 and 12,4 and 12,8).
 


### PR DESCRIPTION
Clarify "bit depth is retained and must match if specified".

Change a semicolon (;) to a comma (,) to make it clear that "Dextension is unsupported" is part of the y4m case.