### PR TITLE
codec_libgav1.c: Remove #include <string.h>

### DIFF
--- a/src/codec_libgav1.c
+++ b/src/codec_libgav1.c
@@ -5,7 +5,7 @@
 
 #include "gav1/decoder.h"
 
-#include <string.h>
+#include <stddef.h>
 
 struct avifCodecInternal
 {


### PR DESCRIPTION
After commit c64ea94, codec_libgav1.c no longer calls any function declared in <string.h>. This can be verified by searching for "str" and "mem" in this file. Include <stddef.h> instead (for NULL).