### PR TITLE
ci: pin actions to full commit SHAs in ci-format-check and ci-mingw

### DIFF
--- a/.github/workflows/ci-format-check.yml
+++ b/.github/workflows/ci-format-check.yml
@@ -24,6 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: neg-c/cmake-format-action@v0.1.3
+      - uses: neg-c/cmake-format-action@ba83660ac46d64c12ca96f39478dcde7680a52bf # v0.1.3
         with:
           exclude: libavif.pc.cmake

--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -27,7 +27,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: ${{ matrix.sys }}
           update: true


### PR DESCRIPTION
## Summary

Two workflow files used mutable action tag references that can be silently re-pointed to different—potentially malicious—commits.

### Changes

**`ci-format-check.yml`**
- `neg-c/cmake-format-action`: `@v0.1.3` → `@ba83660ac46d64c12ca96f39478dcde7680a52bf`

**`ci-mingw.yml`**
- `msys2/setup-msys2`: `@v2` → `@66cd2cce69caa17b53920067426061ca1de3a884`

Original tags are kept as comments for readability. All other workflows in the repo already use pinned SHAs.

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards) for proactive CI/supply-chain security hardening.