### PR TITLE
Make avifAlloc(0) deterministic and fix RWData shrink-to-zero handling

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -154,7 +154,7 @@ AVIF_API unsigned int avifLibYUVVersion(void); // returns 0 if libavif wasn't co
 // ---------------------------------------------------------------------------
 // Memory management
 
-// Returns NULL on memory allocation failure.
+// Returns NULL on memory allocation failure or if size is 0.
 AVIF_API void * avifAlloc(size_t size);
 AVIF_API void avifFree(void * p);
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -3,12 +3,17 @@
 
 #include "avif/avif.h"
 
-#include <assert.h>
 #include <stdlib.h>
 
 void * avifAlloc(size_t size)
 {
-    assert(size != 0); // Implementation-defined. See https://en.cppreference.com/w/cpp/memory/c/malloc
+    // malloc(0) is implementation-defined (see
+    // https://en.cppreference.com/w/cpp/memory/c/malloc), so collapse the
+    // zero-size case to a deterministic NULL return. Callers must either treat
+    // 0 as an allocation failure or guard against it before calling.
+    if (size == 0) {
+        return NULL;
+    }
     return malloc(size);
 }
 

--- a/src/rawdata.c
+++ b/src/rawdata.c
@@ -8,9 +8,15 @@
 avifResult avifRWDataRealloc(avifRWData * raw, size_t newSize)
 {
     if (raw->size != newSize) {
+        if (newSize == 0) {
+            // Shrink-to-zero: release the buffer instead of calling avifAlloc(0),
+            // which would return NULL under the new contract and falsely look like OOM.
+            avifRWDataFree(raw);
+            return AVIF_RESULT_OK;
+        }
         uint8_t * newData = (uint8_t *)avifAlloc(newSize);
         AVIF_CHECKERR(newData, AVIF_RESULT_OUT_OF_MEMORY);
-        if (raw->size && newSize) {
+        if (raw->size) {
             memcpy(newData, raw->data, AVIF_MIN(raw->size, newSize));
         }
         avifFree(raw->data);

--- a/src/rawdata.c
+++ b/src/rawdata.c
@@ -9,8 +9,7 @@ avifResult avifRWDataRealloc(avifRWData * raw, size_t newSize)
 {
     if (raw->size != newSize) {
         if (newSize == 0) {
-            // Shrink-to-zero: release the buffer instead of calling avifAlloc(0),
-            // which would return NULL under the new contract and falsely look like OOM.
+            // avifAlloc(0) returns NULL, so handle the shrink-to-zero case by freeing the buffer.
             avifRWDataFree(raw);
             return AVIF_RESULT_OK;
         }

--- a/tests/gtest/avifallocationtest.cc
+++ b/tests/gtest/avifallocationtest.cc
@@ -208,5 +208,27 @@ TEST(AvifAllocTest, Extremes) {
 }
 #endif
 
+TEST(AvifAllocTest, ZeroReturnsNull) {
+  // avifAlloc(0) must return NULL deterministically (rather than aborting via
+  // assert or relying on implementation-defined malloc(0) behavior). Callers
+  // rely on this contract to treat 0 as an allocation failure.
+  EXPECT_EQ(avifAlloc(0), nullptr);
+}
+
+TEST(AvifAllocTest, RWDataReallocShrinkToZeroSucceeds) {
+  // Shrinking an avifRWData to size 0 must release the buffer and return OK,
+  // not surface a phantom OOM from avifAlloc(0) returning NULL.
+  avifRWData raw = {};
+  ASSERT_EQ(avifRWDataRealloc(&raw, 16), AVIF_RESULT_OK);
+  ASSERT_NE(raw.data, nullptr);
+  ASSERT_EQ(raw.size, 16u);
+
+  EXPECT_EQ(avifRWDataRealloc(&raw, 0), AVIF_RESULT_OK);
+  EXPECT_EQ(raw.data, nullptr);
+  EXPECT_EQ(raw.size, 0u);
+
+  avifRWDataFree(&raw);
+}
+
 }  // namespace
 }  // namespace avif


### PR DESCRIPTION
This PR updates the `avifAlloc()` contract to handle zero-size allocations deterministically and fixes a latent bug in `avifRWDataRealloc()` when shrinking buffers to size `0`.

Previously, `avifAlloc(0)` asserted in debug builds and relied on implementation-defined `malloc(0)` behavior in release builds. This patch standardizes the behavior by returning `NULL` for zero-size allocations.

During the allocator audit, a bug was identified in `avifRWDataRealloc()`: shrinking an existing buffer to zero incorrectly routed through `avifAlloc(0)`, which could previously assert/crash or incorrectly surface as an out-of-memory failure. The shrink-to-zero path is now handled explicitly.

## Changes Made

### Memory allocation contract

* Updated `include/avif/avif.h`

  * Documented that `avifAlloc()` returns `NULL` when `size == 0`.

* Updated `src/mem.c`

  * Removed the debug-only assertion for `size != 0`.
  * Added deterministic handling for zero-size allocations:

    * `avifAlloc(0)` now returns `NULL`.
  * Avoids implementation-defined `malloc(0)` behavior.

### RWData realloc fix

* Updated `src/rawdata.c`

  * Added explicit handling for:

    ```c
    avifRWDataRealloc(raw, 0)
    ```
  * Shrinking to zero now:

    * releases the existing buffer,
    * resets the allocation state correctly,
    * returns `AVIF_RESULT_OK`.

* Simplified the copy condition after introducing the early-return path:

  ```c
  if (raw->size)
  ```

## Tests Added

Added regression tests covering both the new allocator contract and the realloc fix:

* `AvifAllocTest.ZeroReturnsNull`

  * Verifies `avifAlloc(0)` consistently returns `NULL`.

* `AvifAllocTest.RWDataReallocShrinkToZeroSucceeds`

  * Verifies shrinking RWData buffers to zero:

    * succeeds,
    * releases memory,
    * clears internal state correctly.