### PR TITLE
Honor unaligned 16-bit RGB row strides

### DIFF
--- a/src/alpha.c
+++ b/src/alpha.c
@@ -6,6 +6,19 @@
 #include <assert.h>
 #include <string.h>
 
+// High-depth samples in caller-owned RGB buffers may be unaligned when rows are padded.
+static inline uint16_t avifLoadU16Unaligned(const uint8_t * src)
+{
+    uint16_t value;
+    memcpy(&value, src, sizeof(value));
+    return value;
+}
+
+static inline void avifStoreU16Unaligned(uint8_t * dst, uint16_t value)
+{
+    memcpy(dst, &value, sizeof(value));
+}
+
 void avifFillAlpha(const avifAlphaParams * params)
 {
     if (params->dstDepth > 8) {
@@ -14,7 +27,7 @@ void avifFillAlpha(const avifAlphaParams * params)
         for (uint32_t j = 0; j < params->height; ++j) {
             uint8_t * dstPixel = dstRow;
             for (uint32_t i = 0; i < params->width; ++i) {
-                *((uint16_t *)dstPixel) = maxChannel;
+                avifStoreU16Unaligned(dstPixel, maxChannel);
                 dstPixel += params->dstPixelBytes;
             }
             dstRow += params->dstRowBytes;
@@ -53,7 +66,7 @@ void avifReformatAlpha(const avifAlphaParams * params)
                 const uint8_t * srcPixel = srcRow;
                 uint8_t * dstPixel = dstRow;
                 for (uint32_t i = 0; i < params->width; ++i) {
-                    *((uint16_t *)dstPixel) = *((const uint16_t *)srcPixel);
+                    avifStoreU16Unaligned(dstPixel, avifLoadU16Unaligned(srcPixel));
                     srcPixel += params->srcPixelBytes;
                     dstPixel += params->dstPixelBytes;
                 }
@@ -90,11 +103,11 @@ void avifReformatAlpha(const avifAlphaParams * params)
                     const uint8_t * srcPixel = srcRow;
                     uint8_t * dstPixel = dstRow;
                     for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = *((const uint16_t *)srcPixel);
+                        int srcAlpha = avifLoadU16Unaligned(srcPixel);
                         float alphaF = (float)srcAlpha / srcMaxChannelF;
                         int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
                         dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                        *((uint16_t *)dstPixel) = (uint16_t)dstAlpha;
+                        avifStoreU16Unaligned(dstPixel, (uint16_t)dstAlpha);
                         srcPixel += params->srcPixelBytes;
                         dstPixel += params->dstPixelBytes;
                     }
@@ -110,7 +123,7 @@ void avifReformatAlpha(const avifAlphaParams * params)
                     const uint8_t * srcPixel = srcRow;
                     uint8_t * dstPixel = dstRow;
                     for (uint32_t i = 0; i < params->width; ++i) {
-                        int srcAlpha = *((const uint16_t *)srcPixel);
+                        int srcAlpha = avifLoadU16Unaligned(srcPixel);
                         float alphaF = (float)srcAlpha / srcMaxChannelF;
                         int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
                         dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
@@ -137,7 +150,7 @@ void avifReformatAlpha(const avifAlphaParams * params)
                     float alphaF = (float)srcAlpha / srcMaxChannelF;
                     int dstAlpha = (int)(0.5f + (alphaF * dstMaxChannelF));
                     dstAlpha = AVIF_CLAMP(dstAlpha, 0, dstMaxChannel);
-                    *((uint16_t *)dstPixel) = (uint16_t)dstAlpha;
+                    avifStoreU16Unaligned(dstPixel, (uint16_t)dstAlpha);
                     srcPixel += params->srcPixelBytes;
                     dstPixel += params->dstPixelBytes;
                 }
@@ -174,78 +187,87 @@ avifResult avifRGBImagePremultiplyAlpha(avifRGBImage * rgb)
         if (rgb->format == AVIF_RGB_FORMAT_RGBA || rgb->format == AVIF_RGB_FORMAT_BGRA) {
             uint8_t * row = rgb->pixels;
             for (uint32_t j = 0; j < rgb->height; ++j) {
-                uint16_t * pixel = (uint16_t *)row;
+                uint8_t * pixel = row;
                 for (uint32_t i = 0; i < rgb->width; ++i) {
-                    uint16_t a = pixel[3];
+                    uint16_t a = avifLoadU16Unaligned(pixel + 3 * sizeof(uint16_t));
                     if (a >= max) {
                         // opaque is no-op
                     } else if (a == 0) {
                         // result must be zero
-                        pixel[0] = 0;
-                        pixel[1] = 0;
-                        pixel[2] = 0;
+                        avifStoreU16Unaligned(pixel, 0);
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t), 0);
+                        avifStoreU16Unaligned(pixel + 2 * sizeof(uint16_t), 0);
                     } else {
                         // a < maxF is always true now, so we don't need clamp here
-                        pixel[0] = (uint16_t)avifRoundf((float)pixel[0] * (float)a / maxF);
-                        pixel[1] = (uint16_t)avifRoundf((float)pixel[1] * (float)a / maxF);
-                        pixel[2] = (uint16_t)avifRoundf((float)pixel[2] * (float)a / maxF);
+                        avifStoreU16Unaligned(pixel, (uint16_t)avifRoundf((float)avifLoadU16Unaligned(pixel) * (float)a / maxF));
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t),
+                                              (uint16_t)avifRoundf((float)avifLoadU16Unaligned(pixel + sizeof(uint16_t)) * (float)a / maxF));
+                        avifStoreU16Unaligned(pixel + 2 * sizeof(uint16_t),
+                                              (uint16_t)avifRoundf((float)avifLoadU16Unaligned(pixel + 2 * sizeof(uint16_t)) *
+                                                                   (float)a / maxF));
                     }
-                    pixel += 4;
+                    pixel += 4 * sizeof(uint16_t);
                 }
                 row += rgb->rowBytes;
             }
         } else if (rgb->format == AVIF_RGB_FORMAT_ARGB || rgb->format == AVIF_RGB_FORMAT_ABGR) {
             uint8_t * row = rgb->pixels;
             for (uint32_t j = 0; j < rgb->height; ++j) {
-                uint16_t * pixel = (uint16_t *)row;
+                uint8_t * pixel = row;
                 for (uint32_t i = 0; i < rgb->width; ++i) {
-                    uint16_t a = pixel[0];
+                    uint16_t a = avifLoadU16Unaligned(pixel);
                     if (a >= max) {
                     } else if (a == 0) {
-                        pixel[1] = 0;
-                        pixel[2] = 0;
-                        pixel[3] = 0;
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t), 0);
+                        avifStoreU16Unaligned(pixel + 2 * sizeof(uint16_t), 0);
+                        avifStoreU16Unaligned(pixel + 3 * sizeof(uint16_t), 0);
                     } else {
-                        pixel[1] = (uint16_t)avifRoundf((float)pixel[1] * (float)a / maxF);
-                        pixel[2] = (uint16_t)avifRoundf((float)pixel[2] * (float)a / maxF);
-                        pixel[3] = (uint16_t)avifRoundf((float)pixel[3] * (float)a / maxF);
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t),
+                                              (uint16_t)avifRoundf((float)avifLoadU16Unaligned(pixel + sizeof(uint16_t)) * (float)a / maxF));
+                        avifStoreU16Unaligned(pixel + 2 * sizeof(uint16_t),
+                                              (uint16_t)avifRoundf((float)avifLoadU16Unaligned(pixel + 2 * sizeof(uint16_t)) *
+                                                                   (float)a / maxF));
+                        avifStoreU16Unaligned(pixel + 3 * sizeof(uint16_t),
+                                              (uint16_t)avifRoundf((float)avifLoadU16Unaligned(pixel + 3 * sizeof(uint16_t)) *
+                                                                   (float)a / maxF));
                     }
