### PR TITLE
Bump libyuv to 078d7f6ff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 ### Changed since 1.4.2
 
 * Update LocalAvm.cmake: v1.0.0
+* Update libyuv.cmd/LocalLibyuv.cmake: 078d7f6ff (1948)
 * Copy XMP/Exif in avifgainmaputil tonemap
 * Apply patch to SVT-AV1 with AVIF_CODEC_SVT=LOCAL to fix corrupted encoded
   files when SVT-AV1 is built with MSVC. See

--- a/cmake/Modules/LocalLibyuv.cmake
+++ b/cmake/Modules/LocalLibyuv.cmake
@@ -1,7 +1,7 @@
 # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 # because the test suite of chromium provides additional test coverage of libyuv.
 # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-set(AVIF_LIBYUV_TAG "644251f252a84bf8ce91ff0aca86a9b16b069ab8")
+set(AVIF_LIBYUV_TAG "078d7f6ffc0bf912403ea2b775cf1b3ff65cafc4")
 
 set(AVIF_LIBYUV_BUILD_DIR "${AVIF_SOURCE_DIR}/ext/libyuv/build")
 # If ${ANDROID_ABI} is set, look for the library under that subdirectory.

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -17,7 +17,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout 644251f25
+git checkout 078d7f6ff
 cd ..
 
 cmake -G Ninja -S libyuv -B libyuv/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/ext/libyuv_android.sh
+++ b/ext/libyuv_android.sh
@@ -19,7 +19,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout 644251f25
+git checkout 078d7f6ff
 
 mkdir build
 cd build


### PR DESCRIPTION
Used on the Chrome M151 branch, plus the fix for three Coverity Control flow issues (DEADCODE): CID 561616, CID 561617, CID 561618.