### PR TITLE
Support grids with too many items for 16-bit item IDs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ The changes are relative to the previous release, unless the baseline is specifi
 * Keep the premultiplied alpha flag of a MinimizedImageBox. The one bit
   alpha_is_premultiplied value was stored in a field compared against the alpha
   item ID, so such an image used to decode as straight alpha.
+* Support encoding image grids containing more items than the 16-bit item ID
+  space allows, such as a color grid and an alpha grid of 128x256 cells each
+  (65538 items in total). The encoder now relies on 32-bit item IDs and writes
+  the 'infe' version 3, 'iloc' version 2, 'iref' version 1 and 'ipma' version 1
+  boxes when item IDs do not fit on 16 bits, instead of silently overflowing
+  them and generating an invalid file.
+* Reject grids with more than 65535 cells (e.g. 256x256 cells) with
+  AVIF_RESULT_INVALID_IMAGE_GRID instead of generating an invalid file:
+  ISO/IEC 14496-12 Section 8.11.12 requires all references from one item to
+  fit in a single item type reference box with a 16-bit reference_count field
+  (and ISO/IEC 23008-12 Section 6.6.1 forbids splitting them across several
+  'dimg' boxes).
 
 ## [1.4.2] - 2026-05-26
 

--- a/src/write.c
+++ b/src/write.c
@@ -163,7 +163,7 @@ void avifCodecEncodeOutputDestroy(avifCodecEncodeOutput * encodeOutput)
 // one "item" worth for encoder
 typedef struct avifEncoderItem
 {
-    uint16_t id;
+    uint32_t id;                          // Item IDs are unsigned int(32) in the file format (ISO/IEC 14496-12 Section 8.11.6)
     uint8_t type[4];                      // 4-character 'item_type' field in the 'infe' (item info entry) box
     avifCodec * codec;                    // only present on image items
     avifCodecEncodeOutput * encodeOutput; // AV1 sample data
@@ -180,7 +180,7 @@ typedef struct avifEncoderItem
     size_t infeContentTypeSize;
     avifOffsetFixupArray mdatFixups;
 
-    uint16_t irefToID; // if non-zero, make an iref from this id -> irefToID
+    uint32_t irefToID; // if non-zero, make an iref from this id -> irefToID
     const char * irefType;
 
     uint32_t gridCols; // if non-zero (legal range [1-256]), this is a grid item
@@ -192,7 +192,7 @@ typedef struct avifEncoderItem
 
     uint32_t extraLayerCount; // if non-zero (legal range [1-(AVIF_MAX_AV1_LAYER_COUNT-1)]), this is a layered AV1 image
 
-    uint16_t dimgFromID; // if non-zero, make an iref from dimgFromID -> this id
+    uint32_t dimgFromID; // if non-zero, make an iref from dimgFromID -> this id
 
     avifItemPropertyAssociationArray associations; // 'ipma'
 } avifEncoderItem;
@@ -217,7 +217,7 @@ AVIF_ARRAY_DECLARE(avifEncoderFrameArray, avifEncoderFrame, frame);
 // ---------------------------------------------------------------------------
 // avifEncoderData
 
