### PR TITLE
Keep every target of a track 'auxl' or 'prem' reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Support a 'thmb', 'auxl', 'cdsc' or 'prem' item reference that links one item
   to several items. Only the target parsed last used to be kept, silently
   dropping the others.
+* Support a track 'auxl' or 'prem' reference that names several tracks, and
+  several such boxes in one 'tref'. Only the first track_ID of a box was read,
+  and a later box overwrote what an earlier one recorded, so the alpha track of
+  an image sequence could be dropped without a diagnostic.
 * Keep the premultiplied alpha flag of a MinimizedImageBox. The one bit
   alpha_is_premultiplied value was stored in a field compared against the alpha
   item ID, so such an image used to decode as straight alpha.

--- a/src/read.c
+++ b/src/read.c
@@ -252,21 +252,21 @@ typedef struct avifDecoderItem
 } avifDecoderItem;
 AVIF_ARRAY_DECLARE(avifDecoderItemArray, avifDecoderItem *, item);
 
-// Records "this item is a {type} for item #{toID}".
-static avifResult avifDecoderItemAddReference(avifDecoderItem * item, const char * type, uint32_t toID)
+// Records "this item or track is a {type} for #{toID}".
+static avifResult avifAddReference(avifItemReferenceArray * references, const char * type, uint32_t toID)
 {
-    avifItemReference * reference = (avifItemReference *)avifArrayPush(&item->references);
+    avifItemReference * reference = (avifItemReference *)avifArrayPush(references);
     AVIF_CHECKERR(reference != NULL, AVIF_RESULT_OUT_OF_MEMORY);
     memcpy(reference->type, type, 4);
     reference->toID = toID;
     return AVIF_RESULT_OK;
 }
 
