### PR TITLE
Allow any value for avifDecoder's imageSizeLimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Fix printed image size in avifgainmaputil when using --grid.
 * Fix printed gain map size in avifenc when converting a jpeg with a gain map
   and using --grid.
+* Allow setting avifDecoder's imageSizeLimit to any value
 
 ## [1.4.2] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Fix printed image size in avifgainmaputil when using --grid.
 * Fix printed gain map size in avifenc when converting a jpeg with a gain map
   and using --grid.
-* Allow setting avifDecoder's imageSizeLimit to any value
+* Allow setting avifDecoder::imageSizeLimit to any value.
 
 ## [1.4.2] - 2026-05-26
 

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -47,10 +47,10 @@ static void syntax(void)
     printf("    -i,--info         : Decode all frames and display all image information instead of saving to disk\n");
     printf("    --icc FILENAME    : Provide an ICC profile payload (implies --ignore-icc)\n");
     printf("    --ignore-icc      : If the input file contains an embedded ICC profile, ignore it (no-op if absent)\n");
-    printf("    --size-limit C    : Maximum image size (in total pixels) that should be tolerated. (Default: %u)\n",
-           AVIF_DEFAULT_IMAGE_SIZE_LIMIT);
+    printf("    --size-limit C    : Maximum image size (in total pixels) that should be tolerated.\n");
+    printf("                        0 means unlimited. (Default: %u)\n", AVIF_DEFAULT_IMAGE_SIZE_LIMIT);
     printf("  --dimension-limit C : Maximum image dimension (width or height) that should be tolerated.\n");
