### PR TITLE
DO NOT SUBMIT: Generate v1.4.2 release artifacts

### DIFF
--- a/.github/workflows/ci-linux-artifacts.yml
+++ b/.github/workflows/ci-linux-artifacts.yml
@@ -2,8 +2,7 @@
 
 name: CI Linux Release Artifacts
 on:
-  release:
-    types: [created]
+  pull_request:
 
 permissions:
   contents: write
@@ -47,20 +46,20 @@ jobs:
             avifenc
             avifdec
             avifgainmaputil
-      - name: Upload artifacts
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: build/linux-artifacts.zip
-          asset_name: linux-artifacts.zip
-          asset_content_type: application/zip
+      # - name: Upload artifacts
+      #   uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
+      #     upload_url: ${{ github.event.release.upload_url }}
+      #     asset_path: build/linux-artifacts.zip
+      #     asset_name: linux-artifacts.zip
+      #     asset_content_type: application/zip
 
     # Use the following instead of the above to test this workflow outside of a release event.
-    # - name: Upload artifacts
-    #   uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
-    #   with:
-    #     name: linux-artifacts.zip
-    #     path: build/linux-artifacts.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: linux-artifacts.zip
+          path: build/linux-artifacts.zip

--- a/.github/workflows/ci-macos-artifacts.yml
+++ b/.github/workflows/ci-macos-artifacts.yml
@@ -2,8 +2,7 @@
 
 name: CI macOS Release Artifacts
 on:
-  release:
-    types: [created]
+  pull_request:
 
 permissions:
   contents: write
@@ -58,20 +57,20 @@ jobs:
             avifdec
             avifgainmaputil
             README.txt
-      - name: Upload artifacts
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: build/${{ runner.os }}-artifacts.zip
-          asset_name: ${{ runner.os }}-artifacts.zip
-          asset_content_type: application/zip
+      # - name: Upload artifacts
+      #   uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
+      #     upload_url: ${{ github.event.release.upload_url }}
+      #     asset_path: build/${{ runner.os }}-artifacts.zip
+      #     asset_name: ${{ runner.os }}-artifacts.zip
+      #     asset_content_type: application/zip
 
     # Use the following instead of the above to test this workflow outside of a release event.
-    # - name: Upload artifacts
-    #   uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
-    #   with:
-    #     name: ${{ runner.os }}-artifacts.zip
-    #     path: build/${{ runner.os }}-artifacts.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: ${{ runner.os }}-artifacts.zip
+          path: build/${{ runner.os }}-artifacts.zip

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -2,8 +2,7 @@
 
 name: CI Windows Release Artifacts
 on:
-  release:
-    types: [created]
+  pull_request:
 
 permissions:
   contents: write
@@ -78,20 +77,20 @@ jobs:
           filename: "windows-artifacts.zip"
           directory: "build/Release"
           path: "*.exe"
-      - name: Upload artifacts
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: build/Release/windows-artifacts.zip
-          asset_name: windows-artifacts.zip
-          asset_content_type: application/zip
+      # - name: Upload artifacts
+      #   uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
+      #     upload_url: ${{ github.event.release.upload_url }}
+      #     asset_path: build/Release/windows-artifacts.zip
+      #     asset_name: windows-artifacts.zip
+      #     asset_content_type: application/zip
 
     # Use the following instead of the above to test this workflow outside of a release event.
-    # - name: Upload artifacts
-    #   uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
-    #   with:
-    #     name: windows-artifacts.zip
-    #     path: build/Release/windows-artifacts.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: windows-artifacts.zip
+          path: build/Release/windows-artifacts.zip

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -79,7 +79,7 @@ extern "C" {
 // to leverage in-development code without breaking their stable builds.
 #define AVIF_VERSION_MAJOR 1
 #define AVIF_VERSION_MINOR 4
-#define AVIF_VERSION_PATCH 1
+#define AVIF_VERSION_PATCH 2
 #define AVIF_VERSION_DEVEL 1
 #define AVIF_VERSION \
     ((AVIF_VERSION_MAJOR * 1000000) + (AVIF_VERSION_MINOR * 10000) + (AVIF_VERSION_PATCH * 100) + AVIF_VERSION_DEVEL)


### PR DESCRIPTION
Steps to verify that the binary artifacts are correctly generated:
- Create a draft Pull Request such as this one (change the trigger from `release` to `pull_request` and use `actions/upload-artifact` instead of `actions/upload-release-asset`),
- Wait for all Continuous Integration tests to pass,
- For each "CI Linux/macOS/Windows Release Artifacts" workflow:
  - Click on it,
  - Expand the "Upload artifacts" section,
  - Download the archive from the link given after "Artifact download URL",
  - Unzip it twice,
  - Test the binaries with `avifenc --version` and/or by (de)compressing images.
- Close the Pull Request without merging it.