-AVIF_ARRAY_DECLARE(avifEncoderItemIdArray, uint16_t, itemID);
+AVIF_ARRAY_DECLARE(avifEncoderItemIdArray, uint32_t, itemID);
 
 typedef struct avifEncoderData
 {
@@ -243,8 +243,8 @@ typedef struct avifEncoderData
     avifImage * imageMetadata;
     // Holds metadata derived from the avifGainMap struct (when present) about the alternate image
     avifImage * altImageMetadata;
-    uint16_t lastItemID;
-    uint16_t primaryItemID;
+    uint32_t lastItemID;
+    uint32_t primaryItemID;
     avifEncoderItemIdArray alternativeItemIDs; // list of item ids for an 'altr' box (group of alternatives to each other)
     avifBool singleImage; // if true, the AVIF_ADD_IMAGE_FLAG_SINGLE flag was set on the first call to avifEncoderAddImage()
     avifBool alphaPresent;
@@ -278,7 +278,7 @@ static avifEncoderData * avifEncoderDataCreate(void)
     if (!avifArrayCreate(&data->frames, sizeof(avifEncoderFrame), 1)) {
         goto error;
     }
-    if (!avifArrayCreate(&data->alternativeItemIDs, sizeof(uint16_t), 1)) {
+    if (!avifArrayCreate(&data->alternativeItemIDs, sizeof(uint32_t), 1)) {
         goto error;
     }
     return data;
@@ -290,6 +290,11 @@ error:
 
 static avifEncoderItem * avifEncoderDataCreateItem(avifEncoderData * data, const char * type, const char * infeName, size_t infeNameSize, uint32_t cellIndex)
 {
+    if (data->lastItemID == UINT32_MAX) {
+        // Item IDs are unsigned int(32) in the file format and the item ID 0 is invalid
+        // (ISO/IEC 14496-12 Section 8.11.1.1), so all possible IDs were used by the previous items.
+        return NULL;
+    }
     avifEncoderItem * item = (avifEncoderItem *)avifArrayPush(&data->items);
     if (item == NULL) {
         return NULL;
@@ -322,7 +327,7 @@ error:
     return NULL;
 }
 
-static avifEncoderItem * avifEncoderDataFindItemByID(avifEncoderData * data, uint16_t id)
+static avifEncoderItem * avifEncoderDataFindItemByID(avifEncoderData * data, uint32_t id)
 {
     for (uint32_t itemIndex = 0; itemIndex < data->items.count; ++itemIndex) {
         avifEncoderItem * item = &data->items.item[itemIndex];
@@ -887,11 +892,11 @@ static avifResult avifEncoderWriteTrackMetaBox(avifEncoder * encoder, avifRWStre
             continue;
         }
 
-        AVIF_CHECKRES(avifRWStreamWriteU16(s, item->id));          // unsigned int(16) item_ID;
-        AVIF_CHECKRES(avifRWStreamWriteU16(s, 0));                 // unsigned int(16) data_reference_index;
-        AVIF_CHECKRES(avifRWStreamWriteU16(s, 1));                 // unsigned int(16) extent_count;
-        AVIF_CHECKRES(avifEncoderItemAddMdatFixup(item, s));       //
-        AVIF_CHECKRES(avifRWStreamWriteU32(s, 0 /* set later */)); // unsigned int(offset_size*8) extent_offset;
+        AVIF_CHECKRES(avifRWStreamWriteU16(s, (uint16_t)item->id)); // unsigned int(16) item_ID;
+        AVIF_CHECKRES(avifRWStreamWriteU16(s, 0));                  // unsigned int(16) data_reference_index;
+        AVIF_CHECKRES(avifRWStreamWriteU16(s, 1));                  // unsigned int(16) extent_count;
+        AVIF_CHECKRES(avifEncoderItemAddMdatFixup(item, s));        //
+        AVIF_CHECKRES(avifRWStreamWriteU32(s, 0 /* set later */));  // unsigned int(offset_size*8) extent_offset;
         AVIF_CHECKRES(avifRWStreamWriteU32(s, (uint32_t)item->metadataPayload.size)); // unsigned int(length_size*8) extent_length;
     }
     AVIF_CHECKRES(avifRWStreamFinishBox(s, iloc));
@@ -908,7 +913,9 @@ static avifResult avifEncoderWriteTrackMetaBox(avifEncoder * encoder, avifRWStre
         AVIF_ASSERT_OR_RETURN(!item->hiddenImage);
         avifBoxMarker infe;
         AVIF_CHECKRES(avifRWStreamWriteFullBox(s, "infe", AVIF_BOX_SIZE_TBD, 2, 0, &infe));
-        AVIF_CHECKRES(avifRWStreamWriteU16(s, item->id));                             // unsigned int(16) item_ID;
+        // The trak meta box only contains metadata items (Exif/XMP) of image sequences,
+        // which are too few to require 32-bit item IDs.
+        AVIF_CHECKRES(avifRWStreamWriteU16(s, (uint16_t)item->id));                   // unsigned int(16) item_ID;
         AVIF_CHECKRES(avifRWStreamWriteU16(s, 0));                                    // unsigned int(16) item_protection_index;
         AVIF_CHECKRES(avifRWStreamWrite(s, item->type, 4));                           // unsigned int(32) item_type;
         AVIF_CHECKRES(avifRWStreamWriteChars(s, item->infeName, item->infeNameSize)); // string item_name; (writing null terminator)
@@ -1245,7 +1252,7 @@ static const char * getInfeName(avifItemCategory itemCategory)
 
 // Adds the items for a single cell or a grid of cells. Outputs the topLevelItemID which is
 // the only item if there is exactly one cell, or the grid item for multiple cells.
-// Note: The topLevelItemID output argument has the type uint16_t* instead of avifEncoderItem** because
+// Note: The topLevelItemID output argument has the type uint32_t* instead of avifEncoderItem** because
 //       the avifEncoderItem pointer may be invalidated by a call to avifEncoderDataCreateItem().
 static avifResult avifEncoderAddImageItems(avifEncoder * encoder,
                                            uint32_t gridCols,
@@ -1253,7 +1260,7 @@ static avifResult avifEncoderAddImageItems(avifEncoder * encoder,
                                            uint32_t gridWidth,
                                            uint32_t gridHeight,
                                            avifItemCategory itemCategory,
-                                           uint16_t * topLevelItemID)
+                                           uint32_t * topLevelItemID)
 {
     const uint32_t cellCount = gridCols * gridRows;
     const char * infeName = getInfeName(itemCategory);
@@ -1295,7 +1302,7 @@ static avifResult avifEncoderCreateBitDepthExtensionItems(avifEncoder * encoder,
                                                           uint32_t gridRows,
                                                           uint32_t gridWidth,
                                                           uint32_t gridHeight,
-                                                          uint16_t colorItemID)
+                                                          uint32_t colorItemID)
 {
     AVIF_ASSERT_OR_RETURN(encoder->sampleTransformRecipe == AVIF_SAMPLE_TRANSFORM_BIT_DEPTH_EXTENSION_8B_8B ||
                           encoder->sampleTransformRecipe == AVIF_SAMPLE_TRANSFORM_BIT_DEPTH_EXTENSION_12B_4B ||
@@ -1321,17 +1328,17 @@ static avifResult avifEncoderCreateBitDepthExtensionItems(avifEncoder * encoder,
                                                                       /*cellIndex=*/0);
     AVIF_CHECKRES(avifEncoderWriteSampleTransformPayload(encoder, &sampleTransformItem->metadataPayload));
     sampleTransformItem->itemCategory = AVIF_ITEM_SAMPLE_TRANSFORM;
-    uint16_t sampleTransformItemID = sampleTransformItem->id;
+    uint32_t sampleTransformItemID = sampleTransformItem->id;
     // 'altr' group
     AVIF_ASSERT_OR_RETURN(encoder->data->alternativeItemIDs.count == 0);
-    uint16_t * alternativeItemID = (uint16_t *)avifArrayPush(&encoder->data->alternativeItemIDs);
+    uint32_t * alternativeItemID = (uint32_t *)avifArrayPush(&encoder->data->alternativeItemIDs);
     AVIF_CHECKERR(alternativeItemID != NULL, AVIF_RESULT_OUT_OF_MEMORY);
     *alternativeItemID = sampleTransformItem->id;
-    alternativeItemID = (uint16_t *)avifArrayPush(&encoder->data->alternativeItemIDs);
+    alternativeItemID = (uint32_t *)avifArrayPush(&encoder->data->alternativeItemIDs);
     AVIF_CHECKERR(alternativeItemID != NULL, AVIF_RESULT_OUT_OF_MEMORY);
     *alternativeItemID = colorItemID;
 
-    uint16_t bitDepthExtensionColorItemId;
+    uint32_t bitDepthExtensionColorItemId;
     AVIF_CHECKRES(
         avifEncoderAddImageItems(encoder, gridCols, gridRows, gridWidth, gridHeight, AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_COLOR, &bitDepthExtensionColorItemId));
     avifEncoderItem * bitDepthExtensionColorItem = avifEncoderDataFindItemByID(encoder->data, bitDepthExtensionColorItemId);
@@ -1350,7 +1357,7 @@ static avifResult avifEncoderCreateBitDepthExtensionItems(avifEncoder * encoder,
     bitDepthExtensionColorItem->dimgFromID = sampleTransformItemID;
 
     if (encoder->data->alphaPresent) {
-        uint16_t bitDepthExtensionAlphaItemId;
+        uint32_t bitDepthExtensionAlphaItemId;
         AVIF_CHECKRES(
             avifEncoderAddImageItems(encoder, gridCols, gridRows, gridWidth, gridHeight, AVIF_ITEM_SAMPLE_TRANSFORM_INPUT_0_ALPHA, &bitDepthExtensionAlphaItemId));
         avifEncoderItem * bitDepthExtensionAlphaItem = avifEncoderDataFindItemByID(encoder->data, bitDepthExtensionAlphaItemId);
@@ -1876,7 +1883,7 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         }
 
         // Prepare all AV1 items
-        uint16_t colorItemID;
+        uint32_t colorItemID;
         AVIF_CHECKRES(avifEncoderAddImageItems(encoder, gridCols, gridRows, gridWidth, gridHeight, AVIF_ITEM_COLOR, &colorItemID));
         encoder->data->primaryItemID = colorItemID;
 
@@ -1902,7 +1909,7 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
         }
 
         if (encoder->data->alphaPresent) {
-            uint16_t alphaItemID;
+            uint32_t alphaItemID;
             AVIF_CHECKRES(avifEncoderAddImageItems(encoder, gridCols, gridRows, gridWidth, gridHeight, AVIF_ITEM_ALPHA, &alphaItemID));
             avifEncoderItem * alphaItem = avifEncoderDataFindItemByID(encoder->data, alphaItemID);
             AVIF_ASSERT_OR_RETURN(alphaItem);
@@ -1925,14 +1932,14 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             AVIF_CHECKRES(avifWriteToneMappedImagePayload(&toneMappedItem->metadataPayload, firstCell->gainMap, &encoder->diag));
             // Even though the 'tmap' item is related to the gain map, it represents a color image and its metadata is more similar to the color item.
             toneMappedItem->itemCategory = AVIF_ITEM_COLOR;
-            uint16_t toneMappedItemID = toneMappedItem->id;
+            uint32_t toneMappedItemID = toneMappedItem->id;
 
             AVIF_ASSERT_OR_RETURN(encoder->data->alternativeItemIDs.count == 0);
-            uint16_t * alternativeItemID = (uint16_t *)avifArrayPush(&encoder->data->alternativeItemIDs);
+            uint32_t * alternativeItemID = (uint32_t *)avifArrayPush(&encoder->data->alternativeItemIDs);
             AVIF_CHECKERR(alternativeItemID != NULL, AVIF_RESULT_OUT_OF_MEMORY);
             *alternativeItemID = toneMappedItemID;
 
-            alternativeItemID = (uint16_t *)avifArrayPush(&encoder->data->alternativeItemIDs);
+            alternativeItemID = (uint32_t *)avifArrayPush(&encoder->data->alternativeItemIDs);
             AVIF_CHECKERR(alternativeItemID != NULL, AVIF_RESULT_OUT_OF_MEMORY);
             *alternativeItemID = colorItemID;
 
@@ -1941,7 +1948,7 @@ static avifResult avifEncoderAddImageInternal(avifEncoder * encoder,
             const uint32_t gainMapGridHeight =
                 avifGridHeight(gridRows, cellImages[0]->gainMap->image, cellImages[gridCols * gridRows - 1]->gainMap->image);
 
-            uint16_t gainMapItemID;
+            uint32_t gainMapItemID;
             AVIF_CHECKRES(
                 avifEncoderAddImageItems(encoder, gridCols, gridRows, gainMapGridWidth, gainMapGridHeight, AVIF_ITEM_GAIN_MAP, &gainMapItemID));
             avifEncoderItem * gainMapItem = avifEncoderDataFindItemByID(encoder->data, gainMapItemID);
@@ -2152,6 +2159,20 @@ avifResult avifEncoderAddImageGrid(avifEncoder * encoder,
 {
     avifDiagnosticsClearError(&encoder->diag);
     if ((gridCols == 0) || (gridCols > 256) || (gridRows == 0) || (gridRows > 256)) {
+        return AVIF_RESULT_INVALID_IMAGE_GRID;
+    }
+    if ((uint64_t)gridCols * gridRows > 65535) {
+        // Section 8.11.12.1 of ISO/IEC 14496-12: "All the references for one item of a specific type
+        // are collected into a single item type reference box", whose reference_count field is
+        // unsigned int(16) whatever the 'iref' version (Section 8.11.12.2). Moreover, ISO/IEC 23008-12
+        // (HEIF) Section 6.6.1 states that "The number of SingleItemTypeReferenceBoxes with the box
+        // type 'dimg' and with the same value of from_item_ID shall not be greater than 1".
+        // A grid item therefore cannot reference more than 65535 cell items, so a 256x256-cell grid
+        // cannot be encoded in a conformant way, whatever the item ID width.
+        avifDiagnosticsPrintf(&encoder->diag,
+                              "avifEncoderAddImageGrid() failed because a grid cannot have more than 65535 cells due to the 16-bit 'dimg' reference_count field (%u columns x %u rows)",
+                              gridCols,
+                              gridRows);
         return AVIF_RESULT_INVALID_IMAGE_GRID;
     }
     if (encoder->extraLayerCount == 0) {
@@ -3334,25 +3355,47 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     // Write pitm
 
     if (encoder->data->primaryItemID != 0) {
-        AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "pitm", sizeof(uint16_t), 0, 0, /*marker=*/NULL));
-        AVIF_CHECKRES(avifRWStreamWriteU16(&s, encoder->data->primaryItemID)); //  unsigned int(16) item_ID;
+        if (encoder->data->primaryItemID <= UINT16_MAX) {
+            AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "pitm", sizeof(uint16_t), 0, 0, /*marker=*/NULL));
+            AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)encoder->data->primaryItemID)); //  unsigned int(16) item_ID;
+        } else {
+            // Section 8.11.4.2 of ISO/IEC 14496-12: item_ID is unsigned int(32) if the pitm version is 1.
+            AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "pitm", sizeof(uint32_t), 1, 0, /*marker=*/NULL));
+            AVIF_CHECKRES(avifRWStreamWriteU32(&s, encoder->data->primaryItemID)); //  unsigned int(32) item_ID;
+        }
     }
 
     // -----------------------------------------------------------------------
     // Write iloc
 
+    // Section 8.11.3 of ISO/IEC 14496-12: if the item count or any item ID does not fit on 16 bits,
+    // the 'iloc' box shall use version 2, the 'iinf' box version 1 with 'infe' version 3 entries,
+    // the 'iref' box version 1, and the 'ipma' box version 1. Item IDs are consecutive and start at
+    // 1, so all item IDs fit on 16 bits if and only if the last item ID does.
+    const avifBool largeItemIDs = (encoder->data->lastItemID > UINT16_MAX);
+
     avifBoxMarker iloc;
-    AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "iloc", AVIF_BOX_SIZE_TBD, 0, 0, &iloc));
-    AVIF_CHECKRES(avifRWStreamWriteBits(&s, 4, /*bitCount=*/4));                   // unsigned int(4) offset_size;
-    AVIF_CHECKRES(avifRWStreamWriteBits(&s, 4, /*bitCount=*/4));                   // unsigned int(4) length_size;
-    AVIF_CHECKRES(avifRWStreamWriteBits(&s, 0, /*bitCount=*/4));                   // unsigned int(4) base_offset_size;
-    AVIF_CHECKRES(avifRWStreamWriteBits(&s, 0, /*bitCount=*/4));                   // unsigned int(4) reserved;
-    AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)encoder->data->items.count)); // unsigned int(16) item_count;
+    AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "iloc", AVIF_BOX_SIZE_TBD, largeItemIDs ? 2 : 0, 0, &iloc));
+    AVIF_CHECKRES(avifRWStreamWriteBits(&s, 4, /*bitCount=*/4)); // unsigned int(4) offset_size;
+    AVIF_CHECKRES(avifRWStreamWriteBits(&s, 4, /*bitCount=*/4)); // unsigned int(4) length_size;
+    AVIF_CHECKRES(avifRWStreamWriteBits(&s, 0, /*bitCount=*/4)); // unsigned int(4) base_offset_size;
+    AVIF_CHECKRES(avifRWStreamWriteBits(&s, 0, /*bitCount=*/4)); // unsigned int(4) index_size (version 1/2) or reserved (version 0);
+    if (largeItemIDs) {
+        AVIF_CHECKRES(avifRWStreamWriteU32(&s, encoder->data->items.count)); // unsigned int(32) item_count;
+    } else {
+        AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)encoder->data->items.count)); // unsigned int(16) item_count;
+    }
 
     for (uint32_t itemIndex = 0; itemIndex < encoder->data->items.count; ++itemIndex) {
         avifEncoderItem * item = &encoder->data->items.item[itemIndex];
-        AVIF_CHECKRES(avifRWStreamWriteU16(&s, item->id)); // unsigned int(16) item_ID;
-        AVIF_CHECKRES(avifRWStreamWriteU16(&s, 0));        // unsigned int(16) data_reference_index;
+        if (largeItemIDs) {
+            AVIF_CHECKRES(avifRWStreamWriteU32(&s, item->id));            // unsigned int(32) item_ID;
+            AVIF_CHECKRES(avifRWStreamWriteBits(&s, 0, /*bitCount=*/12)); // unsigned int(12) reserved = 0;
+            AVIF_CHECKRES(avifRWStreamWriteBits(&s, 0, /*bitCount=*/4)); // unsigned int(4) construction_method = 0 (file offset);
+        } else {
+            AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)item->id)); // unsigned int(16) item_ID;
+        }
+        AVIF_CHECKRES(avifRWStreamWriteU16(&s, 0)); // unsigned int(16) data_reference_index;
 
         // Layered Image, write location for all samples
         if (item->extraLayerCount > 0) {
@@ -3389,16 +3432,24 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
 
     // Section 8.11.6.2 of ISO/IEC 14496-12.
     avifBoxMarker iinf;
-    AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "iinf", AVIF_BOX_SIZE_TBD, 0, 0, &iinf));
-    AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)encoder->data->items.count)); //  unsigned int(16) entry_count;
+    AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "iinf", AVIF_BOX_SIZE_TBD, largeItemIDs ? 1 : 0, 0, &iinf));
+    if (largeItemIDs) {
+        AVIF_CHECKRES(avifRWStreamWriteU32(&s, encoder->data->items.count)); //  unsigned int(32) entry_count;
+    } else {
+        AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)encoder->data->items.count)); //  unsigned int(16) entry_count;
+    }
 
     for (uint32_t itemIndex = 0; itemIndex < encoder->data->items.count; ++itemIndex) {
         avifEncoderItem * item = &encoder->data->items.item[itemIndex];
 
         uint32_t flags = item->hiddenImage ? 1 : 0;
         avifBoxMarker infe;
-        AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "infe", AVIF_BOX_SIZE_TBD, 2, flags, &infe));
-        AVIF_CHECKRES(avifRWStreamWriteU16(&s, item->id));                             // unsigned int(16) item_ID;
+        AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "infe", AVIF_BOX_SIZE_TBD, largeItemIDs ? 3 : 2, flags, &infe));
+        if (largeItemIDs) {
+            AVIF_CHECKRES(avifRWStreamWriteU32(&s, item->id)); // unsigned int(32) item_ID;
+        } else {
+            AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)item->id)); // unsigned int(16) item_ID;
+        }
         AVIF_CHECKRES(avifRWStreamWriteU16(&s, 0));                                    // unsigned int(16) item_protection_index;
         AVIF_CHECKRES(avifRWStreamWrite(&s, item->type, 4));                           // unsigned int(32) item_type;
         AVIF_CHECKRES(avifRWStreamWriteChars(&s, item->infeName, item->infeNameSize)); // utf8string item_name; (writing null terminator)