-    printf("                        Set to 0 to ignore. (Default: %u)\n", AVIF_DEFAULT_IMAGE_DIMENSION_LIMIT);
+    printf("                        0 means unlimited. (Default: %u)\n", AVIF_DEFAULT_IMAGE_DIMENSION_LIMIT);
     printf("    --                : Signal the end of options. Everything after this is interpreted as file names.\n");
     printf("\n");
     avifPrintVersions();

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -229,7 +229,7 @@ int main(int argc, char * argv[])
         } else if (!strcmp(arg, "--size-limit")) {
             NEXTARG();
             unsigned long value = strtoul(arg, NULL, 10);
-            if ((value > AVIF_DEFAULT_IMAGE_SIZE_LIMIT) || (value == 0)) {
+            if (value > UINT32_MAX) {
                 fprintf(stderr, "ERROR: invalid image size limit: %s\n", arg);
                 return 1;
             }

--- a/doc/avifdec.1.md
+++ b/doc/avifdec.1.md
@@ -83,11 +83,11 @@ Output format can be either JPEG, PNG or YUV4MPEG2 (Y4M).
 
 **\--size-limit** _C_
 :   Maximum image size (in total pixels) that should be tolerated.
-    (Default: 268435456).
+    0 means unlimited. (Default: 268435456).
 
 **\--dimension-limit** _C_
 :   Maximum image dimension (width or height) that should be tolerated.
-    Set to 0 to ignore. (Default: 32768).
+    0 means unlimited. (Default: 32768).
 
 **\--**
 :   Signal the end of options. Everything after this is interpreted as file names.

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1290,9 +1290,10 @@ typedef struct avifDecoder
     avifBool ignoreXMP;
 
     // This represents the maximum size of an image (in pixel count) that libavif and the underlying
-    // AV1 decoder should attempt to decode. It defaults to AVIF_DEFAULT_IMAGE_SIZE_LIMIT, and can
-    // be set to a smaller value. The value 0 is reserved.
-    // Note: Only some underlying AV1 codecs support a configurable size limit (such as dav1d).
+    // AV1 decoder should attempt to decode. It defaults to AVIF_DEFAULT_IMAGE_SIZE_LIMIT. Set it to
+    // 0 to ignore the limit.
+    // Note: Only some underlying AV1 codecs support a configurable size limit (such as dav1d and
+    // libaom v3.14.0 or later).
     uint32_t imageSizeLimit;
 
     // This represents the maximum dimension of an image (width or height) that libavif should

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1290,15 +1290,14 @@ typedef struct avifDecoder
     avifBool ignoreXMP;
 
     // This represents the maximum size of an image (in pixel count) that libavif and the underlying
-    // AV1 decoder should attempt to decode. It defaults to AVIF_DEFAULT_IMAGE_SIZE_LIMIT. Set it to
-    // 0 to ignore the limit.
+    // AV1 decoder should attempt to decode. It defaults to AVIF_DEFAULT_IMAGE_SIZE_LIMIT. 0 means
+    // unlimited.
     // Note: Only some underlying AV1 codecs support a configurable size limit (such as dav1d and
     // libaom v3.14.0 or later).
     uint32_t imageSizeLimit;
 
     // This represents the maximum dimension of an image (width or height) that libavif should
-    // attempt to decode. It defaults to AVIF_DEFAULT_IMAGE_DIMENSION_LIMIT. Set it to 0 to ignore
-    // the limit.
+    // attempt to decode. It defaults to AVIF_DEFAULT_IMAGE_DIMENSION_LIMIT. 0 means unlimited.
     uint32_t imageDimensionLimit;
 
     // This provides an upper bound on how many images the decoder is willing to attempt to decode,

--- a/src/avif.c
+++ b/src/avif.c
@@ -645,7 +645,7 @@ uint32_t avifImagePlaneHeight(const avifImage * image, int channel)
 
 avifBool avifDimensionsTooLarge(uint32_t width, uint32_t height, uint32_t imageSizeLimit, uint32_t imageDimensionLimit)
 {
-    if (width > (imageSizeLimit / height)) {
+    if ((imageSizeLimit != 0) && (width > (imageSizeLimit / height))) {
         return AVIF_TRUE;
     }
     if ((imageDimensionLimit != 0) && ((width > imageDimensionLimit) || (height > imageDimensionLimit))) {

--- a/src/read.c
+++ b/src/read.c
@@ -5289,11 +5289,6 @@ avifResult avifDecoderParse(avifDecoder * decoder)
 {
     avifDiagnosticsClearError(&decoder->diag);
 
-    // An imageSizeLimit greater than AVIF_DEFAULT_IMAGE_SIZE_LIMIT and the special value of 0 to
-    // disable the limit are not yet implemented.
-    if ((decoder->imageSizeLimit > AVIF_DEFAULT_IMAGE_SIZE_LIMIT) || (decoder->imageSizeLimit == 0)) {
-        return AVIF_RESULT_NOT_IMPLEMENTED;
-    }
     // Color only or alpha only is not currently supported.
     if ((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) != 0 &&
         (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) != AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) {

--- a/tests/gtest/avif_fuzztest_dec_incr.cc
+++ b/tests/gtest/avif_fuzztest_dec_incr.cc
@@ -75,10 +75,6 @@ void DecodeIncr(const std::string& arbitrary_bytes, bool is_persistent,
   // Reduce the limit further to include pixel buffer copies and other memory
   // allocations.
   constexpr uint32_t kImageSizeLimit = kMaxImageSize / 4;
-  // avifDecoderParse returns AVIF_RESULT_NOT_IMPLEMENTED if kImageSizeLimit is
-  // bigger than AVIF_DEFAULT_IMAGE_SIZE_LIMIT.
-  static_assert(kImageSizeLimit <= AVIF_DEFAULT_IMAGE_SIZE_LIMIT,
-                "Too big an image size limit");
   decoder->imageSizeLimit = kImageSizeLimit;
   // This can lead to AVIF_RESULT_NO_CONTENT.
   decoder->imageContentToDecode = content_to_decode;


### PR DESCRIPTION
All known integer overflows in libavif's decoder code, excluding external dependencies, have been fixed.