### PR TITLE
avifImageCopy: check avifImageCreateEmpty() result for gain map image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Update svt.cmd/svt.sh/LocalSvt.cmake: v4.1.0
 * Fix decoding layered image with multiple scaled alpha layers
 * Fix NaN bypass of AVIF_CLAMP in gain map tone mapping (use fminf/fmaxf)
+* Fix null pointer dereference in avifImageCopy() when avifImageCreateEmpty()
+  fails to allocate the destination gain map image.
 * avifenc: reject mismatched --depth for Y4M input
 * Use libaom AOMD_SET_FRAME_SIZE_LIMIT if available
 

--- a/src/avif.c
+++ b/src/avif.c
@@ -305,6 +305,7 @@ avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifP
         if (srcImage->gainMap->image) {
             if (!dstImage->gainMap->image) {
                 dstImage->gainMap->image = avifImageCreateEmpty();
+                AVIF_CHECKERR(dstImage->gainMap->image, AVIF_RESULT_OUT_OF_MEMORY);
             }
             AVIF_CHECKRES(avifImageCopy(dstImage->gainMap->image, srcImage->gainMap->image, planes));
         } else if (dstImage->gainMap->image) {


### PR DESCRIPTION
## Summary

`avifImageCopy()` calls `avifImageCreateEmpty()` to lazily create the destination gain map image, but does not check the return value before passing it to the recursive `avifImageCopy()` call. Under allocation failure the recursive call dereferences a NULL `dstImage` in `avifImageFreePlanes()` (called as its first statement) and crashes.

The neighbouring `avifGainMapCreate()` call a few lines above already uses `AVIF_CHECKERR(..., AVIF_RESULT_OUT_OF_MEMORY)`; this change applies the same pattern to the gain map image allocation.

```diff
         if (srcImage->gainMap->image) {
             if (!dstImage->gainMap->image) {
                 dstImage->gainMap->image = avifImageCreateEmpty();
+                AVIF_CHECKERR(dstImage->gainMap->image, AVIF_RESULT_OUT_OF_MEMORY);
             }
             AVIF_CHECKRES(avifImageCopy(dstImage->gainMap->image, srcImage->gainMap->image, planes));
```

## Reproduction

With a small instrumentation hook in `avifAlloc()` that returns NULL on the N-th allocation, calling `avifImageCopy()` from a source image that has a `gainMap->image` to a destination that does not crashes when N matches the `avifImageCreateEmpty()` call inside the gain map branch. With this patch the same input returns `AVIF_RESULT_OUT_OF_MEMORY` cleanly.

## Test plan

- [x] Library builds without warnings.
- [x] Verified with an `avifAlloc` fault-injection harness: pre-patch crashes with SIGSEGV at the offending allocation index, post-patch returns `AVIF_RESULT_OUT_OF_MEMORY`. Every other allocation in the function already handles failure correctly and continues to do so.
- [x] Normal (non-OOM) `avifImageCopy()` calls with a gain map still copy the gain map image correctly.