### PR TITLE
Remove ignoreGainMap param of avifImageCreateView

### DIFF
--- a/apps/avifdec.c
+++ b/apps/avifdec.c
@@ -417,8 +417,7 @@ int main(int argc, char * argv[])
             result = avifImageCreateView(imageView,
                                          decoder->image,
                                          /*ignoreColorProfile=*/AVIF_TRUE,
-                                         /*ignoreAlpha=*/AVIF_FALSE,
-                                         /*ignoreGainMap=*/AVIF_FALSE);
+                                         /*ignoreAlpha=*/AVIF_FALSE);
             if (result != AVIF_RESULT_OK) {
                 fprintf(stderr, "ERROR: Failed to create image view\n");
                 goto cleanup;

--- a/apps/avifgainmaputil/extractgainmap_command.cc
+++ b/apps/avifgainmaputil/extractgainmap_command.cc
@@ -37,8 +37,7 @@ avifResult ExtractGainMapCommand::Run() {
   }
   result = avifImageCreateView(image.get(), decoder->image,
                                /*ignoreColorProfile=*/true,
-                               /*ignoreAlpha=*/false,
-                               /*ignoreGainMap=*/false);
+                               /*ignoreAlpha=*/false);
   if (result != AVIF_RESULT_OK) {
     return result;
   }

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -214,10 +214,8 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
     if (!view) {
       return AVIF_RESULT_OUT_OF_MEMORY;
     }
-    // When ignore_gain_map is true, decoder->image won't have a gain map but
-    // may have gain map metadata. It is fine to copy gain map metadata.
     result = avifImageCreateView(view.get(), decoder->image, ignore_profile,
-                                 ignore_alpha, /*ignoreGainMap=*/false);
+                                 ignore_alpha);
     if (result != AVIF_RESULT_OK) {
       return result;
     }

--- a/apps/avifgainmaputil/swapbase_command.cc
+++ b/apps/avifgainmaputil/swapbase_command.cc
@@ -176,8 +176,7 @@ avifResult SwapBaseCommand::Run() {
   }
   result = avifImageCreateView(image.get(), decoder->image,
                                arg_image_read_.ignore_profile,
-                               arg_image_read_.ignore_alpha,
-                               /*ignore_gain_map=*/false);
+                               arg_image_read_.ignore_alpha);
   if (result != AVIF_RESULT_OK) {
     return result;
   }

--- a/apps/avifgainmaputil/tonemap_command.cc
+++ b/apps/avifgainmaputil/tonemap_command.cc
@@ -78,8 +78,7 @@ avifResult TonemapCommand::Run() {
   }
   result = avifImageCreateView(image.get(), decoder->image,
                                arg_image_read_.ignore_profile,
-                               arg_image_read_.ignore_alpha,
-                               /*ignore_gain_map=*/false);
+                               arg_image_read_.ignore_alpha);
   if (result != AVIF_RESULT_OK) {
     return result;
   }

--- a/apps/shared/avifutil.c
+++ b/apps/shared/avifutil.c
@@ -824,7 +824,7 @@ avifResult avifApplyTransforms(avifRGBImage * dstView, avifRGBImage * srcImage, 
     return AVIF_RESULT_OK;
 }
 
-avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage, avifBool ignoreColorProfile, avifBool ignoreAlpha, avifBool ignoreGainMap)
+avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage, avifBool ignoreColorProfile, avifBool ignoreAlpha)
 {
     avifResult res = AVIF_RESULT_OK;
     if (!dstImage || !srcImage) {
@@ -876,7 +876,7 @@ avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage,
         }
     }
 
-    if (!ignoreGainMap && srcImage->gainMap) {
+    if (srcImage->gainMap) {
         dstImage->gainMap = avifGainMapCreate();
         if (!dstImage->gainMap) {
             return AVIF_RESULT_OUT_OF_MEMORY;
@@ -904,8 +904,7 @@ avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage,
             res = avifImageCreateView(dstImage->gainMap->image,
                                       srcImage->gainMap->image,
                                       ignoreColorProfile,
-                                      /*ignoreAlpha=*/AVIF_TRUE,
-                                      /*ignoreGainMap=*/AVIF_TRUE);
+                                      /*ignoreAlpha=*/AVIF_TRUE);
             if (res != AVIF_RESULT_OK) {
                 return res;
             }

--- a/apps/shared/avifutil.h
+++ b/apps/shared/avifutil.h
@@ -132,7 +132,7 @@ void avifImageFixXMP(avifImage * image);
 // If a gain map is present in 'srcImage', the gain map of 'dstImage' is also set to
 // a view of the original gain map.
 // 'dstImage' should be an empty image. It will not own the pixel data.
-avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage, avifBool ignoreColorProfile, avifBool ignoreAlpha, avifBool ignoreGainMap);
+avifResult avifImageCreateView(avifImage * dstImage, const avifImage * srcImage, avifBool ignoreColorProfile, avifBool ignoreAlpha);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
Remove the ignoreGainMap parameter of the avifImageCreateView() function.

All the callers of avifImageCreateView() pass ignoreGainMap=false to the function. (The only exception is the recursive call on the gain map image, but the gain map image cannot have its own gain map image, so it doesn't really matter.)