### PR TITLE
Test alphaPresent when decoder ignores alpha

### DIFF
--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -581,8 +581,6 @@ TEST(GainMapTest, IgnoreColorAndAlpha) {
   ASSERT_EQ(result, AVIF_RESULT_OK)
       << avifResultToString(result) << ": " << encoder->diag.error;
 
-  ImagePtr decoded(avifImageCreateEmpty());
-  ASSERT_NE(decoded, nullptr);
   DecoderPtr decoder(avifDecoderCreate());
   ASSERT_NE(decoder, nullptr);
   // Decode just the gain map.
@@ -604,9 +602,6 @@ TEST(GainMapTest, IgnoreColorAndAlpha) {
   result = avifDecoderNextImage(decoder.get());
   ASSERT_EQ(result, AVIF_RESULT_OK)
       << avifResultToString(result) << ": " << decoder->diag.error;
-  result = avifImageCopy(decoded.get(), decoder->image, AVIF_PLANES_ALL);
-  ASSERT_EQ(result, AVIF_RESULT_OK)
-      << avifResultToString(result) << ": " << decoder->diag.error;
 
   // Main image metadata is available.
   EXPECT_EQ(decoder->image->width, 12u);
@@ -624,11 +619,12 @@ TEST(GainMapTest, IgnoreColorAndAlpha) {
   EXPECT_EQ(decoder->image->alphaPlane, nullptr);
   EXPECT_EQ(decoder->image->alphaRowBytes, 0u);
   // The gain map was decoded.
-  ASSERT_NE(decoded->gainMap, nullptr);
-  ASSERT_NE(decoded->gainMap->image, nullptr);
-  EXPECT_GT(testutil::GetPsnr(*image->gainMap->image, *decoded->gainMap->image),
+  ASSERT_NE(decoder->image->gainMap, nullptr);
+  ASSERT_NE(decoder->image->gainMap->image, nullptr);
+  EXPECT_GT(testutil::GetPsnr(*image->gainMap->image,
+                              *decoder->image->gainMap->image),
             40.0);
-  CheckGainMapMetadataMatches(*decoded->gainMap, *image->gainMap);
+  CheckGainMapMetadataMatches(*decoder->image->gainMap, *image->gainMap);
 }
 
 TEST(GainMapTest, IgnoreAll) {

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -587,18 +587,41 @@ TEST(GainMapTest, IgnoreColorAndAlpha) {
   ASSERT_NE(decoder, nullptr);
   // Decode just the gain map.
   decoder->imageContentToDecode = AVIF_IMAGE_CONTENT_GAIN_MAP;
-  result = avifDecoderReadMemory(decoder.get(), decoded.get(), encoded.data,
-                                 encoded.size);
+  result = avifDecoderSetIOMemory(decoder.get(), encoded.data, encoded.size);
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << ": " << decoder->diag.error;
+  result = avifDecoderParse(decoder.get());
   ASSERT_EQ(result, AVIF_RESULT_OK)
       << avifResultToString(result) << ": " << decoder->diag.error;
 
   // Main image metadata is available.
   EXPECT_EQ(decoder->image->width, 12u);
   EXPECT_EQ(decoder->image->height, 34u);
+  EXPECT_EQ(decoder->image->depth, 10);
+  EXPECT_EQ(decoder->image->yuvFormat, AVIF_PIXEL_FORMAT_YUV420);
+  EXPECT_EQ(decoder->alphaPresent, AVIF_TRUE);
+
+  result = avifDecoderNextImage(decoder.get());
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << ": " << decoder->diag.error;
+  result = avifImageCopy(decoded.get(), decoder->image, AVIF_PLANES_ALL);
+  ASSERT_EQ(result, AVIF_RESULT_OK)
+      << avifResultToString(result) << ": " << decoder->diag.error;
+
+  // Main image metadata is available.
+  EXPECT_EQ(decoder->image->width, 12u);
+  EXPECT_EQ(decoder->image->height, 34u);
+  EXPECT_EQ(decoder->image->depth, 10);
+  EXPECT_EQ(decoder->image->yuvFormat, AVIF_PIXEL_FORMAT_YUV420);
+  EXPECT_EQ(decoder->alphaPresent, AVIF_TRUE);
   // But pixels are not.
+  EXPECT_EQ(decoder->image->yuvPlanes[0], nullptr);
+  EXPECT_EQ(decoder->image->yuvPlanes[1], nullptr);
+  EXPECT_EQ(decoder->image->yuvPlanes[2], nullptr);
   EXPECT_EQ(decoder->image->yuvRowBytes[0], 0u);
   EXPECT_EQ(decoder->image->yuvRowBytes[1], 0u);
   EXPECT_EQ(decoder->image->yuvRowBytes[2], 0u);
+  EXPECT_EQ(decoder->image->alphaPlane, nullptr);
   EXPECT_EQ(decoder->image->alphaRowBytes, 0u);
   // The gain map was decoded.
   ASSERT_NE(decoded->gainMap, nullptr);
@@ -629,6 +652,13 @@ TEST(GainMapTest, IgnoreAll) {
   ASSERT_EQ(avifDecoderSetIOMemory(decoder.get(), encoded.data, encoded.size),
             AVIF_RESULT_OK);
   ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_OK);
+
+  // Main image metadata is available.
+  EXPECT_EQ(decoder->image->width, 12u);
+  EXPECT_EQ(decoder->image->height, 34u);
+  EXPECT_EQ(decoder->image->depth, 10);
+  EXPECT_EQ(decoder->image->yuvFormat, AVIF_PIXEL_FORMAT_YUV420);
+  EXPECT_EQ(decoder->alphaPresent, AVIF_TRUE);
 
   EXPECT_TRUE(decoder->image->gainMap != nullptr);
   CheckGainMapMetadataMatches(*decoder->image->gainMap, *image->gainMap);


### PR DESCRIPTION
Modify GainMapTest.IgnoreColorAndAlpha and GainMapTest.IgnoreAll to check whether alphaPresent and other main image metadata are set when the decoder ignores color and alpha.

Since this requires examining the decoder's fields after avifDecoderParse() is called, the avifDecoderReadMemory() call in GainMapTest.IgnoreColorAndAlpha is replaced with calls to the equivalent avifDecoder functions (except avifImageCopy()).