### PR TITLE
Relax SampleTransformZeroInputItemsRejected error

### DIFF
--- a/tests/gtest/avifaltrtest.cc
+++ b/tests/gtest/avifaltrtest.cc
@@ -140,7 +140,7 @@ TEST(AltrTest, SampleTransformZeroInputItemsRejected) {
   ASSERT_NE(image, nullptr);
   const avifResult result = avifDecoderReadMemory(decoder.get(), image.get(),
                                                   encoded.data, encoded.size);
-  EXPECT_EQ(result, AVIF_RESULT_BMFF_PARSE_FAILED);
+  EXPECT_NE(result, AVIF_RESULT_OK);
   EXPECT_NE(result, AVIF_RESULT_INTERNAL_ERROR);
 }
 


### PR DESCRIPTION
In the SampleTransformZeroInputItemsRejected test, do not require the error code of avifDecoderReadMemory() be AVIF_RESULT_BMFF_PARSE_FAILED. This allows the implementation to return a different error code such as AVIF_RESULT_DECODE_SAMPLE_TRANSFORM_FAILED.

Note: Without this change, the next statement,
  EXPECT_NE(result, AVIF_RESULT_INTERNAL_ERROR);
is redundant.