### PR TITLE
Bump libyuv to 957f295ea (1944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 ### Changed since 1.4.2
 
 * Update LocalAvm.cmake: v1.0.0
+* Update libyuv.cmd/LocalLibyuv.cmake: 3c5fa6ef2 (1945)
 
 ## [1.4.2] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 ### Changed since 1.4.2
 
 * Update LocalAvm.cmake: v1.0.0
-* Update libyuv.cmd/LocalLibyuv.cmake: 3c5fa6ef2 (1945)
+* Update libyuv.cmd/LocalLibyuv.cmake: 957f295ea (1944)
 
 ## [1.4.2] - 2026-05-26
 

--- a/cmake/Modules/LocalLibyuv.cmake
+++ b/cmake/Modules/LocalLibyuv.cmake
@@ -1,7 +1,7 @@
 # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 # because the test suite of chromium provides additional test coverage of libyuv.
 # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-set(AVIF_LIBYUV_TAG "3c5fa6ef272f6077d76816ee3d6a697ef1d6d272")
+set(AVIF_LIBYUV_TAG "957f295ea946cbbd13fcfc46e7066f2efa801233")
 
 set(AVIF_LIBYUV_BUILD_DIR "${AVIF_SOURCE_DIR}/ext/libyuv/build")
 # If ${ANDROID_ABI} is set, look for the library under that subdirectory.

--- a/cmake/Modules/LocalLibyuv.cmake
+++ b/cmake/Modules/LocalLibyuv.cmake
@@ -1,7 +1,7 @@
 # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 # because the test suite of chromium provides additional test coverage of libyuv.
 # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-set(AVIF_LIBYUV_TAG "644251f252a84bf8ce91ff0aca86a9b16b069ab8")
+set(AVIF_LIBYUV_TAG "3c5fa6ef272f6077d76816ee3d6a697ef1d6d272")
 
 set(AVIF_LIBYUV_BUILD_DIR "${AVIF_SOURCE_DIR}/ext/libyuv/build")
 # If ${ANDROID_ABI} is set, look for the library under that subdirectory.

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -17,7 +17,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout 3c5fa6ef2
+git checkout 957f295ea
 cd ..
 
 cmake -G Ninja -S libyuv -B libyuv/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -17,7 +17,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout 644251f25
+git checkout 3c5fa6ef2
 cd ..
 
 cmake -G Ninja -S libyuv -B libyuv/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/ext/libyuv_android.sh
+++ b/ext/libyuv_android.sh
@@ -19,7 +19,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout 3c5fa6ef2
+git checkout 957f295ea
 
 mkdir build
 cd build

--- a/ext/libyuv_android.sh
+++ b/ext/libyuv_android.sh
@@ -19,7 +19,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout 644251f25
+git checkout 3c5fa6ef2
 
 mkdir build
 cd build


### PR DESCRIPTION
One commit older than the commit used on the Chrome M150 branch.