@@ -3418,30 +3469,79 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     // Write iref boxes
 
     avifBoxMarker iref = 0;
+
+    // A grid, tone mapped or sample transform item is the target of the 'dimg' references of its
+    // cell items, and there are at most a handful of such targets. Listing them first avoids an
+    // O(items²) scan below, which is noticeably slow for a 256x256-cell grid (65537 items).
+    uint32_t dimgTargetIDs[16];
+    uint32_t dimgTargetIDCount = 0;
+    avifBool anyItemMayBeDimgTarget = AVIF_FALSE;
+    for (uint32_t dimgIndex = 0; dimgIndex < encoder->data->items.count; ++dimgIndex) {
+        const uint32_t dimgFromID = encoder->data->items.item[dimgIndex].dimgFromID;
+        if (dimgFromID == 0) {
+            continue;
+        }
+        avifBool isKnownTarget = AVIF_FALSE;
+        for (uint32_t targetIndex = 0; targetIndex < dimgTargetIDCount; ++targetIndex) {
+            if (dimgTargetIDs[targetIndex] == dimgFromID) {
+                isKnownTarget = AVIF_TRUE;
+                break;
+            }
+        }
+        if (!isKnownTarget) {
+            if (dimgTargetIDCount == sizeof(dimgTargetIDs) / sizeof(dimgTargetIDs[0])) {
+                // Unexpected: fall back to scanning every item as a potential 'dimg' target.
+                anyItemMayBeDimgTarget = AVIF_TRUE;
+                break;
+            }
+            dimgTargetIDs[dimgTargetIDCount++] = dimgFromID;
+        }
+    }
+
     for (uint32_t itemIndex = 0; itemIndex < encoder->data->items.count; ++itemIndex) {
         avifEncoderItem * item = &encoder->data->items.item[itemIndex];
 
         // Count how many other items refer to this item with dimgFromID
-        uint16_t dimgCount = 0;
-        for (uint32_t dimgIndex = 0; dimgIndex < encoder->data->items.count; ++dimgIndex) {
-            avifEncoderItem * dimgItem = &encoder->data->items.item[dimgIndex];
-            if (dimgItem->dimgFromID == item->id) {
-                ++dimgCount;
+        avifBool isDimgTarget = anyItemMayBeDimgTarget;
+        for (uint32_t targetIndex = 0; !isDimgTarget && targetIndex < dimgTargetIDCount; ++targetIndex) {
+            isDimgTarget = (item->id == dimgTargetIDs[targetIndex]);
+        }
+        uint32_t dimgCount = 0;
+        if (isDimgTarget) {
+            for (uint32_t dimgIndex = 0; dimgIndex < encoder->data->items.count; ++dimgIndex) {
+                avifEncoderItem * dimgItem = &encoder->data->items.item[dimgIndex];
+                if (dimgItem->dimgFromID == item->id) {
+                    ++dimgCount;
+                }
             }
         }
 
         if (dimgCount > 0) {
             if (!iref) {
-                AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "iref", AVIF_BOX_SIZE_TBD, 0, 0, &iref));
+                AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "iref", AVIF_BOX_SIZE_TBD, largeItemIDs ? 1 : 0, 0, &iref));
             }
