### PR TITLE
Fix unchecked integer overflow in encoder UV plane allocation

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -234,6 +234,7 @@ static avifResult avifImageCopyProperties(avifImage * dstImage, const avifImage 
     dstImage->numProperties = 0;
 
     if (srcImage->numProperties != 0) {
+        AVIF_CHECKERR(srcImage->numProperties < SIZE_MAX / sizeof(srcImage->properties[0]), AVIF_RESULT_INVALID_ARGUMENT);
         dstImage->properties = (avifImageItemProperty *)avifAlloc(srcImage->numProperties * sizeof(srcImage->properties[0]));
         AVIF_CHECKERR(dstImage->properties != NULL, AVIF_RESULT_OUT_OF_MEMORY);
         memset(dstImage->properties, 0, srcImage->numProperties * sizeof(srcImage->properties[0]));

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -911,17 +911,17 @@ static avifResult avmCodecEncodeImage(avifCodec * codec,
             // monochrome. Manually set UV planes to 0.5.
 
             // avmImage is always 420 when we're monochrome
+            if (image->width == UINT32_MAX || image->height == UINT32_MAX) {
+                return AVIF_RESULT_INVALID_ARGUMENT;
+            }
             uint32_t monoUVWidth = (image->width + 1) >> 1;
             uint32_t monoUVHeight = (image->height + 1) >> 1;
 
             // Allocate the U plane if necessary.
             if (!avmImageAllocated) {
                 uint32_t channelSize = avifImageUsesU16(image) ? 2 : 1;
-                if (monoUVWidth > UINT32_MAX / channelSize) {
-                    return AVIF_RESULT_INVALID_ARGUMENT;
-                }
                 uint32_t monoUVRowBytes = channelSize * monoUVWidth;
-                if (monoUVHeight > PTRDIFF_MAX / monoUVRowBytes) {
+                if (monoUVHeight > SIZE_MAX / monoUVRowBytes) {
                     return AVIF_RESULT_INVALID_ARGUMENT;
                 }
                 size_t monoUVSize = (size_t)monoUVHeight * monoUVRowBytes;

--- a/src/codec_avm.c
+++ b/src/codec_avm.c
@@ -917,7 +917,13 @@ static avifResult avmCodecEncodeImage(avifCodec * codec,
             // Allocate the U plane if necessary.
             if (!avmImageAllocated) {
                 uint32_t channelSize = avifImageUsesU16(image) ? 2 : 1;
+                if (monoUVWidth > UINT32_MAX / channelSize) {
+                    return AVIF_RESULT_INVALID_ARGUMENT;
+                }
                 uint32_t monoUVRowBytes = channelSize * monoUVWidth;
+                if (monoUVHeight > PTRDIFF_MAX / monoUVRowBytes) {
+                    return AVIF_RESULT_INVALID_ARGUMENT;
+                }
                 size_t monoUVSize = (size_t)monoUVHeight * monoUVRowBytes;
 
                 monoUVPlane = avifAlloc(monoUVSize);

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -283,7 +283,13 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
 #if SVT_AV1_CHECK_VERSION(1, 8, 0)
         // Simulate 4:2:0 UV planes. SVT-AV1 does not support 4:0:0 samples.
         const uint32_t uvWidth = (image->width + y_shift) >> y_shift;
+        if (uvWidth > UINT32_MAX / bytesPerPixel) {
+            goto cleanup;
+        }
         const uint32_t uvRowBytes = uvWidth * bytesPerPixel;
+        if (uvHeight > PTRDIFF_MAX / uvRowBytes) {
+            goto cleanup;
+        }
         const size_t uvSize = (size_t)uvRowBytes * uvHeight;
         if (uvSize > UINT32_MAX / 2) {
             goto cleanup;

--- a/src/codec_svt.c
+++ b/src/codec_svt.c
@@ -282,12 +282,12 @@ static avifResult svtCodecEncodeImage(avifCodec * codec,
 
 #if SVT_AV1_CHECK_VERSION(1, 8, 0)
         // Simulate 4:2:0 UV planes. SVT-AV1 does not support 4:0:0 samples.
-        const uint32_t uvWidth = (image->width + y_shift) >> y_shift;
-        if (uvWidth > UINT32_MAX / bytesPerPixel) {
+        if (image->width == UINT32_MAX || image->height == UINT32_MAX) {
             goto cleanup;
         }
+        const uint32_t uvWidth = (image->width + y_shift) >> y_shift;
         const uint32_t uvRowBytes = uvWidth * bytesPerPixel;
-        if (uvHeight > PTRDIFF_MAX / uvRowBytes) {
+        if (uvHeight > SIZE_MAX / uvRowBytes) {
             goto cleanup;
         }
         const size_t uvSize = (size_t)uvRowBytes * uvHeight;


### PR DESCRIPTION
## Summary

- Add pre-multiplication overflow checks to `codec_avm.c` and `codec_svt.c` for UV plane size computations, consistent with the existing safe pattern in `avifImageAllocatePlanes()` (`avif.c:435-441`)
- Add overflow check in `avifImageCopyProperties()` before `numProperties` allocation, consistent with `avifImagePushProperty()` (`avif.c:387`)

## Details

Three sites compute allocation sizes via unchecked integer multiplication, unlike their parallel functions which validate before multiplying:

**codec_avm.c:919** — `channelSize * monoUVWidth` (uint32_t) and `monoUVHeight * monoUVRowBytes` (size_t) used for `avifAlloc()` without overflow checks. The parallel code in `avifImageAllocatePlanes()` checks `width > UINT32_MAX / channelSize` and `height > PTRDIFF_MAX / fullRowBytes` before the same operations.

**codec_svt.c:286** — `uvWidth * bytesPerPixel` (uint32_t) and `uvHeight * uvRowBytes` (size_t) computed without pre-multiplication validation. The existing post-hoc check (`uvSize > UINT32_MAX / 2`) cannot detect a wrap that already occurred.

**avif.c:237** — `numProperties * sizeof(...)` passed to `avifAlloc()` without an overflow guard. `avifImagePushProperty()` in the same file already checks `numProperties < SIZE_MAX / sizeof(avifImageItemProperty)` before an identical allocation.

## Test plan

- [x] Builds cleanly with `cmake --build . --target avif_obj` (zero warnings)
- [ ] Existing test suite passes (CI)