-// Returns AVIF_TRUE if this item is a {type} for item #{toID}.
-static avifBool avifDecoderItemReferences(const avifDecoderItem * item, const char * type, uint32_t toID)
+// Returns AVIF_TRUE if this item or track is a {type} for #{toID}.
+static avifBool avifReferences(const avifItemReferenceArray * references, const char * type, uint32_t toID)
 {
-    for (uint32_t i = 0; i < item->references.count; ++i) {
-        const avifItemReference * reference = &item->references.ref[i];
+    for (uint32_t i = 0; i < references->count; ++i) {
+        const avifItemReference * reference = &references->ref[i];
         if (!memcmp(reference->type, type, 4) && reference->toID == toID) {
             return AVIF_TRUE;
         }
@@ -274,11 +274,11 @@ static avifBool avifDecoderItemReferences(const avifDecoderItem * item, const ch
     return AVIF_FALSE;
 }
 
-// Returns AVIF_TRUE if this item is a {type} for at least one item.
-static avifBool avifDecoderItemHasReference(const avifDecoderItem * item, const char * type)
+// Returns AVIF_TRUE if this item or track is a {type} for at least one item or track.
+static avifBool avifHasReference(const avifItemReferenceArray * references, const char * type)
 {
-    for (uint32_t i = 0; i < item->references.count; ++i) {
-        if (!memcmp(item->references.ref[i].type, type, 4)) {
+    for (uint32_t i = 0; i < references->count; ++i) {
+        if (!memcmp(references->ref[i].type, type, 4)) {
             return AVIF_TRUE;
         }
     }
@@ -501,8 +501,10 @@ typedef struct avifTrack
 {
     uint32_t id;
     uint8_t handlerType[4];
-    uint32_t auxForID; // if non-zero, this track is an auxC plane for Track #{auxForID}
-    uint32_t premByID; // if non-zero, this track is premultiplied by Track #{premByID}
+    // The 'auxl' and 'prem' references from this track. Section 8.3.3.2 of ISO/IEC 14496-12
+    // allows an array of track_IDs per box, and nothing stops a 'tref' from holding several
+    // boxes of the same type, so one track can hold several of these.
+    avifItemReferenceArray references;
     uint32_t mediaTimescale;
     uint64_t mediaDuration;
     uint64_t trackDuration;
@@ -1128,6 +1130,11 @@ static avifTrack * avifDecoderDataCreateTrack(avifDecoderData * data)
         avifArrayPop(&data->tracks);
         return NULL;
     }
+    if (!avifArrayCreate(&track->references, sizeof(avifItemReference), 1)) {
+        avifMetaDestroy(track->meta);
+        avifArrayPop(&data->tracks);
+        return NULL;
+    }
     return track;
 }
 
@@ -1179,6 +1186,7 @@ static void avifDecoderDataDestroy(avifDecoderData * data)
         if (track->meta) {
             avifMetaDestroy(track->meta);
         }
+        avifArrayDestroy(&track->references);
     }
     avifArrayDestroy(&data->tracks);
     avifDecoderDataClearTiles(data);
@@ -1947,7 +1955,7 @@ static avifResult avifDecoderFindMetadata(avifDecoder * decoder, avifMeta * meta
             continue;
         }
 
-        if ((colorId > 0) && !avifDecoderItemReferences(item, "cdsc", colorId)) {
+        if ((colorId > 0) && !avifReferences(&item->references, "cdsc", colorId)) {
             // Not a content description (metadata) for the colorOBU, skip it
             continue;
         }
@@ -3446,7 +3454,7 @@ static avifResult avifParseItemReferenceBox(avifMeta * meta, const uint8_t * raw
                 //   The items linked to are then represented by an array of to_item_IDs.
                 // Several boxes of the same type may also share a from_item_ID, so an item can
                 // be the source of more than one reference of a given type. Every target is kept.
-                AVIF_CHECKRES(avifDecoderItemAddReference(item, (const char *)irefHeader.type, toID));
+                AVIF_CHECKRES(avifAddReference(&item->references, (const char *)irefHeader.type, toID));
             } else if (!memcmp(irefHeader.type, "dimg", 4)) {
                 // derived images refer in the opposite direction
                 avifDecoderItem * dimg;
@@ -3910,18 +3918,28 @@ static avifBool avifTrackReferenceBox(avifTrack * track, const uint8_t * raw, si
         avifBoxHeader header;
         AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
-        if (!memcmp(header.type, "auxl", 4)) {
+        if (!memcmp(header.type, "auxl", 4) || !memcmp(header.type, "prem", 4)) {
+            // Keep refusing a box that holds no track_ID at all, as added in #3324.
             AVIF_CHECK(header.size >= sizeof(uint32_t));
-            uint32_t toID;
-            AVIF_CHECK(avifROStreamReadU32(&s, &toID));                       // unsigned int(32) track_IDs[];
-            AVIF_CHECK(avifROStreamSkip(&s, header.size - sizeof(uint32_t))); // just take the first one
-            track->auxForID = toID;
-        } else if (!memcmp(header.type, "prem", 4)) {
-            AVIF_CHECK(header.size >= sizeof(uint32_t));
-            uint32_t byID;
-            AVIF_CHECK(avifROStreamReadU32(&s, &byID));                       // unsigned int(32) track_IDs[];
-            AVIF_CHECK(avifROStreamSkip(&s, header.size - sizeof(uint32_t))); // just take the first one
-            track->premByID = byID;
+            // Section 8.3.3.2 of ISO/IEC 14496-12:
+            //   unsigned int(32) track_IDs[];
+            // There is no count field: the number of track_IDs follows from the box size. Every
+            // target is kept. Bytes that do not make up a whole track_ID are skipped as before,
+            // so this does not refuse a file that used to be read.
+            const size_t numTrackIDs = header.size / sizeof(uint32_t);
+            for (size_t i = 0; i < numTrackIDs; ++i) {
+                uint32_t toID;
+                AVIF_CHECK(avifROStreamReadU32(&s, &toID));
+                if (toID == 0) {
+                    // auxForID and premByID used to be plain IDs where 0 meant "no reference", so a
+                    // track_ID of 0 was the same as no reference at all. ISO/IEC 14496-12 does not
+                    // allow a track_ID of 0 anyway. Skipping it keeps that behaviour instead of
+                    // turning such a file into a track that suddenly declares itself auxiliary.
+                    continue;
+                }
+                AVIF_CHECK(avifAddReference(&track->references, (const char *)header.type, toID) == AVIF_RESULT_OK);
+            }
+            AVIF_CHECK(avifROStreamSkip(&s, header.size - numTrackIDs * sizeof(uint32_t)));
         } else {
             AVIF_CHECK(avifROStreamSkip(&s, header.size));
         }
@@ -4581,9 +4599,9 @@ static avifResult avifParseMinimizedImageBox(avifDecoderData * data,
 
     if (hasAlpha) {
         // Property with fixed index 7.
-        AVIF_CHECKRES(avifDecoderItemAddReference(alphaItem, "auxl", colorItem->id));
+        AVIF_CHECKRES(avifAddReference(&alphaItem->references, "auxl", colorItem->id));
         if (alphaIsPremultiplied) {
-            AVIF_CHECKRES(avifDecoderItemAddReference(colorItem, "prem", alphaItem->id));
+            AVIF_CHECKRES(avifAddReference(&colorItem->references, "prem", alphaItem->id));
         }
         avifProperty * alphaAuxProp = avifMetaCreateProperty(meta, "auxC");
         AVIF_CHECKERR(alphaAuxProp, AVIF_RESULT_OUT_OF_MEMORY);
@@ -4808,7 +4826,7 @@ static avifResult avifParseMinimizedImageBox(avifDecoderData * data,
         avifDecoderItem * exifItem;
         AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, /*itemID=*/6, &exifItem));
         memcpy(exifItem->type, "Exif", 4);
-        AVIF_CHECKRES(avifDecoderItemAddReference(exifItem, "cdsc", colorItem->id));
+        AVIF_CHECKRES(avifAddReference(&exifItem->references, "cdsc", colorItem->id));
 
         avifExtent * exifExtent = (avifExtent *)avifArrayPush(&exifItem->extents);
         AVIF_CHECKERR(exifExtent, AVIF_RESULT_OUT_OF_MEMORY);
@@ -4823,7 +4841,7 @@ static avifResult avifParseMinimizedImageBox(avifDecoderData * data,
         AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, /*itemID=*/7, &xmpItem));
         memcpy(xmpItem->type, "mime", 4);
         memcpy(xmpItem->contentType.contentType, AVIF_CONTENT_TYPE_XMP, sizeof(AVIF_CONTENT_TYPE_XMP));
-        AVIF_CHECKRES(avifDecoderItemAddReference(xmpItem, "cdsc", colorItem->id));
+        AVIF_CHECKRES(avifAddReference(&xmpItem->references, "cdsc", colorItem->id));
 
         avifExtent * xmpExtent = (avifExtent *)avifArrayPush(&xmpItem->extents);
         AVIF_CHECKERR(xmpExtent, AVIF_RESULT_OUT_OF_MEMORY);
@@ -5343,7 +5361,7 @@ static avifBool avifDecoderItemShouldBeSkipped(const avifDecoderItem * item)
 {
     return !item->size || item->hasUnsupportedEssentialProperty ||
            (avifGetCodecType(item->type) == AVIF_CODEC_TYPE_UNKNOWN && memcmp(item->type, "grid", 4)) ||
-           avifDecoderItemHasReference(item, "thmb");
+           avifHasReference(&item->references, "thmb");
 }
 
 avifResult avifDecoderParse(avifDecoder * decoder)
@@ -5541,7 +5559,7 @@ static avifDecoderItem * avifMetaFindColorItem(avifMeta * meta)
 // item.
 static avifBool avifDecoderItemIsAlphaAux(const avifDecoderItem * item, uint32_t colorItemId)
 {
-    if (!avifDecoderItemReferences(item, "auxl", colorItemId))
+    if (!avifReferences(&item->references, "auxl", colorItemId))
         return AVIF_FALSE;
     const avifProperty * auxCProp = avifPropertyArrayFind(&item->properties, "auxC");
     return auxCProp && isAlphaURN(auxCProp->u.auxC.auxType);
@@ -5755,7 +5773,7 @@ static avifResult avifDecoderDataFindToneMappedImageItem(const avifDecoderData *
 {
     for (uint32_t itemIndex = 0; itemIndex < data->meta->items.count; ++itemIndex) {
         avifDecoderItem * item = data->meta->items.item[itemIndex];
-        if (!item->size || item->hasUnsupportedEssentialProperty || avifDecoderItemHasReference(item, "thmb")) {
+        if (!item->size || item->hasUnsupportedEssentialProperty || avifHasReference(&item->references, "thmb")) {
             continue;
         }
         if (!memcmp(item->type, "tmap", 4)) {
@@ -6064,7 +6082,7 @@ static avifDecoderItem * avifDecoderDataFindSampleTransformImageItem(avifDecoder
     for (uint32_t itemIndex = 0; itemIndex < data->meta->items.count; ++itemIndex) {
         avifDecoderItem * item = data->meta->items.item[itemIndex];
         if (!memcmp(item->type, "sato", 4) && item->id != data->meta->primaryItemID && item->size != 0 &&
-            !item->hasUnsupportedEssentialProperty && !avifDecoderItemHasReference(item, "thmb") &&
+            !item->hasUnsupportedEssentialProperty && !avifHasReference(&item->references, "thmb") &&
             avifIsPreferredAlternativeTo(data, item->id, data->meta->primaryItemID)) {
             return item;
         }
@@ -6210,7 +6228,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             if (colorCodecType == AVIF_CODEC_TYPE_UNKNOWN) {
                 continue;
             }
-            if (track->auxForID != 0) {
+            if (avifHasReference(&track->references, "auxl")) {
                 continue;
             }
             // HEIF (ISO/IEC 23008-12:2022), Section 7.1:
@@ -6272,7 +6290,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
             // HEIF (ISO/IEC 23008-12:2022), Section 7.5.3.1, but old versions of libavif used to write
             // "pict" instead. See https://github.com/AOMediaCodec/libavif/commit/65d0af9
 
-            if (track->auxForID == colorTrack->id) {
+            if (avifReferences(&track->references, "auxl", colorTrack->id)) {
                 // Found it!
                 alphaProperties = properties;
                 break;
@@ -6353,7 +6371,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         decoder->image->width = colorTrack->width;
         decoder->image->height = colorTrack->height;
         decoder->alphaPresent = (alphaTrack != NULL);
-        decoder->image->alphaPremultiplied = decoder->alphaPresent && (colorTrack->premByID == alphaTrack->id);
+        decoder->image->alphaPremultiplied = decoder->alphaPresent && avifReferences(&colorTrack->references, "prem", alphaTrack->id);
     } else {
         // Create from items
 
@@ -6502,8 +6520,8 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                 AVIF_CHECKERR(!mainItems[alphaCategory] == !mainItems[AVIF_ITEM_ALPHA], AVIF_RESULT_NOT_IMPLEMENTED);
                 if (mainItems[alphaCategory] != NULL) {
                     AVIF_CHECKERR(isAlphaInputImageItemInInput == isAlphaItemInInput, AVIF_RESULT_NOT_IMPLEMENTED);
-                    AVIF_CHECKERR(avifDecoderItemReferences(mainItems[*category], "prem", mainItems[alphaCategory]->id) ==
-                                      avifDecoderItemReferences(mainItems[AVIF_ITEM_COLOR], "prem", mainItems[AVIF_ITEM_ALPHA]->id),
+                    AVIF_CHECKERR(avifReferences(&mainItems[*category]->references, "prem", mainItems[alphaCategory]->id) ==
+                                      avifReferences(&mainItems[AVIF_ITEM_COLOR]->references, "prem", mainItems[AVIF_ITEM_ALPHA]->id),
                                   AVIF_RESULT_NOT_IMPLEMENTED);
                     AVIF_CHECKRES(avifDecoderItemReadAndParse(decoder,
                                                               mainItems[alphaCategory],
@@ -6604,7 +6622,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
         decoder->image->height = mainItems[AVIF_ITEM_COLOR]->height;
         decoder->alphaPresent = (mainItems[AVIF_ITEM_ALPHA] != NULL);
         decoder->image->alphaPremultiplied =
-            decoder->alphaPresent && avifDecoderItemReferences(mainItems[AVIF_ITEM_COLOR], "prem", mainItems[AVIF_ITEM_ALPHA]->id);
+            decoder->alphaPresent && avifReferences(&mainItems[AVIF_ITEM_COLOR]->references, "prem", mainItems[AVIF_ITEM_ALPHA]->id);
 
         if (mainItems[AVIF_ITEM_ALPHA]) {
             alphaProperties = &mainItems[AVIF_ITEM_ALPHA]->properties;

--- a/src/read.c
+++ b/src/read.c
@@ -501,9 +501,9 @@ typedef struct avifTrack
 {
     uint32_t id;
     uint8_t handlerType[4];
-    // The 'auxl' and 'prem' references from this track. Section 8.3.3.2 of ISO/IEC 14496-12
-    // allows an array of track_IDs per box, and nothing stops a 'tref' from holding several
-    // boxes of the same type, so one track can hold several of these.
+    // The 'auxl' and 'prem' references from this track. Section 8.3.3.1 of ISO/IEC 14496-12
+    // says each reference type shall occur at most once, but that is not enforced for backward
+    // compatibility, and a box can name several track_IDs, so one track can hold several of these.
     avifItemReferenceArray references;
     uint32_t mediaTimescale;
     uint64_t mediaDuration;
@@ -3919,22 +3919,20 @@ static avifBool avifTrackReferenceBox(avifTrack * track, const uint8_t * raw, si
         AVIF_CHECK(avifROStreamReadBoxHeader(&s, &header));
 
         if (!memcmp(header.type, "auxl", 4) || !memcmp(header.type, "prem", 4)) {
-            // Keep refusing a box that holds no track_ID at all, as added in #3324.
+            // Refuse a box that holds no track_ID at all.
             AVIF_CHECK(header.size >= sizeof(uint32_t));
             // Section 8.3.3.2 of ISO/IEC 14496-12:
             //   unsigned int(32) track_IDs[];
-            // There is no count field: the number of track_IDs follows from the box size. Every
-            // target is kept. Bytes that do not make up a whole track_ID are skipped as before,
-            // so this does not refuse a file that used to be read.
+            // There is no count field: the number of track_IDs follows from the box size.
+            // Bytes that do not make up a whole track_ID are skipped.
             const size_t numTrackIDs = header.size / sizeof(uint32_t);
             for (size_t i = 0; i < numTrackIDs; ++i) {
                 uint32_t toID;
                 AVIF_CHECK(avifROStreamReadU32(&s, &toID));
                 if (toID == 0) {
-                    // auxForID and premByID used to be plain IDs where 0 meant "no reference", so a
-                    // track_ID of 0 was the same as no reference at all. ISO/IEC 14496-12 does not
-                    // allow a track_ID of 0 anyway. Skipping it keeps that behaviour instead of
-                    // turning such a file into a track that suddenly declares itself auxiliary.
+                    // Section 8.3.3.3 of ISO/IEC 14496-12:
+                    //   The value 0 shall not be present.
+                    // Skip it instead of rejecting for backward compatibility.
                     continue;
                 }
                 AVIF_CHECK(avifAddReference(&track->references, (const char *)header.type, toID) == AVIF_RESULT_OK);

--- a/tests/gtest/avifanimationtest.cc
+++ b/tests/gtest/avifanimationtest.cc
@@ -123,8 +123,9 @@ void WriteBE32(uint32_t value, uint8_t* bytes) {
   bytes[3] = static_cast<uint8_t>(value);
 }
 
-void AppendBox(const char* type, const std::vector<uint32_t>& track_ids,
-               std::vector<uint8_t>* bytes) {
+void AppendTrackReferenceTypeBox(const char* type,
+                                 const std::vector<uint32_t>& track_ids,
+                                 std::vector<uint8_t>* bytes) {
   const size_t size = 8 + 4 * track_ids.size();
   const size_t offset = bytes->size();
   bytes->resize(offset + size);
@@ -173,42 +174,40 @@ TEST(AvifDecodeTest, AlphaTrackWithoutEdts) {
       testutil::ReadFile(std::string(data_path) + kAlphaTrackFileName);
   ASSERT_NE(encoded.size, size_t{0});
   std::vector<uint8_t> tref;
-  AppendBox("auxl", {1}, &tref);
+  AppendTrackReferenceTypeBox("auxl", {1}, &tref);
   std::vector<uint8_t> boxes;
-  AppendBox("tref", {}, &boxes);
+  AppendTrackReferenceTypeBox("tref", {}, &boxes);
   WriteBE32(static_cast<uint32_t>(8 + tref.size()), boxes.data());
   boxes.insert(boxes.end(), tref.begin(), tref.end());
   ASSERT_NO_FATAL_FAILURE(ReplaceTrefAndEdts(boxes, &encoded));
   ExpectAlphaTrackIsFound(encoded);
 }
 
-// The 'tref' box holds two 'auxl' boxes. The second one used to overwrite the
-// track_ID read from the first, so the alpha track was no longer found.
+// The 'tref' box holds two 'auxl' boxes. Check that both are read.
 TEST(AvifDecodeTest, AlphaTrackWithTwoAuxlBoxes) {
   testutil::AvifRwData encoded =
       testutil::ReadFile(std::string(data_path) + kAlphaTrackFileName);
   ASSERT_NE(encoded.size, size_t{0});
   std::vector<uint8_t> children;
-  AppendBox("auxl", {1}, &children);
-  AppendBox("auxl", {99}, &children);
+  AppendTrackReferenceTypeBox("auxl", {1}, &children);
+  AppendTrackReferenceTypeBox("auxl", {99}, &children);
   std::vector<uint8_t> boxes;
-  AppendBox("tref", {}, &boxes);
+  AppendTrackReferenceTypeBox("tref", {}, &boxes);
   WriteBE32(static_cast<uint32_t>(8 + children.size()), boxes.data());
   boxes.insert(boxes.end(), children.begin(), children.end());
   ASSERT_NO_FATAL_FAILURE(ReplaceTrefAndEdts(boxes, &encoded));
   ExpectAlphaTrackIsFound(encoded);
 }
 
-// One 'auxl' box names two tracks. Every track_ID after the first one used to
-// be skipped, so naming the color track second lost it.
+// One 'auxl' box names two tracks. Check that both are read.
 TEST(AvifDecodeTest, AlphaTrackWithTwoTrackIds) {
   testutil::AvifRwData encoded =
       testutil::ReadFile(std::string(data_path) + kAlphaTrackFileName);
   ASSERT_NE(encoded.size, size_t{0});
   std::vector<uint8_t> children;
-  AppendBox("auxl", {99, 1}, &children);
+  AppendTrackReferenceTypeBox("auxl", {99, 1}, &children);
   std::vector<uint8_t> boxes;
-  AppendBox("tref", {}, &boxes);
+  AppendTrackReferenceTypeBox("tref", {}, &boxes);
   WriteBE32(static_cast<uint32_t>(8 + children.size()), boxes.data());
   boxes.insert(boxes.end(), children.begin(), children.end());
   ASSERT_NO_FATAL_FAILURE(ReplaceTrefAndEdts(boxes, &encoded));

--- a/tests/gtest/avifanimationtest.cc
+++ b/tests/gtest/avifanimationtest.cc
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <vector>
 
 #include "avif/avif.h"
 #include "aviftest_helpers.h"
@@ -97,6 +100,122 @@ TEST(AvifDecodeTest, AnimatedImageWithAlphaAndMetadata) {
   EXPECT_EQ(avifDecoderNextImage(decoder.get()),
             AVIF_RESULT_NO_IMAGES_REMAINING);
 }
+
+//------------------------------------------------------------------------------
+// The alpha track of colors-animated-8bpc-alpha-exif-xmp.avif holds a 20 byte
+// 'tref' box at offset 1586, with a single 'auxl' box naming track 1, directly
+// followed by a 44 byte 'edts' box. Section 8.3.3.2 of ISO/IEC 14496-12 gives
+// TrackReferenceTypeBox an array of track_IDs, and nothing limits a 'tref' to
+// one box of a given type. The cases below rewrite those 64 bytes in place and
+// pad with a 'free' box, so the file size and every absolute offset in the file
+// keep the values of the valid file.
+
+constexpr const char* kAlphaTrackFileName =
+    "colors-animated-8bpc-alpha-exif-xmp.avif";
+constexpr size_t kTrefOffset = 1586;
+constexpr size_t kTrefSize = 20;
+constexpr size_t kTrefAndEdtsSize = 64;
+
+void WriteBE32(uint32_t value, uint8_t* bytes) {
+  bytes[0] = static_cast<uint8_t>(value >> 24);
+  bytes[1] = static_cast<uint8_t>(value >> 16);
+  bytes[2] = static_cast<uint8_t>(value >> 8);
+  bytes[3] = static_cast<uint8_t>(value);
+}
+
+void AppendBox(const char* type, const std::vector<uint32_t>& track_ids,
+               std::vector<uint8_t>* bytes) {
+  const size_t size = 8 + 4 * track_ids.size();
+  const size_t offset = bytes->size();
+  bytes->resize(offset + size);
+  WriteBE32(static_cast<uint32_t>(size), bytes->data() + offset);
+  std::memcpy(bytes->data() + offset + 4, type, 4);
+  for (size_t i = 0; i < track_ids.size(); ++i) {
+    WriteBE32(track_ids[i], bytes->data() + offset + 8 + 4 * i);
+  }
+}
+
+// Overwrites the 'tref' and 'edts' boxes of the alpha track with |boxes| and
+// fills the rest of the 64 bytes with a 'free' box.
+void ReplaceTrefAndEdts(const std::vector<uint8_t>& boxes,
+                        testutil::AvifRwData* encoded) {
+  ASSERT_GE(encoded->size, kTrefOffset + kTrefAndEdtsSize);
+  uint8_t* p = encoded->data + kTrefOffset;
+  // Sanity check: the fixture is the file these tests were authored against.
+  ASSERT_EQ(std::memcmp(p + 4, "tref", 4), 0);
+  ASSERT_EQ(std::memcmp(p + kTrefSize + 4, "edts", 4), 0);
+  ASSERT_LE(boxes.size() + 8, kTrefAndEdtsSize);
+  std::copy(boxes.begin(), boxes.end(), p);
+  uint8_t* free_box = p + boxes.size();
+  const size_t free_size = kTrefAndEdtsSize - boxes.size();
+  WriteBE32(static_cast<uint32_t>(free_size), free_box);
+  std::memcpy(free_box + 4, "free", 4);
+  std::memset(free_box + 8, 0, free_size - 8);
+}
+
+void ExpectAlphaTrackIsFound(const testutil::AvifRwData& encoded) {
+  DecoderPtr decoder(avifDecoderCreate());
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderSetIOMemory(decoder.get(), encoded.data, encoded.size),
+            AVIF_RESULT_OK);
+  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_OK);
+  EXPECT_EQ(decoder->alphaPresent, AVIF_TRUE);
+  EXPECT_EQ(decoder->imageSequenceTrackPresent, AVIF_TRUE);
+  EXPECT_EQ(decoder->imageCount, 5);
+}
+
+// Control for the two cases below. The alpha track keeps its single reference,
+// only its 'edts' box is replaced by a 'free' box. Dropping it leaves that
+// track's repetition count unknown, which the decoder takes from the color
+// track anyway, so the alpha track still has to be found.
+TEST(AvifDecodeTest, AlphaTrackWithoutEdts) {
+  testutil::AvifRwData encoded =
+      testutil::ReadFile(std::string(data_path) + kAlphaTrackFileName);
+  ASSERT_NE(encoded.size, size_t{0});
+  std::vector<uint8_t> tref;
+  AppendBox("auxl", {1}, &tref);
+  std::vector<uint8_t> boxes;
+  AppendBox("tref", {}, &boxes);
+  WriteBE32(static_cast<uint32_t>(8 + tref.size()), boxes.data());
+  boxes.insert(boxes.end(), tref.begin(), tref.end());
+  ASSERT_NO_FATAL_FAILURE(ReplaceTrefAndEdts(boxes, &encoded));
+  ExpectAlphaTrackIsFound(encoded);
+}
+
+// The 'tref' box holds two 'auxl' boxes. The second one used to overwrite the
+// track_ID read from the first, so the alpha track was no longer found.
+TEST(AvifDecodeTest, AlphaTrackWithTwoAuxlBoxes) {
+  testutil::AvifRwData encoded =
+      testutil::ReadFile(std::string(data_path) + kAlphaTrackFileName);
+  ASSERT_NE(encoded.size, size_t{0});
+  std::vector<uint8_t> children;
+  AppendBox("auxl", {1}, &children);
+  AppendBox("auxl", {99}, &children);
+  std::vector<uint8_t> boxes;
+  AppendBox("tref", {}, &boxes);
+  WriteBE32(static_cast<uint32_t>(8 + children.size()), boxes.data());
+  boxes.insert(boxes.end(), children.begin(), children.end());
+  ASSERT_NO_FATAL_FAILURE(ReplaceTrefAndEdts(boxes, &encoded));
+  ExpectAlphaTrackIsFound(encoded);
+}
+
+// One 'auxl' box names two tracks. Every track_ID after the first one used to
+// be skipped, so naming the color track second lost it.
+TEST(AvifDecodeTest, AlphaTrackWithTwoTrackIds) {
+  testutil::AvifRwData encoded =
+      testutil::ReadFile(std::string(data_path) + kAlphaTrackFileName);
+  ASSERT_NE(encoded.size, size_t{0});
+  std::vector<uint8_t> children;
+  AppendBox("auxl", {99, 1}, &children);
+  std::vector<uint8_t> boxes;
+  AppendBox("tref", {}, &boxes);
+  WriteBE32(static_cast<uint32_t>(8 + children.size()), boxes.data());
+  boxes.insert(boxes.end(), children.begin(), children.end());
+  ASSERT_NO_FATAL_FAILURE(ReplaceTrefAndEdts(boxes, &encoded));
+  ExpectAlphaTrackIsFound(encoded);
+}
+
+//------------------------------------------------------------------------------
 
 TEST(AvifDecodeTest, AnimatedImageWithAlphaAndMetadataIgnoreAlpha) {
   const char* file_name = "colors-animated-8bpc-alpha-exif-xmp.avif";


### PR DESCRIPTION
Follow-up to your note on #3331, that `avifTrack`s have a similar issue with
`auxForID` and `premByID` not being arrays:
https://github.com/AOMediaCodec/libavif/pull/3331#discussion_r3844045380

`avifTrackReferenceBox` loses track references in two ways.

The first is the one the code comment admits to:

    AVIF_CHECK(avifROStreamReadU32(&s, &toID));                       // unsigned int(32) track_IDs[];
    AVIF_CHECK(avifROStreamSkip(&s, header.size - sizeof(uint32_t))); // just take the first one

Section 8.3.3.2 of ISO/IEC 14496-12 gives TrackReferenceTypeBox an array of
track_IDs with no count field, so the number of entries follows from the box
size and everything after the first is dropped.

The second is that `track->auxForID = toID` is unconditional, and nothing limits
a 'tref' to one box of a given type, so a second 'auxl' box overwrites what the
first one recorded. `avifParseTrackBox` keeps a seen flag for 'tkhd' and for
'edts' but not for 'tref', so several 'tref' boxes in one 'trak' do the same.

## What it costs

`auxForID` is compared against `colorTrack->id` when the alpha track is looked
up. If the color track is not the target that survived, the loop ends without a
match, `alphaTrack` stays null and `decoder->alphaPresent` is false. There is no
diagnostic and no error code: the file decodes as a plain color sequence.

`premByID` has the same shape, with `alphaPremultiplied` as its consumer. I did
not build a file for that path, so I am reporting it from the code rather than
from a run.

You wrote that this may be less of a problem, and that matches what it does: a
file that a conformant reader shows with alpha decodes here without it, quietly.
There is no attacker gain and no memory error in it.

## The change

The three reference helpers added in #3331 are renamed and now take the
`avifItemReferenceArray` instead of the item, so tracks can use them unchanged.
That is why the diff touches the item call sites.

`avifTrack` gets the same `references` array, created with the track and
destroyed with it. `avifTrackReferenceBox` reads track_IDs until the box runs
out, and the three places that compared `auxForID` and `premByID` now ask
`avifReferences` and `avifHasReference`.

Three deliberate decisions, so they do not have to be found in the diff:

1. The `header.size >= sizeof(uint32_t)` check from #3324 stays, so a box that
   holds no track_ID at all is still refused.
2. The box size is not required to be a multiple of four. Trailing bytes that do
   not make up a whole track_ID are skipped as before.
3. A track_ID of 0 is skipped rather than recorded. `auxForID` was an in-band
   sentinel where 0 meant "no reference", so recording it would turn a file that
   used to read as "no reference" into one that has one. The item side answers
   the same question differently: `avifParseItemReferenceBox` passes to_item_ID
   through `avifCheckItemID`, which refuses 0 outright. There is no equivalent
   check for track_IDs today, and adding one would refuse files that are read
   now, so this skips instead. Happy to make it refuse if you prefer the item
   side's answer here too.

That third one is a compatibility choice, not a measurement, and it is not
complete: a 'tref' whose only 'auxl' names 0 and then a real track used to leave
`auxForID` at 0, so the track stayed a color candidate. It now has a reference
and is skipped, and if it were the only usable track the decode would end in
`AVIF_RESULT_NO_CONTENT`. I think refusing to treat a track that declares itself
auxiliary as the color track is the better reading, but say the word if you would
rather keep the old one.

## Tests

The alpha track of `colors-animated-8bpc-alpha-exif-xmp.avif` holds a 20 byte
'tref' at offset 1586 with one 'auxl' box naming track 1, directly followed by a
44 byte 'edts'. The three tests rewrite those 64 bytes in place and pad with a
'free' box, so the file size and every absolute offset in it are untouched, which
matters because the file carries 'iloc' and 'stco' entries.

The first test is the control: it keeps the single reference and only turns the
'edts' box into a 'free' box, so the rewrite itself does not cost the alpha
channel. Dropping 'edts' leaves that track's repetition count unknown, which the
decoder takes from the color track.

The other two present the two cases above: two 'auxl' boxes, and one 'auxl' box
naming two tracks with the color track second. They fail without the change and
pass with it, and the control passes either way.

## One thing I left alone

`avifTrackReferenceBox` still returns `avifBool`, so an allocation failure inside
it surfaces as `AVIF_RESULT_BMFF_PARSE_FAILED` rather than
`AVIF_RESULT_OUT_OF_MEMORY`. Changing the signature would widen the diff; happy
to do it here if you would rather have it in one go.
