### PR TITLE
Check null return value from avifImageCreateEmpty

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -545,6 +545,10 @@ static avifBool avifInputReadImage(avifInput * input,
 #if defined(AVIF_ENABLE_JPEG_GAIN_MAP_CONVERSION)
         if (cached->image->gainMap && cached->image->gainMap->image) {
             image->gainMap->image = avifImageCreateEmpty();
+            if (!image->gainMap->image) {
+                fprintf(stderr, "ERROR: Out of memory\n");
+                return AVIF_FALSE;
+            }
             const avifCropRect gainMapRect = { 0, 0, cached->image->gainMap->image->width, cached->image->gainMap->image->height };
             if (avifImageSetViewRect(image->gainMap->image, cached->image->gainMap->image, &gainMapRect) != AVIF_RESULT_OK) {
                 assert(AVIF_FALSE);
@@ -573,7 +577,7 @@ static avifBool avifInputReadImage(avifInput * input,
     avifAppSourceTiming * dstSourceTiming = sourceTiming;
     if (input->cacheEnabled) {
         if (!avifInputAddCachedImage(input)) {
-            fprintf(stderr, "ERROR: Out of memory");
+            fprintf(stderr, "ERROR: Out of memory\n");
             return AVIF_FALSE;
         }
         assert(imageIndex + 1 == input->cacheCount);

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -1062,7 +1062,7 @@ static avifBool avifJPEGExtractGainMapImage(FILE * f,
             !memcmp(marker->data, tagMpf.data, tagMpf.size)) {
             avifImage * image = avifImageCreateEmpty();
             if (!image) {
-                fprintf(stderr, "Warning: out of memory\n");
+                fprintf(stderr, "Warning: out of memory when reading gain map\n");
                 return AVIF_FALSE;
             }
             // Set jpeg native matrix coefficients to allow copying YUV values directly.

--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -1061,6 +1061,10 @@ static avifBool avifJPEGExtractGainMapImage(FILE * f,
         if ((marker->marker == (JPEG_APP0 + 2)) && (marker->data_length > tagMpf.size) &&
             !memcmp(marker->data, tagMpf.data, tagMpf.size)) {
             avifImage * image = avifImageCreateEmpty();
+            if (!image) {
+                fprintf(stderr, "Warning: out of memory\n");
+                return AVIF_FALSE;
+            }
             // Set jpeg native matrix coefficients to allow copying YUV values directly.
             image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
             assert(avifJPEGHasCompatibleMatrixCoefficients(image->matrixCoefficients));
@@ -1069,7 +1073,7 @@ static avifBool avifJPEGExtractGainMapImage(FILE * f,
             if (!avifJPEGExtractGainMapImageFromMpf(f, sizeLimit, &mpfData, image, chromaDownsampling)) {
                 if (f == stdin) {
                     // Not supported because fseek doesn't work on stdin.
-                    fprintf(stderr, "Warning: gain map transcoding is not supported with sdtin\n");
+                    fprintf(stderr, "Warning: gain map transcoding is not supported with stdin\n");
                 } else if (expectIsoGainMap) {
                     fprintf(stderr, "Note: XMP metadata indicated the presence of a gain map, but it could not be found or decoded\n");
                 }


### PR DESCRIPTION
Audit all calls to avifImageCreateEmpty() and avifImageCreate() in the libavif source tree (except the tests) and make sure that the callers check for a null return value.

Fix nits in two error messages.