### PR TITLE
Delete two unneeded avifImageCreateView() calls

### DIFF
--- a/apps/avifgainmaputil/extractgainmap_command.cc
+++ b/apps/avifgainmaputil/extractgainmap_command.cc
@@ -32,14 +32,7 @@ avifResult ExtractGainMapCommand::Run() {
     return result;
   }
 
-  ImagePtr image(avifImageCreateEmpty());
-  if (!image) {
-    return AVIF_RESULT_OUT_OF_MEMORY;
-  }
-  result = avifImageCreateView(image.get(), decoder->image);
-  if (result != AVIF_RESULT_OK) {
-    return result;
-  }
+  const avifImage* image = decoder->image;
 
   if (image->gainMap == nullptr || image->gainMap->image == nullptr) {
     std::cerr << "Input image " << arg_input_filename_

--- a/apps/avifgainmaputil/imageio.cc
+++ b/apps/avifgainmaputil/imageio.cc
@@ -215,21 +215,12 @@ avifResult ReadImage(avifImage* image, const std::string& input_filename,
       return result;
     }
 
-    ImagePtr view(avifImageCreateEmpty());
-    if (!view) {
-      return AVIF_RESULT_OUT_OF_MEMORY;
-    }
-    result = avifImageCreateView(view.get(), decoder->image);
-    if (result != AVIF_RESULT_OK) {
-      return result;
-    }
-
     const avifColorPrimaries in_primaries = image->colorPrimaries;
     const avifTransferCharacteristics in_transfer =
         image->transferCharacteristics;
     const avifMatrixCoefficients in_matrix = image->matrixCoefficients;
 
-    result = avifImageCopy(image, view.get(), AVIF_PLANES_ALL);
+    result = avifImageCopy(image, decoder->image, AVIF_PLANES_ALL);
     if (result != AVIF_RESULT_OK) {
       return result;
     }


### PR DESCRIPTION
If we don't modify the image view, we can omit the avifImageCreateView() call.