### PR TITLE
Disallow dstImage == srcImage

### DIFF
--- a/src/avif.c
+++ b/src/avif.c
@@ -251,6 +251,9 @@ static avifResult avifImageCopyProperties(avifImage * dstImage, const avifImage 
 
 avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes)
 {
+    if (dstImage == srcImage) {
+        return AVIF_RESULT_INVALID_ARGUMENT;
+    }
     avifImageFreePlanes(dstImage, AVIF_PLANES_ALL);
     avifImageCopyNoAlloc(dstImage, srcImage);
 
@@ -322,6 +325,9 @@ avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifP
 
 avifResult avifImageSetViewRect(avifImage * dstImage, const avifImage * srcImage, const avifCropRect * rect)
 {
+    if (dstImage == srcImage) {
+        return AVIF_RESULT_INVALID_ARGUMENT;
+    }
     avifPixelFormatInfo formatInfo;
     avifGetPixelFormatInfo(srcImage->yuvFormat, &formatInfo);
     if ((rect->width > srcImage->width) || (rect->height > srcImage->height) || (rect->x > (srcImage->width - rect->width)) ||

--- a/src/avif.c
+++ b/src/avif.c
@@ -251,9 +251,7 @@ static avifResult avifImageCopyProperties(avifImage * dstImage, const avifImage 
 
 avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifPlanesFlags planes)
 {
-    if (dstImage == srcImage) {
-        return AVIF_RESULT_INVALID_ARGUMENT;
-    }
+    AVIF_CHECKERR(dstImage != srcImage, AVIF_RESULT_INVALID_ARGUMENT);
     avifImageFreePlanes(dstImage, AVIF_PLANES_ALL);
     avifImageCopyNoAlloc(dstImage, srcImage);
 
@@ -325,9 +323,7 @@ avifResult avifImageCopy(avifImage * dstImage, const avifImage * srcImage, avifP
 
 avifResult avifImageSetViewRect(avifImage * dstImage, const avifImage * srcImage, const avifCropRect * rect)
 {
-    if (dstImage == srcImage) {
-        return AVIF_RESULT_INVALID_ARGUMENT;
-    }
+    AVIF_CHECKERR(dstImage != srcImage, AVIF_RESULT_INVALID_ARGUMENT);
     avifPixelFormatInfo formatInfo;
     avifGetPixelFormatInfo(srcImage->yuvFormat, &formatInfo);
     if ((rect->width > srcImage->width) || (rect->height > srcImage->height) || (rect->x > (srcImage->width - rect->width)) ||


### PR DESCRIPTION
Disallow dstImage == srcImage in avifImageCopy() and avifImageSetViewRect().