### PR TITLE
Use AVIF_IMAGE_CONTENT_NONE instead of 0

### DIFF
--- a/tests/gtest/avifanimationtest.cc
+++ b/tests/gtest/avifanimationtest.cc
@@ -129,7 +129,7 @@ TEST(AvifDecodeTest, AnimatedImageWithAlphaAndMetadataIgnoreAll) {
   const char* file_name = "colors-animated-8bpc-alpha-exif-xmp.avif";
   DecoderPtr decoder(avifDecoderCreate());
   ASSERT_NE(decoder, nullptr);
-  decoder->imageContentToDecode = 0;
+  decoder->imageContentToDecode = AVIF_IMAGE_CONTENT_NONE;
   ASSERT_EQ(avifDecoderSetIOFile(decoder.get(),
                                  (std::string(data_path) + file_name).c_str()),
             AVIF_RESULT_OK);


### PR DESCRIPTION
The symbolic constant AVIF_IMAGE_CONTENT_NONE is more readable.