### PR TITLE
reformat: fix u32 row offset wrap in slow path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Update svt.cmd/svt.sh/LocalSvt.cmake: v4.1.0
 * Fix decoding layered image with multiple scaled alpha layers
 * Fix NaN bypass of AVIF_CLAMP in gain map tone mapping (use fminf/fmaxf)
+* Fix uint32_t overflow in row offset arithmetic in
+  avifImageYUVAnyToRGBAnySlow().
 * avifenc: reject mismatched --depth for Y4M input
 * Use libaom AOMD_SET_FRAME_SIZE_LIMIT if available
 

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -686,10 +686,10 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
     for (uint32_t j = 0; j < image->height; ++j) {
         // uvJ is used only when yuvHasColor is true.
         const uint32_t uvJ = yuvHasColor ? (j >> state->yuv.formatInfo.chromaShiftY) : 0;
-        const uint8_t * ptrY8 = &yPlane[j * yRowBytes];
-        const uint8_t * ptrU8 = uPlane ? &uPlane[(uvJ * uRowBytes)] : NULL;
-        const uint8_t * ptrV8 = vPlane ? &vPlane[(uvJ * vRowBytes)] : NULL;
-        const uint8_t * ptrA8 = aPlane ? &aPlane[j * aRowBytes] : NULL;
+        const uint8_t * ptrY8 = &yPlane[(size_t)j * yRowBytes];
+        const uint8_t * ptrU8 = uPlane ? &uPlane[((size_t)uvJ * uRowBytes)] : NULL;
+        const uint8_t * ptrV8 = vPlane ? &vPlane[((size_t)uvJ * vRowBytes)] : NULL;
+        const uint8_t * ptrA8 = aPlane ? &aPlane[(size_t)j * aRowBytes] : NULL;
         const uint16_t * ptrY16 = (const uint16_t *)ptrY8;
         const uint16_t * ptrU16 = (const uint16_t *)ptrU8;
         const uint16_t * ptrV16 = (const uint16_t *)ptrV8;


### PR DESCRIPTION
## Summary

In the slow YUV-to-RGB fallback `avifImageYUVAnyToRGBAnySlow()` ([src/reformat.c:686-692](src/reformat.c#L686-L692)), the per-row Y/U/V/A pointers are computed with `j * yRowBytes` style multiplications where both operands are `uint32_t`. When the plane size exceeds 4 GiB (e.g. a 70000x70000 8-bit YUV400 image, or any combination whose `height * yRowBytes` exceeds `UINT32_MAX`), the product wraps around in 32 bits before being promoted to `size_t` for the pointer arithmetic. The loop then reads from a different row inside the same plane buffer, producing silently corrupted output.

The neighbouring RGB destination pointers in the same loop body already use `(size_t)j * rgb->rowBytes`, and the same pattern was applied across the file in c79a400a and f17110da. This change applies the same cast to the four YUV/A reads that were missed.

```diff
-        const uint8_t * ptrY8 = &yPlane[j * yRowBytes];
-        const uint8_t * ptrU8 = uPlane ? &uPlane[(uvJ * uRowBytes)] : NULL;
-        const uint8_t * ptrV8 = vPlane ? &vPlane[(uvJ * vRowBytes)] : NULL;
-        const uint8_t * ptrA8 = aPlane ? &aPlane[j * aRowBytes] : NULL;
+        const uint8_t * ptrY8 = &yPlane[(size_t)j * yRowBytes];
+        const uint8_t * ptrU8 = uPlane ? &uPlane[((size_t)uvJ * uRowBytes)] : NULL;
+        const uint8_t * ptrV8 = vPlane ? &vPlane[((size_t)uvJ * vRowBytes)] : NULL;
+        const uint8_t * ptrA8 = aPlane ? &aPlane[(size_t)j * aRowBytes] : NULL;
```

## Reproduction

Built a small driver that constructs an `avifImage` with `width=2, height=4, AVIF_PIXEL_FORMAT_YUV420`, points the Y plane at an `mmap` region (virtual, only a few pages touched physically) and sets `yuvRowBytes[Y] = 0x60000000`. Distinct sentinel bytes are written at offsets `0`, `0x60000000`, `0xC0000000`, the true row-3 offset `0x120000000` (`0xCC`), and the wrapped uint32_t row-3 offset `0x20000000` (`0xBB`). `avifImageYUVToRGB` is then called with `AVIF_CHROMA_UPSAMPLING_BILINEAR` and `alphaPremultiplied=AVIF_TRUE` to force the slow path.

Pre-patch output:
```
row0_r=a0 row1_r=a1 row2_r=a2 row3_r=bb
```
i.e. row 3 of the output mirrors the wrapped-offset sentinel, not the true row-3 sentinel.

Post-patch output:
```
row0_r=a0 row1_r=a1 row2_r=a2 row3_r=cc
```
i.e. row 3 reads from the correct offset.

## Test plan

- [x] Library builds without warnings.
- [x] Confirmed with the mmap-backed driver above: pre-patch reads `0xBB` (wrapped offset) for the last row, post-patch reads `0xCC` (true offset).
- [x] Existing `avifyuv_limited` / `avifyuv_rgb` tests still pass (`aviftest` is unrelated and fails only because the local build is configured without an AV1 codec).
- [x] No regression in the normal (sub-4 GiB) case: smaller-image YUV-to-RGB conversions through the slow path still produce identical output.