### PR TITLE
cast to unsigned char before ctype calls in image readers

### DIFF
--- a/apps/shared/avifjpeg.c
+++ b/apps/shared/avifjpeg.c
@@ -766,7 +766,7 @@ static avifBool avifJPEGFindGainMapPropertyDoubles(const xmlNode * descriptionNo
             // Make sure that remaining characters (if any) are only whitespace.
             const int len = (int)strlen(textValues[i]);
             while (charsRead < len) {
-                if (!isspace(textValues[i][charsRead])) {
+                if (!isspace((unsigned char)textValues[i][charsRead])) {
                     return AVIF_FALSE; // Invalid character.
                 }
                 ++charsRead;

--- a/apps/shared/avifpng.c
+++ b/apps/shared/avifpng.c
@@ -38,7 +38,7 @@ static avifBool avifHexStringToBytes(const char * hexString, size_t hexStringLen
             ++i;
             continue;
         }
-        if (!isxdigit(hexString[i]) || !isxdigit(hexString[i + 1])) {
+        if (!isxdigit((unsigned char)hexString[i]) || !isxdigit((unsigned char)hexString[i + 1])) {
             avifRWDataFree(bytes);
             fprintf(stderr, "Metadata extraction failed: invalid character at %" AVIF_FMT_ZU "\n", i);
             return AVIF_FALSE;


### PR DESCRIPTION
avifHexStringToBytes() in avifpng.c and the gain map property parser in avifjpeg.c hand a plain char straight to isxdigit()/isspace(), so a byte above 0x7f coming from a png raw profile or an xmp property value promotes to a negative int and falls outside the [-1, 255] domain those functions are defined for, which is undefined behaviour and can index before the ctype table on some libcs. cast to unsigned char first, the same way read.c and avifutil.c already do for their isprint()/tolower() calls.