### PR TITLE
Don't delete gain map metadata if ignore_gain_map

### DIFF
--- a/apps/avifgainmaputil/combine_command.cc
+++ b/apps/avifgainmaputil/combine_command.cc
@@ -135,9 +135,11 @@ avifResult CombineCommand::Run() {
             << gain_map_height << "\n";
 
   // Because base_image is read with ignore_gain_map=true, there is no
-  // preexisting gain map. Otherwise, overwriting the pointer would cause a
-  // memory leak.
-  assert(base_image->gainMap == nullptr);
+  // preexisting gain map but there may be preexisting gain map metadata.
+  if (base_image->gainMap) {
+    assert(base_image->gainMap->image == nullptr);
+    avifGainMapDestroy(base_image->gainMap);
+  }
   base_image->gainMap = avifGainMapCreate();
   base_image->gainMap->image =
       avifImageCreate(gain_map_width, gain_map_height, arg_gain_map_depth_,

--- a/apps/avifgainmaputil/combine_command.cc
+++ b/apps/avifgainmaputil/combine_command.cc
@@ -139,6 +139,7 @@ avifResult CombineCommand::Run() {
   if (base_image->gainMap) {
     assert(base_image->gainMap->image == nullptr);
     avifGainMapDestroy(base_image->gainMap);
+    base_image->gainMap = nullptr;
   }
   base_image->gainMap = avifGainMapCreate();
   base_image->gainMap->image =

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -210,23 +210,26 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
       return result;
     }
 
+    ImagePtr view(avifImageCreateEmpty());
+    if (!view) {
+      return AVIF_RESULT_OUT_OF_MEMORY;
+    }
+    // When ignore_gain_map is true, decoder->image won't have a gain map but
+    // may have gain map metadata. It is fine to copy gain map metadata.
+    result = avifImageCreateView(view.get(), decoder->image, ignore_profile,
+                                 ignore_alpha, /*ignoreGainMap=*/false);
+    if (result != AVIF_RESULT_OK) {
+      return result;
+    }
+
     const avifColorPrimaries in_primaries = image->colorPrimaries;
     const avifTransferCharacteristics in_transfer =
         image->transferCharacteristics;
     const avifMatrixCoefficients in_matrix = image->matrixCoefficients;
 
-    result = avifImageCopy(image, decoder->image, AVIF_PLANES_ALL);
+    result = avifImageCopy(image, view.get(), AVIF_PLANES_ALL);
     if (result != AVIF_RESULT_OK) {
       return result;
-    }
-    if (ignore_profile) {
-      avifRWDataFree(&image->icc);
-      if (image->gainMap) {
-        avifRWDataFree(&image->gainMap->altICC);
-      }
-    }
-    if (ignore_alpha && image->alphaPlane) {
-      avifImageFreePlanes(image, AVIF_PLANES_A);
     }
 
     if (in_primaries != AVIF_COLOR_PRIMARIES_UNSPECIFIED ||

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -210,24 +210,23 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
       return result;
     }
 
-    ImagePtr view(avifImageCreateEmpty());
-    if (!view) {
-      return AVIF_RESULT_OUT_OF_MEMORY;
-    }
-    result = avifImageCreateView(view.get(), decoder->image, ignore_profile,
-                                 ignore_alpha, ignore_gain_map);
-    if (result != AVIF_RESULT_OK) {
-      return result;
-    }
-
     const avifColorPrimaries in_primaries = image->colorPrimaries;
     const avifTransferCharacteristics in_transfer =
         image->transferCharacteristics;
     const avifMatrixCoefficients in_matrix = image->matrixCoefficients;
 
-    result = avifImageCopy(image, view.get(), AVIF_PLANES_ALL);
+    result = avifImageCopy(image, decoder->image, AVIF_PLANES_ALL);
     if (result != AVIF_RESULT_OK) {
       return result;
+    }
+    if (ignore_profile) {
+      avifRWDataFree(&image->icc);
+      if (image->gainMap) {
+        avifRWDataFree(&image->gainMap->altICC);
+      }
+    }
+    if (ignore_alpha && image->alphaPlane) {
+      avifImageFreePlanes(image, AVIF_PLANES_A);
     }
 
     if (in_primaries != AVIF_COLOR_PRIMARIES_UNSPECIFIED ||


### PR DESCRIPTION
 Don't delete gain map metadata if ignore_gain_map
    
In avif::ReadImage(), if ignore_gain_map is true, don't delete gain map
metadata. Let the caller do that.
    
Also, since avif::ReadImage() calls avifImageCopy(), it doesn't need to
call avifImageCreateView().