### PR TITLE
Improve ToneMapTest.ToneMapRGBPaddedBaseStride

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -1721,6 +1721,8 @@ AVIF_NODISCARD AVIF_API avifBool avifPeekCompatibleFileType(const avifROData * i
 // Performs tone mapping on a base image using the provided gain map.
 // The HDR headroom is log2 of the ratio of HDR to SDR white brightness of the display to tone map for.
 // 'toneMappedImage' should have the 'format', 'depth', and 'isFloat' fields set to the desired values.
+// This function sets the 'width' and 'height' fields of 'toneMappedImage' to the width and height of
+// `baseImage`, and allocates the 'pixels' buffer and sets the 'rowBytes' field of 'toneMappedImage'.
 // If non NULL, 'clli' will be filled with the light level information of the tone mapped image.
 AVIF_API avifResult avifImageApplyGainMap(const avifImage * baseImage,
                                           const avifGainMap * gainMap,

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -1287,7 +1287,10 @@ TEST(ToneMapTest, ToneMapRGBPaddedBaseStride) {
   const uint32_t pixel_size = avifRGBImagePixelSize(&base);
   // Padded stride, as produced by an Android Bitmap or a cropped GPU readback.
   base.rowBytes = kWidth * pixel_size + 16;
-  std::vector<uint8_t> base_pixels((size_t)base.rowBytes * base.height, 0x41);
+  std::vector<uint8_t> base_pixels((size_t)base.rowBytes * base.height);
+  for (size_t i = 0; i < base_pixels.size(); ++i) {
+    base_pixels[i] = i & 0xff;
+  }
   base.pixels = base_pixels.data();
 
   // avifRGBImageApplyGainMap() allocates the output itself, so only the fields


### PR DESCRIPTION
This is a follow-up to PR #3316.

In the ToneMapTest.ToneMapRGBPaddedBaseStride test, set the `base` image to different sample values to enable the memcmp() check at the end of the test to detect the bug.

Add a comment to describe how avifImageApplyGainMap() sets the fields of the 'toneMappedImage' in/out parameter.