+            // Section 8.11.12.1 of ISO/IEC 14496-12: all the references for one item of a specific
+            // type are collected into a single item type reference box, whose reference_count
+            // field is unsigned int(16) whatever the 'iref' version (Section 8.11.12.2).
+            // A grid item therefore cannot have more than 65535 cells (enforced in
+            // avifEncoderAddImageGrid()).
+            AVIF_ASSERT_OR_RETURN(dimgCount <= UINT16_MAX);
             avifBoxMarker refType;
             AVIF_CHECKRES(avifRWStreamWriteBox(&s, "dimg", AVIF_BOX_SIZE_TBD, &refType));
-            AVIF_CHECKRES(avifRWStreamWriteU16(&s, item->id));  // unsigned int(16) from_item_ID;
-            AVIF_CHECKRES(avifRWStreamWriteU16(&s, dimgCount)); // unsigned int(16) reference_count;
+            if (largeItemIDs) {
+                AVIF_CHECKRES(avifRWStreamWriteU32(&s, item->id)); // unsigned int(32) from_item_ID;
+            } else {
+                AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)item->id)); // unsigned int(16) from_item_ID;
+            }
+            AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)dimgCount)); // unsigned int(16) reference_count;
             for (uint32_t dimgIndex = 0; dimgIndex < encoder->data->items.count; ++dimgIndex) {
                 avifEncoderItem * dimgItem = &encoder->data->items.item[dimgIndex];
                 if (dimgItem->dimgFromID == item->id) {
-                    AVIF_CHECKRES(avifRWStreamWriteU16(&s, dimgItem->id)); // unsigned int(16) to_item_ID;
+                    if (largeItemIDs) {
+                        AVIF_CHECKRES(avifRWStreamWriteU32(&s, dimgItem->id)); // unsigned int(32) to_item_ID;
+                    } else {
+                        AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)dimgItem->id)); // unsigned int(16) to_item_ID;
+                    }
                 }
             }
             AVIF_CHECKRES(avifRWStreamFinishBox(&s, refType));
