### PR TITLE
Bump libyuv to 7138e0a2a (1953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The changes are relative to the previous release, unless the baseline is specifi
 
 * Update dav1d.cmd/dav1d_android.sh/LocalDav1d.cmake: 1.5.4
 * Update LocalAvm.cmake: v1.0.0
-* Update libyuv.cmd/LocalLibyuv.cmake: 5d03bf9ba (1949)
+* Update libyuv.cmd/LocalLibyuv.cmake: 7138e0a2a (1953)
 * Update svt.cmd/svt.sh/LocalSvt.cmake: v4.2.0
 * Copy XMP/Exif in avifgainmaputil tonemap
 * Apply patch to SVT-AV1 with AVIF_CODEC_SVT=LOCAL to fix corrupted encoded

--- a/cmake/Modules/LocalLibyuv.cmake
+++ b/cmake/Modules/LocalLibyuv.cmake
@@ -1,7 +1,7 @@
 # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 # because the test suite of chromium provides additional test coverage of libyuv.
 # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-set(AVIF_LIBYUV_TAG "5d03bf9bab5693ccf692f18b538d8d9c00387c73")
+set(AVIF_LIBYUV_TAG "7138e0a2a7eab0ea7e200e49f047b80e6d7c474e")
 
 set(AVIF_LIBYUV_BUILD_DIR "${AVIF_SOURCE_DIR}/ext/libyuv/build")
 # If ${ANDROID_ABI} is set, look for the library under that subdirectory.

--- a/ext/libyuv.cmd
+++ b/ext/libyuv.cmd
@@ -17,7 +17,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout 5d03bf9ba
+git checkout 7138e0a2a
 cd ..
 
 cmake -G Ninja -S libyuv -B libyuv/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/ext/libyuv_android.sh
+++ b/ext/libyuv_android.sh
@@ -19,7 +19,7 @@ cd libyuv
 : # When changing the commit below to a newer version of libyuv, it is best to make sure it is being used by chromium,
 : # because the test suite of chromium provides additional test coverage of libyuv.
 : # It can be looked up at https://source.chromium.org/chromium/chromium/src/+/main:DEPS?q=libyuv.
-git checkout 5d03bf9ba
+git checkout 7138e0a2a
 
 mkdir build
 cd build


### PR DESCRIPTION
Used on the Chrome M152 branch, plus three more commits.