### PR TITLE
Don't delete gain map metadata if ignore_gain_map

### DIFF
--- a/apps/avifgainmaputil/combine_command.cc
+++ b/apps/avifgainmaputil/combine_command.cc
@@ -135,9 +135,12 @@ avifResult CombineCommand::Run() {
             << gain_map_height << "\n";
 
   // Because base_image is read with ignore_gain_map=true, there is no
-  // preexisting gain map. Otherwise, overwriting the pointer would cause a
-  // memory leak.
-  assert(base_image->gainMap == nullptr);
+  // preexisting gain map image but there may be preexisting gain map metadata.
+  assert(base_image->gainMap == nullptr ||
+         base_image->gainMap->image == nullptr);
+  if (base_image->gainMap) {
+    avifGainMapDestroy(base_image->gainMap);
+  }
   base_image->gainMap = avifGainMapCreate();
   base_image->gainMap->image =
       avifImageCreate(gain_map_width, gain_map_height, arg_gain_map_depth_,

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -210,10 +210,6 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
     if (result != AVIF_RESULT_OK) {
       return result;
     }
-    if (ignore_gain_map && decoder->image->gainMap) {
-      avifGainMapDestroy(decoder->image->gainMap);
-      decoder->image->gainMap = nullptr;
-    }
     const avifColorPrimaries in_primaries = image->colorPrimaries;
     const avifTransferCharacteristics in_transfer =
         image->transferCharacteristics;


### PR DESCRIPTION
In avif::ReadImage(), if ignore_gain_map is true, don't ignore gain map metadata. Let the caller do that.