@@ -3449,13 +3549,19 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
 
         if (item->irefToID != 0) {
             if (!iref) {
-                AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "iref", AVIF_BOX_SIZE_TBD, 0, 0, &iref));
+                AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "iref", AVIF_BOX_SIZE_TBD, largeItemIDs ? 1 : 0, 0, &iref));
             }
             avifBoxMarker refType;
             AVIF_CHECKRES(avifRWStreamWriteBox(&s, item->irefType, AVIF_BOX_SIZE_TBD, &refType));
-            AVIF_CHECKRES(avifRWStreamWriteU16(&s, item->id));       // unsigned int(16) from_item_ID;
-            AVIF_CHECKRES(avifRWStreamWriteU16(&s, 1));              // unsigned int(16) reference_count;
-            AVIF_CHECKRES(avifRWStreamWriteU16(&s, item->irefToID)); // unsigned int(16) to_item_ID;
+            if (largeItemIDs) {
+                AVIF_CHECKRES(avifRWStreamWriteU32(&s, item->id));       // unsigned int(32) from_item_ID;
+                AVIF_CHECKRES(avifRWStreamWriteU16(&s, 1));              // unsigned int(16) reference_count;
+                AVIF_CHECKRES(avifRWStreamWriteU32(&s, item->irefToID)); // unsigned int(32) to_item_ID;
+            } else {
+                AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)item->id));       // unsigned int(16) from_item_ID;
+                AVIF_CHECKRES(avifRWStreamWriteU16(&s, 1));                        // unsigned int(16) reference_count;
+                AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)item->irefToID)); // unsigned int(16) to_item_ID;
+            }
             AVIF_CHECKRES(avifRWStreamFinishBox(&s, refType));
         }
     }