-                    pixel += 4;
+                    pixel += 4 * sizeof(uint16_t);
                 }
                 row += rgb->rowBytes;
             }
         } else if (rgb->format == AVIF_RGB_FORMAT_GRAYA) {
             uint8_t * row = rgb->pixels;
             for (uint32_t j = 0; j < rgb->height; ++j) {
-                uint16_t * pixel = (uint16_t *)row;
+                uint8_t * pixel = row;
                 for (uint32_t i = 0; i < rgb->width; ++i) {
-                    uint16_t a = pixel[1];
+                    uint16_t a = avifLoadU16Unaligned(pixel + sizeof(uint16_t));
                     if (a >= max) {
                         // opaque is no-op
                     } else if (a == 0) {
                         // result must be zero
-                        pixel[0] = 0;
+                        avifStoreU16Unaligned(pixel, 0);
                     } else {
                         // a < maxF is always true now, so we don't need clamp here
-                        pixel[0] = (uint16_t)avifRoundf((float)pixel[0] * (float)a / maxF);
+                        avifStoreU16Unaligned(pixel, (uint16_t)avifRoundf((float)avifLoadU16Unaligned(pixel) * (float)a / maxF));
                     }
-                    pixel += 2;
+                    pixel += 2 * sizeof(uint16_t);
                 }
                 row += rgb->rowBytes;
             }
         } else if (rgb->format == AVIF_RGB_FORMAT_AGRAY) {
             uint8_t * row = rgb->pixels;
             for (uint32_t j = 0; j < rgb->height; ++j) {
-                uint16_t * pixel = (uint16_t *)row;
+                uint8_t * pixel = row;
                 for (uint32_t i = 0; i < rgb->width; ++i) {
-                    uint16_t a = pixel[0];
+                    uint16_t a = avifLoadU16Unaligned(pixel);
                     if (a >= max) {
                     } else if (a == 0) {
-                        pixel[1] = 0;
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t), 0);
                     } else {
-                        pixel[1] = (uint16_t)avifRoundf((float)pixel[1] * (float)a / maxF);
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t),
+                                              (uint16_t)avifRoundf((float)avifLoadU16Unaligned(pixel + sizeof(uint16_t)) * (float)a / maxF));
                     }
-                    pixel += 2;
+                    pixel += 2 * sizeof(uint16_t);
                 }
                 row += rgb->rowBytes;
             }
@@ -361,84 +383,84 @@ avifResult avifRGBImageUnpremultiplyAlpha(avifRGBImage * rgb)
         if (rgb->format == AVIF_RGB_FORMAT_RGBA || rgb->format == AVIF_RGB_FORMAT_BGRA) {
             uint8_t * row = rgb->pixels;
             for (uint32_t j = 0; j < rgb->height; ++j) {
-                uint16_t * pixel = (uint16_t *)row;
+                uint8_t * pixel = row;
                 for (uint32_t i = 0; i < rgb->width; ++i) {
-                    uint16_t a = pixel[3];
+                    uint16_t a = avifLoadU16Unaligned(pixel + 3 * sizeof(uint16_t));
                     if (a >= max) {
                         // opaque is no-op
                     } else if (a == 0) {
                         // prevent division by zero
-                        pixel[0] = 0;
-                        pixel[1] = 0;
-                        pixel[2] = 0;
+                        avifStoreU16Unaligned(pixel, 0);
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t), 0);
+                        avifStoreU16Unaligned(pixel + 2 * sizeof(uint16_t), 0);
                     } else {
-                        float c1 = avifRoundf((float)pixel[0] * maxF / (float)a);
-                        float c2 = avifRoundf((float)pixel[1] * maxF / (float)a);
-                        float c3 = avifRoundf((float)pixel[2] * maxF / (float)a);
-                        pixel[0] = (uint16_t)AVIF_MIN(c1, maxF);
-                        pixel[1] = (uint16_t)AVIF_MIN(c2, maxF);
-                        pixel[2] = (uint16_t)AVIF_MIN(c3, maxF);
+                        float c1 = avifRoundf((float)avifLoadU16Unaligned(pixel) * maxF / (float)a);
+                        float c2 = avifRoundf((float)avifLoadU16Unaligned(pixel + sizeof(uint16_t)) * maxF / (float)a);
+                        float c3 = avifRoundf((float)avifLoadU16Unaligned(pixel + 2 * sizeof(uint16_t)) * maxF / (float)a);
+                        avifStoreU16Unaligned(pixel, (uint16_t)AVIF_MIN(c1, maxF));
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t), (uint16_t)AVIF_MIN(c2, maxF));
+                        avifStoreU16Unaligned(pixel + 2 * sizeof(uint16_t), (uint16_t)AVIF_MIN(c3, maxF));
                     }
