### PR TITLE
Use windows-2022 until issue #3255 is fixed

### DIFF
--- a/.github/workflows/ci-windows-installed.yml
+++ b/.github/workflows/ci-windows-installed.yml
@@ -16,7 +16,9 @@ concurrency:
 
 jobs:
   build-windows-installed:
-    runs-on: windows-latest
+    # Use windows-2022 instead of windows-latest until
+    # https://github.com/AOMediaCodec/libavif/issues/3255 is fixed.
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -32,9 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use windows-2022 instead of windows-latest until
-        # https://github.com/AOMediaCodec/libavif/issues/3255 is fixed.
-        os: [windows-2022]
+        os: [windows-latest]
         generator: ["-G Ninja", ""]
 
     steps:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -32,7 +32,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        # Use windows-2022 instead of windows-latest until
+        # https://github.com/AOMediaCodec/libavif/issues/3255 is fixed.
+        os: [windows-2022]
         generator: ["-G Ninja", ""]
 
     steps:


### PR DESCRIPTION
Use windows-2022 instead of windows-latest until
https://github.com/AOMediaCodec/libavif/issues/3255 is fixed.

windows-latest points to windows-2025 right now, which is being updated
to Visual Studio 2026. Visual Studio 2026 version >= 19.50 has an AVX2
intrinsics inlining bug, described at
https://gitlab.com/AOMediaCodec/SVT-AV1/-/work_items/2322#note_3455144085.