@@ -3482,7 +3588,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
     AVIF_CHECKRES(avifRWStreamFinishBox(&s, ipco));
 
     avifBoxMarker ipma;
-    AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "ipma", AVIF_BOX_SIZE_TBD, 0, 0, &ipma));
+    AVIF_CHECKRES(avifRWStreamWriteFullBox(&s, "ipma", AVIF_BOX_SIZE_TBD, largeItemIDs ? 1 : 0, 0, &ipma));
     {
         uint32_t ipmaCount = 0;
         for (uint32_t itemIndex = 0; itemIndex < encoder->data->items.count; ++itemIndex) {
@@ -3500,7 +3606,11 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
                 continue;
             }
 
-            AVIF_CHECKRES(avifRWStreamWriteU16(&s, item->id)); // unsigned int(16) item_ID;
+            if (largeItemIDs) {
+                AVIF_CHECKRES(avifRWStreamWriteU32(&s, item->id)); // unsigned int(32) item_ID;
+            } else {
+                AVIF_CHECKRES(avifRWStreamWriteU16(&s, (uint16_t)item->id)); // unsigned int(16) item_ID;
+            }
             AVIF_ASSERT_OR_RETURN(item->associations.count < (1 << 8));
             AVIF_CHECKRES(avifRWStreamWriteU8(&s, (uint8_t)item->associations.count)); // unsigned int(8) association_count;
             for (uint32_t i = 0; i < item->associations.count; ++i) {
@@ -3524,7 +3634,7 @@ avifResult avifEncoderFinish(avifEncoder * encoder, avifRWData * output)
         //   group_id value of any other EntityToGroupBox, any item_ID value of the hierarchy level
         //   (file, movie. or track) that contains the GroupsListBox, or any track_ID value (when the
         //   GroupsListBox is contained in the file level).
-        AVIF_ASSERT_OR_RETURN(encoder->data->lastItemID < UINT16_MAX);
+        AVIF_ASSERT_OR_RETURN(encoder->data->lastItemID != UINT32_MAX);
         ++encoder->data->lastItemID;
         const uint32_t groupID = encoder->data->lastItemID;
         AVIF_CHECKRES(avifWriteAltrGroup(&s, groupID, &encoder->data->alternativeItemIDs));

--- a/tests/gtest/avifgridapitest.cc
+++ b/tests/gtest/avifgridapitest.cc
@@ -277,5 +277,74 @@ TEST(GridApiTest, DifferentMatrixCoefficients) {
       AVIF_RESULT_INVALID_IMAGE_GRID);
 }
 
+TEST(GridApiTest, CellsTooManyForDimgReferenceCount) {
+  // Section 8.11.12.1 of ISO/IEC 14496-12 requires all the references from one
+  // item to be collected into a single item type reference box, whose
+  // reference_count field is unsigned int(16) whatever the 'iref' version
+  // (Section 8.11.12.2). ISO/IEC 23008-12 (HEIF) Section 6.6.1 additionally
+  // forbids more than one 'dimg' box with the same from_item_ID. A grid item
+  // therefore cannot have more than 65535 cells, so a 256x256-cell grid is
+  // rejected upfront instead of silently generating a broken file.
+  ImagePtr cell = testutil::CreateImage(
+      /*width=*/64, /*height=*/64, /*depth=*/8, AVIF_PIXEL_FORMAT_YUV400,
+      AVIF_PLANES_YUV);
+  ASSERT_NE(cell, nullptr);
+  testutil::FillImageGradient(cell.get());
+  const std::vector<avifImage*> cell_image_ptrs(256 * 256, cell.get());
+
+  EncoderPtr encoder(avifEncoderCreate());
+  ASSERT_NE(encoder, nullptr);
+  encoder->speed = AVIF_SPEED_FASTEST;
+  ASSERT_EQ(avifEncoderAddImageGrid(encoder.get(), /*gridCols=*/256,
+                                    /*gridRows=*/256, cell_image_ptrs.data(),
+                                    AVIF_ADD_IMAGE_FLAG_SINGLE),
+            AVIF_RESULT_INVALID_IMAGE_GRID);
+}
+
+TEST(GridApiTest, ColorAlphaGridExceeding16BitItemIDs) {
+  // A color grid and an alpha grid of 128x256 cells each contain 32768 cells,
+  // so encoding them requires 65538 distinct item IDs (2 grid items + 2 x 32768
+  // cell items), which does not fit in the 16-bit item ID space. Such a file is
+  // conformant though, so the encoder relies on 32-bit item IDs, switching to
+  // the 'infe' version 3, 'iloc' version 2, 'iref' version 1 and 'ipma' version
+  // 1 boxes, rather than overflowing the item IDs. The cells are 64x64 because
+  // it is the smallest size allowed by [MIAF].
+  ImagePtr cell = testutil::CreateImage(
+      /*width=*/64, /*height=*/64, /*depth=*/8, AVIF_PIXEL_FORMAT_YUV420,
+      AVIF_PLANES_ALL /* alpha channel needed */);
+  ASSERT_NE(cell, nullptr);
+  // The pixels do not matter but avoid use-of-uninitialized-value errors.
+  testutil::FillImageGradient(cell.get());
+  const std::vector<avifImage*> cell_image_ptrs(128 * 256, cell.get());
+
+  EncoderPtr encoder(avifEncoderCreate());
+  ASSERT_NE(encoder, nullptr);
+  // Worst quality to keep the encoding of the 65536 cells fast.
+  encoder->speed = AVIF_SPEED_FASTEST;
+  encoder->minQuantizer = 63;
+  encoder->maxQuantizer = 63;
+  encoder->minQuantizerAlpha = 63;
+  encoder->maxQuantizerAlpha = 63;
+  ASSERT_EQ(avifEncoderAddImageGrid(encoder.get(), /*gridCols=*/128,
+                                    /*gridRows=*/256, cell_image_ptrs.data(),
+                                    AVIF_ADD_IMAGE_FLAG_SINGLE),
+            AVIF_RESULT_OK);
+  testutil::AvifRwData encoded_avif;
+  ASSERT_EQ(avifEncoderFinish(encoder.get(), &encoded_avif), AVIF_RESULT_OK);
+
+  // Decoding all 65536 cells would take too long for a test, so only parse the
+  // file, which still walks the whole 'iinf', 'iloc', 'iref' and 'ipma' boxes
+  // and verifies that all 65538 item IDs are valid and unique.
+  DecoderPtr decoder(avifDecoderCreate());
+  ASSERT_NE(decoder, nullptr);
+  ASSERT_EQ(avifDecoderSetIOMemory(decoder.get(), encoded_avif.data,
+                                   encoded_avif.size),
+            AVIF_RESULT_OK);
+  ASSERT_EQ(avifDecoderParse(decoder.get()), AVIF_RESULT_OK);
+  EXPECT_EQ(decoder->image->width, 64 * 128);
+  EXPECT_EQ(decoder->image->height, 64 * 256);
+  EXPECT_EQ(decoder->alphaPresent, AVIF_TRUE);
+}
+
 }  // namespace
 }  // namespace avif