-                    pixel += 4;
+                    pixel += 4 * sizeof(uint16_t);
                 }
                 row += rgb->rowBytes;
             }
         } else if (rgb->format == AVIF_RGB_FORMAT_ARGB || rgb->format == AVIF_RGB_FORMAT_ABGR) {
             uint8_t * row = rgb->pixels;
             for (uint32_t j = 0; j < rgb->height; ++j) {
-                uint16_t * pixel = (uint16_t *)row;
+                uint8_t * pixel = row;
                 for (uint32_t i = 0; i < rgb->width; ++i) {
-                    uint16_t a = pixel[0];
+                    uint16_t a = avifLoadU16Unaligned(pixel);
                     if (a >= max) {
                     } else if (a == 0) {
-                        pixel[1] = 0;
-                        pixel[2] = 0;
-                        pixel[3] = 0;
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t), 0);
+                        avifStoreU16Unaligned(pixel + 2 * sizeof(uint16_t), 0);
+                        avifStoreU16Unaligned(pixel + 3 * sizeof(uint16_t), 0);
                     } else {
-                        float c1 = avifRoundf((float)pixel[1] * maxF / (float)a);
-                        float c2 = avifRoundf((float)pixel[2] * maxF / (float)a);
-                        float c3 = avifRoundf((float)pixel[3] * maxF / (float)a);
-                        pixel[1] = (uint16_t)AVIF_MIN(c1, maxF);
-                        pixel[2] = (uint16_t)AVIF_MIN(c2, maxF);
-                        pixel[3] = (uint16_t)AVIF_MIN(c3, maxF);
+                        float c1 = avifRoundf((float)avifLoadU16Unaligned(pixel + sizeof(uint16_t)) * maxF / (float)a);
+                        float c2 = avifRoundf((float)avifLoadU16Unaligned(pixel + 2 * sizeof(uint16_t)) * maxF / (float)a);
+                        float c3 = avifRoundf((float)avifLoadU16Unaligned(pixel + 3 * sizeof(uint16_t)) * maxF / (float)a);
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t), (uint16_t)AVIF_MIN(c1, maxF));
+                        avifStoreU16Unaligned(pixel + 2 * sizeof(uint16_t), (uint16_t)AVIF_MIN(c2, maxF));
+                        avifStoreU16Unaligned(pixel + 3 * sizeof(uint16_t), (uint16_t)AVIF_MIN(c3, maxF));
                     }
-                    pixel += 4;
+                    pixel += 4 * sizeof(uint16_t);
                 }
                 row += rgb->rowBytes;
             }
         } else if (rgb->format == AVIF_RGB_FORMAT_GRAYA) {
             uint8_t * row = rgb->pixels;
             for (uint32_t j = 0; j < rgb->height; ++j) {
-                uint16_t * pixel = (uint16_t *)row;
+                uint8_t * pixel = row;
                 for (uint32_t i = 0; i < rgb->width; ++i) {
-                    uint16_t a = pixel[1];
+                    uint16_t a = avifLoadU16Unaligned(pixel + sizeof(uint16_t));
                     if (a >= max) {
                         // opaque is no-op
                     } else if (a == 0) {
                         // prevent division by zero
-                        pixel[0] = 0;
+                        avifStoreU16Unaligned(pixel, 0);
                     } else {
-                        float c1 = avifRoundf((float)pixel[0] * maxF / (float)a);
-                        pixel[0] = (uint16_t)AVIF_MIN(c1, maxF);
+                        float c1 = avifRoundf((float)avifLoadU16Unaligned(pixel) * maxF / (float)a);
+                        avifStoreU16Unaligned(pixel, (uint16_t)AVIF_MIN(c1, maxF));
                     }
-                    pixel += 2;
+                    pixel += 2 * sizeof(uint16_t);
                 }
                 row += rgb->rowBytes;
             }
         } else if (rgb->format == AVIF_RGB_FORMAT_AGRAY) {
             uint8_t * row = rgb->pixels;
             for (uint32_t j = 0; j < rgb->height; ++j) {
-                uint16_t * pixel = (uint16_t *)row;
+                uint8_t * pixel = row;
                 for (uint32_t i = 0; i < rgb->width; ++i) {
-                    uint16_t a = pixel[0];
+                    uint16_t a = avifLoadU16Unaligned(pixel);
                     if (a >= max) {
                     } else if (a == 0) {
-                        pixel[1] = 0;
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t), 0);
                     } else {
-                        float c1 = avifRoundf((float)pixel[1] * maxF / (float)a);
-                        pixel[1] = (uint16_t)AVIF_MIN(c1, maxF);
+                        float c1 = avifRoundf((float)avifLoadU16Unaligned(pixel + sizeof(uint16_t)) * maxF / (float)a);
+                        avifStoreU16Unaligned(pixel + sizeof(uint16_t), (uint16_t)AVIF_MIN(c1, maxF));
                     }
-                    pixel += 2;
+                    pixel += 2 * sizeof(uint16_t);
                 }
                 row += rgb->rowBytes;
             }

--- a/src/reformat.c
+++ b/src/reformat.c
@@ -14,6 +14,19 @@
 #include <pthread.h>
 #endif
 
