### PR TITLE
Free tone mapped pixels on error

### DIFF
--- a/src/gainmap.c
+++ b/src/gainmap.c
@@ -310,6 +310,9 @@ cleanup:
     if (rescaledGainMap != NULL) {
         avifImageDestroy(rescaledGainMap);
     }
+    if (res != AVIF_RESULT_OK) {
+        avifRGBImageFreePixels(toneMappedImage);
+    }
 
     return res;
 }

--- a/tests/gtest/avifgainmaptest.cc
+++ b/tests/gtest/avifgainmaptest.cc
@@ -1801,6 +1801,8 @@ TEST(GainMapTest, ApplyGainMapNaN) {
 
   EXPECT_EQ(result, AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE)
       << avifResultToString(result) << " (" << diag.error << ")";
+  EXPECT_EQ(toneMap.pixels, nullptr);
+  EXPECT_EQ(toneMap.rowBytes, 0u);
 
   avifRGBImageFreePixels(&toneMap);
 }


### PR DESCRIPTION
`avifRGBImageApplyGainMap()` allocates `toneMappedImage->pixels` before applying the gain-map math. Error paths after that allocation go through `cleanup`, but the cleanup only releases the temporary gain-map buffers.

A degenerate gain map that produces NaN reaches the existing `AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE` path after the output allocation, leaving `toneMappedImage->pixels` allocated on failure. Repeated failed applications can therefore retain output-sized buffers unless the caller explicitly compensates.

Free the output pixels when the function exits with an error. Successful calls continue to return the allocated output unchanged.

The existing `ApplyGainMapNaN` regression now also verifies that `pixels` is NULL and `rowBytes` is zero after the error.

Validation:
- `git diff --check`
- full CMake test build completed successfully
- `avifgainmaptest`: 54/54 tests passed
- public-API reproduction: before the fix, `AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE` left `pixels` non-NULL; after the fix, the same error leaves `pixels == NULL` and `rowBytes == 0`