### PR DESCRIPTION
Problem
avifEncoderDataCreateItem() used a uint16_t lastItemID counter and silentlyoverflowed it when a file needed more than 65535 items: the new item IDs wrappedaround (the item ID 0 is invalid per ISO/IEC 14496-12 §8.11.1.1, and the lastcell item collided with an existing item), the 'iinf' entry_count and'iloc' item_count fields were truncated, and the 'dimg' reference_countof the grid item wrapped to 0 so that its 'dimg' box was omitted entirely.avifEncoderAddImageGrid() and avifEncoderFinish() still returnedAVIF_RESULT_OK, and only the decoder complained (AVIF_RESULT_BMFF_PARSE_FAILED)when reading the generated file.

Fix
All encoder item IDs are now uint32_t. Item IDs are unsigned int(32) inthe file format (ISO/IEC 14496-12 §8.11.6), so this matches the format andremoves the overflow.
When an item ID or item count does not fit on 16 bits, the encoder writes the32-bit box variants: 'iloc' version 2, 'iinf' version 1 with 'infe'version 3 entries, 'iref' version 1 and 'ipma' version 1 ('pitm'version 1 if ever needed). These variants are only used when required: outputfiles that fit within the 16-bit item ID space are byte-for-byte identical tobefore. The reading side already supports all these box versions, sosrc/read.c is unchanged.
However, a grid item cannot reference more than 65535 cells:ISO/IEC 14496-12 §8.11.12.1 requires all references from one item of a giventype to be collected into a single item type reference box whosereference_count is unsigned int(16) whatever the 'iref' version(§8.11.12.2), and ISO/IEC 23008-12 (HEIF) §6.6.1 forbids more than one'dimg' box with the same from_item_ID. avifEncoderAddImageGrid()therefore now rejects grids with more than 65535 cells (e.g. 256×256)upfront with AVIF_RESULT_INVALID_IMAGE_GRID and a diagnostic, instead ofgenerating a broken file. Since 65535 = 3×5×17×257 has no factor pair withboth factors ≤ 256, the largest single-plane grid is 256×255 cells; gridswith several planes (color+alpha, gain map) can still total more than 65535items, which is what the uint32_t rework enables.
The 'dimg' target items are listed before the item loop inavifEncoderFinish(), avoiding an O(items²) scan which took about 20 secondsfor a 65538-item file.
Tests
GridApiTest.ColorAlphaGridExceeding16BitItemIDs: encodes a 128×256-cellcolor grid with a 128×256-cell alpha grid (64×64 cells, the smallest allowedby [MIAF]; 65538 items in total) and checks that the generated file parsesback with all 65538 unique item IDs. The generated file was also verifiedbyte-per-byte against the ISO/IEC 14496-12 box layouts and decodes correctlywith libheif (with its default 1000-item security limit raised).
GridApiTest.CellsTooManyForDimgReferenceCount: checks that a 256×256-cellgrid is rejected with AVIF_RESULT_INVALID_IMAGE_GRID.