### PR TITLE
Reject unsupported nonzero iloc data_reference_index values

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2054,6 +2054,10 @@ static avifResult avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw,
 
         uint16_t dataReferenceIndex;
         AVIF_CHECKERR(avifROStreamReadU16(&s, &dataReferenceIndex), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(16) data_reference_index;
+        if (dataReferenceIndex != 0) {
+            avifDiagnosticsPrintf(diag, "Box[iloc] has an unsupported data_reference_index [%u]", dataReferenceIndex);
+            return AVIF_RESULT_BMFF_PARSE_FAILED;
+        }
         uint64_t baseOffset;
         AVIF_CHECKERR(avifROStreamReadUX8(&s, &baseOffset, baseOffsetSize), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(base_offset_size*8) base_offset;
         uint16_t extentCount;

--- a/tests/gtest/avifilocextenttest.cc
+++ b/tests/gtest/avifilocextenttest.cc
@@ -5,11 +5,48 @@
 #include "aviftest_helpers.h"
 #include "gtest/gtest.h"
 
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
 namespace avif {
 namespace {
 
 // Used to pass the data folder path to the GoogleTest suites.
 const char* data_path = nullptr;
+
+//------------------------------------------------------------------------------
+
+uint32_t ReadU32(const uint8_t* data) {
+  return (static_cast<uint32_t>(data[0]) << 24) |
+         (static_cast<uint32_t>(data[1]) << 16) |
+         (static_cast<uint32_t>(data[2]) << 8) | static_cast<uint32_t>(data[3]);
+}
+
+bool SetFirstIlocDataReferenceIndex(std::vector<uint8_t>* bytes,
+                                    uint16_t data_reference_index) {
+  constexpr uint8_t kIlocType[] = {'i', 'l', 'o', 'c'};
+  auto iloc =
+      std::search(bytes->begin(), bytes->end(), std::begin(kIlocType),
+                  std::end(kIlocType));
+  if (iloc == bytes->end() || iloc - bytes->begin() < 4) return false;
+  const size_t box_start = static_cast<size_t>(iloc - bytes->begin()) - 4;
+  const uint32_t box_size = ReadU32(bytes->data() + box_start);
+  if (box_size < 20 || box_start > bytes->size() - box_size) return false;
+
+  // This helper mutates the version 0 iloc box written by libavif. The first
+  // entry's data_reference_index follows the full box header, iloc size fields,
+  // item_count and item_ID.
+  const size_t version_offset = box_start + 8;
+  if ((*bytes)[version_offset] != 0) return false;
+  const size_t data_reference_index_offset = box_start + 18;
+  if (data_reference_index_offset + 1 >= box_start + box_size) return false;
+  (*bytes)[data_reference_index_offset] =
+      static_cast<uint8_t>(data_reference_index >> 8);
+  (*bytes)[data_reference_index_offset + 1] =
+      static_cast<uint8_t>(data_reference_index);
+  return true;
+}
 
 //------------------------------------------------------------------------------
 
@@ -28,6 +65,20 @@ TEST(IlocTest, TwoExtents) {
   const double psnr = testutil::GetPsnr(*source, *decoded);
   EXPECT_GT(psnr, 30.0);
   EXPECT_LT(psnr, 45.0);
+}
+
+TEST(IlocTest, NonZeroDataReferenceIndexIsRejected) {
+  testutil::AvifRwData encoded =
+      testutil::ReadFile(std::string(data_path) + "white_1x1.avif");
+  ASSERT_NE(encoded.data, nullptr);
+  std::vector<uint8_t> bytes(encoded.data, encoded.data + encoded.size);
+  ASSERT_TRUE(SetFirstIlocDataReferenceIndex(&bytes, 1));
+
+  DecoderPtr decoder(avifDecoderCreate());
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderSetIOMemory(decoder.get(), bytes.data(), bytes.size()),
+            AVIF_RESULT_OK);
+  EXPECT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_BMFF_PARSE_FAILED);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reject unsupported nonzero `data_reference_index` values while parsing `iloc` item locations.

libavif currently interprets item extents using the local file / `idat` storage model and does not implement external item data reference resolution (`dref`). However, nonzero `data_reference_index` values were previously accepted silently.

This change rejects unsupported external item references early during `iloc` parsing.

## Changes

- Validate `data_reference_index == 0` in `avifParseItemLocationBox()`
- Return `AVIF_RESULT_BMFF_PARSE_FAILED` for unsupported nonzero values
- Add regression test covering malformed `iloc` metadata

## Rationale

- MIAF requires `data_reference_index` to be `0`
- libavif does not support external item data references
- Rejecting unsupported metadata avoids silently interpreting item extents using an unsupported storage model
- Validation is centralized in the shared `iloc` parser path and applies to all item types using item locations