### PR TITLE
Reset Sample Transform depth in avifDecoderReset()

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -6095,6 +6095,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
     avifDecoderDataClearTiles(data);
     data->sampleTransformNumInputImageItems = 0;
     avifArrayDestroy(&data->meta->sampleTransformExpression);
+    data->meta->sampleTransformDepth = 0;
 
     // Prepare / cleanup decoded image state
     if (decoder->image) {


### PR DESCRIPTION
Follow-up to #3327. This resets sampleTransformDepth to 0 alongside the other Sample Transform state in avifDecoderReset(), as suggested in the review. A fresh Release library build passes.