### PR TITLE
avifenc: refer to "standard input" in the stdin Y4M error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Fix NaN bypass of AVIF_CLAMP in gain map tone mapping (use fminf/fmaxf)
 * avifenc: reject mismatched --depth for Y4M input
 * Use libaom AOMD_SET_FRAME_SIZE_LIMIT if available
+* avifenc: refer to "standard input" in the stdin Y4M error message
 
 ## [1.4.1] - 2026-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Fix NaN bypass of AVIF_CLAMP in gain map tone mapping (use fminf/fmaxf)
 * avifenc: reject mismatched --depth for Y4M input
 * Use libaom AOMD_SET_FRAME_SIZE_LIMIT if available
-* avifenc: refer to "standard input" in the stdin Y4M error message
 
 ## [1.4.1] - 2026-03-20
 

--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -630,7 +630,7 @@ static avifBool avifInputReadImage(avifInput * input,
                 avifFileFormatToString(inputFormat),
                 currentFile->filename == AVIF_FILENAME_STDIN ? "from standard input" : currentFile->filename);
         if (currentFile->filename == AVIF_FILENAME_STDIN && inputFormat == AVIF_APP_FILE_FORMAT_Y4M) {
-            fprintf(stderr, "Specify --input-format if the input is not y4m\n");
+            fprintf(stderr, "Specify --input-format if the standard input is not Y4M\n");
         }
         return AVIF_FALSE;
     }


### PR DESCRIPTION
The outer error already says "from standard input"; make the hint consistent.

Note: this PR fixes the wording only. The underlying question from #3194 (when this message should fire, and what it should say) can be addressed separately.

Refs #3194