### PR TITLE
Avoid self-copy data loss in avifImageCopy()

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -251,6 +251,9 @@ static avifResult avifImageCopyProperties(avifImage * dstImage, const avifImage 
 
 avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes)
 {
+    if (dstImage == srcImage) {
+        return AVIF_RESULT_OK;
+    }
     avifImageFreePlanes(dstImage, AVIF_PLANES_ALL);
     avifImageCopyNoAlloc(dstImage, srcImage);
 

--- a/tests/gtest/avifimagetest.cc
+++ b/tests/gtest/avifimagetest.cc
@@ -49,5 +49,22 @@ TEST(AvifImageTest, WriteImage) {
       image.get(), (testing::TempDir() + "/avifimagetest.png").c_str()));
 }
 
+TEST(AvifImageTest, CopySelf) {
+  ImagePtr image =
+      testutil::CreateImage(/*width=*/1, /*height=*/1, /*depth=*/8,
+                            AVIF_PIXEL_FORMAT_YUV400, AVIF_PLANES_YUV);
+  ASSERT_NE(image, nullptr);
+  ASSERT_NE(image->yuvPlanes[AVIF_CHAN_Y], nullptr);
+  image->yuvPlanes[AVIF_CHAN_Y][0] = 42;
+
+  ASSERT_EQ(avifImageCopy(image.get(), image.get(), AVIF_PLANES_ALL),
+            AVIF_RESULT_OK);
+  EXPECT_EQ(image->width, 1u);
+  EXPECT_EQ(image->height, 1u);
+  ASSERT_NE(image->yuvPlanes[AVIF_CHAN_Y], nullptr);
+  EXPECT_TRUE(image->imageOwnsYUVPlanes);
+  EXPECT_EQ(image->yuvPlanes[AVIF_CHAN_Y][0], 42);
+}
+
 }  // namespace
 }  // namespace avif


### PR DESCRIPTION
## Summary

`avifImageCopy()` does not handle self-copy correctly.

When the same image is passed as both source and destination:

```c
avifImageCopy(image, image, AVIF_PLANES_ALL);
```

the function frees the image planes before copying, causing owned image data to be discarded while still returning `AVIF_RESULT_OK`.

## Fix

Add an early return for self-copy operations:

```c
if (dstImage == srcImage) {
    return AVIF_RESULT_OK;
}
```

This preserves existing image data and avoids unnecessary work when the source and destination are the same object.
