### PR TITLE
Reject oversized BMFF box sizes before serialization

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -397,13 +397,11 @@ avifResult avifRWStreamWriteChars(avifRWStream * stream, const char * chars, siz
 avifResult avifRWStreamWriteFullBox(avifRWStream * stream, const char * type, size_t contentSize, int version, uint32_t flags, avifBoxMarker * marker)
 {
     assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
-    if (marker) {
-        *marker = stream->offset;
-    }
     size_t headerSize = sizeof(uint32_t) + 4 /* size of type */;
     if (version != -1) {
         headerSize += 4;
     }
+    AVIF_CHECKERR(contentSize <= UINT32_MAX - headerSize, AVIF_RESULT_INVALID_ARGUMENT);
 
     AVIF_CHECKRES(makeRoom(stream, headerSize));
     memset(stream->raw->data + stream->offset, 0, headerSize);
@@ -415,6 +413,9 @@ avifResult avifRWStreamWriteFullBox(avifRWStream * stream, const char * type, si
         stream->raw->data[stream->offset + 9] = (uint8_t)((flags >> 16) & 0xff);
         stream->raw->data[stream->offset + 10] = (uint8_t)((flags >> 8) & 0xff);
         stream->raw->data[stream->offset + 11] = (uint8_t)((flags >> 0) & 0xff);
+    }
+    if (marker) {
+        *marker = stream->offset;
     }
     stream->offset += headerSize;
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -397,7 +397,6 @@ avifResult avifRWStreamWriteChars(avifRWStream * stream, const char * chars, siz
 avifResult avifRWStreamWriteFullBox(avifRWStream * stream, const char * type, size_t contentSize, int version, uint32_t flags, avifBoxMarker * marker)
 {
     assert(stream->numUsedBitsInPartialByte == 0); // Byte alignment is required.
-    avifBoxMarker oldOffset = stream->offset;
     size_t headerSize = sizeof(uint32_t) + 4 /* size of type */;
     if (version != -1) {
         headerSize += 4;
@@ -405,6 +404,9 @@ avifResult avifRWStreamWriteFullBox(avifRWStream * stream, const char * type, si
     AVIF_CHECKERR(contentSize <= UINT32_MAX - headerSize, AVIF_RESULT_INVALID_ARGUMENT);
 
     AVIF_CHECKRES(makeRoom(stream, headerSize));
+    if (marker) {
+        *marker = stream->offset;
+    }
     memset(stream->raw->data + stream->offset, 0, headerSize);
     uint32_t noSize = avifHTONL((uint32_t)(headerSize + contentSize));
     memcpy(stream->raw->data + stream->offset, &noSize, sizeof(uint32_t));
@@ -414,9 +416,6 @@ avifResult avifRWStreamWriteFullBox(avifRWStream * stream, const char * type, si
         stream->raw->data[stream->offset + 9] = (uint8_t)((flags >> 16) & 0xff);
         stream->raw->data[stream->offset + 10] = (uint8_t)((flags >> 8) & 0xff);
         stream->raw->data[stream->offset + 11] = (uint8_t)((flags >> 0) & 0xff);
-    }
-    if (marker) {
-        *marker = oldOffset;
     }
     stream->offset += headerSize;
 

--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -202,6 +202,43 @@ TEST(StreamTest, WriteBitsLimit) {
             AVIF_RESULT_INVALID_ARGUMENT);
 }
 
+TEST(StreamTest, WriteBoxSizeLimit) {
+  testutil::AvifRwData rw_data;
+  avifRWStream rw_stream;
+  avifRWStreamStart(&rw_stream, &rw_data);
+  const char box_type[] = "type";
+  avifBoxMarker marker = 123;
+
+  EXPECT_EQ(avifRWStreamWriteBox(&rw_stream, box_type,
+                                 std::numeric_limits<uint32_t>::max() -
+                                     sizeof(uint32_t) - 4,
+                                 &marker),
+            AVIF_RESULT_OK);
+  EXPECT_EQ(marker, size_t{0});
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), sizeof(uint32_t) + 4);
+
+  EXPECT_EQ(avifRWStreamWriteBox(&rw_stream, box_type,
+                                 std::numeric_limits<uint32_t>::max() -
+                                     sizeof(uint32_t) - 3,
+                                 &marker),
+            AVIF_RESULT_INVALID_ARGUMENT);
+
+  EXPECT_EQ(avifRWStreamWriteFullBox(
+                &rw_stream, box_type,
+                std::numeric_limits<uint32_t>::max() - sizeof(uint32_t) - 8,
+                /*version=*/0, /*flags=*/0, &marker),
+            AVIF_RESULT_OK);
+  EXPECT_EQ(marker, sizeof(uint32_t) + 4);
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), 2 * (sizeof(uint32_t) + 4) + 4);
+
+  EXPECT_EQ(avifRWStreamWriteFullBox(
+                &rw_stream, box_type,
+                std::numeric_limits<uint32_t>::max() - sizeof(uint32_t) - 7,
+                /*version=*/0, /*flags=*/0, &marker),
+            AVIF_RESULT_INVALID_ARGUMENT);
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), 2 * (sizeof(uint32_t) + 4) + 4);
+}
+
 // Test the overflow checks in the makeRoom() function in src/stream.c.
 TEST(StreamTest, OverflowChecksInMakeRoom) {
   testutil::AvifRwData rw_data;

--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -202,6 +202,43 @@ TEST(StreamTest, WriteBitsLimit) {
             AVIF_RESULT_INVALID_ARGUMENT);
 }
 
