### PR TITLE
Fix printed gain map size in avifenc/avifgainmap when using a grid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The changes are relative to the previous release, unless the baseline is specifi
   files when SVT-AV1 is built with MSVC. See
   https://github.com/AOMediaCodec/libavif/issues/3255.
 * Link with -lm when NOT WIN32 AND NOT APPLE
+* Fix printed image size in avifgainmaputil when using --grid.
+* Fix printed gain map size in avifenc when converting a jpeg with a gain map
+  and using --grid.
 
 ## [1.4.2] - 2026-05-26
 

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -147,9 +147,15 @@ static void avifImageDumpInternal(const avifImage * avif, uint32_t gridCols, uin
     printf(" * Gain map       : ");
     avifImage * gainMapImage = avif->gainMap ? avif->gainMap->image : NULL;
     if (gainMapImage != NULL) {
+        uint32_t gainMapWidth = gainMapImage->width;
+        uint32_t gainMapHeight = gainMapImage->height;
+        if (gridCols && gridRows) {
+            gainMapWidth *= gridCols;
+            gainMapHeight *= gridRows;
+        }
         printf("%ux%u pixels, %u bit, %s, %s Range, Matrix Coeffs. %u, Base Headroom %.2f (%s), Alternate Headroom %.2f (%s)\n",
-               gainMapImage->width,
-               gainMapImage->height,
+               gainMapWidth,
+               gainMapHeight,
                gainMapImage->depth,
                avifPixelFormatToString(gainMapImage->yuvFormat),
                (gainMapImage->yuvRange == AVIF_RANGE_FULL) ? "Full" : "Limited",

--- a/tests/test_cmd_avifgainmaputil.sh
+++ b/tests/test_cmd_avifgainmaputil.sh
@@ -48,7 +48,10 @@ pushd ${TMP_DIR}
   "${AVIFGAINMAPUTIL}" combine "${INPUT_JPEG_GAINMAP_SDR}" "${INPUT_AVIF_GAINMAP_HDR}" "${AVIF_OUTPUT}" \
       -q 50 --qgain-map 90 --ignore-profile
   "${AVIFGAINMAPUTIL}" combine "${INPUT_AVIF_GAINMAP_SDR}" "${INPUT_AVIF_HDR2020}" "${AVIF_OUTPUT}" \
-      -q 50 --downscaling 2 --yuv-gain-map 400 --grid 2x2
+      -q 50 --downscaling 2 --yuv-gain-map 400 --grid 2x2 > "${OUT_MSG}"
+  cat "${OUT_MSG}"
+  grep "Resolution     : 400x300$" "${OUT_MSG}"
+  grep "Gain map       : 200x150 pixels" "${OUT_MSG}"
 
   "${AVIFGAINMAPUTIL}" combine "${INPUT_AVIF_GAINMAP_HDR}" "${INPUT_AVIF_GAINMAP_SDR}" "${AVIF_OUTPUT}" \
       -q 90 --qgain-map 90
@@ -57,6 +60,7 @@ pushd ${TMP_DIR}
   "${ARE_IMAGES_EQUAL}" "${PNG_OUTPUT}" "${INPUT_JPEG_GAINMAP_SDR}" 0 40 1
   # Check that metadata is copied over.
   "${AVIFGAINMAPUTIL}" tonemap "${AVIF_OUTPUT}" "${AVIF_OUTPUT}" --headroom 0 > "${OUT_MSG}"
+  cat "${OUT_MSG}"
   grep "XMP Metadata   : Present" "${OUT_MSG}"
   grep "Exif Metadata  : Present" "${OUT_MSG}"
 


### PR DESCRIPTION
Follow up of #3264
Fixes #3261