### PR TITLE
Reject unsupported external iloc data references

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2054,6 +2054,10 @@ static avifResult avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw,
 
         uint16_t dataReferenceIndex;
         AVIF_CHECKERR(avifROStreamReadU16(&s, &dataReferenceIndex), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(16) data_reference_index;
+        if (dataReferenceIndex != 0) {
+            avifDiagnosticsPrintf(diag, "Item ID [%u] contains an unsupported data reference index [%u]", itemID, dataReferenceIndex);
+            return AVIF_RESULT_BMFF_PARSE_FAILED;
+        }
         uint64_t baseOffset;
         AVIF_CHECKERR(avifROStreamReadUX8(&s, &baseOffset, baseOffsetSize), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(base_offset_size*8) base_offset;
         uint16_t extentCount;

--- a/src/read.c
+++ b/src/read.c
@@ -2033,13 +2033,15 @@ static avifResult avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw,
             return AVIF_RESULT_BMFF_PARSE_FAILED;
         }
 
+        // Version 0 has no construction_method field; the data is located by file offsets,
+        // matching construction method 0.
+        uint8_t constructionMethod = 0;
         if (version == 1 || version == 2) {
             AVIF_CHECKERR(avifROStreamReadBitsU32(&s, &reserved, /*bitCount=*/12), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(12) reserved = 0;
             if (reserved) {
                 avifDiagnosticsPrintf(diag, "Box[iloc] has a non null reserved field [%u]", reserved);
                 return AVIF_RESULT_BMFF_PARSE_FAILED;
             }
-            uint8_t constructionMethod;
             AVIF_CHECKERR(avifROStreamReadBitsU8(&s, &constructionMethod, /*bitCount=*/4),
                           AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(4) construction_method;
             if (constructionMethod != 0 /* file offset */ && constructionMethod != 1 /* idat offset */) {
@@ -2054,7 +2056,7 @@ static avifResult avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw,
 
         uint16_t dataReferenceIndex;
         AVIF_CHECKERR(avifROStreamReadU16(&s, &dataReferenceIndex), AVIF_RESULT_BMFF_PARSE_FAILED); // unsigned int(16) data_reference_index;
-        if (dataReferenceIndex != 0) {
+        if (constructionMethod == 0 /* file offset */ && dataReferenceIndex != 0) {
             avifDiagnosticsPrintf(diag, "Item ID [%u] contains an unsupported data reference index [%u]", itemID, dataReferenceIndex);
             return AVIF_RESULT_BMFF_PARSE_FAILED;
         }

--- a/tests/gtest/avifilocextenttest.cc
+++ b/tests/gtest/avifilocextenttest.cc
@@ -1,6 +1,9 @@
 // Copyright 2024 Google LLC
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include <algorithm>
+#include <string>
+
 #include "avif/avif.h"
 #include "aviftest_helpers.h"
 #include "gtest/gtest.h"
@@ -28,6 +31,35 @@ TEST(IlocTest, TwoExtents) {
   const double psnr = testutil::GetPsnr(*source, *decoded);
   EXPECT_GT(psnr, 30.0);
   EXPECT_LT(psnr, 45.0);
+}
+
+TEST(IlocTest, NonZeroDataReferenceIndex) {
+  testutil::AvifRwData avif =
+      testutil::ReadFile(std::string(data_path) + "white_1x1.avif");
+  ASSERT_NE(avif.data, nullptr);
+
+  const uint8_t kIloc[] = {'i', 'l', 'o', 'c'};
+  uint8_t* iloc_position =
+      std::search(avif.data, avif.data + avif.size, kIloc, kIloc + 4);
+  ASSERT_NE(iloc_position, avif.data + avif.size);
+  ASSERT_GE(static_cast<size_t>(avif.data + avif.size - iloc_position),
+            size_t{16});
+
+  // white_1x1.avif uses iloc version 0 with a single item. The
+  // data_reference_index field follows the item_ID field.
+  ASSERT_EQ(iloc_position[4], 0);
+  ASSERT_EQ(iloc_position[10], 0);
+  ASSERT_EQ(iloc_position[11], 1);
+  ASSERT_EQ(iloc_position[14], 0);
+  ASSERT_EQ(iloc_position[15], 0);
+  iloc_position[14] = 0;
+  iloc_position[15] = 1;
+
+  DecoderPtr decoder(avifDecoderCreate());
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderSetIOMemory(decoder.get(), avif.data, avif.size),
+            AVIF_RESULT_OK);
+  EXPECT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_BMFF_PARSE_FAILED);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
libavif currently supports same-file item extents and `idat` extents only.

`iloc.data_reference_index` values were previously parsed but ignored, causing extents declared as external references to be interpreted as same-file offsets.

This change rejects unsupported nonzero `data_reference_index` values during `iloc` parsing so downstream extent handling operates under validated source-boundary assumptions.

### Changes

* Reject nonzero `iloc.data_reference_index` values in `avifParseItemLocationBox()`
* Add a regression test covering unsupported external data references

### Test

* Mutate `white_1x1.avif` to set `data_reference_index = 1`
* Verify parsing now fails with `AVIF_RESULT_BMFF_PARSE_FAILED`
* Existing `IlocTest.TwoExtents` continues to pass