### PR TITLE
Update VS version in Windows CI

### DIFF
--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Prepare libavif (cmake)
         run: >
-          cmake -G "Visual Studio 17 2022" -A x64 -S . -B build
+          cmake -G "Visual Studio 18 2026" -A x64 -S . -B build
           -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
           -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_AOM_ENCODE=ON
           -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_DAV1D=LOCAL

--- a/.github/workflows/ci-windows-artifacts.yml
+++ b/.github/workflows/ci-windows-artifacts.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Prepare libavif (cmake)
         run: >
-          cmake -G "Visual Studio 18 2026" -A x64 -S . -B build
+          cmake -A x64 -S . -B build
           -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
           -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_AOM_ENCODE=ON
           -DAVIF_CODEC_AOM_DECODE=OFF -DAVIF_CODEC_DAV1D=LOCAL

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        generator: [Ninja, "Visual Studio 17 2022"]
+        generator: [Ninja, "Visual Studio 18 2026"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        generator: [Ninja, "Visual Studio 18 2026"]
+        generator: ["-G Ninja", ""]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -52,7 +52,7 @@ jobs:
 
       - name: Prepare libavif (cmake)
         run: >
-          cmake -G "${{ matrix.generator }}" -S . -B build
+          cmake "${{ matrix.generator }}" -S . -B build
           -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
           -DAVIF_CODEC_AOM=LOCAL -DAVIF_CODEC_DAV1D=LOCAL
           -DAVIF_CODEC_RAV1E=LOCAL -DAVIF_CODEC_SVT=LOCAL


### PR DESCRIPTION
This change avoids errors such as:

```
CMake Error at CMakeLists.txt:34 (project):
  Generator
    Visual Studio 17 2022
  could not find any instance of Visual Studio.
```

([log](https://github.com/AOMediaCodec/libavif/actions/runs/27531891859/job/81371768152))

Likely related: https://github.com/actions/runner-images/issues/14017