+TEST(StreamTest, WriteBoxSizeLimit) {
+  testutil::AvifRwData rw_data;
+  avifRWStream rw_stream;
+  avifRWStreamStart(&rw_stream, &rw_data);
+  const char box_type[] = "type";
+  avifBoxMarker marker = 123;
+
+  EXPECT_EQ(
+      avifRWStreamWriteBox(
+          &rw_stream, box_type,
+          std::numeric_limits<uint32_t>::max() - sizeof(uint32_t) - 4, &marker),
+      AVIF_RESULT_OK);
+  EXPECT_EQ(marker, size_t{0});
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), sizeof(uint32_t) + 4);
+
+  EXPECT_EQ(
+      avifRWStreamWriteBox(
+          &rw_stream, box_type,
+          std::numeric_limits<uint32_t>::max() - sizeof(uint32_t) - 3, &marker),
+      AVIF_RESULT_INVALID_ARGUMENT);
+
+  EXPECT_EQ(avifRWStreamWriteFullBox(
+                &rw_stream, box_type,
+                std::numeric_limits<uint32_t>::max() - sizeof(uint32_t) - 8,
+                /*version=*/0, /*flags=*/0, &marker),
+            AVIF_RESULT_OK);
+  EXPECT_EQ(marker, sizeof(uint32_t) + 4);
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), 2 * (sizeof(uint32_t) + 4) + 4);
+
+  EXPECT_EQ(avifRWStreamWriteFullBox(
+                &rw_stream, box_type,
+                std::numeric_limits<uint32_t>::max() - sizeof(uint32_t) - 7,
+                /*version=*/0, /*flags=*/0, &marker),
+            AVIF_RESULT_INVALID_ARGUMENT);
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), 2 * (sizeof(uint32_t) + 4) + 4);
+}
+
 // Test the overflow checks in the makeRoom() function in src/stream.c.
 TEST(StreamTest, OverflowChecksInMakeRoom) {
   testutil::AvifRwData rw_data;

--- a/tests/gtest/avifstreamtest.cc
+++ b/tests/gtest/avifstreamtest.cc
@@ -222,6 +222,7 @@ TEST(StreamTest, WriteBoxSizeLimit) {
           &rw_stream, box_type,
           std::numeric_limits<uint32_t>::max() - sizeof(uint32_t) - 3, &marker),
       AVIF_RESULT_INVALID_ARGUMENT);
+  EXPECT_EQ(avifRWStreamOffset(&rw_stream), sizeof(uint32_t) + 4);
 
   EXPECT_EQ(avifRWStreamWriteFullBox(
                 &rw_stream, box_type,


### PR DESCRIPTION
## Summary

Reject box sizes that cannot be represented in the 32-bit ISO BMFF size field before writing the box header.

This prevents silent truncation when `headerSize + contentSize` exceeds `UINT32_MAX`, which could otherwise produce invalid serialized BMFF output.

## Changes

* Add an overflow-safe size validation in `avifRWStreamWriteFullBox()`
* Reject unrepresentable box sizes with `AVIF_RESULT_INVALID_ARGUMENT`
* Move marker assignment until after validation/allocation succeeds
* Add regression tests covering:

  * maximum valid regular box size
  * overflow regular box size
  * maximum valid full box size
  * overflow full box size
  * stream offset stability on failure

## Result

Oversized boxes are now rejected before serialization instead of emitting truncated 32-bit BMFF size values.