### PR TITLE
gainmap: check avifImageCreateEmpty() result

### DIFF
--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -187,6 +187,10 @@ avifResult avifRGBImageApplyGainMap(const avifRGBImage * baseImage,
 
     if (gainMap->image->width != width || gainMap->image->height != height) {
         rescaledGainMap = avifImageCreateEmpty();
+        if (rescaledGainMap == NULL) {
+            res = AVIF_RESULT_OUT_OF_MEMORY;
+            goto cleanup;
+        }
         const avifCropRect rect = { 0, 0, gainMap->image->width, gainMap->image->height };
         res = avifImageSetViewRect(rescaledGainMap, gainMap->image, &rect);
         if (res != AVIF_RESULT_OK) {


### PR DESCRIPTION
## Summary

`avifRGBImageApplyGainMap()` ([src/gainmap.c:189](src/gainmap.c#L189)) backs `rescaledGainMap` with `avifImageCreateEmpty()` when the gain map image's dimensions differ from the base image's, but does not check the return value. The very next line passes that pointer to `avifImageSetViewRect()`, which dereferences the destination image via `avifImageFreePlanes(dstImage, AVIF_PLANES_ALL)` at [src/avif.c:333](src/avif.c#L333) before any rect validation. Under memory pressure, `avifImageCreateEmpty()` returns NULL and the caller crashes.

```diff
     if (gainMap->image->width != width || gainMap->image->height != height) {
         rescaledGainMap = avifImageCreateEmpty();
+        if (rescaledGainMap == NULL) {
+            res = AVIF_RESULT_OUT_OF_MEMORY;
+            goto cleanup;
+        }
         const avifCropRect rect = { 0, 0, gainMap->image->width, gainMap->image->height };
         res = avifImageSetViewRect(rescaledGainMap, gainMap->image, &rect);
```

This is the same defect class fixed in `avifImageCopy()` by #3201; this PR closes the remaining instance in the public gain-map apply path. Reachable from the public APIs `avifImageApplyGainMap()` and `avifRGBImageApplyGainMap()`.

## Test plan

- [x] Library builds clean with the patch.
- [x] Added smoke driver that exercises the rescale path (4x4 base image with a 2x2 gain map) under `avifImageApplyGainMap` — succeeds and produces the expected output, confirming the success path is unchanged.
- [x] `avifyuv_limited` / `avifyuv_rgb` tests still pass (`aviftest` is unrelated and fails only because the local build is configured without an AV1 codec).