+// High-depth samples in caller-owned RGB buffers may be unaligned when rows are padded.
+static inline uint16_t avifLoadU16Unaligned(const uint8_t * src)
+{
+    uint16_t value;
+    memcpy(&value, src, sizeof(value));
+    return value;
+}
+
+static inline void avifStoreU16Unaligned(uint8_t * dst, uint16_t value)
+{
+    memcpy(dst, &value, sizeof(value));
+}
+
 static void * avifMemset16(void * dest, int val, size_t count)
 {
     uint16_t * dest16 = (uint16_t *)dest;
@@ -310,11 +323,11 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
 
                         // Unpack RGB into normalized float
                         if (state.rgb.channelBytes > 1) {
-                            rgbPixel[0] = *((uint16_t *)(&rgb->pixels[offsetBytesR + (i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                            rgbPixel[0] = avifLoadU16Unaligned(&rgb->pixels[offsetBytesR + (i * rgbPixelBytes) + (j * rgbRowBytes)]) /
                                           rgbMaxChannelF;
-                            rgbPixel[1] = *((uint16_t *)(&rgb->pixels[offsetBytesG + (i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                            rgbPixel[1] = avifLoadU16Unaligned(&rgb->pixels[offsetBytesG + (i * rgbPixelBytes) + (j * rgbRowBytes)]) /
                                           rgbMaxChannelF;
-                            rgbPixel[2] = *((uint16_t *)(&rgb->pixels[offsetBytesB + (i * rgbPixelBytes) + (j * rgbRowBytes)])) /
+                            rgbPixel[2] = avifLoadU16Unaligned(&rgb->pixels[offsetBytesB + (i * rgbPixelBytes) + (j * rgbRowBytes)]) /
                                           rgbMaxChannelF;
                         } else {
                             rgbPixel[0] = rgb->pixels[offsetBytesR + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
@@ -325,7 +338,8 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
                         if (alphaMode != AVIF_ALPHA_MULTIPLY_MODE_NO_OP) {
                             float a;
                             if (state.rgb.channelBytes > 1) {
-                                a = *((uint16_t *)(&rgb->pixels[offsetBytesA + (i * rgbPixelBytes) + (j * rgbRowBytes)])) / rgbMaxChannelF;
+                                a = avifLoadU16Unaligned(&rgb->pixels[offsetBytesA + (i * rgbPixelBytes) + (j * rgbRowBytes)]) /
+                                    rgbMaxChannelF;
                             } else {
                                 a = rgb->pixels[offsetBytesA + (i * rgbPixelBytes) + (j * rgbRowBytes)] / rgbMaxChannelF;
                             }
@@ -480,14 +494,14 @@ avifResult avifImageRGBToYUV(avifImage * image, const avifRGBImage * rgb)
             for (size_t i = 0; i < image->width; ++i) {
                 float g;
                 if (state.rgb.channelBytes > 1) {
-                    g = *(uint16_t *)&rgb->pixels[offsetBytesGray + i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
+                    g = avifLoadU16Unaligned(&rgb->pixels[offsetBytesGray + i * grayPixelBytes + (j * grayRowBytes)]) / grayMaxChannelF;
                 } else {
                     g = rgb->pixels[offsetBytesGray + i * grayPixelBytes + (j * grayRowBytes)] / grayMaxChannelF;
                 }
                 if (alphaMode != AVIF_ALPHA_MULTIPLY_MODE_NO_OP) {
                     float a;
                     if (state.rgb.channelBytes > 1) {
-                        a = *((uint16_t *)(&rgb->pixels[offsetBytesA + (i * grayPixelBytes) + (j * grayRowBytes)])) / grayMaxChannelF;
+                        a = avifLoadU16Unaligned(&rgb->pixels[offsetBytesA + (i * grayPixelBytes) + (j * grayRowBytes)]) / grayMaxChannelF;
                     } else {
                         a = rgb->pixels[offsetBytesA + (i * grayPixelBytes) + (j * grayRowBytes)] / grayMaxChannelF;
                     }
@@ -624,7 +638,7 @@ static void avifStoreRGB8Pixel(avifRGBFormat format, uint8_t R, uint8_t G, uint8
         // References for RGB565 color conversion:
         // * https://docs.microsoft.com/en-us/windows/win32/directshow/working-with-16-bit-rgb
         // * https://chromium.googlesource.com/libyuv/libyuv/+/9892d70c965678381d2a70a1c9002d1cf136ee78/source/row_common.cc#2362
-        *(uint16_t *)ptrR = RGB565(R, G, B);
+        avifStoreU16Unaligned(ptrR, RGB565(R, G, B));
         return;
     }
     *ptrR = R;
@@ -637,7 +651,7 @@ static void avifGetRGB565(const uint8_t * ptrR, uint8_t * R, uint8_t * G, uint8_
     // References for RGB565 color conversion:
     // * https://docs.microsoft.com/en-us/windows/win32/directshow/working-with-16-bit-rgb
     // * https://chromium.googlesource.com/libyuv/libyuv/+/331c361581896292fb46c8c6905e41262b7ca95f/source/row_common.cc#185
-    const uint16_t rgb656 = ((const uint16_t *)ptrR)[0];
+    const uint16_t rgb656 = avifLoadU16Unaligned(ptrR);
     const uint16_t r5 = (rgb656 & 0xF800) >> 11;
     const uint16_t g6 = (rgb656 & 0x07E0) >> 5;
     const uint16_t b5 = (rgb656 & 0x001F);
@@ -956,9 +970,9 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
                                        ptrG,
                                        ptrB);
                 } else {
-                    *((uint16_t *)ptrR) = (uint16_t)(0.5f + (Rc * rgbMaxChannelF));
-                    *((uint16_t *)ptrG) = (uint16_t)(0.5f + (Gc * rgbMaxChannelF));
-                    *((uint16_t *)ptrB) = (uint16_t)(0.5f + (Bc * rgbMaxChannelF));
+                    avifStoreU16Unaligned(ptrR, (uint16_t)(0.5f + (Rc * rgbMaxChannelF)));
+                    avifStoreU16Unaligned(ptrG, (uint16_t)(0.5f + (Gc * rgbMaxChannelF)));
+                    avifStoreU16Unaligned(ptrB, (uint16_t)(0.5f + (Bc * rgbMaxChannelF)));
                 }
                 ptrR += rgbPixelBytes;
                 ptrG += rgbPixelBytes;
@@ -967,7 +981,7 @@ static avifResult avifImageYUVAnyToRGBAnySlow(const avifImage * image,
                 if (rgb->depth == 8) {
                     *ptrGray = (uint8_t)(0.5f + (grayc * rgbMaxChannelF));
                 } else {
-                    *((uint16_t *)ptrGray) = (uint16_t)(0.5f + (grayc * rgbMaxChannelF));
+                    avifStoreU16Unaligned(ptrGray, (uint16_t)(0.5f + (grayc * rgbMaxChannelF)));
                 }
                 ptrGray += rgbPixelBytes;
             }
@@ -1018,9 +1032,9 @@ static avifResult avifImageYUV16ToRGB16Color(const avifImage * image, avifRGBIma
             const float Gc = AVIF_CLAMP(G, 0.0f, 1.0f);
             const float Bc = AVIF_CLAMP(B, 0.0f, 1.0f);
 
-            *((uint16_t *)ptrR) = (uint16_t)(0.5f + (Rc * rgbMaxChannelF));
-            *((uint16_t *)ptrG) = (uint16_t)(0.5f + (Gc * rgbMaxChannelF));
-            *((uint16_t *)ptrB) = (uint16_t)(0.5f + (Bc * rgbMaxChannelF));
+            avifStoreU16Unaligned(ptrR, (uint16_t)(0.5f + (Rc * rgbMaxChannelF)));
+            avifStoreU16Unaligned(ptrG, (uint16_t)(0.5f + (Gc * rgbMaxChannelF)));
+            avifStoreU16Unaligned(ptrB, (uint16_t)(0.5f + (Bc * rgbMaxChannelF)));
 
             ptrR += rgbPixelBytes;
             ptrG += rgbPixelBytes;
@@ -1064,9 +1078,9 @@ static avifResult avifImageYUV16ToRGB16Mono(const avifImage * image, avifRGBImag
             const float Gc = AVIF_CLAMP(G, 0.0f, 1.0f);
             const float Bc = AVIF_CLAMP(B, 0.0f, 1.0f);
 
-            *((uint16_t *)ptrR) = (uint16_t)(0.5f + (Rc * maxChannelF));
-            *((uint16_t *)ptrG) = (uint16_t)(0.5f + (Gc * maxChannelF));
-            *((uint16_t *)ptrB) = (uint16_t)(0.5f + (Bc * maxChannelF));
+            avifStoreU16Unaligned(ptrR, (uint16_t)(0.5f + (Rc * maxChannelF)));
+            avifStoreU16Unaligned(ptrG, (uint16_t)(0.5f + (Gc * maxChannelF)));
+            avifStoreU16Unaligned(ptrB, (uint16_t)(0.5f + (Bc * maxChannelF)));
 
             ptrR += rgbPixelBytes;
             ptrG += rgbPixelBytes;
@@ -1220,9 +1234,9 @@ static avifResult avifImageYUV8ToRGB16Color(const avifImage * image, avifRGBImag
             const float Gc = AVIF_CLAMP(G, 0.0f, 1.0f);
             const float Bc = AVIF_CLAMP(B, 0.0f, 1.0f);
 
-            *((uint16_t *)ptrR) = (uint16_t)(0.5f + (Rc * rgbMaxChannelF));
-            *((uint16_t *)ptrG) = (uint16_t)(0.5f + (Gc * rgbMaxChannelF));
-            *((uint16_t *)ptrB) = (uint16_t)(0.5f + (Bc * rgbMaxChannelF));
+            avifStoreU16Unaligned(ptrR, (uint16_t)(0.5f + (Rc * rgbMaxChannelF)));
+            avifStoreU16Unaligned(ptrG, (uint16_t)(0.5f + (Gc * rgbMaxChannelF)));
+            avifStoreU16Unaligned(ptrB, (uint16_t)(0.5f + (Bc * rgbMaxChannelF)));
 
             ptrR += rgbPixelBytes;
             ptrG += rgbPixelBytes;
@@ -1262,9 +1276,9 @@ static avifResult avifImageYUV8ToRGB16Mono(const avifImage * image, avifRGBImage
             const float Gc = AVIF_CLAMP(G, 0.0f, 1.0f);
             const float Bc = AVIF_CLAMP(B, 0.0f, 1.0f);
 
-            *((uint16_t *)ptrR) = (uint16_t)(0.5f + (Rc * rgbMaxChannelF));
-            *((uint16_t *)ptrG) = (uint16_t)(0.5f + (Gc * rgbMaxChannelF));
-            *((uint16_t *)ptrB) = (uint16_t)(0.5f + (Bc * rgbMaxChannelF));
+            avifStoreU16Unaligned(ptrR, (uint16_t)(0.5f + (Rc * rgbMaxChannelF)));
+            avifStoreU16Unaligned(ptrG, (uint16_t)(0.5f + (Gc * rgbMaxChannelF)));
+            avifStoreU16Unaligned(ptrB, (uint16_t)(0.5f + (Bc * rgbMaxChannelF)));
 
             ptrR += rgbPixelBytes;
             ptrG += rgbPixelBytes;
@@ -1291,7 +1305,7 @@ static avifResult avifImageIdentity8ToRGB8ColorFullRange(const avifImage * image
         // "if" path) much faster than having a per-pixel branch.
         if (rgb->format == AVIF_RGB_FORMAT_RGB_565) {
             for (size_t i = 0; i < image->width; ++i) {
-                *(uint16_t *)ptrR = RGB565(ptrV[i], ptrY[i], ptrU[i]);
+                avifStoreU16Unaligned(ptrR, RGB565(ptrV[i], ptrY[i], ptrU[i]));
                 ptrR += rgbPixelBytes;
             }
         } else {
@@ -1428,16 +1442,15 @@ static avifResult avifRGBImageToF16(avifRGBImage * rgb)
     const size_t channelCount = avifRGBFormatChannelCount(rgb->format);
     const float scale = 1.0f / ((1 << rgb->depth) - 1);
     const float multiplier = F16_MULTIPLIER * scale;
-    uint16_t * pixelRowBase = (uint16_t *)rgb->pixels;
-    const uint32_t stride = rgb->rowBytes >> 1;
     for (size_t j = 0; j < rgb->height; ++j) {
-        uint16_t * pixel = pixelRowBase;
-        for (size_t i = 0; i < rgb->width * channelCount; ++i, ++pixel) {
+        uint8_t * pixel = rgb->pixels + j * (size_t)rgb->rowBytes;
+        for (size_t i = 0; i < rgb->width * channelCount; ++i, pixel += sizeof(uint16_t)) {
+            const uint16_t unorm = avifLoadU16Unaligned(pixel);
             avifF16 f16;
-            f16.f = *pixel * multiplier;
-            *pixel = (uint16_t)(f16.u32 >> 13);
+            f16.f = unorm * multiplier;
+            const uint16_t half = (uint16_t)(f16.u32 >> 13);
+            avifStoreU16Unaligned(pixel, half);
         }
-        pixelRowBase += stride;
     }
     return AVIF_RESULT_OK;
 }
@@ -1861,10 +1874,10 @@ void avifGetRGBAPixel(const avifRGBImage * src, uint32_t x, uint32_t y, const av
 
     const uint8_t * const srcPixel = &src->pixels[(size_t)y * src->rowBytes + (size_t)x * info->pixelBytes];
     if (info->channelBytes > 1) {
-        uint16_t r = *((const uint16_t *)(&srcPixel[info->offsetBytesR]));
-        uint16_t g = *((const uint16_t *)(&srcPixel[info->offsetBytesG]));
-        uint16_t b = *((const uint16_t *)(&srcPixel[info->offsetBytesB]));
-        uint16_t a = avifRGBFormatHasAlpha(src->format) ? *((const uint16_t *)(&srcPixel[info->offsetBytesA])) : (uint16_t)info->maxChannel;
+        uint16_t r = avifLoadU16Unaligned(&srcPixel[info->offsetBytesR]);
+        uint16_t g = avifLoadU16Unaligned(&srcPixel[info->offsetBytesG]);
+        uint16_t b = avifLoadU16Unaligned(&srcPixel[info->offsetBytesB]);
+        uint16_t a = avifRGBFormatHasAlpha(src->format) ? avifLoadU16Unaligned(&srcPixel[info->offsetBytesA]) : (uint16_t)info->maxChannel;
         if (src->isFloat) {
             rgbaPixel[0] = avifF16ToFloat(r);
             rgbaPixel[1] = avifF16ToFloat(g);
@@ -1910,18 +1923,18 @@ void avifSetRGBAPixel(const avifRGBImage * dst, uint32_t x, uint32_t y, const av
     uint8_t * const ptrA = avifRGBFormatHasAlpha(dst->format) ? &dstPixel[info->offsetBytesA] : NULL;
     if (dst->depth > 8) {
         if (dst->isFloat) {
-            *((uint16_t *)ptrR) = avifFloatToF16(rgbaPixel[0]);
-            *((uint16_t *)ptrG) = avifFloatToF16(rgbaPixel[1]);
-            *((uint16_t *)ptrB) = avifFloatToF16(rgbaPixel[2]);
+            avifStoreU16Unaligned(ptrR, avifFloatToF16(rgbaPixel[0]));
+            avifStoreU16Unaligned(ptrG, avifFloatToF16(rgbaPixel[1]));
+            avifStoreU16Unaligned(ptrB, avifFloatToF16(rgbaPixel[2]));
             if (ptrA) {
-                *((uint16_t *)ptrA) = avifFloatToF16(rgbaPixel[3]);
+                avifStoreU16Unaligned(ptrA, avifFloatToF16(rgbaPixel[3]));
             }
         } else {
-            *((uint16_t *)ptrR) = (uint16_t)(0.5f + (rgbaPixel[0] * info->maxChannelF));
-            *((uint16_t *)ptrG) = (uint16_t)(0.5f + (rgbaPixel[1] * info->maxChannelF));
-            *((uint16_t *)ptrB) = (uint16_t)(0.5f + (rgbaPixel[2] * info->maxChannelF));
+            avifStoreU16Unaligned(ptrR, (uint16_t)(0.5f + (rgbaPixel[0] * info->maxChannelF)));
+            avifStoreU16Unaligned(ptrG, (uint16_t)(0.5f + (rgbaPixel[1] * info->maxChannelF)));
+            avifStoreU16Unaligned(ptrB, (uint16_t)(0.5f + (rgbaPixel[2] * info->maxChannelF)));
             if (ptrA) {
-                *((uint16_t *)ptrA) = (uint16_t)(0.5f + (rgbaPixel[3] * info->maxChannelF));
+                avifStoreU16Unaligned(ptrA, (uint16_t)(0.5f + (rgbaPixel[3] * info->maxChannelF)));
             }
         }
     } else {

--- a/src/reformat_libyuv.c
+++ b/src/reformat_libyuv.c
@@ -1163,7 +1163,8 @@ avifResult avifRGBImageUnpremultiplyAlphaLibYUV(avifRGBImage * rgb)
 avifResult avifRGBImageToF16LibYUV(avifRGBImage * rgb)
 {
     // The width, height, and stride parameters of libyuv functions are all of the int type.
-    if (rgb->width > INT_MAX || rgb->height > INT_MAX || rgb->rowBytes > INT_MAX) {
+    if (rgb->width > INT_MAX || rgb->height > INT_MAX || rgb->rowBytes > INT_MAX ||
+        ((uintptr_t)rgb->pixels % sizeof(uint16_t)) != 0 || (rgb->rowBytes % sizeof(uint16_t)) != 0) {
         return AVIF_RESULT_NOT_IMPLEMENTED;
     }
     const float scale = 1.0f / ((1 << rgb->depth) - 1);

--- a/tests/gtest/avifalphapremtest.cc
+++ b/tests/gtest/avifalphapremtest.cc
@@ -3,6 +3,8 @@
 
 #include <string.h>
 
+#include <vector>
+
 #include "avif/avif.h"
 #include "aviftest_helpers.h"
 #include "gtest/gtest.h"
@@ -84,6 +86,78 @@ TEST(AlphaMultiplyTest, AGrayImagePremultiplyAlpha) {
   memset(rgb.pixels, 1, (size_t)rgb.rowBytes * rgb.height);
   EXPECT_EQ(avifRGBImagePremultiplyAlpha(&rgb), AVIF_RESULT_OK);
   avifRGBImageFreePixels(&rgb);
+}
+
+TEST(AlphaMultiplyTest, HighDepthUnalignedOddStride) {
+  constexpr uint32_t kWidth = 1;
+  constexpr uint32_t kHeight = 3;
+  for (const avifRGBFormat format :
+       {AVIF_RGB_FORMAT_RGBA, AVIF_RGB_FORMAT_ARGB, AVIF_RGB_FORMAT_BGRA,
+        AVIF_RGB_FORMAT_ABGR, AVIF_RGB_FORMAT_GRAYA, AVIF_RGB_FORMAT_AGRAY}) {
+    SCOPED_TRACE(format);
+    avifRGBImage reference;
+    memset(&reference, 0, sizeof(reference));
+    reference.width = kWidth;
+    reference.height = kHeight;
+    reference.depth = 10;
+    reference.format = format;
+    ASSERT_EQ(avifRGBImageAllocatePixels(&reference), AVIF_RESULT_OK);
+
+    const uint32_t channel_count = avifRGBFormatChannelCount(format);
+    const uint32_t alpha_channel =
+        (format == AVIF_RGB_FORMAT_ARGB || format == AVIF_RGB_FORMAT_ABGR ||
+         format == AVIF_RGB_FORMAT_AGRAY)
+            ? 0
+            : channel_count - 1;
+    const uint16_t alpha[kHeight] = {0, 512, 1023};
+    for (uint32_t y = 0; y < kHeight; ++y) {
+      for (uint32_t channel = 0; channel < channel_count; ++channel) {
+        const uint16_t sample =
+            (channel == alpha_channel)
+                ? alpha[y]
+                : static_cast<uint16_t>(128 * (channel + y + 1));
+        memcpy(reference.pixels + static_cast<size_t>(y) * reference.rowBytes +
+                   channel * sizeof(sample),
+               &sample, sizeof(sample));
+      }
+    }
+
+    avifRGBImage padded = reference;
+    padded.rowBytes = reference.rowBytes + 1;
+    std::vector<uint8_t> pixels(
+        static_cast<size_t>(padded.rowBytes) * kHeight + 1, 0xa5);
+    padded.pixels = pixels.data() + 1;
+    for (uint32_t y = 0; y < kHeight; ++y) {
+      memcpy(padded.pixels + static_cast<size_t>(y) * padded.rowBytes,
+             reference.pixels + static_cast<size_t>(y) * reference.rowBytes,
+             reference.rowBytes);
+    }
+
+    ASSERT_EQ(avifRGBImagePremultiplyAlpha(&reference), AVIF_RESULT_OK);
+    ASSERT_EQ(avifRGBImagePremultiplyAlpha(&padded), AVIF_RESULT_OK);
+    for (uint32_t y = 0; y < kHeight; ++y) {
+      EXPECT_EQ(
+          memcmp(padded.pixels + static_cast<size_t>(y) * padded.rowBytes,
+                 reference.pixels + static_cast<size_t>(y) * reference.rowBytes,
+                 reference.rowBytes),
+          0);
+      EXPECT_EQ(padded.pixels[static_cast<size_t>(y + 1) * padded.rowBytes - 1],
+                0xa5);
+    }
+
+    ASSERT_EQ(avifRGBImageUnpremultiplyAlpha(&reference), AVIF_RESULT_OK);
+    ASSERT_EQ(avifRGBImageUnpremultiplyAlpha(&padded), AVIF_RESULT_OK);
+    for (uint32_t y = 0; y < kHeight; ++y) {
+      EXPECT_EQ(
+          memcmp(padded.pixels + static_cast<size_t>(y) * padded.rowBytes,
+                 reference.pixels + static_cast<size_t>(y) * reference.rowBytes,
+                 reference.rowBytes),
+          0);
+      EXPECT_EQ(padded.pixels[static_cast<size_t>(y + 1) * padded.rowBytes - 1],
+                0xa5);
+    }
+    avifRGBImageFreePixels(&reference);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/tests/gtest/avifrgbtest.cc
+++ b/tests/gtest/avifrgbtest.cc
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <array>
+#include <cstring>
 #include <tuple>
+#include <vector>
 
 #include "avif/internal.h"
 #include "aviftest_helpers.h"
@@ -110,6 +112,96 @@ TEST_P(SetGetRGBATest, GradientTest) {
     }
   }
   EXPECT_TRUE(testutil::AreImagesEqual(input_rgb, output_rgb));
+}
+
+TEST(YuvToRgbTest, FloatOutputWithUnalignedOddPaddedStride) {
+  constexpr uint32_t kWidth = 1;
+  constexpr uint32_t kHeight = 4;
+  ImagePtr yuv = testutil::CreateImage(
+      kWidth, kHeight, /*depth=*/16, AVIF_PIXEL_FORMAT_YUV400, AVIF_PLANES_YUV);
+  ASSERT_NE(yuv, nullptr);
+
+  const uint16_t samples[kHeight] = {0x1000, 0x4000, 0x8000, 0xf000};
+  for (uint32_t y = 0; y < kHeight; ++y) {
+    uint16_t* row = reinterpret_cast<uint16_t*>(
+        yuv->yuvPlanes[AVIF_CHAN_Y] +
+        static_cast<size_t>(y) * yuv->yuvRowBytes[AVIF_CHAN_Y]);
+    row[0] = samples[y];
+  }
+
+  testutil::AvifRgbImage tight(yuv.get(), /*depth=*/16, AVIF_RGB_FORMAT_RGBA);
+  tight.isFloat = true;
+  ASSERT_EQ(avifImageYUVToRGB(yuv.get(), &tight), AVIF_RESULT_OK);
+
+  avifRGBImage padded;
+  avifRGBImageSetDefaults(&padded, yuv.get());
+  padded.depth = 16;
+  padded.format = AVIF_RGB_FORMAT_RGBA;
+  padded.isFloat = true;
+  padded.rowBytes = tight.rowBytes + 1;
+  std::vector<uint8_t> pixels(
+      static_cast<size_t>(padded.rowBytes) * kHeight + 1, 0xa5);
+  padded.pixels = pixels.data() + 1;
+
+  ASSERT_EQ(avifImageYUVToRGB(yuv.get(), &padded), AVIF_RESULT_OK);
+  for (uint32_t y = 0; y < kHeight; ++y) {
+    EXPECT_EQ(
+        std::memcmp(padded.pixels + static_cast<size_t>(y) * padded.rowBytes,
+                    tight.pixels + static_cast<size_t>(y) * tight.rowBytes,
+                    tight.rowBytes),
+        0)
+        << "row " << y;
+    EXPECT_EQ(padded.pixels[static_cast<size_t>(y + 1) * padded.rowBytes - 1],
+              0xa5)
+        << "padding byte for row " << y;
+  }
+}
+
+TEST(RgbToYuvTest, InputWithUnalignedOddPaddedStride) {
+  constexpr uint32_t kWidth = 1;
+  constexpr uint32_t kHeight = 4;
+  ImagePtr tight_yuv(
+      avifImageCreate(kWidth, kHeight, /*depth=*/16, AVIF_PIXEL_FORMAT_YUV444));
+  ImagePtr padded_yuv(
+      avifImageCreate(kWidth, kHeight, /*depth=*/16, AVIF_PIXEL_FORMAT_YUV444));
+  ASSERT_NE(tight_yuv, nullptr);
+  ASSERT_NE(padded_yuv, nullptr);
+
+  testutil::AvifRgbImage tight(tight_yuv.get(), /*depth=*/16,
+                               AVIF_RGB_FORMAT_RGBA);
+  tight.avoidLibYUV = true;
+  avifRGBColorSpaceInfo color_space;
+  ASSERT_TRUE(avifGetRGBColorSpaceInfo(&tight, &color_space));
+  for (uint32_t y = 0; y < kHeight; ++y) {
+    const std::array<float, 4> pixel = {
+        static_cast<float>(y + 1) / 8.0f, static_cast<float>(y + 2) / 8.0f,
+        static_cast<float>(y + 3) / 8.0f, static_cast<float>(y + 4) / 8.0f};
+    avifSetRGBAPixel(&tight, 0, y, &color_space, pixel.data());
+  }
+
+  avifRGBImage padded;
+  avifRGBImageSetDefaults(&padded, padded_yuv.get());
+  padded.depth = 16;
+  padded.format = AVIF_RGB_FORMAT_RGBA;
+  padded.avoidLibYUV = true;
+  padded.rowBytes = tight.rowBytes + 1;
+  std::vector<uint8_t> pixels(
+      static_cast<size_t>(padded.rowBytes) * kHeight + 1, 0xa5);
+  padded.pixels = pixels.data() + 1;
+  for (uint32_t y = 0; y < kHeight; ++y) {
+    std::memcpy(padded.pixels + static_cast<size_t>(y) * padded.rowBytes,
+                tight.pixels + static_cast<size_t>(y) * tight.rowBytes,
+                tight.rowBytes);
+  }
+
+  ASSERT_EQ(avifImageRGBToYUV(tight_yuv.get(), &tight), AVIF_RESULT_OK);
+  ASSERT_EQ(avifImageRGBToYUV(padded_yuv.get(), &padded), AVIF_RESULT_OK);
+  EXPECT_TRUE(testutil::AreImagesEqual(*tight_yuv, *padded_yuv));
+  for (uint32_t y = 0; y < kHeight; ++y) {
+    EXPECT_EQ(padded.pixels[static_cast<size_t>(y + 1) * padded.rowBytes - 1],
+              0xa5)
+        << "padding byte for row " << y;
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
## Problem

`avifRGBImage` allows caller-supplied buffers whose `rowBytes` is larger than the tight pixel width. For high-depth RGB, an odd padded stride makes successive rows alternate between aligned and unaligned addresses.

The scalar RGB and alpha paths currently access these samples through `uint16_t *`. UBSan reports misaligned stores in `avifFillAlpha()` and the 16-bit YUV-to-RGB writers. `avifRGBImageToF16()` also advances a `uint16_t *` by `rowBytes >> 1`, so it discards the low stride bit. On untouched main, a valid 9-byte-stride RGBA output changes when only the row-padding byte changes:

```text
valid odd-stride output depends on padding: yes
end guard changed: no
```

That can turn caller-owned row padding into visible float output and is undefined behavior on strict-alignment targets.

## Change

- Use two-byte `memcpy` helpers for 16-bit samples in caller-owned RGB buffers while preserving native-endian behavior.
- Address every F16 row through byte arithmetic so the exact stride is honored.
- Have the libyuv F16 wrapper fall back when the typed base or byte stride is unaligned.
- Cover unaligned odd-stride conversion in both directions and high-depth alpha multiply/unmultiply across all alpha-bearing formats.

The patched sanitizer run reports no alignment errors and the same reproducer becomes:

```text
valid odd-stride output depends on padding: no
end guard changed: no
```

## Verification

- Normal build: `avifrgbtest`, `avifalphapremtest`, `avifrgbtoyuvtest`, and `avifrgbtoyuvthreadingtest` pass.
- ASan/UBSan build: the same four suites pass.
- libyuv 1949 build: `avifrgbtest` passes, including aligned F16 fast-path output versus the odd-stride scalar fallback.
- Project clang-format and `git diff --check` pass.

## Related work

PR #3312 touches `avifFillAlpha()` and same-depth `avifReformatAlpha()` to add an AArch64 NEON path, but it does not address odd row alignment. If it lands after this change, its 16-bit dispatch and scalar tails will need to retain the unaligned-row behavior fixed here.