### PR TITLE
Reset Sample Transform state in avifDecoderReset()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Parse the children of the 'iref' and 'grpl' boxes within their own
   declared box size. Files with an EntityToGroupBox carrying grouping type
   specific data after the entity_id array are no longer rejected.
+* Reset Sample Transform decoder state in avifDecoderReset() so repeated resets
+  and avifDecoderSetSource() calls do not fail.
 
 ## [1.4.2] - 2026-05-26
 

--- a/src/read.c
+++ b/src/read.c
@@ -6093,6 +6093,8 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         memset(&data->tileInfos[c].grid, 0, sizeof(data->tileInfos[c].grid));
     }
     avifDecoderDataClearTiles(data);
+    data->sampleTransformNumInputImageItems = 0;
+    avifArrayDestroy(&data->meta->sampleTransformExpression);
 
     // Prepare / cleanup decoded image state
     if (decoder->image) {

--- a/tests/gtest/avifaltrtest.cc
+++ b/tests/gtest/avifaltrtest.cc
@@ -73,6 +73,28 @@ TEST(AltrTest, SampleTransformDepthParseNextEqual) {
   EXPECT_EQ(decoder->image->depth, depth);
 }
 
+TEST(AltrTest, SampleTransformDecoderReset) {
+  const testutil::AvifRwData encoded =
+      testutil::ReadFile(std::string(data_path) + "weld_sato_12B_8B_q0.avif");
+
+  DecoderPtr decoder(avifDecoderCreate());
+  ASSERT_NE(decoder, nullptr);
+  decoder->imageContentToDecode |= AVIF_IMAGE_CONTENT_SAMPLE_TRANSFORMS;
+  ASSERT_EQ(avifDecoderSetIOMemory(decoder.get(), encoded.data, encoded.size),
+            AVIF_RESULT_OK);
+
+  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_OK);
+  ASSERT_EQ(avifDecoderReset(decoder.get()), AVIF_RESULT_OK);
+  ASSERT_EQ(avifDecoderNextImage(decoder.get()), AVIF_RESULT_OK);
+  EXPECT_EQ(decoder->image->depth, 16u);
+
+  // avifDecoderSetSource() automatically resets an already parsed decoder.
+  ASSERT_EQ(avifDecoderSetSource(decoder.get(), AVIF_DECODER_SOURCE_AUTO),
+            AVIF_RESULT_OK);
+  ASSERT_EQ(avifDecoderNextImage(decoder.get()), AVIF_RESULT_OK);
+  EXPECT_EQ(decoder->image->depth, 16u);
+}
+
 // Verifies the fix for https://github.com/AOMediaCodec/libavif/issues/2979.
 TEST(AltrTest, ZeroImageContentToDecode) {
   const std::string file_path =


### PR DESCRIPTION
`avifDecoderReset()` leaves the parsed Sample Transform expression and input count in the decoder data. Calling reset again then adds the inputs a second time. In debug builds this reaches an assertion because the count is expected to start at zero. In release builds the reset returns `AVIF_RESULT_INTERNAL_ERROR`.

Clear both fields with the rest of the per-parse decoder state. The new test uses the existing `weld_sato_12B_8B_q0.avif` fixture and covers explicit reset and the reset performed by `avifDecoderSetSource()`.

Tested with the full ASan and UBSan configuration. All 51 tests passed.