### PR TITLE
LocalLibXml2.cmake: Avoid duplicates in PREFIXES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The changes are relative to the previous release, unless the baseline is specifi
 * avifdec: The message "[--ignore-icc] Discarding ICC profile.\n" won't be
   printed if the --ignore-icc or --icc option is specified and the image has an
   ICC profile.
+* LocalLibXml2.cmake: Properly handle a libxml2 library compiled by
+  ext/libxml2.cmd.
 
 ## [1.4.2] - 2026-05-26
 

--- a/cmake/Modules/LocalLibXml2.cmake
+++ b/cmake/Modules/LocalLibXml2.cmake
@@ -1,7 +1,10 @@
 set(AVIF_LIBXML_GIT_TAG "v2.15.3")
 
 # First, whether the library exists.
-set(PREFIXES lib ${AVIF_LIBRARY_PREFIX})
+set(PREFIXES "lib")
+if(NOT AVIF_LIBRARY_PREFIX STREQUAL "lib")
+    list(APPEND PREFIXES ${AVIF_LIBRARY_PREFIX})
+endif()
 set(SUFFIXES "s" "sd" "")
 foreach(PREFIX IN LISTS PREFIXES)
     foreach(SUFFIX IN LISTS SUFFIXES)
@@ -19,13 +22,10 @@ foreach(PREFIX IN LISTS PREFIXES)
             target_compile_definitions(LibXml2 INTERFACE LIBXML_STATIC)
             target_include_directories(LibXml2 INTERFACE "${AVIF_SOURCE_DIR}/ext/libxml2/install.libavif/include/libxml2")
             add_library(LibXml2::LibXml2 ALIAS LibXml2)
+            return()
         endif()
     endforeach()
 endforeach()
-
-if(TARGET LibXml2::LibXml2)
-    return()
-endif()
 
 message(STATUS "libavif(AVIF_LIBXML2=LOCAL): compiled library not found at ${LIB_FILENAME}; using FetchContent")
 if(EXISTS "${AVIF_SOURCE_DIR}/ext/libxml2")


### PR DESCRIPTION
If ${AVIF_LIBRARY_PREFIX} is equal to lib, PREFIXES will check for the prefix "lib" twice. If a compiled libxml2 library exists, we will call add_library() twice. The second add_library() call will fail.

As a second fix, add an early return after finding a compiled libxml2 library.