### PR TITLE
Support ignoring alpha in imageContentToDecode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 ### Added since 1.4.2
 
 * Add the ignoreICC option to avifDecoder
+* Support ignoring alpha in avifDecoder::imageContentToDecode.
 * avifenc: add --ignore-alpha flag to discard alpha channel on encode
 * avifgainmaputil: add --ignore-alpha flag to discard alpha channel
 

--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -413,9 +413,7 @@ int main(int argc, char * argv[])
                 fprintf(stderr, "ERROR: Out of memory\n");
                 goto cleanup;
             }
-            result = avifImageCreateView(imageView,
-                                         decoder->image,
-                                         /*ignoreAlpha=*/AVIF_FALSE);
+            result = avifImageCreateView(imageView, decoder->image);
             if (result != AVIF_RESULT_OK) {
                 fprintf(stderr, "ERROR: Failed to create image view\n");
                 goto cleanup;

--- a/apps/avifgainmaputil/extractgainmap_command.cc
+++ b/apps/avifgainmaputil/extractgainmap_command.cc
@@ -36,8 +36,7 @@ avifResult ExtractGainMapCommand::Run() {
   if (!image) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
-  result = avifImageCreateView(image.get(), decoder->image,
-                               /*ignoreAlpha=*/false);
+  result = avifImageCreateView(image.get(), decoder->image);
   if (result != AVIF_RESULT_OK) {
     return result;
   }

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -203,6 +203,9 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
       return AVIF_RESULT_OUT_OF_MEMORY;
     }
     decoder->maxThreads = jobs;
+    if (ignore_alpha) {
+      decoder->imageContentToDecode &= ~AVIF_IMAGE_CONTENT_ALPHA;
+    }
     if (!ignore_gain_map) {
       decoder->imageContentToDecode |= AVIF_IMAGE_CONTENT_GAIN_MAP;
     }
@@ -216,7 +219,7 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
     if (!view) {
       return AVIF_RESULT_OUT_OF_MEMORY;
     }
-    result = avifImageCreateView(view.get(), decoder->image, ignore_alpha);
+    result = avifImageCreateView(view.get(), decoder->image);
     if (result != AVIF_RESULT_OK) {
       return result;
     }
@@ -279,6 +282,8 @@ avifResult ReadAvif(avifDecoder* decoder, const std::string& input_filename) {
               << decoder->diag.error << ")\n";
     return result;
   }
+  assert((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA) != 0 ||
+         !decoder->alphaPresent);
   result = avifDecoderNextImage(decoder);
   if (result != AVIF_RESULT_OK) {
     std::cerr << "Failed to decode image: " << avifResultToString(result)
@@ -291,6 +296,9 @@ avifResult ReadAvif(avifDecoder* decoder, const std::string& input_filename) {
       assert(decoder->image->gainMap->altICC.size == 0);
     }
   }
+  assert((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA) != 0 ||
+         (decoder->image->alphaPlane == nullptr &&
+          decoder->image->alphaRowBytes == 0));
 
   return AVIF_RESULT_OK;
 }

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -282,8 +282,6 @@ avifResult ReadAvif(avifDecoder* decoder, const std::string& input_filename) {
               << decoder->diag.error << ")\n";
     return result;
   }
