### PR TITLE
Add per-source opt-in support for `-Wunsafe-buffer-usage`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,10 +573,16 @@ endif()
 # (the first step of adopting the Safe Buffers Programming Model). Apply only
 # to .cc files that have been audited to be free of raw pointer arithmetic and
 # raw-pointer indexing; new code added to those files must keep them clean.
+# The libc-call subgroup (Clang 17+) is disabled because it fires on functions
+# such as strdup() that are used in third-party headers (e.g. libargparse) we
+# do not own; our own code avoids those by convention.
 # No-op on toolchains where the flag is not available (Clang < 16, GCC, MSVC).
 function(avif_enable_safe_buffers_warning)
     if(AVIF_HAVE_WUNSAFE_BUFFER_USAGE)
-        set_source_files_properties(${ARGN} PROPERTIES COMPILE_OPTIONS "-Wunsafe-buffer-usage")
+        set_source_files_properties(
+            ${ARGN} PROPERTIES COMPILE_OPTIONS
+                               "-Wunsafe-buffer-usage;-Wno-unsafe-buffer-usage-in-libc-call"
+        )
     endif()
 endfunction()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,25 @@ if(AVIF_LIB_USE_CXX OR AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_FUZZTEST O
     enable_language(CXX)
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag(-Wunsafe-buffer-usage AVIF_HAVE_WUNSAFE_BUFFER_USAGE)
+    endif()
+endif()
+
+# Opt a list of C++ source files into the -Wunsafe-buffer-usage diagnostic
+# (the first step of adopting the Safe Buffers Programming Model). Apply only
+# to .cc files that have been audited to be free of raw pointer arithmetic and
+# raw-pointer indexing; new code added to those files must keep them clean.
+# No-op on toolchains where the flag is not available (Clang < 16, GCC, MSVC).
+function(avif_enable_safe_buffers_warning)
+    if(AVIF_HAVE_WUNSAFE_BUFFER_USAGE)
+        set_source_files_properties(${ARGN} PROPERTIES COMPILE_OPTIONS "-Wunsafe-buffer-usage")
+    endif()
+endfunction()
+
+if(AVIF_ENABLE_COMPLIANCE_WARDEN)
+    avif_enable_safe_buffers_warning(src/compliance.cc)
 endif()
 
 set_target_properties(avif_obj PROPERTIES C_VISIBILITY_PRESET hidden)
@@ -723,6 +742,7 @@ if(AVIF_BUILD_APPS)
         apps/avifgainmaputil/program_command.cc
         apps/avifgainmaputil/swapbase_command.cc
     )
