### PR TITLE
Adopt the __counted_by bounds-safety model on core data buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,22 @@ if(AVIF_ENABLE_COVERAGE)
     endif()
 endif()
 
+option(
+    AVIF_ENABLE_FBOUNDS_SAFETY
+    "Compile the library with Clang's -fbounds-safety to enforce the AVIF_COUNTED_BY() bounds-safety annotations. Requires a Clang that supports -fbounds-safety. No effect with other compilers."
+    OFF
+)
+if(AVIF_ENABLE_FBOUNDS_SAFETY)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        message(STATUS "libavif: Enabling -fbounds-safety for Clang")
+        target_compile_options(avif_obj PRIVATE $<BUILD_INTERFACE:-fbounds-safety>)
+        target_compile_options(avif PRIVATE $<BUILD_INTERFACE:-fbounds-safety>)
+    else()
+        message(WARNING "libavif: Ignoring request for bounds safety (AVIF_ENABLE_FBOUNDS_SAFETY); only clang is currently supported.")
+        set(AVIF_ENABLE_FBOUNDS_SAFETY OFF)
+    endif()
+endif()
+
 if(AVIF_ENABLE_EXPERIMENTAL_MINI)
     add_compile_definitions(AVIF_ENABLE_EXPERIMENTAL_MINI)
 endif()

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -70,6 +70,32 @@ extern "C" {
 #endif
 #endif
 
+// AVIF_COUNTED_BY(N) adopts the C bounds-safety ("Safe Buffers" / -fbounds-safety)
+// model: it annotates a pointer field as referring to exactly N elements, where N
+// is another field of the same struct. When the translation unit is compiled with
+// bounds-safety enabled, the compiler can bounds-check accesses through the pointer
+// and reject annotation mismatches; otherwise the macro expands to nothing, so it
+// is a no-op for normal builds and stays ABI- and source-compatible.
+//
+// The attribute is only spellable while bounds-safety is active: a stock Clang
+// answers __has_attribute(__counted_by__) with 1 even in a normal build, but then
+// rejects the count expression as an "undeclared identifier". So it is gated on
+// __has_feature(bounds_safety) (defined only under -fbounds-safety) in addition to
+// __has_attribute, mirroring how AVIF_NODISCARD probes before using its attribute.
+// Both the reserved spelling (__counted_by__) and the plain spelling (counted_by)
+// are accepted.
+#if defined(__has_feature) && defined(__has_attribute)
+#if __has_feature(bounds_safety) && __has_attribute(__counted_by__)
+#define AVIF_COUNTED_BY(N) __attribute__((__counted_by__(N)))
+#elif __has_feature(bounds_safety) && __has_attribute(counted_by)
+#define AVIF_COUNTED_BY(N) __attribute__((counted_by(N)))
+#else
+#define AVIF_COUNTED_BY(N)
+#endif
+#else
+#define AVIF_COUNTED_BY(N)
+#endif
+
 // ---------------------------------------------------------------------------
 // Constants
 
@@ -237,7 +263,7 @@ typedef int avifHeaderFormatFlags;
 
 typedef struct avifROData
 {
-    const uint8_t * data;
+    const uint8_t * data AVIF_COUNTED_BY(size);
     size_t size;
 } avifROData;
 
@@ -245,7 +271,7 @@ typedef struct avifROData
 
 typedef struct avifRWData
 {
-    uint8_t * data;
+    uint8_t * data AVIF_COUNTED_BY(size);
     size_t size;
 } avifRWData;
 
@@ -839,7 +865,7 @@ typedef struct avifImage
     // At decoding: Forwarded here as opaque byte sequences by the avifDecoder.
     // At encoding: Set using avifImageAddOpaqueProperty() or avifImageAddUUIDProperty() and written by the
     //              avifEncoder as non-essential properties in the order that they are added to the image.
-    avifImageItemProperty * properties; // NULL only if numProperties is 0.
+    avifImageItemProperty * properties AVIF_COUNTED_BY(numProperties); // NULL only if numProperties is 0.
     size_t numProperties;
 
     // Gain map image and metadata. NULL if no gain map is present.


### PR DESCRIPTION
### What
This adopts the C bounds-safety ("Safe Buffers" / `-fbounds-safety`) model on libavif's core data buffers: a feature-guarded `AVIF_COUNTED_BY(N)` macro applied to the data+size pairs whose pointer provably addresses exactly `N` elements:

- `avifROData.data` → `AVIF_COUNTED_BY(size)`
- `avifRWData.data` → `AVIF_COUNTED_BY(size)`
- `avifImage.properties` → `AVIF_COUNTED_BY(numProperties)`

Because `avifROData`/`avifRWData` are embedded by value across the decode path (`icc`/`exif`/`xmp`, item property payloads, decode/encode samples, the RO/RW stream `raw` buffers), annotating these two structs propagates bounds information through much of the parsing surface from a single, airtight invariant.

### Safe by default
`AVIF_COUNTED_BY(N)` follows the same `__has_attribute` probe idiom as `AVIF_NODISCARD`, with one addition: it is also gated on `__has_feature(bounds_safety)`. This matters — a stock Clang answers `__has_attribute(__counted_by__)` with 1 even in an ordinary build, then rejects the count expression as an undeclared identifier, so an `__has_attribute`-only guard would break normal C builds on recent Clang. Gating on the feature makes the annotation expand to nothing unless the TU is compiled with bounds-safety. Both the `__counted_by__` and `counted_by` spellings are accepted.

The headers compile cleanly with `-Wall -Wextra -Werror` under `-std=c11`, `-std=c2x`, and `-std=gnu11`; the macro produces no tokens in a normal build.

### Opt-in enforcement
A new CMake option `AVIF_ENABLE_FBOUNDS_SAFETY` (default `OFF`), modeled on the existing `AVIF_ENABLE_COVERAGE` block, appends `-fbounds-safety` to the library targets on Clang (and warns/skips on other compilers). Default builds are unaffected.

### Compatibility
ABI- and source-compatible: the annotation is a type attribute that changes neither struct layout nor the public API, and is absent from normal builds. No behavior change unless `-fbounds-safety` is enabled.

### Scope / intentionally excluded
Kept tight to airtight cases. Excluded: every `AVIF_ARRAY_DECLARE` dynamic array (over-allocated — pointer sized to `capacity`, not `count`), `avifFileType.compatibleBrands` (interior alias into the input stream), and the stride-based pixel/plane buffers (`avifRGBImage.pixels`/`rowBytes`, `yuvPlanes`/`yuvRowBytes`), whose size is `rowBytes * height` rather than a single adjacent field. These can follow once refactored into bounds-expressible shapes.

### Ask
I can't exercise the enforcing build locally (it needs a Clang with `-fbounds-safety`). Could you run CI with `-DAVIF_ENABLE_FBOUNDS_SAFETY=ON` on a capable Clang to validate the enforcing path against the test corpus? Happy to adjust the macro guards or annotation set based on what your toolchain reports.