### PR TITLE
Replace archived release asset upload action

### DIFF
--- a/.github/workflows/ci-linux-artifacts.yml
+++ b/.github/workflows/ci-linux-artifacts.yml
@@ -48,15 +48,10 @@ jobs:
             avifdec
             avifgainmaputil
       - name: Upload artifacts
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: build/linux-artifacts.zip
-          asset_name: linux-artifacts.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" build/linux-artifacts.zip
 
     # Use the following instead of the above to test this workflow outside of a release event.
     # - name: Upload artifacts

--- a/.github/workflows/ci-macos-artifacts.yml
+++ b/.github/workflows/ci-macos-artifacts.yml
@@ -59,15 +59,10 @@ jobs:
             avifgainmaputil
             README.txt
       - name: Upload artifacts
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: build/${{ runner.os }}-artifacts.zip
-          asset_name: ${{ runner.os }}-artifacts.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" "build/${{ runner.os }}-artifacts.zip"
 
     # Use the following instead of the above to test this workflow outside of a release event.
     # - name: Upload artifacts

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -79,15 +79,11 @@ jobs:
           directory: "build/Release"
           path: "*.exe"
       - name: Upload artifacts
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
+        shell: pwsh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # See https://docs.github.com/en/webhooks/webhook-events-and-payloads#release.
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: build/Release/windows-artifacts.zip
-          asset_name: windows-artifacts.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$env:RELEASE_TAG" "build/Release/windows-artifacts.zip"
 
     # Use the following instead of the above to test this workflow outside of a release event.
     # - name: Upload artifacts


### PR DESCRIPTION
This removes the dependency on the archived `actions/upload-release-asset` action from the release artifact workflows.

The workflows now use `gh release upload` with the existing `contents: write` permission and `GITHUB_TOKEN`-backed authentication. This preserves the current release asset upload behavior while avoiding an archived action in the release path.

I verified the workflow YAML still parses, `git diff --check` passes, and `zizmor` no longer reports archived action usage for these workflows.