+    avif_enable_safe_buffers_warning(${AVIFGAINMAPUTIL_SRCS})
 
     add_executable(avifgainmaputil "${AVIFGAINMAPUTIL_SRCS}")
     if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,9 @@ if(AVIF_LIB_USE_CXX OR AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_FUZZTEST O
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         include(CheckCXXCompilerFlag)
         check_cxx_compiler_flag(-Wunsafe-buffer-usage AVIF_HAVE_WUNSAFE_BUFFER_USAGE)
+        # Probe the positive form: Clang accepts unknown -Wno- flags silently,
+        # so checking -Wno-unsafe-buffer-usage-in-libc-call would always pass.
+        check_cxx_compiler_flag(-Wunsafe-buffer-usage-in-libc-call AVIF_HAVE_WUNSAFE_BUFFER_USAGE_IN_LIBC_CALL)
     endif()
 endif()
 
@@ -573,16 +576,17 @@ endif()
 # (the first step of adopting the Safe Buffers Programming Model). Apply only
 # to .cc files that have been audited to be free of raw pointer arithmetic and
 # raw-pointer indexing; new code added to those files must keep them clean.
-# The libc-call subgroup (Clang 17+) is disabled because it fires on functions
-# such as strdup() that are used in third-party headers (e.g. libargparse) we
-# do not own; our own code avoids those by convention.
+# The libc-call subgroup is disabled where it exists because it fires on
+# functions such as strdup() that are used in third-party headers (e.g.
+# libargparse) we do not own; our own code avoids those by convention.
 # No-op on toolchains where the flag is not available (Clang < 16, GCC, MSVC).
 function(avif_enable_safe_buffers_warning)
     if(AVIF_HAVE_WUNSAFE_BUFFER_USAGE)
-        set_source_files_properties(
-            ${ARGN} PROPERTIES COMPILE_OPTIONS
-                               "-Wunsafe-buffer-usage;-Wno-unsafe-buffer-usage-in-libc-call"
-        )
+        set(safe_buffers_options "-Wunsafe-buffer-usage")
+        if(AVIF_HAVE_WUNSAFE_BUFFER_USAGE_IN_LIBC_CALL)
+            list(APPEND safe_buffers_options "-Wno-unsafe-buffer-usage-in-libc-call")
+        endif()
+        set_source_files_properties(${ARGN} PROPERTIES COMPILE_OPTIONS "${safe_buffers_options}")
     endif()
 endfunction()
 

--- a/apps/avifgainmaputil/avifgainmaputil.cc
+++ b/apps/avifgainmaputil/avifgainmaputil.cc
@@ -91,30 +91,19 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  // argv is a raw pointer with no associated bound, so -Wunsafe-buffer-usage
-  // cannot prove these accesses safe. They are bounded by the argc checks
-  // above and by the host's contract with main(): argv[0..argc-1] are valid.
-  const char* command_cstr;
-  const char* sub_command_cstr = nullptr;
-  char* const* command_argv;
+  // -Wunsafe-buffer-usage doesn't know the raw pointer argv is associated with
+  // the bound argc, so it cannot prove these accesses safe. They are bounded
+  // by the argc checks and by the host's contract with main():
+  // argv[0..argc-1] are valid.
 #ifdef __clang__
 #if __has_warning("-Wunsafe-buffer-usage")
 #pragma clang unsafe_buffer_usage begin
 #endif
 #endif
-  command_cstr = argv[1];
-  if (argc >= 3) sub_command_cstr = argv[2];
-  command_argv = argv + 1;
-#ifdef __clang__
-#if __has_warning("-Wunsafe-buffer-usage")
-#pragma clang unsafe_buffer_usage end
-#endif
-#endif
-
-  const std::string command_name(command_cstr);
+  const std::string command_name(argv[1]);
   if (command_name == "help") {
-    if (sub_command_cstr != nullptr) {
-      const std::string sub_command_name(sub_command_cstr);
+    if (argc >= 3) {
+      const std::string sub_command_name(argv[2]);
       for (const auto& command : commands) {
         if (command->name() == sub_command_name) {
           command->PrintUsage();
@@ -133,7 +122,7 @@ int main(int argc, char** argv) {
   for (const auto& command : commands) {
     if (command->name() == command_name) {
       try {
-        avifResult result = command->ParseArgs(argc - 1, command_argv);
+        avifResult result = command->ParseArgs(argc - 1, argv + 1);
         if (result == AVIF_RESULT_OK) {
           result = command->Run();
         }
@@ -149,6 +138,11 @@ int main(int argc, char** argv) {
       }
     }
   }
+#ifdef __clang__
+#if __has_warning("-Wunsafe-buffer-usage")
+#pragma clang unsafe_buffer_usage end
+#endif
+#endif
 
   std::cerr << "Unknown command " << command_name << "\n";
   avif::PrintUsage(commands);

--- a/apps/avifgainmaputil/avifgainmaputil.cc
+++ b/apps/avifgainmaputil/avifgainmaputil.cc
@@ -91,10 +91,30 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  const std::string command_name(argv[1]);
+  // argv is a raw pointer with no associated bound, so -Wunsafe-buffer-usage
+  // cannot prove these accesses safe. They are bounded by the argc checks
+  // above and by the host's contract with main(): argv[0..argc-1] are valid.
+  const char* command_cstr;
+  const char* sub_command_cstr = nullptr;
+  char* const* command_argv;
+#ifdef __clang__
+#if __has_warning("-Wunsafe-buffer-usage")
+#pragma clang unsafe_buffer_usage begin
+#endif
+#endif
+  command_cstr = argv[1];
+  if (argc >= 3) sub_command_cstr = argv[2];
+  command_argv = argv + 1;
+#ifdef __clang__
+#if __has_warning("-Wunsafe-buffer-usage")
+#pragma clang unsafe_buffer_usage end
+#endif
+#endif
+
+  const std::string command_name(command_cstr);
   if (command_name == "help") {
-    if (argc >= 3) {
-      const std::string sub_command_name(argv[2]);
+    if (sub_command_cstr != nullptr) {
+      const std::string sub_command_name(sub_command_cstr);
       for (const auto& command : commands) {
         if (command->name() == sub_command_name) {
           command->PrintUsage();
@@ -113,7 +133,7 @@ int main(int argc, char** argv) {
   for (const auto& command : commands) {
     if (command->name() == command_name) {
       try {
-        avifResult result = command->ParseArgs(argc - 1, argv + 1);
+        avifResult result = command->ParseArgs(argc - 1, command_argv);
         if (result == AVIF_RESULT_OK) {
           result = command->Run();
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,38 @@ if(AVIF_GTEST)
     target_link_libraries(avifincrtest_helpers PRIVATE GTest::GTest avif_enable_warnings)
 endif()
 
+# Tests that have been audited for the Safe Buffers Programming Model. Adding
+# a new test to this list requires that the file compiles cleanly under
+# -Wunsafe-buffer-usage. See avif_enable_safe_buffers_warning() in the root
+# CMakeLists.txt.
+if(AVIF_GTEST)
+    avif_enable_safe_buffers_warning(
+        gtest/avifalphapremtest.cc
+        gtest/avifbasictest.cc
+        gtest/avifcicptest.cc
+        gtest/avifclaptest.cc
+        gtest/avifcllitest.cc
+        gtest/avifcodectest.cc
+        gtest/avifcolrtest.cc
+        gtest/avifgridapitest.cc
+        gtest/avifimagetest.cc
+        gtest/avifjpeggainmaptest.cc
+        gtest/avifopaquetest.cc
+        gtest/avifpropinternaltest.cc
+        gtest/avifrgbtest.cc
+        gtest/avifsampletransformtest.cc
+        gtest/aviftilingtest.cc
+        gtest/avifutilstest.cc
+        gtest/avify4mtest.cc
+    )
+    if(AVIF_CODEC_AVM_ENABLED)
+        avif_enable_safe_buffers_warning(gtest/avifavmtest.cc)
+        if(AVIF_ENABLE_EXPERIMENTAL_MINI)
+            avif_enable_safe_buffers_warning(gtest/avifavmminitest.cc)
+        endif()
+    endif()
+endif()
+
 if(AVIF_GTEST)
     add_avif_gtest_with_data(avif16bittest)
     add_avif_gtest(avifallocationtest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,7 +89,6 @@ if(AVIF_GTEST)
         gtest/avifcolrtest.cc
         gtest/avifgridapitest.cc
         gtest/avifimagetest.cc
-        gtest/avifjpeggainmaptest.cc
         gtest/avifopaquetest.cc
         gtest/avifpropinternaltest.cc
         gtest/avifrgbtest.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,7 +91,6 @@ if(AVIF_GTEST)
         gtest/avifimagetest.cc
         gtest/avifopaquetest.cc
         gtest/avifpropinternaltest.cc
-        gtest/avifrgbtest.cc
         gtest/avifsampletransformtest.cc
         gtest/aviftilingtest.cc
         gtest/avifutilstest.cc

--- a/tests/gtest/avifrgbtest.cc
+++ b/tests/gtest/avifrgbtest.cc
@@ -1,7 +1,6 @@
 // Copyright 2023 Google LLC
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include <array>
 #include <tuple>
 
 #include "avif/internal.h"
@@ -41,18 +40,18 @@ TEST_P(SetGetRGBATest, SetGetTest) {
     epsilon = 0.0005f;  // Half precision floats are not that precise.
   }
 
-  std::array<float, 4> pixel_read;
+  float pixel_read[4];
   for (uint32_t j = 0; j < rgb.height; ++j) {
     for (uint32_t i = 0; i < rgb.width; ++i) {
       // Generate some arbitrary pixel values.
-      const std::array<float, 4> pixel_to_write = {
+      const float pixel_to_write[4] = {
           0.0f + static_cast<float>(i) / rgb.width,
           0.5f + static_cast<float>(j) / (rgb.height * 2),
           1.0f - static_cast<float>(i + j) / ((rgb.width + rgb.height) * 2),
           1.0f - static_cast<float>(i) / rgb.width};
 
-      avifSetRGBAPixel(&rgb, i, j, &color_space, pixel_to_write.data());
-      avifGetRGBAPixel(&rgb, i, j, &color_space, pixel_read.data());
+      avifSetRGBAPixel(&rgb, i, j, &color_space, pixel_to_write);
+      avifGetRGBAPixel(&rgb, i, j, &color_space, pixel_read);
       EXPECT_NEAR(pixel_read[0], pixel_to_write[0], epsilon);
       EXPECT_NEAR(pixel_read[1], pixel_to_write[1], epsilon);
       EXPECT_NEAR(pixel_read[2], pixel_to_write[2], epsilon);
@@ -65,17 +64,17 @@ TEST_P(SetGetRGBATest, SetGetTest) {
   }
 
   // Check that 0 maps to 0 and 1.0f maps to 1.0f.
-  const std::array<float, 4> pixel_zero = {0.0f, 0.0f, 0.0f, 1.0f};
-  avifSetRGBAPixel(&rgb, 0, 0, &color_space, pixel_zero.data());
-  avifGetRGBAPixel(&rgb, 0, 0, &color_space, pixel_read.data());
+  const float pixel_zero[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+  avifSetRGBAPixel(&rgb, 0, 0, &color_space, pixel_zero);
+  avifGetRGBAPixel(&rgb, 0, 0, &color_space, pixel_read);
   EXPECT_EQ(pixel_read[0], pixel_zero[0]);
   EXPECT_EQ(pixel_read[1], pixel_zero[1]);
   EXPECT_EQ(pixel_read[2], pixel_zero[2]);
   EXPECT_EQ(pixel_read[3], pixel_zero[3]);
 
-  const std::array<float, 4> pixel_one = {1.0f, 1.0f, 1.0f, 1.0f};
-  avifSetRGBAPixel(&rgb, 0, 0, &color_space, pixel_one.data());
-  avifGetRGBAPixel(&rgb, 0, 0, &color_space, pixel_read.data());
+  const float pixel_one[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+  avifSetRGBAPixel(&rgb, 0, 0, &color_space, pixel_one);
+  avifGetRGBAPixel(&rgb, 0, 0, &color_space, pixel_read);
   EXPECT_EQ(pixel_read[0], pixel_one[0]);
   EXPECT_EQ(pixel_read[1], pixel_one[1]);
   EXPECT_EQ(pixel_read[2], pixel_one[2]);
@@ -104,9 +103,9 @@ TEST_P(SetGetRGBATest, GradientTest) {
 
   for (uint32_t j = 0; j < input_rgb.height; ++j) {
     for (uint32_t i = 0; i < input_rgb.width; ++i) {
-      std::array<float, 4> pixel;
-      avifGetRGBAPixel(&input_rgb, i, j, &color_space, pixel.data());
-      avifSetRGBAPixel(&output_rgb, i, j, &color_space, pixel.data());
+      float pixel[4];
+      avifGetRGBAPixel(&input_rgb, i, j, &color_space, pixel);
+      avifSetRGBAPixel(&output_rgb, i, j, &color_space, pixel);
     }
   }
   EXPECT_TRUE(testutil::AreImagesEqual(input_rgb, output_rgb));

--- a/tests/gtest/avifrgbtest.cc
+++ b/tests/gtest/avifrgbtest.cc
@@ -1,6 +1,7 @@
 // Copyright 2023 Google LLC
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include <array>
 #include <tuple>
 
 #include "avif/internal.h"
@@ -40,18 +41,18 @@ TEST_P(SetGetRGBATest, SetGetTest) {
     epsilon = 0.0005f;  // Half precision floats are not that precise.
   }
 
-  float pixel_read[4];
+  std::array<float, 4> pixel_read;
   for (uint32_t j = 0; j < rgb.height; ++j) {
     for (uint32_t i = 0; i < rgb.width; ++i) {
       // Generate some arbitrary pixel values.
-      const float pixel_to_write[4] = {
+      const std::array<float, 4> pixel_to_write = {
           0.0f + static_cast<float>(i) / rgb.width,
           0.5f + static_cast<float>(j) / (rgb.height * 2),
           1.0f - static_cast<float>(i + j) / ((rgb.width + rgb.height) * 2),
           1.0f - static_cast<float>(i) / rgb.width};
 
-      avifSetRGBAPixel(&rgb, i, j, &color_space, pixel_to_write);
-      avifGetRGBAPixel(&rgb, i, j, &color_space, pixel_read);
+      avifSetRGBAPixel(&rgb, i, j, &color_space, pixel_to_write.data());
+      avifGetRGBAPixel(&rgb, i, j, &color_space, pixel_read.data());
       EXPECT_NEAR(pixel_read[0], pixel_to_write[0], epsilon);
       EXPECT_NEAR(pixel_read[1], pixel_to_write[1], epsilon);
       EXPECT_NEAR(pixel_read[2], pixel_to_write[2], epsilon);
@@ -64,17 +65,17 @@ TEST_P(SetGetRGBATest, SetGetTest) {
   }
 
   // Check that 0 maps to 0 and 1.0f maps to 1.0f.
-  const float pixel_zero[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-  avifSetRGBAPixel(&rgb, 0, 0, &color_space, pixel_zero);
-  avifGetRGBAPixel(&rgb, 0, 0, &color_space, pixel_read);
+  const std::array<float, 4> pixel_zero = {0.0f, 0.0f, 0.0f, 1.0f};
+  avifSetRGBAPixel(&rgb, 0, 0, &color_space, pixel_zero.data());
+  avifGetRGBAPixel(&rgb, 0, 0, &color_space, pixel_read.data());
   EXPECT_EQ(pixel_read[0], pixel_zero[0]);
   EXPECT_EQ(pixel_read[1], pixel_zero[1]);
   EXPECT_EQ(pixel_read[2], pixel_zero[2]);
   EXPECT_EQ(pixel_read[3], pixel_zero[3]);
 
-  const float pixel_one[4] = {1.0f, 1.0f, 1.0f, 1.0f};
-  avifSetRGBAPixel(&rgb, 0, 0, &color_space, pixel_one);
-  avifGetRGBAPixel(&rgb, 0, 0, &color_space, pixel_read);
+  const std::array<float, 4> pixel_one = {1.0f, 1.0f, 1.0f, 1.0f};
+  avifSetRGBAPixel(&rgb, 0, 0, &color_space, pixel_one.data());
+  avifGetRGBAPixel(&rgb, 0, 0, &color_space, pixel_read.data());
   EXPECT_EQ(pixel_read[0], pixel_one[0]);
   EXPECT_EQ(pixel_read[1], pixel_one[1]);
   EXPECT_EQ(pixel_read[2], pixel_one[2]);
@@ -103,9 +104,9 @@ TEST_P(SetGetRGBATest, GradientTest) {
 
   for (uint32_t j = 0; j < input_rgb.height; ++j) {
     for (uint32_t i = 0; i < input_rgb.width; ++i) {
-      float pixel[4];
-      avifGetRGBAPixel(&input_rgb, i, j, &color_space, pixel);
-      avifSetRGBAPixel(&output_rgb, i, j, &color_space, pixel);
+      std::array<float, 4> pixel;
+      avifGetRGBAPixel(&input_rgb, i, j, &color_space, pixel.data());
+      avifSetRGBAPixel(&output_rgb, i, j, &color_space, pixel.data());
     }
   }
   EXPECT_TRUE(testutil::AreImagesEqual(input_rgb, output_rgb));


### PR DESCRIPTION
Adds infrastructure for selectively enabling Clang’s `-Wunsafe-buffer-usage` diagnostic on audited C++ source files.

## Changes:

* Detect compiler support for `-Wunsafe-buffer-usage`
* Add `avif_enable_safe_buffers_warning()` helper for per-source opt-in
* Enable the warning for:

  * `src/compliance.cc`
  * all `apps/avifgainmaputil/*.cc`
  * selected audited gtests
* Consolidate raw `argv` access in `avifgainmaputil.cc` into a single guarded region using:

  * `#ifdef __clang__`
  * `__has_warning("-Wunsafe-buffer-usage")`
  * `#pragma clang unsafe_buffer_usage begin/end`