-  assert((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA) != 0 ||
-         !decoder->alphaPresent);
   result = avifDecoderNextImage(decoder);
   if (result != AVIF_RESULT_OK) {
     std::cerr << "Failed to decode image: " << avifResultToString(result)

--- a/apps/avifgainmaputil/swapbase_command.cc
+++ b/apps/avifgainmaputil/swapbase_command.cc
@@ -164,6 +164,9 @@ avifResult SwapBaseCommand::Run() {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
   decoder->maxThreads = arg_jobs_.jobs.value();
+  if (arg_image_read_.ignore_alpha) {
+    decoder->imageContentToDecode &= ~AVIF_IMAGE_CONTENT_ALPHA;
+  }
   decoder->imageContentToDecode |= AVIF_IMAGE_CONTENT_GAIN_MAP;
   decoder->ignoreICC = arg_image_read_.ignore_profile;
   avifResult result = ReadAvif(decoder.get(), arg_input_filename_);
@@ -175,8 +178,7 @@ avifResult SwapBaseCommand::Run() {
   if (!image) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
-  result = avifImageCreateView(image.get(), decoder->image,
-                               arg_image_read_.ignore_alpha);
+  result = avifImageCreateView(image.get(), decoder->image);
   if (result != AVIF_RESULT_OK) {
     return result;
   }

--- a/apps/avifgainmaputil/tonemap_command.cc
+++ b/apps/avifgainmaputil/tonemap_command.cc
@@ -66,6 +66,9 @@ avifResult TonemapCommand::Run() {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
   decoder->maxThreads = arg_jobs_.jobs.value();
+  if (arg_image_read_.ignore_alpha) {
+    decoder->imageContentToDecode &= ~AVIF_IMAGE_CONTENT_ALPHA;
+  }
   decoder->imageContentToDecode |= AVIF_IMAGE_CONTENT_GAIN_MAP;
   decoder->ignoreICC = arg_image_read_.ignore_profile;
   avifResult result = ReadAvif(decoder.get(), arg_input_filename_);
@@ -77,8 +80,7 @@ avifResult TonemapCommand::Run() {
   if (!image) {
     return AVIF_RESULT_OUT_OF_MEMORY;
   }
-  result = avifImageCreateView(image.get(), decoder->image,
-                               arg_image_read_.ignore_alpha);
+  result = avifImageCreateView(image.get(), decoder->image);
   if (result != AVIF_RESULT_OK) {
     return result;
   }

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -824,7 +824,7 @@ avifResult avifApplyTransforms(avifRGBImage * dstView, avifRGBImage * srcImage, 
     return AVIF_RESULT_OK;
 }
 
-avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage, avifBool ignoreAlpha)
+avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage)
 {
     avifResult res = AVIF_RESULT_OK;
     if (!dstImage || !srcImage) {
@@ -835,10 +835,6 @@ avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage,
     res = avifImageSetViewRect(dstImage, srcImage, &rect);
     if (res != AVIF_RESULT_OK) {
         return res;
-    }
-
-    if (ignoreAlpha && dstImage->alphaPlane) {
-        avifImageFreePlanes(dstImage, AVIF_PLANES_A);
     }
 
     if (srcImage->icc.size > 0) {
@@ -901,9 +897,7 @@ avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage,
             if (!dstImage->gainMap->image) {
                 return AVIF_RESULT_OUT_OF_MEMORY;
             }
-            res = avifImageCreateView(dstImage->gainMap->image,
-                                      srcImage->gainMap->image,
-                                      /*ignoreAlpha=*/AVIF_TRUE);
+            res = avifImageCreateView(dstImage->gainMap->image, srcImage->gainMap->image);
             if (res != AVIF_RESULT_OK) {
                 return res;
             }

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -132,7 +132,7 @@ void avifImageFixXMP(avifImage * image);
 // If a gain map is present in 'srcImage', the gain map of 'dstImage' is also set to
 // a view of the original gain map.
 // 'dstImage' should be an empty image. It will not own the pixel data.
-avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage, avifBool ignoreAlpha);
+avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1229,8 +1229,10 @@ AVIF_API const char * avifProgressiveStateToString(avifProgressiveState progress
 typedef enum avifImageContentTypeFlag
 {
     AVIF_IMAGE_CONTENT_NONE = 0,
-    // Color only or alpha only is not currently supported.
-    AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA = (1 << 0) | (1 << 1),
+    AVIF_IMAGE_CONTENT_COLOR = (1 << 0),
+    // Alpha only is not currently supported.
+    AVIF_IMAGE_CONTENT_ALPHA = (1 << 1),
+    AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA = AVIF_IMAGE_CONTENT_COLOR | AVIF_IMAGE_CONTENT_ALPHA,
     AVIF_IMAGE_CONTENT_GAIN_MAP = (1 << 2),
     AVIF_IMAGE_CONTENT_ALL = AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA | AVIF_IMAGE_CONTENT_GAIN_MAP,
 

--- a/src/read.c
+++ b/src/read.c
@@ -6178,59 +6178,60 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             }
         }
 
+        uint32_t alphaTrackIndex = 0;
         avifCodecType alphaCodecType = AVIF_CODEC_TYPE_UNKNOWN;
-        if (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA) {
-            uint32_t alphaTrackIndex = 0;
-            for (; alphaTrackIndex < data->tracks.count; ++alphaTrackIndex) {
-                avifTrack * track = &data->tracks.track[alphaTrackIndex];
-                if (!track->sampleTable) {
-                    continue;
-                }
-                if (!track->id) {
-                    continue;
-                }
-                if (!track->sampleTable->chunks.count) {
-                    continue;
-                }
-                alphaCodecType = avifSampleTableGetCodecType(track->sampleTable);
-                if (alphaCodecType == AVIF_CODEC_TYPE_UNKNOWN) {
-                    continue;
-                }
-                const avifPropertyArray * properties = avifSampleTableGetProperties(track->sampleTable, alphaCodecType);
-                const avifProperty * auxiProp = properties ? avifPropertyArrayFind(properties, "auxi") : NULL;
-                // If auxi is present, check that it contains the alpha URN.
-                // If auxi is not present, assume that the track is alpha. This is for backward compatibility with
-                // old versions of libavif that did not write this property, see
-                // https://github.com/AOMediaCodec/libavif/commit/98faa17
-                if (auxiProp && !isAlphaURN(auxiProp->u.auxC.auxType)) {
-                    continue;
-                }
-                // Do not check the track's handlerType. It should be "auxv" according to
-                // HEIF (ISO/IEC 23008-12:2022), Section 7.5.3.1, but old versions of libavif used to write
-                // "pict" instead. See https://github.com/AOMediaCodec/libavif/commit/65d0af9
+        for (; alphaTrackIndex < data->tracks.count; ++alphaTrackIndex) {
+            avifTrack * track = &data->tracks.track[alphaTrackIndex];
+            if (!track->sampleTable) {
+                continue;
+            }
+            if (!track->id) {
+                continue;
+            }
+            if (!track->sampleTable->chunks.count) {
+                continue;
+            }
+            alphaCodecType = avifSampleTableGetCodecType(track->sampleTable);
+            if (alphaCodecType == AVIF_CODEC_TYPE_UNKNOWN) {
+                continue;
+            }
+            const avifPropertyArray * properties = avifSampleTableGetProperties(track->sampleTable, alphaCodecType);
+            const avifProperty * auxiProp = properties ? avifPropertyArrayFind(properties, "auxi") : NULL;
+            // If auxi is present, check that it contains the alpha URN.
+            // If auxi is not present, assume that the track is alpha. This is for backward compatibility with
+            // old versions of libavif that did not write this property, see
+            // https://github.com/AOMediaCodec/libavif/commit/98faa17
+            if (auxiProp && !isAlphaURN(auxiProp->u.auxC.auxType)) {
+                continue;
+            }
+            // Do not check the track's handlerType. It should be "auxv" according to
+            // HEIF (ISO/IEC 23008-12:2022), Section 7.5.3.1, but old versions of libavif used to write
+            // "pict" instead. See https://github.com/AOMediaCodec/libavif/commit/65d0af9
 
-                if (track->auxForID == colorTrack->id) {
-                    // Found it!
-                    alphaProperties = properties;
-                    break;
-                }
+            if (track->auxForID == colorTrack->id) {
+                // Found it!
+                alphaProperties = properties;
+                break;
             }
-            if (alphaTrackIndex != data->tracks.count) {
-                alphaTrack = &data->tracks.track[alphaTrackIndex];
-            }
+        }
+        if (alphaTrackIndex != data->tracks.count) {
+            alphaTrack = &data->tracks.track[alphaTrackIndex];
         }
 
         const uint8_t operatingPoint = 0; // No way to set operating point via tracks
-        avifTile * colorTile = avifDecoderDataCreateTile(data, colorCodecType, colorTrack->width, colorTrack->height, operatingPoint);
-        AVIF_CHECKERR(colorTile != NULL, AVIF_RESULT_OUT_OF_MEMORY);
-        AVIF_CHECKRES(avifCodecDecodeInputFillFromSampleTable(colorTile->input,
-                                                              colorTrack->sampleTable,
-                                                              decoder->imageCountLimit,
-                                                              decoder->io->sizeHint,
-                                                              data->diag));
-        data->tileInfos[AVIF_ITEM_COLOR].tileCount = 1;
+        avifTile * colorTile = NULL;
+        if (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR) {
+            colorTile = avifDecoderDataCreateTile(data, colorCodecType, colorTrack->width, colorTrack->height, operatingPoint);
+            AVIF_CHECKERR(colorTile != NULL, AVIF_RESULT_OUT_OF_MEMORY);
+            AVIF_CHECKRES(avifCodecDecodeInputFillFromSampleTable(colorTile->input,
+                                                                  colorTrack->sampleTable,
+                                                                  decoder->imageCountLimit,
+                                                                  decoder->io->sizeHint,
+                                                                  data->diag));
+            data->tileInfos[AVIF_ITEM_COLOR].tileCount = 1;
+        }
 
-        if (alphaTrack) {
+        if (alphaTrack && (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA)) {
             avifTile * alphaTile = avifDecoderDataCreateTile(data, alphaCodecType, alphaTrack->width, alphaTrack->height, operatingPoint);
             AVIF_CHECKERR(alphaTile != NULL, AVIF_RESULT_OUT_OF_MEMORY);
             AVIF_CHECKRES(avifCodecDecodeInputFillFromSampleTable(alphaTile->input,
@@ -6247,7 +6248,31 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 
         // Image sequence timing
         decoder->imageIndex = -1;
-        decoder->imageCount = (int)colorTile->input->samples.count;
+        uint32_t imageCount;
+        if (colorTile) {
+            imageCount = colorTile->input->samples.count;
+        } else {
+            imageCount = 0;
+            for (uint32_t chunkIndex = 0; chunkIndex < colorTrack->sampleTable->chunks.count; ++chunkIndex) {
+                // First, figure out how many samples are in this chunk
+                uint32_t sampleCount = avifGetSampleCountOfChunk(&colorTrack->sampleTable->sampleToChunks, chunkIndex);
+                if (sampleCount == 0) {
+                    // chunks with 0 samples are invalid
+                    avifDiagnosticsPrintf(data->diag, "Sample table contains a chunk with 0 samples");
+                    return AVIF_RESULT_BMFF_PARSE_FAILED;
+                }
+                if (imageCount > UINT32_MAX - sampleCount) {
+                    avifDiagnosticsPrintf(data->diag, "Total number of samples exceeds UINT32_MAX");
+                    return AVIF_RESULT_BMFF_PARSE_FAILED;
+                }
+                imageCount += sampleCount;
+            }
+        }
+        if (imageCount > INT_MAX) {
+            avifDiagnosticsPrintf(data->diag, "Total number of samples exceeds INT_MAX");
+            return AVIF_RESULT_BMFF_PARSE_FAILED;
+        }
+        decoder->imageCount = (int)imageCount;
         decoder->timescale = colorTrack->mediaTimescale;
         decoder->durationInTimescales = colorTrack->mediaDuration;
         if (colorTrack->mediaTimescale) {
@@ -6297,21 +6322,19 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         colorCodecType = codecType[AVIF_ITEM_COLOR];
 
         // Optional alpha auxiliary item
-        avifBool isAlphaItemInInput = AVIF_FALSE;
-        if (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA) {
-            AVIF_CHECKRES(avifMetaFindAlphaItem(data->meta,
-                                                mainItems[AVIF_ITEM_COLOR],
-                                                &data->tileInfos[AVIF_ITEM_COLOR],
-                                                &mainItems[AVIF_ITEM_ALPHA],
-                                                &data->tileInfos[AVIF_ITEM_ALPHA],
-                                                &isAlphaItemInInput));
-            if (mainItems[AVIF_ITEM_ALPHA]) {
-                AVIF_CHECKRES(avifDecoderItemReadAndParse(decoder,
-                                                          mainItems[AVIF_ITEM_ALPHA],
-                                                          isAlphaItemInInput,
-                                                          &data->tileInfos[AVIF_ITEM_ALPHA].grid,
-                                                          &codecType[AVIF_ITEM_ALPHA]));
-            }
+        avifBool isAlphaItemInInput;
+        AVIF_CHECKRES(avifMetaFindAlphaItem(data->meta,
+                                            mainItems[AVIF_ITEM_COLOR],
+                                            &data->tileInfos[AVIF_ITEM_COLOR],
+                                            &mainItems[AVIF_ITEM_ALPHA],
+                                            &data->tileInfos[AVIF_ITEM_ALPHA],
+                                            &isAlphaItemInInput));
+        if (mainItems[AVIF_ITEM_ALPHA]) {
+            AVIF_CHECKRES(avifDecoderItemReadAndParse(decoder,
+                                                      mainItems[AVIF_ITEM_ALPHA],
+                                                      isAlphaItemInInput,
+                                                      &data->tileInfos[AVIF_ITEM_ALPHA].grid,
+                                                      &codecType[AVIF_ITEM_ALPHA]));
         }
 
         // Section 10.2.6 of 23008-12:2024/AMD 1:2024(E):
@@ -6976,7 +6999,10 @@ static avifResult avifDecoderApplySampleTransform(const avifDecoder * decoder, a
     }
 
     AVIF_CHECKRES(avifDecoderApplySampleTransformForPlanes(decoder, AVIF_PLANES_YUV, dstImage));
-    if (decoder->alphaPresent) {
+    // If decoder->data->tileInfos[AVIF_ITEM_ALPHA].tileCount == 0, it means
+    // decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA was equal to 0.
+    // Only apply Sample Transforms for the alpha plane if there is an alpha item to apply it onto.
+    if (decoder->data->tileInfos[AVIF_ITEM_ALPHA].tileCount != 0) {
         AVIF_CHECKRES(avifDecoderApplySampleTransformForPlanes(decoder, AVIF_PLANES_A, dstImage));
     }
     return AVIF_RESULT_OK;

--- a/src/read.c
+++ b/src/read.c
@@ -5289,10 +5289,9 @@ avifResult avifDecoderParse(avifDecoder * decoder)
 {
     avifDiagnosticsClearError(&decoder->diag);
 
-    // Color only or alpha only is not currently supported.
-    if ((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) != 0 &&
-        (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) != AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) {
-        avifDiagnosticsPrintf(&decoder->diag, "imageContentToDecode set to only color or only alpha is not supported");
+    // Alpha only is not currently supported.
+    if ((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) == AVIF_IMAGE_CONTENT_ALPHA) {
+        avifDiagnosticsPrintf(&decoder->diag, "imageContentToDecode set to only alpha is not supported");
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
     if (!decoder->io || !decoder->io->read) {
@@ -6097,10 +6096,9 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 
     memset(&decoder->ioStats, 0, sizeof(decoder->ioStats));
 
-    // Color only or alpha only is not currently supported.
-    if ((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) != 0 &&
-        (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) != AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) {
-        avifDiagnosticsPrintf(&decoder->diag, "imageContentToDecode set to only color or only alpha is not supported");
+    // Alpha only is not currently supported.
+    if ((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) == AVIF_IMAGE_CONTENT_ALPHA) {
+        avifDiagnosticsPrintf(&decoder->diag, "imageContentToDecode set to only alpha is not supported");
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
 
@@ -6180,44 +6178,46 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             }
         }
 
-        uint32_t alphaTrackIndex = 0;
         avifCodecType alphaCodecType = AVIF_CODEC_TYPE_UNKNOWN;
-        for (; alphaTrackIndex < data->tracks.count; ++alphaTrackIndex) {
-            avifTrack * track = &data->tracks.track[alphaTrackIndex];
-            if (!track->sampleTable) {
-                continue;
-            }
-            if (!track->id) {
-                continue;
-            }
-            if (!track->sampleTable->chunks.count) {
-                continue;
-            }
-            alphaCodecType = avifSampleTableGetCodecType(track->sampleTable);
-            if (alphaCodecType == AVIF_CODEC_TYPE_UNKNOWN) {
-                continue;
-            }
-            const avifPropertyArray * properties = avifSampleTableGetProperties(track->sampleTable, alphaCodecType);
-            const avifProperty * auxiProp = properties ? avifPropertyArrayFind(properties, "auxi") : NULL;
-            // If auxi is present, check that it contains the alpha URN.
-            // If auxi is not present, assume that the track is alpha. This is for backward compatibility with
-            // old versions of libavif that did not write this property, see
-            // https://github.com/AOMediaCodec/libavif/commit/98faa17
-            if (auxiProp && !isAlphaURN(auxiProp->u.auxC.auxType)) {
-                continue;
-            }
-            // Do not check the track's handlerType. It should be "auxv" according to
-            // HEIF (ISO/IEC 23008-12:2022), Section 7.5.3.1, but old versions of libavif used to write
-            // "pict" instead. See https://github.com/AOMediaCodec/libavif/commit/65d0af9
+        if (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA) {
+            uint32_t alphaTrackIndex = 0;
+            for (; alphaTrackIndex < data->tracks.count; ++alphaTrackIndex) {
+                avifTrack * track = &data->tracks.track[alphaTrackIndex];
+                if (!track->sampleTable) {
+                    continue;
+                }
+                if (!track->id) {
+                    continue;
+                }
+                if (!track->sampleTable->chunks.count) {
+                    continue;
+                }
+                alphaCodecType = avifSampleTableGetCodecType(track->sampleTable);
+                if (alphaCodecType == AVIF_CODEC_TYPE_UNKNOWN) {
+                    continue;
+                }
+                const avifPropertyArray * properties = avifSampleTableGetProperties(track->sampleTable, alphaCodecType);
+                const avifProperty * auxiProp = properties ? avifPropertyArrayFind(properties, "auxi") : NULL;
+                // If auxi is present, check that it contains the alpha URN.
+                // If auxi is not present, assume that the track is alpha. This is for backward compatibility with
+                // old versions of libavif that did not write this property, see
+                // https://github.com/AOMediaCodec/libavif/commit/98faa17
+                if (auxiProp && !isAlphaURN(auxiProp->u.auxC.auxType)) {
+                    continue;
+                }
+                // Do not check the track's handlerType. It should be "auxv" according to
+                // HEIF (ISO/IEC 23008-12:2022), Section 7.5.3.1, but old versions of libavif used to write
+                // "pict" instead. See https://github.com/AOMediaCodec/libavif/commit/65d0af9
 
-            if (track->auxForID == colorTrack->id) {
-                // Found it!
-                alphaProperties = properties;
-                break;
+                if (track->auxForID == colorTrack->id) {
+                    // Found it!
+                    alphaProperties = properties;
+                    break;
+                }
             }
-        }
-        if (alphaTrackIndex != data->tracks.count) {
-            alphaTrack = &data->tracks.track[alphaTrackIndex];
+            if (alphaTrackIndex != data->tracks.count) {
+                alphaTrack = &data->tracks.track[alphaTrackIndex];
+            }
         }
 
         const uint8_t operatingPoint = 0; // No way to set operating point via tracks
@@ -6297,19 +6297,21 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         colorCodecType = codecType[AVIF_ITEM_COLOR];
 
         // Optional alpha auxiliary item
-        avifBool isAlphaItemInInput;
-        AVIF_CHECKRES(avifMetaFindAlphaItem(data->meta,
-                                            mainItems[AVIF_ITEM_COLOR],
-                                            &data->tileInfos[AVIF_ITEM_COLOR],
-                                            &mainItems[AVIF_ITEM_ALPHA],
-                                            &data->tileInfos[AVIF_ITEM_ALPHA],
-                                            &isAlphaItemInInput));
-        if (mainItems[AVIF_ITEM_ALPHA]) {
-            AVIF_CHECKRES(avifDecoderItemReadAndParse(decoder,
-                                                      mainItems[AVIF_ITEM_ALPHA],
-                                                      isAlphaItemInInput,
-                                                      &data->tileInfos[AVIF_ITEM_ALPHA].grid,
-                                                      &codecType[AVIF_ITEM_ALPHA]));
+        avifBool isAlphaItemInInput = AVIF_FALSE;
+        if (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA) {
+            AVIF_CHECKRES(avifMetaFindAlphaItem(data->meta,
+                                                mainItems[AVIF_ITEM_COLOR],
+                                                &data->tileInfos[AVIF_ITEM_COLOR],
+                                                &mainItems[AVIF_ITEM_ALPHA],
+                                                &data->tileInfos[AVIF_ITEM_ALPHA],
+                                                &isAlphaItemInInput));
+            if (mainItems[AVIF_ITEM_ALPHA]) {
+                AVIF_CHECKRES(avifDecoderItemReadAndParse(decoder,
+                                                          mainItems[AVIF_ITEM_ALPHA],
+                                                          isAlphaItemInInput,
+                                                          &data->tileInfos[AVIF_ITEM_ALPHA].grid,
+                                                          &codecType[AVIF_ITEM_ALPHA]));
+            }
         }
 
         // Section 10.2.6 of 23008-12:2024/AMD 1:2024(E):
@@ -6334,7 +6336,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 
         // AVIF_ITEM_SAMPLE_TRANSFORM (not used through mainItems because not a coded item (well grids are not coded items either but it's different)).
         avifDecoderItem * const sampleTransformItem = avifDecoderDataFindSampleTransformImageItem(data);
-        if ((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) &&
+        if ((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR) &&
             (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_SAMPLE_TRANSFORMS) && sampleTransformItem != NULL) {
             AVIF_ASSERT_OR_RETURN(data->sampleTransformNumInputImageItems == 0);
 
@@ -6399,6 +6401,9 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                                                           &codecType[*category]));
 
                 // Optional alpha auxiliary item
+                if (!(decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA)) {
+                    continue;
+                }
                 avifBool isAlphaInputImageItemInInput = AVIF_FALSE;
                 AVIF_CHECKRES(avifMetaFindAlphaItem(data->meta,
                                                     mainItems[*category],
@@ -6465,13 +6470,19 @@ avifResult avifDecoderReset(avifDecoder * decoder)
 
             AVIF_CHECKRES(avifDecoderAdoptGridTileCodecTypeIfNeeded(decoder, mainItems[c], &data->tileInfos[c]));
 
-            if (c == AVIF_ITEM_COLOR || c == AVIF_ITEM_ALPHA) {
-                if (!(decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA)) {
+            if (c == AVIF_ITEM_COLOR) {
+                if (!(decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR)) {
                     continue;
                 }
-            } else if (c == AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_COLOR || c == AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_1_COLOR ||
-                       c == AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_ALPHA || c == AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_1_ALPHA) {
-                AVIF_ASSERT_OR_RETURN((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA) &&
+            } else if (c == AVIF_ITEM_ALPHA) {
+                if (!(decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA)) {
+                    continue;
+                }
+            } else if (c == AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_COLOR || c == AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_1_COLOR) {
+                AVIF_ASSERT_OR_RETURN((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR) &&
+                                      (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_SAMPLE_TRANSFORMS));
+            } else if (c == AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_ALPHA || c == AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_1_ALPHA) {
+                AVIF_ASSERT_OR_RETURN((decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_ALPHA) &&
                                       (decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_SAMPLE_TRANSFORMS));
             } else {
                 AVIF_ASSERT_OR_RETURN(c == AVIF_ITEM_GAIN_MAP);
@@ -7040,7 +7051,7 @@ avifResult avifDecoderNextImage(avifDecoder * decoder)
     }
 
     // If decoder->data->tileInfos[AVIF_ITEM_COLOR].tileCount == 0, it means
-    // decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA was equal to 0.
+    // decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR was equal to 0.
     // Only apply Sample Transforms if there is a color item to apply it onto.
     if (decoder->data->tileInfos[AVIF_ITEM_COLOR].tileCount != 0 && decoder->data->meta->sampleTransformExpression.count > 0) {
         AVIF_CHECKRES(avifDecoderApplySampleTransform(decoder, decoder->image));
@@ -7215,7 +7226,7 @@ static uint32_t avifGetDecodedRowCount(const avifDecoder * decoder, const avifTi
 uint32_t avifDecoderDecodedRowCount(const avifDecoder * decoder)
 {
     if (decoder->data->tileInfos[AVIF_ITEM_COLOR].tileCount == 0) {
-        // decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA
+        // decoder->imageContentToDecode & AVIF_IMAGE_CONTENT_COLOR
         // was likely 0 when avifDecoderNextImage() was called.
         // avifDecoderDecodedRowCount() only describes decoder->image->yuvPlanes[0].
         // There is no available luma plane, so return 0 decoded rows.

--- a/tests/gtest/avif16bittest.cc
+++ b/tests/gtest/avif16bittest.cc
@@ -350,7 +350,18 @@ TEST_P(GainmapSampleTransformTest, ImageContentToDecode) {
     ASSERT_EQ(image->depth, decoded->depth);
     ASSERT_EQ(image->width, decoded->width);
     ASSERT_EQ(image->height, decoded->height);
-    EXPECT_GE(testutil::GetPsnr(*image, *decoded), 20.0);
+    const bool ignore_alpha =
+        (content_to_decode & AVIF_IMAGE_CONTENT_ALPHA) == 0;
+    if (create_alpha && !ignore_alpha) {
+      EXPECT_TRUE(decoder->alphaPresent);
+      EXPECT_NE(decoded->alphaPlane, nullptr);
+      EXPECT_NE(decoded->alphaRowBytes, 0);
+    } else {
+      EXPECT_FALSE(decoder->alphaPresent);
+      EXPECT_EQ(decoded->alphaPlane, nullptr);
+      EXPECT_EQ(decoded->alphaRowBytes, 0);
+    }
+    EXPECT_GE(testutil::GetPsnr(*image, *decoded, ignore_alpha), 20.0);
   }
   if (create_gainmap && content_to_decode & AVIF_IMAGE_CONTENT_GAIN_MAP) {
     ASSERT_NE(image->gainMap, nullptr);
@@ -374,7 +385,8 @@ INSTANTIATE_TEST_SUITE_P(
         // AVIF_IMAGE_CONTENT_SAMPLE_TRANSFORMS is always set in this test.
         testing::Values(AVIF_IMAGE_CONTENT_NONE,
                         AVIF_IMAGE_CONTENT_COLOR_AND_ALPHA,
-                        AVIF_IMAGE_CONTENT_GAIN_MAP, AVIF_IMAGE_CONTENT_ALL)));
+                        AVIF_IMAGE_CONTENT_COLOR, AVIF_IMAGE_CONTENT_GAIN_MAP,
+                        AVIF_IMAGE_CONTENT_ALL)));
 
 //------------------------------------------------------------------------------
 

--- a/tests/gtest/avif16bittest.cc
+++ b/tests/gtest/avif16bittest.cc
@@ -350,14 +350,13 @@ TEST_P(GainmapSampleTransformTest, ImageContentToDecode) {
     ASSERT_EQ(image->depth, decoded->depth);
     ASSERT_EQ(image->width, decoded->width);
     ASSERT_EQ(image->height, decoded->height);
+    EXPECT_EQ(decoder->alphaPresent, create_alpha);
     const bool ignore_alpha =
         (content_to_decode & AVIF_IMAGE_CONTENT_ALPHA) == 0;
     if (create_alpha && !ignore_alpha) {
-      EXPECT_TRUE(decoder->alphaPresent);
       EXPECT_NE(decoded->alphaPlane, nullptr);
       EXPECT_NE(decoded->alphaRowBytes, 0);
     } else {
-      EXPECT_FALSE(decoder->alphaPresent);
       EXPECT_EQ(decoded->alphaPlane, nullptr);
       EXPECT_EQ(decoded->alphaRowBytes, 0);
     }

--- a/tests/gtest/avifanimationtest.cc
+++ b/tests/gtest/avifanimationtest.cc
@@ -86,6 +86,55 @@ TEST(AvifDecodeTest, AnimatedImageWithAlphaAndMetadata) {
   EXPECT_EQ(decoder->repetitionCount, AVIF_REPETITION_COUNT_INFINITE);
   EXPECT_EQ(decoder->image->exif.size, 1126);
   EXPECT_EQ(decoder->image->xmp.size, 3898);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(avifDecoderNextImage(decoder.get()), AVIF_RESULT_OK);
+    EXPECT_NE(decoder->image->alphaPlane, nullptr);
+    EXPECT_GT(decoder->image->alphaRowBytes, 0);
+  }
+  EXPECT_EQ(avifDecoderNextImage(decoder.get()),
+            AVIF_RESULT_NO_IMAGES_REMAINING);
+}
+
+TEST(AvifDecodeTest, AnimatedImageWithAlphaAndMetadataIgnoreAlpha) {
+  const char* file_name = "colors-animated-8bpc-alpha-exif-xmp.avif";
+  DecoderPtr decoder(avifDecoderCreate());
+  ASSERT_NE(decoder, nullptr);
+  decoder->imageContentToDecode &= ~AVIF_IMAGE_CONTENT_ALPHA;
+  ASSERT_EQ(avifDecoderSetIOFile(decoder.get(),
+                                 (std::string(data_path) + file_name).c_str()),
+            AVIF_RESULT_OK);
+  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_OK);
+  EXPECT_EQ(decoder->alphaPresent, AVIF_TRUE);
+  EXPECT_EQ(decoder->imageSequenceTrackPresent, AVIF_TRUE);
+  EXPECT_EQ(decoder->imageCount, 5);
+  EXPECT_EQ(decoder->repetitionCount, AVIF_REPETITION_COUNT_INFINITE);
+  EXPECT_EQ(decoder->image->exif.size, 1126);
+  EXPECT_EQ(decoder->image->xmp.size, 3898);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(avifDecoderNextImage(decoder.get()), AVIF_RESULT_OK);
+    EXPECT_EQ(decoder->image->alphaPlane, nullptr);
+    EXPECT_EQ(decoder->image->alphaRowBytes, 0);
+  }
+  EXPECT_EQ(avifDecoderNextImage(decoder.get()),
+            AVIF_RESULT_NO_IMAGES_REMAINING);
+}
+
+TEST(AvifDecodeTest, AnimatedImageWithAlphaAndMetadataIgnoreAll) {
+  const char* file_name = "colors-animated-8bpc-alpha-exif-xmp.avif";
+  DecoderPtr decoder(avifDecoderCreate());
+  ASSERT_NE(decoder, nullptr);
+  decoder->imageContentToDecode = 0;
+  ASSERT_EQ(avifDecoderSetIOFile(decoder.get(),
+                                 (std::string(data_path) + file_name).c_str()),
+            AVIF_RESULT_OK);
+  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_OK);
+  EXPECT_EQ(decoder->alphaPresent, AVIF_TRUE);
+  EXPECT_EQ(decoder->imageSequenceTrackPresent, AVIF_TRUE);
+  EXPECT_EQ(decoder->imageCount, 5);
+  EXPECT_EQ(decoder->repetitionCount, AVIF_REPETITION_COUNT_INFINITE);
+  EXPECT_EQ(decoder->image->exif.size, 1126);
+  EXPECT_EQ(decoder->image->xmp.size, 3898);
+  EXPECT_EQ(avifDecoderNextImage(decoder.get()), AVIF_RESULT_NO_CONTENT);
 }
 
 TEST(AvifDecodeTest, AnimatedImageWithDepthAndMetadata) {

--- a/tests/gtest/avifdecodetest.cc
+++ b/tests/gtest/avifdecodetest.cc
@@ -74,13 +74,11 @@ TEST(AvifDecodeTest, ParseEmptyData) {
   ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_INVALID_FTYP);
 }
 
-TEST(AvifDecodeTest, ImageContentToDecodeColorXorAlpha) {
+TEST(AvifDecodeTest, ImageContentToDecodeAlphaOnly) {
   DecoderPtr decoder(avifDecoderCreate());
   ASSERT_NE(decoder, nullptr);
   ASSERT_EQ(avifDecoderSetIOMemory(decoder.get(), nullptr, 0), AVIF_RESULT_OK);
-  decoder->imageContentToDecode = static_cast<avifImageContentTypeFlag>(1 << 0);
-  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_NOT_IMPLEMENTED);
-  decoder->imageContentToDecode = static_cast<avifImageContentTypeFlag>(1 << 1);
+  decoder->imageContentToDecode = AVIF_IMAGE_CONTENT_ALPHA;
   ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_NOT_IMPLEMENTED);
 }
 


### PR DESCRIPTION
Add AVIF_IMAGE_CONTENT_COLOR and AVIF_IMAGE_CONTENT_ALPHA and allow
decoding color only. Decoding alpha only is still not supported.
    
Remove the ignoreAlpha parameter from the avifImageCreateView()
function. If alpha should be ignored, the caller of
avifImageCreateView() is responsible for clearing the
AVIF_IMAGE_CONTENT_ALPHA bit in decoder->imageContentToDecode before
decoding (assuming srcImage is decoder->image).