### PR TITLE
reformat: validate rowBytes before entering pixel loop (fixes #3146)

### DIFF
--- a/src/alpha.c
+++ b/src/alpha.c
@@ -154,6 +154,10 @@ avifResult avifRGBImagePremultiplyAlpha(avifRGBImage * rgb)
     if (!rgb->pixels || !rgb->rowBytes) {
         return AVIF_RESULT_REFORMAT_FAILED;
     }
+    // Validate that rowBytes covers a full row (same class as issue #3146).
+    if (rgb->rowBytes < (size_t)rgb->width * avifRGBImagePixelSize(rgb)) {
+        return AVIF_RESULT_REFORMAT_FAILED;
+    }
 
     // no alpha.
     if (!avifRGBFormatHasAlpha(rgb->format)) {
@@ -339,6 +343,10 @@ avifResult avifRGBImageUnpremultiplyAlpha(avifRGBImage * rgb)
 {
     // no data
     if (!rgb->pixels || !rgb->rowBytes) {
+        return AVIF_RESULT_REFORMAT_FAILED;
+    }
+    // Validate that rowBytes covers a full row (same class as issue #3146).
+    if (rgb->rowBytes < (size_t)rgb->width * avifRGBImagePixelSize(rgb)) {
         return AVIF_RESULT_REFORMAT_FAILED;
     }
 

--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -91,6 +91,12 @@ avifResult avifRGBImageApplyGainMap(const avifRGBImage * baseImage,
         avifDiagnosticsPrintf(diag, "NULL input image");
         return AVIF_RESULT_INVALID_ARGUMENT;
     }
+    // Validate that baseImage->rowBytes is large enough before pixel access (issue #3146).
+    if (baseImage->pixels &&
+        baseImage->rowBytes < (size_t)baseImage->width * avifRGBImagePixelSize(baseImage)) {
+        avifDiagnosticsPrintf(diag, "baseImage rowBytes is too small for its width");
+        return AVIF_RESULT_INVALID_ARGUMENT;
+    }
     AVIF_CHECKRES(avifGainMapValidateMetadata(gainMap, diag));
 
     const uint32_t width = baseImage->width;
@@ -547,6 +553,17 @@ avifResult avifRGBImageComputeGainMap(const avifRGBImage * baseRgbImage,
     AVIF_CHECKERR(baseRgbImage != NULL && altRgbImage != NULL && gainMap != NULL && gainMap->image != NULL, AVIF_RESULT_INVALID_ARGUMENT);
     if (baseRgbImage->width != altRgbImage->width || baseRgbImage->height != altRgbImage->height) {
         avifDiagnosticsPrintf(diag, "Both images should have the same dimensions");
+        return AVIF_RESULT_INVALID_ARGUMENT;
+    }
+    // Validate rowBytes for both input images before entering pixel loops (issue #3146).
+    if (baseRgbImage->pixels &&
+        baseRgbImage->rowBytes < (size_t)baseRgbImage->width * avifRGBImagePixelSize(baseRgbImage)) {
+        avifDiagnosticsPrintf(diag, "baseRgbImage rowBytes is too small for its width");
+        return AVIF_RESULT_INVALID_ARGUMENT;
+    }
+    if (altRgbImage->pixels &&
+        altRgbImage->rowBytes < (size_t)altRgbImage->width * avifRGBImagePixelSize(altRgbImage)) {
+        avifDiagnosticsPrintf(diag, "altRgbImage rowBytes is too small for its width");
         return AVIF_RESULT_INVALID_ARGUMENT;
     }
     if (gainMap->image->width == 0 || gainMap->image->height == 0 || gainMap->image->depth == 0 ||

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -223,6 +223,12 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
     if (!rgb->pixels || rgb->format == AVIF_RGB_FORMAT_RGB_565) {
         return AVIF_RESULT_REFORMAT_FAILED;
     }
+    // Validate that rowBytes covers one full row of pixels. Without this check the
+    // manual pixel loop reads (width-1)*pixelSize bytes past the end of each row when
+    // rowBytes is smaller than width*pixelSize. (GitHub issue #3146)
+    if (rgb->rowBytes < (size_t)rgb->width * avifRGBImagePixelSize(rgb)) {
+        return AVIF_RESULT_REFORMAT_FAILED;
+    }
 
     avifReformatState state;
     if (!avifPrepareReformatState(image, rgb, &state)) {
@@ -1651,6 +1657,11 @@ avifResult avifImageYUVToRGB(const avifImage * image, avifRGBImage * rgb)
     // It is okay for rgb->maxThreads to be equal to zero in order to allow clients to zero initialize the avifRGBImage struct
     // with memset.
     if (!image->yuvPlanes[AVIF_CHAN_Y] || rgb->maxThreads < 0) {
+        return AVIF_RESULT_REFORMAT_FAILED;
+    }
+    // Validate that rowBytes covers one full row of pixels when the caller has
+    // pre-allocated rgb->pixels. Same issue as in avifImageRGBToYUV (issue #3146).
+    if (rgb->pixels && rgb->rowBytes < (size_t)rgb->width * avifRGBImagePixelSize(rgb)) {
         return AVIF_RESULT_REFORMAT_FAILED;
     }
 

--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -903,5 +903,27 @@ TEST(RGBToYUVTest, UndersizedRowBytesFails) {
     EXPECT_EQ(avifImageYUVToRGB(image.get(), &rgb), AVIF_RESULT_REFORMAT_FAILED);
 }
 
+// Same class of bug in alpha premultiply / unpremultiply (issue #3146 follow-up).
+TEST(AlphaTest, UndersizedRowBytesFailsPremultiply) {
+    for (uint32_t depth : {8u, 10u, 16u}) {
+        ImagePtr image(avifImageCreate(100, 1, depth, AVIF_PIXEL_FORMAT_YUV444));
+        ASSERT_NE(image, nullptr);
+
+        avifRGBImage rgb;
+        avifRGBImageSetDefaults(&rgb, image.get());
+        rgb.depth = depth;
+
+        const uint32_t pixelSize = avifRGBImagePixelSize(&rgb);
+        rgb.rowBytes = pixelSize;  // one pixel wide, but width = 100
+        std::vector<uint8_t> buf(static_cast<size_t>(rgb.rowBytes) * rgb.height, 0x80);
+        rgb.pixels = buf.data();
+
+        EXPECT_EQ(avifRGBImagePremultiplyAlpha(&rgb), AVIF_RESULT_REFORMAT_FAILED)
+            << "depth=" << depth;
+        EXPECT_EQ(avifRGBImageUnpremultiplyAlpha(&rgb), AVIF_RESULT_REFORMAT_FAILED)
+            << "depth=" << depth;
+    }
+}
+
 }  // namespace
 }  // namespace avif

--- a/tests/gtest/avifrgbtoyuvtest.cc
+++ b/tests/gtest/avifrgbtoyuvtest.cc
@@ -880,5 +880,28 @@ INSTANTIATE_TEST_SUITE_P(
             /*max_average_abs_diff=*/Values(10.),
             /*min_psnr=*/Values(10.)));
 
+// Regression test for GitHub issue #3146:
+// avifImageRGBToYUV and avifImageYUVToRGB must reject an avifRGBImage whose
+// rowBytes is smaller than width * pixelSize before entering the pixel loop.
+TEST(RGBToYUVTest, UndersizedRowBytesFails) {
+    ImagePtr image(avifImageCreate(100, 1, 8, AVIF_PIXEL_FORMAT_YUV444));
+    ASSERT_NE(image, nullptr);
+
+    avifRGBImage rgb;
+    avifRGBImageSetDefaults(&rgb, image.get());
+
+    // rowBytes = 4 (one pixel wide) but rgb.width = 100 — deliberate mismatch.
+    const uint32_t pixelSize = avifRGBImagePixelSize(&rgb);
+    rgb.rowBytes = pixelSize;
+    std::vector<uint8_t> buf(static_cast<size_t>(rgb.rowBytes) * rgb.height, 0x41);
+    rgb.pixels = buf.data();
+    rgb.avoidLibYUV = AVIF_TRUE;
+
+    EXPECT_EQ(avifImageRGBToYUV(image.get(), &rgb), AVIF_RESULT_REFORMAT_FAILED);
+
+    ASSERT_EQ(avifImageAllocatePlanes(image.get(), AVIF_PLANES_YUV), AVIF_RESULT_OK);
+    EXPECT_EQ(avifImageYUVToRGB(image.get(), &rgb), AVIF_RESULT_REFORMAT_FAILED);
+}
+
 }  // namespace
 }  // namespace avif


### PR DESCRIPTION
## Summary

Fixes #3146.

`avifImageRGBToYUV()` and `avifImageYUVToRGB()` accepted an `avifRGBImage`
whose `rowBytes` was smaller than `width * avifRGBImagePixelSize(rgb)`.
The documentation at `include/avif/avif.h:929-932` and the allocation helper
`avifRGBImageAllocatePixels()` both require:

```
rowBytes >= width * avifRGBImagePixelSize(rgb)
```

but neither conversion entry-point enforced this invariant.

### Root cause

The inner pixel loop in the manual RGB→YUV path computes offsets as:

```c
// src/reformat.c:320
rgb->pixels[ offsetBytesR + (i * rgbPixelBytes) + (j * rgbRowBytes) ]
```

When `rgbRowBytes < rgb->width * rgbPixelBytes`, column `i = 1` already
reads 1 byte past the end of the allocation.

The same issue exists in the YUV→RGB direction (`avifImageYUVToRGB`).

### Proof of Concept (ASan confirmed on HEAD)

```c
avifImage *image = avifImageCreate(100, 1, 8, AVIF_PIXEL_FORMAT_YUV444);
avifRGBImage rgb;
avifRGBImageSetDefaults(&rgb, image);
rgb.rowBytes    = avifRGBImagePixelSize(&rgb); // 4, but width = 100
rgb.pixels      = malloc(rgb.rowBytes * rgb.height); // only 4 bytes
rgb.avoidLibYUV = AVIF_TRUE;
avifImageRGBToYUV(image, &rgb); // ← CRASH
```

```
AddressSanitizer: heap-buffer-overflow READ of size 1
    #0 avifImageRGBToYUV src/reformat.c:320
0x… is located 0 bytes after 4-byte region [0x…, 0x…)
```

### Fix

Two early-return guards — one in each conversion entry point — that return
`AVIF_RESULT_REFORMAT_FAILED` when `rowBytes < width * pixelSize`.

### Test

`TEST(RGBToYUVTest, UndersizedRowBytesFails)` in
`tests/gtest/avifrgbtoyuvtest.cc` covers both directions.

After the patch the PoC returns `AVIF_RESULT_REFORMAT_FAILED` with zero ASan
events.