### PR TITLE
Honour the base image stride in the tone map early exit

### DIFF
--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -118,10 +118,9 @@ avifResult avifRGBImageApplyGainMap(const avifRGBImage * baseImage,
     const float weight = avifGetGainMapWeight(hdrHeadroom, gainMap);
 
     // Early exit if the gain map does not need to be applied and the pixel format is the same.
-    if (weight == 0.0f && outputTransferCharacteristics == baseTransferCharacteristics &&
-        outputColorPrimaries == baseColorPrimaries && baseImage->format == toneMappedImage->format &&
-        baseImage->depth == toneMappedImage->depth && baseImage->isFloat == toneMappedImage->isFloat) {
-        assert(baseImage->rowBytes == toneMappedImage->rowBytes);
+    if (weight == 0.0f && outputTransferCharacteristics == baseTransferCharacteristics && outputColorPrimaries == baseColorPrimaries &&
+        baseImage->format == toneMappedImage->format && baseImage->depth == toneMappedImage->depth &&
+        baseImage->isFloat == toneMappedImage->isFloat && baseImage->rowBytes == toneMappedImage->rowBytes) {
         assert(baseImage->height == toneMappedImage->height);
         // Copy the base image.
         memcpy(toneMappedImage->pixels, baseImage->pixels, (size_t)baseImage->rowBytes * baseImage->height);

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -1251,6 +1251,75 @@ TEST(ToneMapTest, ToneMapImageSameHeadroom) {
   }
 }
 
+// avifRGBImage::rowBytes only has to be at least width * pixelSize, so a base
+// image with row padding is a legal input. Check that the "nothing to tone map"
+// early exit honours the source stride instead of assuming it is tight.
+TEST(ToneMapTest, ToneMapRGBPaddedBaseStride) {
+  constexpr uint32_t kWidth = 8;
+  constexpr uint32_t kHeight = 8;
+
+  GainMapPtr gain_map(avifGainMapCreate());
+  ASSERT_NE(gain_map, nullptr);
+  for (int c = 0; c < 3; ++c) {
+    gain_map->gainMapMin[c] = {0, 1};
+    gain_map->gainMapMax[c] = {1, 1};
+    gain_map->gainMapGamma[c] = {1, 1};
+    gain_map->baseOffset[c] = {0, 64};
+    gain_map->alternateOffset[c] = {0, 64};
+  }
+  // baseHdrHeadroom 0 and a target headroom of 0 give a weight of 0, which is
+  // what makes the memcpy fast path eligible. The padded base stride below is
+  // what must keep it from being taken.
+  gain_map->baseHdrHeadroom = {0, 1};
+  gain_map->alternateHdrHeadroom = {1, 1};
+  gain_map->useBaseColorSpace = AVIF_TRUE;
+  gain_map->image =
+      avifImageCreate(kWidth, kHeight, 8, AVIF_PIXEL_FORMAT_YUV400);
+  ASSERT_NE(gain_map->image, nullptr);
+  ASSERT_EQ(avifImageAllocatePlanes(gain_map->image, AVIF_PLANES_YUV),
+            AVIF_RESULT_OK);
+
+  avifRGBImage base = {};
+  base.width = kWidth;
+  base.height = kHeight;
+  base.depth = 8;
+  base.format = AVIF_RGB_FORMAT_RGBA;
+  const uint32_t pixel_size = avifRGBImagePixelSize(&base);
+  // Padded stride, as produced by an Android Bitmap or a cropped GPU readback.
+  base.rowBytes = kWidth * pixel_size + 16;
+  std::vector<uint8_t> base_pixels((size_t)base.rowBytes * base.height, 0x41);
+  base.pixels = base_pixels.data();
+
+  // avifRGBImageApplyGainMap() allocates the output itself, so only the fields
+  // it does not set are needed here.
+  avifRGBImage tone_mapped = {};
+  tone_mapped.depth = 8;
+  tone_mapped.format = AVIF_RGB_FORMAT_RGBA;
+
+  avifDiagnostics diag;
+  avifDiagnosticsClearError(&diag);
+  ASSERT_EQ(avifRGBImageApplyGainMap(
+                &base, AVIF_COLOR_PRIMARIES_BT709,
+                AVIF_TRANSFER_CHARACTERISTICS_SRGB, gain_map.get(),
+                /*hdrHeadroom=*/0.0f, AVIF_COLOR_PRIMARIES_BT709,
+                AVIF_TRANSFER_CHARACTERISTICS_SRGB, &tone_mapped,
+                /*clli=*/nullptr, &diag),
+            AVIF_RESULT_OK)
+      << diag.error;
+
+  // The gain map is a no-op here, so the output should equal the base image
+  // row by row, each row compared over its own stride.
+  for (uint32_t y = 0; y < kHeight; ++y) {
+    EXPECT_EQ(memcmp(tone_mapped.pixels + (size_t)y * tone_mapped.rowBytes,
+                     base.pixels + (size_t)y * base.rowBytes,
+                     (size_t)kWidth * pixel_size),
+              0)
+        << "row " << y << " differs";
+  }
+
+  avifRGBImageFreePixels(&tone_mapped);
+}
+
 TEST(GainMapTest, OpaqueProperties) {
   ImagePtr image = CreateTestImageWithGainMap(/*base_rendition_is_hdr=*/false);
   ASSERT_NE(image, nullptr);


### PR DESCRIPTION
The "nothing to tone map" early exit in `avifRGBImageApplyGainMap()` copies the base image with a single `memcpy` sized from `baseImage->rowBytes`, which assumes the source and destination strides are equal. That assumption was only enforced by an `assert()`, so it is gone in a release build.

## Detail

`src/gainmap.c`, lines 120 to 129:

```c
if (weight == 0.0f && outputTransferCharacteristics == baseTransferCharacteristics &&
    outputColorPrimaries == baseColorPrimaries && baseImage->format == toneMappedImage->format &&
    baseImage->depth == toneMappedImage->depth && baseImage->isFloat == toneMappedImage->isFloat) {
    assert(baseImage->rowBytes == toneMappedImage->rowBytes);
    assert(baseImage->height == toneMappedImage->height);
    // Copy the base image.
    memcpy(toneMappedImage->pixels, baseImage->pixels, (size_t)baseImage->rowBytes * baseImage->height);
    goto cleanup;
}
```

The destination is usually allocated a few lines earlier by `avifRGBImageAllocatePixels()`, which sets a tight stride at `src/avif.c:733`:

```c
const uint32_t rowBytes = rgb->width * pixelSize;
```

Meanwhile `include/avif/avif.h:929` documents the input contract as:

> which should be at least (`->rowBytes` * `->height`) bytes, where `->rowBytes` is at least (`->width` * `avifRGBImagePixelSize()`)

So a base image with row padding is a documented legal input, but the fast path sizes the copy from the padded source stride and writes it into a tightly strided destination. The copy then runs `(baseImage->rowBytes - width * pixelSize) * height` bytes past the end of the destination allocation.

Every other RGB path in the function, including the general path just below through `avifGetRGBAPixel` and `avifSetRGBAPixel`, already handles strides per row. This branch is the only one that does not.

The early exit is easy to reach. An SDR target display gives `hdrHeadroom` of 0, which equals a typical `baseHdrHeadroom` of 0, so `avifGetGainMapWeight()` returns exactly `0.0f`. Matching base and output color spaces, for example sRGB to sRGB, completes the condition. Padded strides are normal for buffers coming from Android Bitmaps, GPU readbacks, cropped views and any 4, 16 or 64 byte aligned image pipeline.

## The change

Promote the `assert` into the branch condition. When the strides differ the early exit is skipped and control falls through to the existing per pixel loop, which honours both strides. There is no behaviour change when the strides are equal, so the fast path still applies in the common case.

The `rowBytes` assert is removed because it is now redundant with the condition. The `height` assert is left alone.

## Test

`ToneMapTest.ToneMapRGBPaddedBaseStride` builds a base `avifRGBImage` with 16 bytes of row padding, sets `baseHdrHeadroom` to 0 so the weight is 0 and the early exit is taken, calls `avifRGBImageApplyGainMap`, and then compares the output to the base image row by row over each buffer own stride. It constructs its images in memory and needs no test data files.

Without the source change, in a Release build with ASAN:

```
==31748==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x611000000640
WRITE of size 384 at 0x611000000640 thread T0
    #1 avifRGBImageApplyGainMap gainmap.c:127
0x611000000640 is located 0 bytes after 256-byte region
allocated by thread T0 here:
    #1 avifRGBImageAllocatePixels avif.c:733
    #2 avifRGBImageApplyGainMap gainmap.c:114
SUMMARY: AddressSanitizer: heap-buffer-overflow gainmap.c:127 in avifRGBImageApplyGainMap
```

With the change applied:

```
[       OK ] ToneMapTest.ToneMapRGBPaddedBaseStride (0 ms)
[  PASSED  ] 1 test.
```

## Suite result

Built with `-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-DNDEBUG -fsanitize=address -g -O1"`, dav1d as the only codec:

```
clean tree      : 37 passed, 15 failed
with this change: 38 passed, 15 failed
```

The 15 failures are identical in both runs and are environmental. They report "No codec available" because I built with a decoder only and those cases encode. The change adds one passing test and alters nothing else.

## Note

`avifRGBImageApplyGainMap` and `avifImageApplyGainMap` have no fuzz target under `tests/gtest/`, and the in tree callers in `apps/avifgainmaputil` and the existing tests all pass tight strides, which is why this has not surfaced before.
