### PR TITLE
Validate property allocation size in avifImageCopyProperties()

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -234,6 +234,7 @@ static avifResult avifImageCopyProperties(avifImage * dstImage, const avifImage 
     dstImage->numProperties = 0;
 
     if (srcImage->numProperties != 0) {
+        AVIF_CHECKERR(srcImage->numProperties <= SIZE_MAX / sizeof(srcImage->properties[0]), AVIF_RESULT_INVALID_ARGUMENT);
         dstImage->properties = (avifImageItemProperty *)avifCalloc(srcImage->numProperties, sizeof(srcImage->properties[0]));
         AVIF_CHECKERR(dstImage->properties != NULL, AVIF_RESULT_OUT_OF_MEMORY);
         dstImage->numProperties = srcImage->numProperties;

--- a/tests/gtest/avifimagetest.cc
+++ b/tests/gtest/avifimagetest.cc
@@ -49,5 +49,27 @@ TEST(AvifImageTest, WriteImage) {
       image.get(), (testing::TempDir() + "/avifimagetest.png").c_str()));
 }
 
+TEST(AvifImageTest, CopyRejectsTooManyProperties) {
+  ImagePtr src(avifImageCreateEmpty());
+  ImagePtr dst(avifImageCreateEmpty());
+  ASSERT_NE(src, nullptr);
+  ASSERT_NE(dst, nullptr);
+
+  const uint8_t property_type[4] = {'a', 'b', 'c', 'd'};
+  const uint8_t property_payload = 0;
+  ASSERT_EQ(
+      avifImageAddOpaqueProperty(src.get(), property_type, &property_payload,
+                                 sizeof(property_payload)),
+      AVIF_RESULT_OK);
+
+  src->numProperties =
+      std::numeric_limits<size_t>::max() / sizeof(avifImageItemProperty) + 1;
+  EXPECT_EQ(avifImageCopy(dst.get(), src.get(), AVIF_PLANES_ALL),
+            AVIF_RESULT_INVALID_ARGUMENT);
+  src->numProperties = 1;
+  EXPECT_EQ(dst->properties, nullptr);
+  EXPECT_EQ(dst->numProperties, 0u);
+}
+
 }  // namespace
 }  // namespace avif


### PR DESCRIPTION
## Summary
Add overflow validation before computing the property allocation size in `avifImageCopyProperties()`.

The copy path previously multiplied `numProperties` by the property size without validating for `size_t` overflow. Extremely large values could wrap the allocation size and produce an undersized allocation.

This change:
- validates the multiplication before allocation,
- reuses the validated allocation size for initialization,
- and returns `AVIF_RESULT_INVALID_ARGUMENT` for oversized values.

## Test
Add a regression test covering oversized `numProperties` values.

The test:
- creates a valid property through the public API,
- corrupts only `numProperties`,
- and verifies `avifImageCopy()` rejects the malformed state with `AVIF_RESULT_INVALID_ARGUMENT`.